### PR TITLE
Remove redundant field initialization in XamlContextStack

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
@@ -15,9 +15,9 @@ namespace MS.Internal.Xaml.Context
     //  2) it is <T>, and avoids activator.createinstance with the creationDelegate
     class XamlContextStack<T> where T : XamlFrame
     {
-        private int _depth = -1;
-        T _currentFrame = null;
-        T _recycledFrame = null;
+        private int _depth;
+        T _currentFrame;
+        T _recycledFrame;
         Func<T> _creationDelegate;
 
         public XamlContextStack(Func<T> creationDelegate)


### PR DESCRIPTION
The '-1' value of _depth is always overwritten by '0' in constructor.
The default values for _currentFrame and _recycledFrame are null,
so we don't need set them explicitly.