### PR TITLE
adding back platform builds

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -41,6 +41,8 @@ jobs:
           value: ''
         - name: _Platform
           value: x86
+        - name: _PlatformArgs
+          value: /p:Platform=$(_Platform)
 
         # Override some values if we're building internally
         - ${{ if eq(parameters.runAsPublic, 'false') }}:
@@ -69,8 +71,6 @@ jobs:
               /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - name: _PlatformArgs
-            value: /p:Platform=$(_Platform)
       strategy:
         matrix:
           Build_Debug_x86:

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -69,14 +69,26 @@ jobs:
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       strategy:
         matrix:
-          Build_Debug:
+          Build_Debug_x86:
             _BuildConfig: Debug
             # override some variables for debug
             _PublishType: none
             _SignType: test
             _DotNetPublishToBlobFeed : false
-          Build_Release:
+            _Platform: x86
+          Build_Release_x86:
             _BuildConfig: Release
+            _Platform: x86
+          Build_Debug_x64:
+            _BuildConfig: Debug
+            # override some variables for debug
+            _PublishType: none
+            _SignType: test
+            _DotNetPublishToBlobFeed : false
+            _Platform: x64
+          Build_Release_x64:
+            _BuildConfig: Release
+            _Platform: x64
       steps:
       - checkout: self
         clean: true

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -39,6 +39,8 @@ jobs:
           value: ''
         - name: _OfficialBuildIdArgs
           value: ''
+        - name: _Platform
+          value: x86
 
         # Override some values if we're building internally
         - ${{ if eq(parameters.runAsPublic, 'false') }}:
@@ -67,6 +69,8 @@ jobs:
               /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _PlatformArgs
+            value: /p:Platform=$(_Platform)
       strategy:
         matrix:
           Build_Debug_x86:
@@ -75,10 +79,8 @@ jobs:
             _PublishType: none
             _SignType: test
             _DotNetPublishToBlobFeed : false
-            _Platform: x86
           Build_Release_x86:
             _BuildConfig: Release
-            _Platform: x86
           Build_Debug_x64:
             _BuildConfig: Debug
             # override some variables for debug
@@ -99,4 +101,5 @@ jobs:
           $(_PublishArgs)
           $(_SignArgs)
           $(_OfficialBuildIdArgs)
+          $(_PlatformArgs)
         displayName: Windows Build / Publish


### PR DESCRIPTION
when I made the change to move to the new jobs.yml arcade templates, I accidently removed the platform specific configurations. this pr adds them back

Fixes #339 