### PR TITLE
LOC CHECKIN: Strings not intended to be translated should not be included in System.Xaml satellite assemblies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -486,27 +486,6 @@
   <data name="UnexpectedNodeType" xml:space="preserve">
     <value>Unexpected '{0}' in parse rule '{1}'.</value>
   </data>
-  <data name="ElementRuleException" xml:space="preserve">
-    <value>Element ::= . EmptyElement | ( StartElement ElementBody ).</value>
-  </data>
-  <data name="EmptyElementRuleException" xml:space="preserve">
-    <value>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</value>
-  </data>
-  <data name="EmptyPropertyElementRuleException" xml:space="preserve">
-    <value>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</value>
-  </data>
-  <data name="StartElementRuleException" xml:space="preserve">
-    <value>StartElement ::= . ELEMENT DIRECTIVE*.</value>
-  </data>
-  <data name="ElementBodyRuleException" xml:space="preserve">
-    <value>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</value>
-  </data>
-  <data name="NonemptyPropertyElementRuleException" xml:space="preserve">
-    <value>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</value>
-  </data>
-  <data name="PropertyElementRuleException" xml:space="preserve">
-    <value>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</value>
-  </data>
   <data name="UnknownAttributeProperty" xml:space="preserve">
     <value>['{0}'('{1}')] on '{2}' is not a known property.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -312,26 +312,6 @@
         <target state="translated">Existuje konflikt v atributech XmlnsCompatibleWithAttributes v sestaveních {0} a {1} pro obor OldNamespace {2}. Změňte atributy tak, aby měly stejný obor NewNamespace, nebo v konstruktoru objektu XamlSchemaContext předejte nekonfliktní sadu referenčních sestavení.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Událost {0} nelze přiřadit hodnotě, která není přiřaditelná k {1}.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Typ s pozičními parametry není rozšíření značek.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">{0}.{1} není vedlejší vlastnost.</target>
@@ -992,11 +967,6 @@
         <target state="translated">Vlastnost {0} v {1} vám neumožňuje zadat text.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">Vlastnost {0} není implementována.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Přímo přiřaditelné opravy musí mít pouze jeden název.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -312,26 +312,6 @@
         <target state="translated">In den Assemblys "{0}" und "{1}" für OldNamespace "{2}" sind in Konflikt stehende XmlnsCompatibleWithAttributes vorhanden. Ändern Sie die Attribute so, dass sie den gleichen NewNamespace besitzen, oder übergeben Sie eine keine Konflikte verursachende Gruppe von Verweisassemblys im XamlSchemaContext-Konstruktor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Dem {0}-Ereignis kann kein Wert zugewiesen werden, der nicht "{1}" zugewiesen werden kann.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Der Typ mit den Positionsparametern ist keine Markuperweiterung.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">"{0}"."{1}" ist keine Ambient-Eigenschaft.</target>
@@ -992,11 +967,6 @@
         <target state="translated">Die {0}-Eigenschaft für "{1}" ermöglicht nicht das Angeben von Text.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">"{0}" ist nicht implementiert.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Direkt zuweisbare Fixups dürfen nur einen Namen besitzen.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -312,26 +312,6 @@
         <target state="translated">Hay XmlnsCompatibleWithAttributes en conflicto en los ensamblados '{0}' y '{1}' para OldNamespace '{2}'. Cambie los atributos para que tengan el mismo NewNamespace, o pase un conjunto de ensamblados de referencia sin conflictos en el constructor XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Al evento '{0}' no se le puede asignar un valor que no se pueda asignar a '{1}'.</target>
@@ -802,11 +782,6 @@
         <target state="translated">El tipo con parámetros posicionales no es una extensión de marcado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' no es una propiedad ambiente.</target>
@@ -992,11 +967,6 @@
         <target state="translated">La propiedad '{0}' en '{1}' no permite especificar texto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' no está implementado.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Las correcciones directamente asignables deben tener solo un nombre.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -312,26 +312,6 @@
         <target state="translated">Des XmlnsCompatibleWithAttributes sont en conflit dans les assemblys '{0}' et '{1}' pour OldNamespace '{2}'. Modifiez les attributs de sorte qu'ils aient le même NewNamespace, ou passez un jeu d'assemblys de référence qui ne sont pas en conflit dans le constructeur XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Impossible d'assigner à l'événement '{0}' une valeur qui ne peut pas être assignée à '{1}'.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Le type avec des paramètres positionnels n'est pas une extension de balisage.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' n'est pas une propriété ambiante.</target>
@@ -992,11 +967,6 @@
         <target state="translated">La propriété '{0}' sur '{1}' ne vous permet pas de spécifier du texte.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' n'est pas implémenté.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Les corrections pouvant directement être assignées doivent avoir un seul nom.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -312,26 +312,6 @@
         <target state="translated">Sono presenti XmlnsCompatibleWithAttributes in conflitto negli assembly '{0}' e '{1}' per OldNamespace '{2}'. Modificare gli attributi affinché abbiano lo stesso NewNamespace o passare un set di assembly di riferimento non in conflitto nel costruttore XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Impossibile assegnare l'evento '{0}' a un valore non assegnabile a '{1}'.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Un tipo con parametri posizionali non è un'estensione di markup.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' non è una proprietà di ambiente.</target>
@@ -992,11 +967,6 @@
         <target state="translated">La proprietà '{0}' su '{1}' non consente la specifica di testo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' non implementato.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Le correzioni assegnabili direttamente devono avere un solo nome.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -312,26 +312,6 @@
         <target state="translated">OldNamespace '{2}' のアセンブリ '{0}' および '{1}' に、競合する XmlnsCompatibleWithAttributes があります。同じ NewNamespace になるように属性を変更するか、競合しない参照アセンブリのセットを XamlSchemaContext コンストラクターに渡してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">'{1}' に割り当て可能でない値を '{0}' イベントに割り当てることはできません。</target>
@@ -802,11 +782,6 @@
         <target state="translated">位置指定パラメーターを持つ型は、マークアップ拡張ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' はアンビエント プロパティではありません。</target>
@@ -992,11 +967,6 @@
         <target state="translated">'{1}' の '{0}' プロパティにテキストを指定することはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' は実装されていません。</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">直接割り当て可能なフィックスアップには、名前を 1 つだけ指定する必要があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -312,26 +312,6 @@
         <target state="translated">OldNamespace '{2}'에 대한 '{0}' 및 '{1}' 어셈블리에 충돌하는 XmlnsCompatibleWithAttributes가 있습니다. 특성을 변경하여 같은 NewNamespace를 포함하거나 XamlSchemaContext 생성자에서 충돌하지 않는 참조 어셈블리를 전달하십시오.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">'{0}' 이벤트에는 '{1}'에 할당하지 못하는 값을 할당할 수 없습니다.</target>
@@ -802,11 +782,6 @@
         <target state="translated">위치 매개 변수가 포함된 형식은 태그 확장이 아닙니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}'은(는) 앰비언트 속성이 아닙니다.</target>
@@ -992,11 +967,6 @@
         <target state="translated">'{1}'의 '{0}' 속성으로 인해 텍스트를 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}'이(가) 구현되지 않았습니다.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">직접 할당 가능한 픽스업에는 이름이 하나만 있어야 합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -312,26 +312,6 @@
         <target state="translated">W zestawach „{0}” i „{1}” dla właściwości OldNamespace „{2}” występują kolidujące atrybuty XmlnsCompatibleWithAttributes. Ustaw dla tych atrybutów tę samą wartość właściwości NewNamespace lub przekaż zbiór niekolidujących ze sobą zestawów odwołań w konstruktorze XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Zdarzeniu „{0}” nie można przypisać wartości, która nie jest możliwa do przypisania elementowi „{1}”.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Typ z parametrami pozycyjnymi nie jest rozszerzeniem znacznika.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">{0}.{1} nie jest właściwością otoczenia.</target>
@@ -992,11 +967,6 @@
         <target state="translated">Właściwość „{0}” elementu „{1}” nie zezwala na określanie tekstu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">Nie zaimplementowano właściwości „{0}”.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Naprawy możliwe do bezpośredniego przypisania muszą mieć tylko jedną nazwę.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -312,26 +312,6 @@
         <target state="translated">Há XmlnsCompatibleWithAttributes conflitantes nos assemblies '{0}' e '{1}' para OldNamespace '{2}'. Altere os atributos para que tenham o mesmo NewNamespace ou passe um conjunto de Assemblies de Referência não conflitantes no construtor XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Não é possível atribuir um valor ao evento '{0}' que não possa ser atribuído a '{1}'.</target>
@@ -802,11 +782,6 @@
         <target state="translated">O tipo com parâmetros posicionais não é uma extensão de marcação.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' não é uma propriedade de ambiente.</target>
@@ -992,11 +967,6 @@
         <target state="translated">A propriedade '{0}' em '{1}' não permite a especificação de texto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' não está implementado.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Ajustes que possam ser atribuídos diretamente devem ter somente um nome.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -312,26 +312,6 @@
         <target state="translated">В сборках "{0}" и "{1}" присутствуют конфликтующие атрибуты XmlnsCompatibleWithAttributes для OldNamespace "{2}" . Измените атрибуты так, чтобы у них было одинаковое свойство NewNamespace, либо передайте неконфликтующий набор ссылочных сборок в конструктор XamlSchemaContext.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">Событию "{0}" нельзя присвоить значение, которое невозможно присвоить для "{1}".</target>
@@ -802,11 +782,6 @@
         <target state="translated">Тип с позиционными параметрами не является расширением разметки.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">"{0}"."{1}" не является внешним свойством.</target>
@@ -992,11 +967,6 @@
         <target state="translated">Свойство "{0}" для "{1}" не позволяет указывать текст.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">"{0}" не реализовано.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">У напрямую присваиваемых адресных привязок может быть только одно имя.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -312,26 +312,6 @@
         <target state="translated">'{2}' OldNamespace için '{0}' ve '{1}' derlemelerinde çakışan XmlnsCompatibleWithAttributes değerleri var. Öznitelikleri aynı NewNamespace'e sahip olacak şekilde değiştirin veya XamlSchemaContext oluşturucusuna çakışmayan bir Başvuru Derlemeleri kümesi geçirin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">'{0}' olayı, '{1}' öğesine atanamayan bir değeri atayamaz.</target>
@@ -802,11 +782,6 @@
         <target state="translated">Konum parametreleri içeren tür bir işaretleme uzantısı değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' bir ortam özelliği değil.</target>
@@ -992,11 +967,6 @@
         <target state="translated">'{1}' öğesindeki '{0}' özelliği metin belirtmenize izin vermiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' uygulanmadı.</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">Doğrudan Atanabilir Düzeltmelerin tek bir adı olmalıdır.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -312,26 +312,6 @@
         <target state="translated">OldNamespace“{2}”的程序集“{0}”和“{1}”中的 XmlnsCompatibleWithAttributes 出现冲突。更改相应特性使其具有相同的 NewNamespace，或者在 XamlSchemaContext 构造函数中传递一组不会发生冲突的引用程序集。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">不能为“{0}”事件分配一个不可赋给“{1}”的值。</target>
@@ -802,11 +782,6 @@
         <target state="translated">带有位置参数的类型不是标记扩展。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' 不是环境属性。</target>
@@ -992,11 +967,6 @@
         <target state="translated">“{1}”上的“{0}”属性不允许您指定文本。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">未实现“{0}”。</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">可直接指定的链接地址信息只能有一个名称。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -312,26 +312,6 @@
         <target state="translated">OldNamespace '{2}' 的組件 '{0}' 和 '{1}' 中有衝突的 XmlnsCompatibleWithAttributes。請變更這些屬性讓它們具有相同的 NewNamespace，或者在 XamlSchemaContext 建構函式中傳遞一組不衝突的參考組件。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ElementBodyRuleException">
-        <source>ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</source>
-        <target state="translated">ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ElementRuleException">
-        <source>Element ::= . EmptyElement | ( StartElement ElementBody ).</source>
-        <target state="translated">Element ::= . EmptyElement | ( StartElement ElementBody ).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyElementRuleException">
-        <source>EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</source>
-        <target state="translated">EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EmptyPropertyElementRuleException">
-        <source>EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</source>
-        <target state="translated">EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EventCannotBeAssigned">
         <source>'{0}' event cannot be assigned a value that is not assignable to '{1}'.</source>
         <target state="translated">不可將無法指派給 '{1}' 的值指派給 '{0}' 事件。</target>
@@ -802,11 +782,6 @@
         <target state="translated">具有位置參數的型別不是標記延伸。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NonemptyPropertyElementRuleException">
-        <source>NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</source>
-        <target state="translated">NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NotAmbientProperty">
         <source>'{0}'.'{1}' is not an ambient property.</source>
         <target state="translated">'{0}'.'{1}' 不是環境屬性。</target>
@@ -992,11 +967,6 @@
         <target state="translated">'{1}' 上的屬性 '{0}' 不允許指定文字。</target>
         <note />
       </trans-unit>
-      <trans-unit id="PropertyElementRuleException">
-        <source>PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</source>
-        <target state="translated">PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PropertyNotImplemented">
         <source>'{0}' is not implemented.</source>
         <target state="translated">'{0}' 未實作。</target>
@@ -1115,11 +1085,6 @@
       <trans-unit id="SimpleFixupsMustHaveOneName">
         <source>Directly Assignable Fixups must only have one name.</source>
         <target state="translated">可直接指派的修復只能有一個名稱。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StartElementRuleException">
-        <source>StartElement ::= . ELEMENT DIRECTIVE*.</source>
-        <target state="translated">StartElement ::= . ELEMENT DIRECTIVE*.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringIsNullOrEmpty">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
@@ -39,6 +39,16 @@ namespace MS.Internal.Xaml.Parser
         //
         // Attribute and Directive values can be markup extensions.
 
+        ///////////////////////////
+        //  XamlPullParser Exception Strings 
+        //
+        private const string ElementRuleException = "Element ::= . EmptyElement | ( StartElement ElementBody ).";
+        private const string EmptyElementRuleException = "EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.";
+        private const string StartElementRuleException = "StartElement ::= . ELEMENT DIRECTIVE*.";
+        private const string ElementBodyRuleException = "ElementBody ::= ATTRIBUTE* ( PropertyElement | Content )* . ENDTAG.";
+        private const string PropertyElementRuleException = "PropertyElement ::= EmptyPropertyElement | NonemptyPropertyElement";
+        private const string EmptyPropertyElementRuleException = "EmptyPropertyElement ::= EMPTYPROPERTYELEMENT.";
+        private const string NonemptyPropertyElementRuleException = "NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.";
 
         ///////////////////////////
         //  Document::= PREFIXDEFINITION* Element
@@ -98,8 +108,7 @@ namespace MS.Internal.Xaml.Parser
                 }
                 break;
             default:
-                throw new XamlUnexpectedParseException(_xamlScanner, nodeType,
-                    SR.Get(SRID.ElementRuleException));
+                throw new XamlUnexpectedParseException(_xamlScanner, nodeType, ElementRuleException);
             }
         }
 
@@ -111,7 +120,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.EMPTYELEMENT)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.EmptyElementRuleException));
+                    EmptyElementRuleException);
             }
             yield return Logic_StartObject(_xamlScanner.Type, _xamlScanner.Namespace);
             _xamlScanner.Read();
@@ -158,7 +167,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.ELEMENT)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.StartElementRuleException));
+                    StartElementRuleException);
             }
             yield return Logic_StartObject(_xamlScanner.Type, _xamlScanner.Namespace);
             _xamlScanner.Read();
@@ -276,7 +285,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.ENDTAG)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.ElementBodyRuleException));
+                    ElementBodyRuleException);
             }
             yield return Logic_EndObject();
             _xamlScanner.Read();
@@ -309,7 +318,7 @@ namespace MS.Internal.Xaml.Parser
                     break;
                 default:
                     throw new XamlUnexpectedParseException(_xamlScanner, nodeType,
-                        SR.Get(SRID.PropertyElementRuleException));
+                        PropertyElementRuleException);
             }
         }
 
@@ -321,7 +330,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.EMPTYPROPERTYELEMENT)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.EmptyPropertyElementRuleException));
+                    EmptyPropertyElementRuleException);
             }
             yield return Logic_StartMember(_xamlScanner.PropertyElement);
             yield return Logic_EndMember();
@@ -340,7 +349,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.PROPERTYELEMENT)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.NonemptyPropertyElementRuleException));
+                    NonemptyPropertyElementRuleException);
             }
             yield return Logic_StartMember(_xamlScanner.PropertyElement);
             _xamlScanner.Read();
@@ -398,7 +407,7 @@ namespace MS.Internal.Xaml.Parser
             if (_xamlScanner.NodeType != ScannerNodeType.ENDTAG)
             {
                 throw new XamlUnexpectedParseException(_xamlScanner, _xamlScanner.NodeType,
-                    SR.Get(SRID.NonemptyPropertyElementRuleException));
+                    NonemptyPropertyElementRuleException);
             }
             yield return Logic_EndMember();
             _xamlScanner.Read();


### PR DESCRIPTION
Untranslated strings should not be included in System.Xaml satellite assemblies.  Remove strings from shared Strings.resx, add strings to XamlPullParser, and update XLF files for all languages.