### PR TITLE
Remove unused parameter from ClrNamespaceUriParser

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -161,11 +161,6 @@ ElementBodyRuleException=ElementBody ::= ATTRIBUTE* ( PropertyElement | Content 
 NonemptyPropertyElementRuleException=NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.
 PropertyElementRuleException=PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement
 
-
-; ClrNamespaceUriParser
-MissingTagInNamespace=Missing '{0}' in URI '{1}'.
-AssemblyTagMissing=Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.
-
 ; TypeReflector
 UnknownAttributeProperty=['{0}'('{1}')] on '{2}' is not a known property.
 NotDeclaringTypeAttributeProperty=['{0}'('{1}')] on '{2}' is not a property declared on this type.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -507,12 +507,6 @@
   <data name="PropertyElementRuleException" xml:space="preserve">
     <value>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</value>
   </data>
-  <data name="MissingTagInNamespace" xml:space="preserve">
-    <value>Missing '{0}' in URI '{1}'.</value>
-  </data>
-  <data name="AssemblyTagMissing" xml:space="preserve">
-    <value>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</value>
-  </data>
   <data name="UnknownAttributeProperty" xml:space="preserve">
     <value>['{0}'('{1}')] on '{2}' is not a known property.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -37,11 +37,6 @@
         <target state="new">Array Add method is not implemented.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AssemblyTagMissing">
-        <source>Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</source>
-        <target state="new">Part between semicolon ';' and equals sign '=' is not '{0}' URI '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AttachableEventNotImplemented">
         <source>Attachable events are not implemented.</source>
         <target state="new">Attachable events are not implemented.</target>
@@ -640,11 +635,6 @@
       <trans-unit id="MissingPropertyCaseClrType">
         <source>Missing case in ClrType 'Member' lookup.</source>
         <target state="new">Missing case in ClrType 'Member' lookup.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MissingTagInNamespace">
-        <source>Missing '{0}' in URI '{1}'.</source>
-        <target state="new">Missing '{0}' in URI '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTypeConverter">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
@@ -6,7 +6,7 @@ using System.Xaml.MS.Impl;
 
 namespace System.Xaml.Schema
 {
-    static class ClrNamespaceUriParser
+    internal static class ClrNamespaceUriParser
     {
         public static string GetUri(string clrNs, string assemblyName)
         {
@@ -16,43 +16,28 @@ namespace System.Xaml.Schema
 
         public static bool TryParseUri(string uriInput, out string clrNs, out string assemblyName)
         {
-            return TryParseUri(uriInput, out clrNs, out assemblyName, out _, false);
-        }
-
-        private static bool TryParseUri(string uriInput, out string clrNs, out string assemblyName,
-            out string error, bool returnErrors)
-        {
             clrNs = null;
             assemblyName = null;
-            error = null;
 
             // xmlns:foo="clr-namespace:System.Windows;assembly=myassemblyname"
             // xmlns:bar="clr-namespace:MyAppsNs"
             // xmlns:spam="clr-namespace:MyAppsNs;assembly="  
 
             int colonIdx = KS.IndexOf(uriInput, ":");
-            if (-1 == colonIdx)
+            if (colonIdx == -1)
             {
-                if (returnErrors)
-                {
-                    error = SR.Get(SRID.MissingTagInNamespace, ":", uriInput);
-                }
                 return false;
             }
 
             string keyword = uriInput.Substring(0, colonIdx);
             if (!KS.Eq(keyword, KnownStrings.UriClrNamespace))
             {
-                if (returnErrors)
-                {
-                    error = SR.Get(SRID.MissingTagInNamespace, KnownStrings.UriClrNamespace, uriInput);
-                }
                 return false;
             }
 
             int clrNsStartIdx = colonIdx + 1;
             int semicolonIdx = KS.IndexOf(uriInput, ";");
-            if (-1 == semicolonIdx)
+            if (semicolonIdx == -1)
             {
                 clrNs = uriInput.Substring(clrNsStartIdx);
                 assemblyName = null;
@@ -66,23 +51,17 @@ namespace System.Xaml.Schema
 
             int assemblyKeywordStartIdx = semicolonIdx+1;
             int equalIdx = KS.IndexOf(uriInput, "=");
-            if (-1 == equalIdx)
+            if (equalIdx == -1)
             {
-                if (returnErrors)
-                {
-                    error = SR.Get(SRID.MissingTagInNamespace, "=", uriInput);
-                }
                 return false;
             }
+
             keyword = uriInput.Substring(assemblyKeywordStartIdx, equalIdx - assemblyKeywordStartIdx);
             if (!KS.Eq(keyword, KnownStrings.UriAssembly))
             {
-                if (returnErrors)
-                {
-                    error = SR.Get(SRID.AssemblyTagMissing, KnownStrings.UriAssembly, uriInput);
-                }
                 return false;
             }
+
             assemblyName = uriInput.Substring(equalIdx + 1);
             return true;
         }


### PR DESCRIPTION
Unused, so we can remove the parameter and delete the corresponding strings