### PR TITLE
build against latest core fx packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,6 @@ phases:
   parameters:
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
-      agentPool: dotnet-internal-temp
+      agentPool: dotnet-internal-temp-vs2019
       # runAsPublic is used in expressions, which can't read from user-defined variables
       runAsPublic: false

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,7 +4,7 @@
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19058.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha></Sha>
+      <Sha>3220be53ac764d9ee160b0bc64baa492af219aa7</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview.19060.1">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,5 +46,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha></Sha>
     </Dependency>
+      <Dependency Name="System.CodeDom" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,7 +4,47 @@
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19058.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3220be53ac764d9ee160b0bc64baa492af219aa7</Sha>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.Emit" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.TypeExtensions" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Security.AccessControl" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Permissions" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Principal.Windows" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Windows.Extensions" Version="4.6.0-preview.19060.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,10 +4,32 @@
     <VersionPrefix>4.8.0</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <SystemSecurityVersion>4.5.0</SystemSecurityVersion>
-    <SystemReflectionEmitVersion>4.3.0</SystemReflectionEmitVersion>
-    <XUnitVersion>2.4.0</XUnitVersion>
+  </PropertyGroup>
+  <!-- NuGet Package Versions -->
+  <PropertyGroup>
+    <!-- Packages that come from https://github.com/dotnet/corefx -->
+    <MicrosoftWin32RegistryPackageVersion>4.6.0-preview.19060.1</MicrosoftWin32RegistryPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>4.6.0-preview.19060.1</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview.19060.1</SystemDiagnosticsEventLogPackageVersion>
+    <SystemReflectionEmitPackageVersion>4.6.0-preview.19060.1</SystemReflectionEmitPackageVersion>
+    <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview.19060.1</SystemReflectionTypeExtensionsPackageVersion>
+    <SystemSecurityAccessControlPackageVersion>4.6.0-preview.19060.1</SystemSecurityAccessControlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.6.0-preview.19060.1</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>4.6.0-preview.19060.1</SystemSecurityPermissionsPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>4.6.0-preview.19060.1</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>4.6.0-preview.19060.1</SystemWindowsExtensionsPackageVersion>
+    <!-- Packages that come from https://github.com/dotnet/corefxlab -->
+    <SystemReflectionTypeLoaderPackageVersion>0.1.0-preview2-181205-2</SystemReflectionTypeLoaderPackageVersion>
+    <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
+    <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>
+    <!-- Other Packages that require manual updating-->
+    <AccessibilityPackageVersion>4.6.0-alpha-27128-8</AccessibilityPackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
+    <SystemReflectionPackageVersion>4.3.0</SystemReflectionPackageVersion>
+    <SystemSecurityPackageVersion>4.5.0</SystemSecurityPackageVersion>
     <XUnitRunnerConsoleVersion>2.4.0</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion>2.4.0</XUnitRunnerVisualStudioVersion>
+    <XUnitVersion>2.4.0</XUnitVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,4 +32,8 @@
     <XUnitRunnerVisualStudioVersion>2.4.0</XUnitRunnerVisualStudioVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- This is required to restore System.Reflection.Typeloader successfully -->
+    <RestoreSources>$(RestoreSources);https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json</RestoreSources>
+  </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,16 +18,15 @@
     <SystemSecurityPermissionsPackageVersion>4.6.0-preview.19060.1</SystemSecurityPermissionsPackageVersion>
     <SystemSecurityPrincipalWindowsPackageVersion>4.6.0-preview.19060.1</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>4.6.0-preview.19060.1</SystemWindowsExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>4.6.0-preview.19060.1</SystemCodeDomPackageVersion>
     <!-- Packages that come from https://github.com/dotnet/corefxlab -->
     <SystemReflectionTypeLoaderPackageVersion>0.1.0-preview2-181205-2</SystemReflectionTypeLoaderPackageVersion>
     <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
-    <SystemCodeDomPackageVersion>4.4.0</SystemCodeDomPackageVersion>
+    <SystemCodeDomPackageVersionForPresentationBuildTasks>4.4.0</SystemCodeDomPackageVersionForPresentationBuildTasks>
     <!-- Other Packages that require manual updating-->
     <AccessibilityPackageVersion>4.6.0-alpha-27128-8</AccessibilityPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
-    <SystemReflectionPackageVersion>4.3.0</SystemReflectionPackageVersion>
-    <SystemSecurityPackageVersion>4.5.0</SystemSecurityPackageVersion>
     <XUnitRunnerConsoleVersion>2.4.0</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion>2.4.0</XUnitRunnerVisualStudioVersion>
     <XUnitVersion>2.4.0</XUnitVersion>

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -1,8 +1,8 @@
 parameters:
 
   # Needed because agent pool can't be read from a user-defined variable (Azure DevOps limitation)
-  # Defaults to dotnet-external-temp
-  agentPool: dotnet-external-temp
+  # Defaults to dotnet-external-temp-vs2019
+  agentPool: dotnet-external-temp-vs2019
 
   # Needed because runAsPublic is used in template expressions, which can't read from user-defined variables
   # Defaults to true

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview-009764",
+    "dotnet": "3.0.100-preview-010024",
     "vs": {
       "version": "15.9"
     }

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "tools": {
     "dotnet": "3.0.100-preview-010024",
     "vs": {
-      "version": "15.9"
+      "version": "16.0"
     }
   },
   "sdk": {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -99,6 +99,6 @@
     
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityVersion)" />
+    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/test/MultiTargeting.props
+++ b/src/Microsoft.DotNet.Wpf/test/MultiTargeting.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'!='net35'">
-    <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
+    <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitPackageVersion)" />
   </ItemGroup>
   
   <!-- When IsUnitTestProject is set by Arcade, these ProjectReferences are implicitly included -->


### PR DESCRIPTION
I've added the darc subscription for the ".NET Core 3 Dev" channel from the CoreFX repo to the WPF (this) repo. This change checks-in the files required by darc to allow Maestro to update these files and get the latest packages that come from the CoreFX build


I've also added other packages that are required for building WPF that come from the prototype branch.

Fixes #248 