### PR TITLE
Backing out problematic shared source changes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CriticalExceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CriticalExceptions.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Threading;
+using System;
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup
@@ -32,9 +29,9 @@ namespace MS.Internal
             return ex is NullReferenceException ||
                    ex is StackOverflowException ||
                    ex is OutOfMemoryException   ||
-                   ex is ThreadAbortException ||
-                   ex is SEHException ||
-                   ex is SecurityException;
+                   ex is System.Threading.ThreadAbortException ||
+                   ex is System.Runtime.InteropServices.SEHException ||
+                   ex is System.Security.SecurityException;
         }
 
         // these are exceptions that we should treat as critical when they
@@ -60,7 +57,7 @@ namespace MS.Internal
             // for certain types of exceptions, we care more about the inner
             // exception
             while (ex.InnerException != null &&
-                    (   ex is TargetInvocationException
+                    (   ex is System.Reflection.TargetInvocationException
                     ))
             {
                 ex = ex.InnerException;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -6,12 +6,15 @@
 // History:
 //   10/15/04:    Microsoft        Created
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Security;
+using System.Security.Permissions;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
-
 #if SYSTEM_XAML
 using TypeConverterHelper = System.Xaml.TypeConverterHelper;
 #else
@@ -483,9 +486,9 @@ namespace System.Xaml
 
         public static bool operator ==(WeakRefKey left, WeakRefKey right)
         {
-            if (ReferenceEquals(left, null))
+            if (object.ReferenceEquals(left, null))
             {
-                return ReferenceEquals(right, null);
+                return object.ReferenceEquals(right, null);
             }
             return left.Equals(right);
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityCriticalDataForSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityCriticalDataForSet.cs
@@ -10,9 +10,9 @@
 //              For example a filepath variable might control what part of the file system the
 //              code gets access to.
 
-using System;
-using System.Diagnostics;
-using System.Security;
+using System ; 
+using System.Security ;
+
 #if WINDOWS_BASE
     using MS.Internal.WindowsBase;
 #elif PRESENTATION_CORE
@@ -61,7 +61,7 @@ namespace MS.Internal
         internal T Value 
         {
         #if DEBUG
-            [DebuggerStepThrough]
+            [System.Diagnostics.DebuggerStepThrough]
         #endif
             [SecurityCritical, SecurityTreatAsSafe]
             get
@@ -70,7 +70,7 @@ namespace MS.Internal
             }
 
         #if DEBUG
-            [DebuggerStepThrough]
+            [System.Diagnostics.DebuggerStepThrough]
         #endif
             [SecurityCritical]
             set

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Diagnostics;
 using System.Globalization;
-using System.Text;
 
 namespace MS.Internal.Xaml.Context
 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Diagnostics;
 
 namespace MS.Internal.Xaml.Context

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -5,6 +5,7 @@
 //  Description: Data model for the Bracket characters specified on a Markup Extension property.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -2,11 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-
-#if !SYSTEM_XAML
+using System.Windows;
+using System.Diagnostics.CodeAnalysis;
+#if SYSTEM_XAML
+using System.Xaml;
+#else
 using MS.Internal.WindowsBase;
 #endif
 
@@ -1592,7 +1596,7 @@ namespace MS.Utility
         }
 
         // array-based implementation - compacts in-place or into a new array
-        internal class ArrayCompacter : Compacter
+        internal class ArrayCompacter : FrugalListBase<T>.Compacter
         {
             public ArrayCompacter(ArrayItemList<T> store, int newCount)
                 : base(store, newCount)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -4,14 +4,16 @@
 
 //  Description: Specifies that the whitespace surrounding an element should be trimmed.
 
+using System;
+using System.IO;
+using System.Reflection;
+using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Security;
+using System.Runtime.CompilerServices;
+using MS.Internal;
 
 #if PBTCOMPILER
 using MS.Utility;
@@ -120,7 +122,7 @@ namespace System.Xaml
                     {
                         a = null;
                     }
-                    catch (SecurityException)
+                    catch (System.Security.SecurityException)
                     {
                         a = null;
                     }
@@ -477,7 +479,7 @@ namespace System.Xaml
                         {
                             retassem = Assembly.Load(assemblyGivenName);
                         }
-                        catch (FileNotFoundException)
+                        catch (System.IO.FileNotFoundException)
                         {
                             // This may be a locally defined assembly that has not been created yet.
                             // To support these cases, just set a null assembly and return.  This

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
@@ -4,13 +4,14 @@
 
 //  Contents:  Limited converter for string <--> System.Uri
 
-using System.ComponentModel;
-using System.ComponentModel.Design.Serialization;
-using System.Globalization;
-using System.Reflection;
-
 namespace System.Xaml.Replacements
 {
+    using System;
+    using System.ComponentModel;
+    using System.ComponentModel.Design.Serialization;
+    using System.Globalization;
+    using System.Reflection;
+
     internal class TypeUriConverter : TypeConverter
     {
         public TypeUriConverter()

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
@@ -6,6 +6,8 @@
 //   This attribute is placed on a class to identify the property that will
 //   function as an Name for the given class
 
+using System;
+using System.Globalization;
 using SRCS = System.Runtime.CompilerServices;
 
 #if PBTCOMPILER

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -4,10 +4,11 @@
 
 //  Description: Specifies that the whitespace surrounding an element should be trimmed.
 
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Globalization;
+using System;
 using System.Reflection;
+using System.ComponentModel;
+using System.Globalization;
+using System.Diagnostics;
 #if SYSTEM_XAML
 using System.Xaml.Replacements;
 #endif
@@ -254,71 +255,71 @@ namespace System.Windows.Markup
             TypeConverter typeConverter = null;
             if (type == typeof(Int32))
             {
-                typeConverter = new Int32Converter();
+                typeConverter = new System.ComponentModel.Int32Converter();
             }
             else if (type == typeof(Int16))
             {
-                typeConverter = new Int16Converter();
+                typeConverter = new System.ComponentModel.Int16Converter();
             }
             else if (type == typeof(Int64))
             {
-                typeConverter = new Int64Converter();
+                typeConverter = new System.ComponentModel.Int64Converter();
             }
             else if (type == typeof(UInt32))
             {
-                typeConverter = new UInt32Converter();
+                typeConverter = new System.ComponentModel.UInt32Converter();
             }
             else if (type == typeof(UInt16))
             {
-                typeConverter = new UInt16Converter();
+                typeConverter = new System.ComponentModel.UInt16Converter();
             }
             else if (type == typeof(UInt64))
             {
-                typeConverter = new UInt64Converter();
+                typeConverter = new System.ComponentModel.UInt64Converter();
             }
             else if (type == typeof(Boolean))
             {
-                typeConverter = new BooleanConverter();
+                typeConverter = new System.ComponentModel.BooleanConverter();
             }
             else if (type == typeof(Double))
             {
-                typeConverter = new DoubleConverter();
+                typeConverter = new System.ComponentModel.DoubleConverter();
             }
             else if (type == typeof(Single))
             {
-                typeConverter = new SingleConverter();
+                typeConverter = new System.ComponentModel.SingleConverter();
             }
             else if (type == typeof(Byte))
             {
-                typeConverter = new ByteConverter();
+                typeConverter = new System.ComponentModel.ByteConverter();
             }
             else if (type == typeof(SByte))
             {
-                typeConverter = new SByteConverter();
+                typeConverter = new System.ComponentModel.SByteConverter();
             }
             else if (type == typeof(Char))
             {
-                typeConverter = new CharConverter();
+                typeConverter = new System.ComponentModel.CharConverter();
             }
             else if (type == typeof(Decimal))
             {
-                typeConverter = new DecimalConverter();
+                typeConverter = new System.ComponentModel.DecimalConverter();
             }
             else if (type == typeof(TimeSpan))
             {
-                typeConverter = new TimeSpanConverter();
+                typeConverter = new System.ComponentModel.TimeSpanConverter();
             }
             else if (type == typeof(Guid))
             {
-                typeConverter = new GuidConverter();
+                typeConverter = new System.ComponentModel.GuidConverter();
             }
             else if (type == typeof(String))
             {
-                typeConverter = new StringConverter();
+                typeConverter = new System.ComponentModel.StringConverter();
             }
             else if (type == typeof(CultureInfo))
             {
-                typeConverter = new CultureInfoConverter();
+                typeConverter = new System.ComponentModel.CultureInfoConverter();
             }
 #if !SYSTEM_XAML
             else if (type == typeof(Type))
@@ -328,7 +329,7 @@ namespace System.Windows.Markup
 #else
             else if (type == typeof(Type))
             {
-                typeConverter = new TypeTypeConverter();
+                typeConverter = new System.Xaml.Replacements.TypeTypeConverter();
             }
 #endif
             else if (type == typeof(DateTime))
@@ -337,7 +338,7 @@ namespace System.Windows.Markup
             }
             else if (ReflectionHelper.IsNullableType(type))
             {
-                typeConverter = new NullableConverter(type);
+                typeConverter = new System.ComponentModel.NullableConverter(type);
             }
 
             return typeConverter;
@@ -350,75 +351,75 @@ namespace System.Windows.Markup
             {
                 // Need to handle Enums types specially as they require a ctor that
                 // takes the underlying type.
-                typeConverter = new EnumConverter(type);
+                typeConverter = new System.ComponentModel.EnumConverter(type);
             }
             else if (typeof(Int32).IsAssignableFrom(type))
             {
-                typeConverter = new Int32Converter();
+                typeConverter = new System.ComponentModel.Int32Converter();
             }
             else if (typeof(Int16).IsAssignableFrom(type))
             {
-                typeConverter = new Int16Converter();
+                typeConverter = new System.ComponentModel.Int16Converter();
             }
             else if (typeof(Int64).IsAssignableFrom(type))
             {
-                typeConverter = new Int64Converter();
+                typeConverter = new System.ComponentModel.Int64Converter();
             }
             else if (typeof(UInt32).IsAssignableFrom(type))
             {
-                typeConverter = new UInt32Converter();
+                typeConverter = new System.ComponentModel.UInt32Converter();
             }
             else if (typeof(UInt16).IsAssignableFrom(type))
             {
-                typeConverter = new UInt16Converter();
+                typeConverter = new System.ComponentModel.UInt16Converter();
             }
             else if (typeof(UInt64).IsAssignableFrom(type))
             {
-                typeConverter = new UInt64Converter();
+                typeConverter = new System.ComponentModel.UInt64Converter();
             }
             else if (typeof(Boolean).IsAssignableFrom(type))
             {
-                typeConverter = new BooleanConverter();
+                typeConverter = new System.ComponentModel.BooleanConverter();
             }
             else if (typeof(Double).IsAssignableFrom(type))
             {
-                typeConverter = new DoubleConverter();
+                typeConverter = new System.ComponentModel.DoubleConverter();
             }
             else if (typeof(Single).IsAssignableFrom(type))
             {
-                typeConverter = new SingleConverter();
+                typeConverter = new System.ComponentModel.SingleConverter();
             }
             else if (typeof(Byte).IsAssignableFrom(type))
             {
-                typeConverter = new ByteConverter();
+                typeConverter = new System.ComponentModel.ByteConverter();
             }
             else if (typeof(SByte).IsAssignableFrom(type))
             {
-                typeConverter = new SByteConverter();
+                typeConverter = new System.ComponentModel.SByteConverter();
             }
             else if (typeof(Char).IsAssignableFrom(type))
             {
-                typeConverter = new CharConverter();
+                typeConverter = new System.ComponentModel.CharConverter();
             }
             else if (typeof(Decimal).IsAssignableFrom(type))
             {
-                typeConverter = new DecimalConverter();
+                typeConverter = new System.ComponentModel.DecimalConverter();
             }
             else if (typeof(TimeSpan).IsAssignableFrom(type))
             {
-                typeConverter = new TimeSpanConverter();
+                typeConverter = new System.ComponentModel.TimeSpanConverter();
             }
             else if (typeof(Guid).IsAssignableFrom(type))
             {
-                typeConverter = new GuidConverter();
+                typeConverter = new System.ComponentModel.GuidConverter();
             }
             else if (typeof(String).IsAssignableFrom(type))
             {
-                typeConverter = new StringConverter();
+                typeConverter = new System.ComponentModel.StringConverter();
             }
             else if (typeof(CultureInfo).IsAssignableFrom(type))
             {
-                typeConverter = new CultureInfoConverter();
+                typeConverter = new System.ComponentModel.CultureInfoConverter();
             }
 #if !SYSTEM_XAML
             else if (typeof(Type).IsAssignableFrom(type))
@@ -428,7 +429,7 @@ namespace System.Windows.Markup
 #else
             else if (type == typeof(Type))
             {
-                typeConverter = new TypeTypeConverter();
+                typeConverter = new System.Xaml.Replacements.TypeTypeConverter();
             }
 #endif
             else if (typeof(DateTime).IsAssignableFrom(type))
@@ -437,7 +438,7 @@ namespace System.Windows.Markup
             }
             else if (typeof(Uri).IsAssignableFrom(type))
             {
-                typeConverter = new TypeUriConverter();
+                typeConverter = new System.Xaml.Replacements.TypeUriConverter();
             }
 
             return typeConverter;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -2,16 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.Text;
+using System;
 using System.Xml;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Diagnostics;
+using System.Threading;
+
+#if SYSTEM_XAML
+using System.Xaml;
+#endif
 
 #if PBTCOMPILER
 using MS.Utility;
 namespace MS.Internal.Markup
 #elif SYSTEM_XAML
+using System.Windows;
 
 namespace System.Xaml
 #else
@@ -218,7 +225,7 @@ namespace System.Windows.Markup
             string namespaceName = NamespaceURI;
             bool result = false;
 
-            if (ReferenceEquals(namespaceName, CompatibilityUri))
+            if (object.ReferenceEquals(namespaceName, CompatibilityUri))
             {
                 // if the element is a markup-compatibility element, we get the appropriate handler for
                 // the element type, and call the appropriate delegate.  If the element is not recognized
@@ -304,12 +311,12 @@ namespace System.Windows.Markup
             string namespaceName = NamespaceURI;
             bool result = false;  // return value
 
-            if (ReferenceEquals(namespaceName, CompatibilityUri))
+            if (object.ReferenceEquals(namespaceName, CompatibilityUri))
             {
                 // if the element is a markup-compatibility element, pop a scope, decrement the
                 // depth offset and read the next element.
                 string elementName = Reader.LocalName;
-                if (ReferenceEquals(elementName, AlternateContent))
+                if (object.ReferenceEquals(elementName, AlternateContent))
                 {
                     if (!Scope.ChoiceSeen)
                     {
@@ -717,14 +724,14 @@ namespace System.Windows.Markup
         /// <summary>
         /// Answer the encoding of the underlying xaml stream
         /// </summary>
-        internal Encoding Encoding
+        internal System.Text.Encoding Encoding
         {
             get
             {
                 XmlTextReader textReader = Reader as XmlTextReader;
                 if (textReader == null)
                 {
-                    return new UTF8Encoding(true, true);
+                    return new System.Text.UTF8Encoding(true, true);
                 }
                 else
                 {
@@ -921,7 +928,7 @@ namespace System.Windows.Markup
             bool result;
             if (IsNamespaceKnown(namespaceName))
             {
-                result = ReferenceEquals(namespaceName, CompatibilityUri);
+                result = object.ReferenceEquals(namespaceName, CompatibilityUri);
             }
             else
             {
@@ -1063,7 +1070,7 @@ namespace System.Windows.Markup
                     if (ShouldIgnoreNamespace(namespaceName))
                     {
                         // check each attribute's namespace to see if it should be ignored
-                        if (ReferenceEquals(namespaceName, CompatibilityUri))
+                        if (object.ReferenceEquals(namespaceName, CompatibilityUri))
                         {
                             // if the attribute is in the markup-compatibility namespace
                             // find and call the appropriate attribute handler callback.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Diagnostics;
+using System;
 using System.Xml;
 using System.Xml.Schema;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Security.Policy;
 
 #if PBTCOMPILER
 namespace MS.Internal.Markup
@@ -51,7 +53,7 @@ namespace System.Windows.Markup
         public override XmlSpace XmlSpace           { get { return _reader.XmlSpace; } }
         public override string XmlLang              { get { return _reader.XmlLang; } }
         public override IXmlSchemaInfo SchemaInfo   { get { return _reader.SchemaInfo; } }
-        public override Type ValueType              { get { return _reader.ValueType; } }
+        public override System.Type ValueType       { get { return _reader.ValueType; } }
         public override int AttributeCount          { get { return _reader.AttributeCount; } }
         public override string this [ int i ]       { get { return _reader[i]; } }
         public override string this [ string name ] { get { return _reader[ name ];}}


### PR DESCRIPTION
Certain changes to shared sources proved to be a problem when integrated into our unpublished sources.  This is due to the fact that analyzers do not have a full picture of what is needed based on the fact that the sources are not published.

@AndreyAkinshin I had to revert the changes to shared sources caused by #103.  I should have caught this prior to merging, but I am fixing them up now.  The cleanup done in System.Xaml is perfectly fine as no unpublished mirror exists for those files.  However, the Shared directory still contains files used by PresentationBuildTasks (which multi-targets with 4.7.2) and WindowsBase.  Due to this, we can cause build breaks of various kinds in our unpublished sources.  It's more expedient to revert these for now and wait until all code that requires these shared sources can be published.  Apologies for not catching this during the PR review.

@karelz and @vatsan-madhavan FYI.  We're working on a clarifying statement regarding the shared sources.