### PR TITLE
Adding Sdk section to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,9 @@
       "version": "15.9"
     }
   },
+  "sdk": {
+    "version": "3.0.100-preview-009764"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18605.3"
   }


### PR DESCRIPTION
Adding an Sdk section to global.json. This is needed to ensure that CI servers deterministically use the version of .NET Core 3.0 Sdk specified here to build the projects in the repo.