### PR TITLE
Adding NU5125 to NoWarn due to NuGet breaking change.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <Platforms>AnyCPU;x64</Platforms>
     
-    <NoWarn>$(NoWarn);0618</NoWarn>
+    <NoWarn>$(NoWarn);0618;NU5125</NoWarn>
     <DefineConstants>$(DefineConstants);OLDRESOURCES;SYSTEM_XAML</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #18 