### PR TITLE
 Fix NullReferenceException in XamlType.Equals/XamlType.GetHashCode

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1725,8 +1725,11 @@ namespace System.Xaml
         {
             if (IsUnknown)
             {
-                Debug.Assert(_namespaces != null && _namespaces.Count > 0);
-                int result = _name.GetHashCode() ^ _namespaces[0].GetHashCode();
+                int result = _name.GetHashCode();
+                if (_namespaces != null && _namespaces.Count > 0)
+                {
+                    result ^= _namespaces[0].GetHashCode();
+                }
                 if (_typeArguments != null && _typeArguments.Count > 0)
                 {
                     foreach (XamlType typeArgument in _typeArguments)
@@ -1768,11 +1771,20 @@ namespace System.Xaml
             {
                 if (xamlType2.IsUnknown)
                 {
-                    Debug.Assert(xamlType1._namespaces != null && xamlType1._namespaces.Count > 0);
-                    Debug.Assert(xamlType2._namespaces != null && xamlType2._namespaces.Count > 0);
+                    if (xamlType1._namespaces != null)
+                    {
+                        if (xamlType2._namespaces == null || xamlType1._namespaces[0] != xamlType2._namespaces[0])
+                        {
+                            return false;
+                        }
+                    }
+                    else if (xamlType2._namespaces != null)
+                    {
+                        return false;
+                    }
+
                     return (xamlType1._name == xamlType2._name) &&
-                        (xamlType1._namespaces[0] == xamlType2._namespaces[0]) &&
-                        typeArgumentsAreEqual(xamlType1, xamlType2);
+                        TypeArgumentsAreEqual(xamlType1, xamlType2);
                 }
                 return false;
             }
@@ -1791,9 +1803,10 @@ namespace System.Xaml
             return !(xamlType1 == xamlType2);
         }
 
-        private static bool typeArgumentsAreEqual(XamlType xamlType1, XamlType xamlType2)
+        private static bool TypeArgumentsAreEqual(XamlType xamlType1, XamlType xamlType2)
         {
-            Debug.Assert(xamlType1.IsUnknown && xamlType2.IsUnknown);
+            Debug.Assert(xamlType1.IsUnknown);
+            Debug.Assert(xamlType2.IsUnknown);
             if (!xamlType1.IsGeneric)
             {
                 return !xamlType2.IsGeneric;


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/217

The issue here is that `XamlType._namespaces` can actually be null, for example when a `XamlType` is constructed using the `XamlType(string typeName, IList<XamlType> typeArguments, XamlSchemaContext schemaContext` constructor