### PR TITLE
Better TimeSpan comparison with zero

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -124,7 +124,7 @@ namespace System.Windows.Markup
             // Build up the format string to be used in DateTime.ToString()
             StringBuilder formatString = new StringBuilder("yyyy-MM-dd");
             
-            if (dateTime.TimeOfDay.TotalSeconds == 0)
+            if (dateTime.TimeOfDay == TimeSpan.Zero)
             {
                 // The time portion of this DateTime is exactly at midnight.  
                 // We don't include the time component if the Kind is unspecified.


### PR DESCRIPTION
It's a bad practice to compare double values with zero.
A better way to compare TimeSpan with zero is using the Ticks property.