### PR TITLE
Add OSX gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,16 @@ ASALocalRun/
 /.dotnet
 /.packages
 /.tools/vswhere/2.5.2
+
+### OSX ###
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
A `DS_Store` file popped up when I cloned the repo so I'm adding this gitignore to prevent unwanted files sneaking their way in