### PR TITLE
Remove dead checks from TypeConverterHelper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -312,10 +312,12 @@ namespace System.Windows.Markup
             {
                 typeConverter = new System.ComponentModel.GuidConverter();
             }
+#if !SYSTEM_XAML
             else if (type == typeof(String))
             {
                 typeConverter = new System.ComponentModel.StringConverter();
             }
+#endif
             else if (type == typeof(CultureInfo))
             {
                 typeConverter = new System.ComponentModel.CultureInfoConverter();


### PR DESCRIPTION
- `GetCoreConverterFromCoreType` is only called from `GetTypeConverter` which is only called from `ValueSerializer.GetSerializerFor`. This special-cases `typeof(string)`

```cs
public static ValueSerializer GetSerializerFor(Type type)
{
    if (type == null)
        throw new ArgumentNullException("type");
    object value = _valueSerializers[type];
    if (value != null)
        // This uses _valueSerializersLock's instance as a sentinal for null  (as opposed to not attempted yet).
        return value == _valueSerializersLock ? null : value as ValueSerializer;

    AttributeCollection attributes = TypeDescriptor.GetAttributes(type);
    ValueSerializerAttribute attribute = attributes[typeof(ValueSerializerAttribute)] as ValueSerializerAttribute;
    ValueSerializer result = null;

    if (attribute != null)
        result = (ValueSerializer)Activator.CreateInstance(attribute.ValueSerializerType);

    if (result == null)
    {
        if (type == typeof(string))
        {
            result = new StringValueSerializer();
        }
        else
        {
            // Try to use the type converter
            TypeConverter converter = TypeConverterHelper.GetTypeConverter(type);

            // DateTime is a special-case.  We can't use the DateTimeConverter, because it doesn't
            // support anything other than user culture and invariant culture, and we need to specify
            // en-us culture.
            if (converter.GetType() == typeof(DateTimeConverter2))
            {
                result = new DateTimeValueSerializer();
            }
            else if (converter.CanConvertTo(typeof(string)) && converter.CanConvertFrom(typeof(string)) &&
                        !(converter is ReferenceConverter))
            {
                result = new TypeConverterValueSerializer(converter);
            }
        }
    }
    lock (_valueSerializersLock)
    {
        // This uses _valueSerializersLock's instance as a sentinal for null (as opposed to not attempted yet).
        _valueSerializers[type] = result == null ? _valueSerializersLock : result;
    }

    return result;
}
```