### PR TITLE
 Remove dead code from ReflectionHelper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/Strings.resx
@@ -633,9 +633,6 @@
   <data name="TemplateNoTriggerTarget" xml:space="preserve">
     <value>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</value>
   </data>
-  <data name="QualifiedNameHasWrongFormat" xml:space="preserve">
-    <value>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</value>
-  </data>
   <data name="InvalidDeSerialize" xml:space="preserve">
     <value>MC4401: Serializer does not support Convert operations.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.cs.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Připravuji kompilaci označení...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: Název typu {0} není v očekávaném formátu className, assembly.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Načítám soubor Resource: {0}...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Markupkompilierung wird vorbereitet...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: Der Typname "{0}" besitzt nicht das erwartete Format "className, Assembly".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Resource-Datei "{0}" wird gelesen...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Preparando la compilación de marcado...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: el nombre de tipo '{0}' no tiene el formato esperado 'nombreDeClase, ensamblado'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Leyendo el archivo Resource: '{0}'...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Préparation de la compilation du balisage...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301 : le nom de type '{0}' n'a pas le format attendu, 'className, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Lecture du fichier Resource : '{0}'...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Preparazione della compilazione del markup in corso...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: il nome di tipo '{0}' non è specificato nel formato previsto 'nomeClasse, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Lettura del file Resource '{0}' in corso...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
@@ -812,11 +812,6 @@
         <target state="translated">マークアップのコンパイルを準備しています...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: 型名 '{0}' には、予期された書式 'className, assembly' がありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Resource ファイル '{0}' を読み取っています...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ko.xlf
@@ -812,11 +812,6 @@
         <target state="translated">태그 컴파일을 준비하는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: 형식 이름 '{0}'에 필요한 형식 'className, assembly'가 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Resource 파일 '{0}'을(를) 읽는 중입니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Trwa przygotowywanie do kompilacji znaczników...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: Nazwa typu „{0}” nie ma oczekiwanego formatu „nazwa_klasy, zestaw”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Trwa odczytywanie pliku Resource: „{0}”...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Preparando para a compilação da marcação...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: o nome do tipo '{0}' não tem o formato esperado 'className, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Lendo o arquivo Resource: '{0}'...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
@@ -812,11 +812,6 @@
         <target state="translated">Подготовка компиляции разметки...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: имя типа "{0}" не имеет ожидаемый формат "имя_класса, сборка".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Чтение файла Resource: "{0}"...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
@@ -812,11 +812,6 @@
         <target state="translated">İşaretleme derlemesi için hazırlanıyor...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: '{0}' tür adı beklenen 'className, assembly' biçiminde değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">Resource dosyası okunuyor: '{0}'...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -812,11 +812,6 @@
         <target state="translated">正在准备标记编译...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: 类型名“{0}”不具有预期的格式“className, assembly”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">正在读取 Resource 文件:“{0}”...</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -812,11 +812,6 @@
         <target state="translated">正在準備標記編譯...</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="translated">MC4301: 型別名稱 '{0}' 不是預期的格式 'className, assembly'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
         <target state="translated">正在讀取 Resource 檔案: '{0}'...</target>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -79,60 +79,45 @@ namespace System.Xaml
 
 #region Type
         /// <summary>
-        /// Parse and get the type of the passed in string
+        /// Parse and get the type of the passed-in string.
         /// </summary>
         internal static Type GetQualifiedType(string typeName)
         {
-            // ISSUE: we only parse the assembly name and type name
-            // all other Type.GetType() type fragments (version, culture info, pub key token etc) are ignored!!!
-            string[] nameFrags = typeName.Split(new Char[] { ',' }, 2);
-            Type type = null;
+            // We only parse the assembly name and type name.
+            // All other Type.GetType() type fragments (version, culture info, public
+            // key token etc) are ignored.
+            string[] nameFrags = typeName.Split(new char[] { ',' }, 2);
             if (nameFrags.Length == 1)
             {
-                // treat it as an absolute name
-                type = Type.GetType(nameFrags[0]);
+                // Treat this as an absolute name.
+                return Type.GetType(nameFrags[0]);
             }
-            else
+
+            Assembly a = null;
+            try
             {
-                if (nameFrags.Length != 2)
-                    throw new InvalidOperationException(SR.Format(SR.QualifiedNameHasWrongFormat, typeName));
-
-                Assembly a = null;
-                try
-                {
-                    a = LoadAssembly(nameFrags[1].TrimStart(), null);
-                }
-                // ifdef magic to save compiler update.
-                // the fix below is for an FxCop rule about non-CLR exceptions.
-                // however this rule has now been removed.
-                catch (Exception e)   // Load throws generic Exceptions, so this can't be made more specific.
-                {
-                    if (CriticalExceptions.IsCriticalException(e))
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        // If we can't load the assembly, just return null (fall-through).
-                        a = null;
-                    }
-                }
-
-                if (a != null)
-                {
-                    try
-                    {
-                        type = a.GetType(nameFrags[0]);
-                        // If we can't get the type, just return null (fall-through).
-                    }
-                    catch (ArgumentException)
-                    {
-                        a = null;
-                    }
-                }
+                a = LoadAssembly(nameFrags[1].TrimStart(), null);
+            }
+            catch (Exception e) when (!CriticalExceptions.IsCriticalException(e))
+            {
             }
 
-            return type;
+            // If we can't load the assembly, just return null.
+            if (a == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return a.GetType(nameFrags[0]);
+            }
+            catch (ArgumentException)
+            {
+            }
+
+            // If we can't get the type, just return null.
+            return null;
         }
 
         internal static bool IsNullableType(Type type)
@@ -196,10 +181,12 @@ namespace System.Xaml
             return type;
         }
 
+#if PBTCOMPILER
         internal static Type GetMscorlibType(Type type)
         {
             return GetFrameworkType(MscorlibReflectionAssemblyName, type);
         }
+#endif
 
         internal static Type GetSystemType(Type type)
         {
@@ -516,10 +503,12 @@ namespace System.Xaml
             return isFriend;
         }
 
+#if PBTCOMPILER
         internal static bool IsInternalAllowedOnType(Type type)
         {
             return ((LocalAssemblyName == type.Assembly.GetName().Name) || IsFriendAssembly(type.Assembly));
         }
+#endif
 
         // The local assembly that contains the baml.
         internal static string LocalAssemblyName

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -392,7 +392,6 @@ ConvertFromException='{0}' ValueSerializer cannot convert from '{1}'.
 
 ;System.Windows.Markup
 ServiceTypeAlreadyAdded=This serviceType is already registered to another service.
-QualifiedNameHasWrongFormat='{0}' type name does not have the expected format 'className, assembly'.
 ParserAttributeArgsHigh=Too many attributes are specified for '{0}'.
 ParserAttributeArgsLow='{0}' requires more attributes.
 ParserAssemblyLoadVersionMismatch=Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -783,9 +783,6 @@
   <data name="ProvideValueCycle" space_="preserve">
     <value>Cannot call MarkupExtension.ProvideValue because of a cyclical dependency. Properties inside a MarkupExtension cannot reference objects that reference the result of the MarkupExtension. The affected MarkupExtensions are:</value>
   </data>
-  <data name="QualifiedNameHasWrongFormat" space_="preserve">
-    <value>'{0}' type name does not have the expected format 'className, assembly'.</value>
-  </data>
   <data name="QuoteCharactersOutOfPlace" space_="preserve">
     <value>Quote characters ' or " are only allowed at the start of values.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Nelze volat metodu MarkupExtension.ProvideValue z důvodu cyklické závislosti. Vlastnosti uvnitř objektu MarkupExtension nemohou odkazovat na objekty, které odkazují na výsledek MarkupExtension. Toto se týká následujících objektů MarkupExtensions:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Název typu {0} nemá očekávaný formát className, assembly.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Znaky uvozovek ' nebo " jsou povoleny pouze na začátku hodnot.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">MarkupExtension.ProvideValue kann aufgrund einer zyklischen Abhängigkeit nicht aufgerufen werden. Eigenschaften in MarkupExtension können nicht auf Objekte verweisen, die auf das Ergebnis der MarkupExtension verweisen. Betroffene MarkupExtensions:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Typname "{0}" hat nicht das erwartete Format "className, assembly".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Die Anführungszeichen ' oder " sind nur am Anfang von Werten zulässig.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">No se puede llamar a MarkupExtension.ProvideValue debido a una dependencia cíclica. Las propiedades dentro de MarkupExtension no pueden hacer referencia a objetos que hagan referencia al resultado de MarkupExtension. Los elementos MarkupExtension afectados son:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">El nombre de tipo '{0}' no tiene el formato esperado 'nombreDeClase, ensamblado'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Las comillas ' o " se permiten solo en el inicio de los valores.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Impossible d'appeler MarkupExtension.ProvideValue en raison d'une dépendance cyclique. Les propriétés dans un MarkupExtension ne peuvent pas référencer des objets qui référencent le résultat de MarkupExtension. Les MarkupExtensions affectés sont :</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Le nom de type '{0}' n'a pas le format attendu 'className, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Les guillemets ' ou " sont uniquement autorisés au début des valeurs.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Impossibile chiamare MarkupExtension.ProvideValue a causa di una dipendenza ciclica. Le proprietà all'interno di MarkupExtension non possono fare riferimento a oggetti che fanno riferimento al risultato di MarkupExtension. MarkupExtensions interessate:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Il nome di tipo '{0}' non è specificato nel formato previsto 'nomeClasse, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Le virgolette ' o " sono consentite solo all'inizio di valori.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">循環する依存関係があるため、MarkupExtension.ProvideValue を呼び出すことができません。MarkupExtension 内のプロパティから、MarkupExtension の結果を参照するオブジェクトを参照することはできません。影響を受ける MarkupExtension は次のとおりです。</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 型名には、必要な形式 'className, assembly' がありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">引用符 ' または " は、値の始めにしか使用できません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">순환 종속으로 인해 MarkupExtension.ProvideValue를 호출할 수 없습니다. MarkupExtension 안의 속성에서 MarkupExtension의 결과를 참조하는 개체를 참조할 수 없습니다. 영향을 받는 MarkupExtension은 다음과 같습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 형식 이름에 'className, assembly' 형식이 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">따옴표 문자 ' 또는 "는 값의 시작에서만 사용할 수 있습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Nie można wywołać metody MarkupExtension.ProvideValue z powodu zależności cyklicznej. Właściwości wewnątrz obiektu MarkupExtension nie mogą odwoływać się do obiektów, które odwołują się do wyniku obiektu MarkupExtension. Chodzi o następujące obiekty MarkupExtension:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Nazwa typu „{0}” nie ma oczekiwanego formatu „nazwaKlasy, zestaw”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Znaki cudzysłowu ' i " są dozwolone tylko na początku wartości.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Não é possível chamar MarkupExtension.ProvideValue devido a uma dependência cíclica. As propriedades em uma MarkupExtension não podem referenciar objetos que referenciam o resultado da MarkupExtension. As MarkupExtensions afetadas são:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">O nome de tipo '{0}' não tem o formato esperado 'nomeDaClasse, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">As aspas ' ou " só são permitidas no início de valores.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Не удается вызвать MarkupExtension.ProvideValue из-за циклической зависимости. Свойства внутри MarkupExtension не могут ссылаться на объекты, ссылающиеся на результат MarkupExtension. Связанные объекты MarkupExtension:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Формат имени типа "{0}" отличается от ожидаемого формата "имя класса, сборка".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Символы кавычек ' и " допустимы только в начале значений.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">Döngüsel bağımlılık nedeniyle MarkupExtension.ProvideValue çağrılamıyor. MarkupExtension'ın içindeki özellikler, MarkupExtension'ın sonucuna başvurun nesneler başvuruda bulunamaz. Etkilenen MarkupExtension öğeleri:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' tür adı beklenen 'className, assembly' biçiminde değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">Tırnak işareti karakterlerine (' veya ") yalnızca değerlerin başında izin verilir.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">因存在循环依赖而无法调用 MarkupExtension.ProvideValue。MarkupExtension 内的属性无法对引用 MarkupExtension 的结果的对象进行引用。受影响的 MarkupExtensions 有:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">“{0}”类型名称不具有要求的格式“className, assembly”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">仅允许在值的开头使用引号字符 ' 或 "。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1112,11 +1112,6 @@
         <target state="translated">無法呼叫 MarkupExtension.ProvideValue，因為有循環相依性。MarkupExtension 內部的屬性不可參考會參考 MarkupExtension 結果的物件。受影響的 MarkupExtensions 為:</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 型別名稱不是預期的格式 'className, assembly'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="QuoteCharactersOutOfPlace">
         <source>Quote characters ' or " are only allowed at the start of values.</source>
         <target state="translated">引號字元 ' 或 " 只能使用在值的開頭。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1491,9 +1491,6 @@
   <data name="ServiceTypeAlreadyAdded" xml:space="preserve">
     <value>This serviceType is already registered to another service.</value>
   </data>
-  <data name="QualifiedNameHasWrongFormat" xml:space="preserve">
-    <value>'{0}' type name does not have the expected format 'className, assembly'.</value>
-  </data>
   <data name="ParserAttributeArgsHigh" xml:space="preserve">
     <value>Too many attributes are specified for '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">Hlavička proměnné délky ve streamu publikační licence má {0} bajtů, což je více než maximální délka {1} bajtů.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Název typu {0} nemá očekávaný formát className, assembly.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">Index {0} přesahuje maximum {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">Der Header mit variabler Länge im Datenstrom für die Veröffentlichungslizenz umfasst {0} Bytes. Die maximal zulässige Länge von {1} Bytes wird damit überschritten.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Typname "{0}" hat nicht das erwartete Format "className, assembly".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">Der Index "{0}" liegt über dem Höchstwert "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">El encabezado de longitud variable en la secuencia de licencias de publicación es de {0} bytes, que supera la longitud máxima de {1} bytes.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">El nombre de tipo '{0}' no tiene el formato esperado 'nombreDeClase, ensamblado'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">El índice "{0}" está por encima del máximo "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">L'en-tête de longueur variable du flux de licence de publication est de {0} octets, ce qui dépasse la longueur maximale fixée à {1} octets.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Le nom de type '{0}' n'a pas le format attendu 'className, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">L'index '{0}' se situe au-delà de la limite maximale fixée à '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">L'intestazione di lunghezza variabile nel flusso della licenza di pubblicazione è di {0} byte e supera la lunghezza massima di {1} byte.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Il nome di tipo '{0}' non è specificato nel formato previsto 'nomeClasse, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">L'indice '{0}' supera il valore massimo consentito di '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">公開ライセンス ストリームの可変長ヘッダーが {0} バイトです。これは、最大長の {1} バイトを超えています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 型名には、必要な形式 'className, assembly' がありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">'{0}' インデックスが最大値 '{1}' を超えています。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">게시 라이선스 스트림의 가변 길이 헤더가 {0}바이트로, 최대 길이인 {1}바이트를 초과합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 형식 이름에 'className, assembly' 형식이 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">'{0}' 인덱스는 최댓값 '{1}'을(를) 초과합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">Nagłówek o zmiennej długości strumienia licencji publikowania ma bajtów: {0}, co przekracza maksymalną liczbę bajtów wynoszącą {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Nazwa typu „{0}” nie ma oczekiwanego formatu „nazwaKlasy, zestaw”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">Indeks „{0}” przekroczył maksimum: „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">O cabeçalho de comprimento variável no fluxo de licença de publicação tem {0} bytes, o que ultrapassa o comprimento máximo de {1} bytes.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">O nome de tipo '{0}' não tem o formato esperado 'nomeDaClasse, assembly'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">O índice '{0}' está além do valor máximo de '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">Заголовок переменной длины в потоке лицензии на публикацию имеет длину в байтах: {0}. Это значение превышает максимальную длину в байтах: {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">Формат имени типа "{0}" отличается от ожидаемого формата "имя класса, сборка".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">Индекс "{0}" превышает максимальное значение "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">Yayımlama lisansı akışındaki değişken uzunluklu üst bilgi {0} bayt boyutunda ve {1} bayt olan en fazla uzunluk sınırını aşıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' tür adı beklenen 'className, assembly' biçiminde değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">'{0}' dizini '{1}' üst sınırın üzerinde.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">发布许可证流中的可变长度标头为 {0} 个字节，它超过 {1} 个字节的最大长度。</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">“{0}”类型名称不具有要求的格式“className, assembly”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">“{0}”索引超出了最大值“{1}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -1417,11 +1417,6 @@
         <target state="translated">發佈授權資料流中的變數長度標頭為 {0} 個位元組，超過了長度上限 {1} 個位元組。</target>
         <note />
       </trans-unit>
-      <trans-unit id="QualifiedNameHasWrongFormat">
-        <source>'{0}' type name does not have the expected format 'className, assembly'.</source>
-        <target state="translated">'{0}' 型別名稱不是預期的格式 'className, assembly'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReachOutOfRange">
         <source>'{0}' index is beyond maximum '{1}'.</source>
         <target state="translated">'{0}' 索引超過上限 '{1}'。</target>


### PR DESCRIPTION
Above, we have the code
```
string[] nameFrags = typeName.Split(new char[] { ',' }, 2);
```

This guarantees that `nameFrags.Length` is maximum 2/

We know that the string can not be empty and check for length one before, so therefore this check if irrelevant

Also put some minor code cleanup in there