### PR TITLE
Fix bug in `XamlTypeInvoker.GetAddMethod` if there is no such match

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -208,6 +208,11 @@ namespace System.Xaml.Schema
 
         public virtual MethodInfo GetEnumeratorMethod()
         {
+            if (IsUnknown)
+            {
+                return null;
+            }
+
             return _xamlType.GetEnumeratorMethod;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -180,7 +180,9 @@ namespace System.Xaml.Schema
                         _xamlType.UnderlyingType, type.UnderlyingType);
                     if (addMethod != null)
                     {
-                        addMethods.Add(type, addMethod);
+                        // Use TryAdd as AllowedContentTypes can contain
+                        // duplicate types.
+                        addMethods.TryAdd(type, addMethod);
                     }
                 }
                 _addMethods = addMethods;


### PR DESCRIPTION
## Fix 1: Use `Dictionary.TryAdd` instead of `Add` to prevent duplicates

Example code:
```cs
[Fact]
public void GetAddMethod_NoSuchContentType_ReturnsNull()
{
    var invoker = new XamlTypeInvoker(new XamlType(typeof(List<int>), new XamlSchemaContext()));
    var type = new XamlType(typeof(string), new XamlSchemaContext());
    Assert.Null(invoker.GetAddMethod(type));
};
```

Use `Dictionary.TryAdd` to avoid throwing if there is more than one value. I opted to change this to `TryAdd` rather than removing `addMethods.Add(_xamlType.ItemType, _xamlType.AddMethod);`, as firstly a user can override `LookupContentWrappers` so removing this value could be breaking, and secondly because `ContentWrappers` could contain duplicate types which could throw anyway previously

Expected: we return null
Actual: we throw an ArgumentException for duplicate value in a dictionary

Fixes #210

## Fix 2: Bail out of `GetEnumeratorMethod` if the type invoker is unknown

```
[Fact]
public void GetEnumeratorMethod_Unknown_ReturnsNull()
{
    XamlTypeInvoker invoker = XamlTypeInvoker.UnknownInvoker;
    Assert.Null(invoker.GetEnumeratorMethod());
}
```

Expected: returns null, matching behaviour with GetAddMethod()
Actual: throws NullReferenceException

Fixes #216