### PR TITLE
Null check missing before calling a method marked with 'NotNull' attribute

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeConverter2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeConverter2.cs
@@ -42,7 +42,10 @@ namespace System.Xaml.Replacements
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            return _dateTimeValueSerializer.ConvertFromString( value as string, _valueSerializerContext );
+            string stringValue = value as string;
+            if (stringValue == null)
+                throw new ArgumentException(SR.Get(SRID.MustBeOfType, "value", "String"));
+            return _dateTimeValueSerializer.ConvertFromString(stringValue, _valueSerializerContext );
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)


### PR DESCRIPTION
Was looking through the code and noticed a missing null check where the method to be called is marked as NotNull