### PR TITLE
Update eng/common files to match the new publish-build-assets mechanism in Arcade

### DIFF
--- a/eng/common/PublishBuildAssets.cmd
+++ b/eng/common/PublishBuildAssets.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -publishBuildAssets %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -msbuildEngine dotnet -restore /p:PublishBuildAssets=true /p:SdkProjects=PublishBuildAssets.proj %*"
 exit /b %ErrorLevel%

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -6,6 +6,7 @@ Param(
   [string] $msbuildEngine = $null,
   [bool] $warnaserror = $true,
   [bool] $nodereuse = $true,
+  [switch] $execute,
   [switch] $restore,
   [switch] $deployDeps,
   [switch] $build,
@@ -88,7 +89,6 @@ try {
     /p:PerformanceTest=$performanceTest `
     /p:Sign=$sign `
     /p:Publish=$publish `
-    /p:PublishBuildAssets=$publishBuildAssets `
     /p:ContinuousIntegrationBuild=$ci `
     @properties
 


### PR DESCRIPTION
Updating some eng/common files manually to match the ones needed by Arcade to see if it will help with a successful build. Hopefully, future DARC updates to Arcade will overwrite these files without actually canceling out the changes being made here (because these changes are borrowed from Arcade itself)