### PR TITLE
Fallbacks for building internal WPF projects that use PresentationBuildTasks.dll and Microsoft.WinFX.targets for markup compilation

### DIFF
--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -333,9 +333,6 @@ $(PreparePackageAssetsDependsOn):
       <RepoCommitVersionFileLines Remove="@(RepoCommitVersionFileLines)" />
       <RepoCommitVersionFileLines Include="$(SourceRevisionId)" />
     </ItemGroup>
-    <CreateItem Include="$(SourceRevisionId)">
-      <Output TaskParameter="Include" ItemName="RepoCommitVersionFileLines"/>
-    </CreateItem>
 
     <PropertyGroup>
       <RepoCommitVersionFileDir>$(ArtifactsPackagingDir)$(NormalizedPackageName)\</RepoCommitVersionFileDir>

--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -315,13 +315,27 @@ $(PreparePackageAssetsDependsOn):
 
   <!-- Create version.txt containing latest commit ID -->
   <Target Name="GenerateVersionFileWithRepositoryCommit"  
-          Condition="'$(RepositoryCommit)'!='' and '$(IsPackable)'=='true' and '$(CreateArchNeutralPackage)'=='true' and !Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\version.txt')" 
+          Condition="'$(IsPackable)'=='true' and '$(CreateArchNeutralPackage)'=='true' and !Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\version.txt')" 
           BeforeTargets="CreateContentFolder" 
           Outputs="$(ArtifactsPackagingDir)$(NormalizedPackageName)\version.txt">
+    <!-- 
+      Workaround 
+        Ensure that SourceRevisionId is obtained if it has not already been read in 
+        Reuse tasks from Microsoft.Build.Tasks.Git.targets
+    --> 
+    <Microsoft.Build.Tasks.Git.LocateRepository Directory="$(MSBuildProjectDirectory)" Condition="'$(SourceRevisionId)' == ''" >
+      <Output TaskParameter="Id" PropertyName="_GitRepositoryRoot" />
+    </Microsoft.Build.Tasks.Git.LocateRepository>
+    <Microsoft.Build.Tasks.Git.GetSourceRevisionId Root="$(_GitRepositoryRoot)" Condition="'$(SourceRevisionId)' == ''">
+      <Output TaskParameter="RevisionId" PropertyName="SourceRevisionId" />
+    </Microsoft.Build.Tasks.Git.GetSourceRevisionId>
     <ItemGroup>
       <RepoCommitVersionFileLines Remove="@(RepoCommitVersionFileLines)" />
-      <RepoCommitVersionFileLines Include="$(RepositoryCommit)" />
+      <RepoCommitVersionFileLines Include="$(SourceRevisionId)" />
     </ItemGroup>
+    <CreateItem Include="$(SourceRevisionId)">
+      <Output TaskParameter="Include" ItemName="RepoCommitVersionFileLines"/>
+    </CreateItem>
 
     <PropertyGroup>
       <RepoCommitVersionFileDir>$(ArtifactsPackagingDir)$(NormalizedPackageName)\</RepoCommitVersionFileDir>

--- a/eng/WpfArcadeSdk/tools/Pbt.props
+++ b/eng/WpfArcadeSdk/tools/Pbt.props
@@ -1,11 +1,37 @@
 <Project>
   <PropertyGroup>
+    <LocalMicrosoftWinFXTargets>$(RepoRoot)src\Microsoft.DotNet.Wpf\src\PresentationBuildTasks\Microsoft.WinFX.targets</LocalMicrosoftWinFXTargets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="Exists('$(LocalMicrosoftWinFXTargets)')">
     <PbtTfm Condition="'$(MSBuildRuntimeType)'=='Core'">netcoreapp2.1</PbtTfm>
     <PbtTfm Condition="'$(MSBuildRuntimeType)'!='Core'">net472</PbtTfm>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="Exists('$(LocalMicrosoftWinFXTargets)')">
     <PbtDir>$(ArtifactsTmpDir)PresentationBuildTasks\$(PbtTfm)\</PbtDir>
   </PropertyGroup>
 
+  <!-- 
+    We will use Microsoft.NET.Sdk.WindowsDesktop targets directly when local PresentationBuildTasks is not available
+    We do not need to import Microsoft.NET.Sdk.WindowsDesktop.props from the Sdk - this only provides us with 
+    WPF references and Page, ApplicationDefinition globbing functionality - neither of which is used by our projects. 
+    
+    If we had needed to use this props file, we'd have imported it like this:
+    
+    <PropertyGroup Condition="!Exists('$(LocalMicrosoftWinFXTargets)') And '$(InternalMarkupCompilation)'=='true'">
+      <UseWpf>true</UseWpf>
+    </PropertyGroup>
+    <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
+            Project="../targets/Microsoft.NET.Sdk.WindowsDesktop.props"
+            Condition="!Exists('$(LocalMicrosoftWinFXTargets)') And '$(InternalMarkupCompilation)'=='true'"/>
+            
+    The use of Microsoft.NET.Sdk.WindowsDesktop doesn't break the source-build promise. 
+      - Microsoft.NET.Sdk.WindowsDesktop is built from sources
+      - It is used for compilation of assemblies in dotnet-wpf-int (the internal WPF repo), and serves as a 
+        'transport package' for PresentationBuildTasks.dll and related props+targets file.
+      - When the corresponding projects move from dotnet-wpf-int to dotnet/wpf in the future, their build will 
+        fall back to use local PBT project outputs for their compilation (instead of using WindowsDesktop Sdk package
+        as a convenient 'transport package'). 
+  -->
 </Project>

--- a/eng/WpfArcadeSdk/tools/Pbt.targets
+++ b/eng/WpfArcadeSdk/tools/Pbt.targets
@@ -7,7 +7,16 @@
       It is also OK for a DLL to NOT exist at the time <UsingTask> is encountered against this assembly path. 
       We must ensure that an actual DLL exists at this location prior to the very first execution of a Task from within this assembly.
     -->
-    <_PresentationBuildTasksAssembly Condition="'$(InternalMarkupCompilation)'=='true'">$(PbtDir)PresentationBuildTasks.dll</_PresentationBuildTasksAssembly>
+    <_PresentationBuildTasksAssembly Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)')">$(PbtDir)PresentationBuildTasks.dll</_PresentationBuildTasksAssembly>
+
+    <!-- 
+     When PresentationBuildTasks project is not present locally (presumably because in our split-repo build model, it has been moved off of the repo
+     being built (typically, dotnet-wpf-int) over to GitHub (dotnet/wpf), we will leverage WindowsDesktop Sdk package directly as a 'transport package'
+     for providing PresentationBuildTasks.dll and related props+targets. These targets require UseWpf=true to be set. 
+     
+     Also see additional note in Pbt.props
+    -->
+    <UseWpf Condition="'$(InternalMarkupCompilation)'=='true' And !Exists('$(LocalMicrosoftWinFXTargets)')"></UseWpf>
   </PropertyGroup>
   <!-- 
     Internal PBT compilation requires that we use <NetCoreReference> 
@@ -23,7 +32,7 @@
     <NetCoreReference Include="System.Runtime" />
   </ItemGroup>
   
-  <PropertyGroup Condition="'$(InternalMarkupCompilation)'=='true'">
+  <PropertyGroup Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)')">
     <PrepareResourceNamesDependsOn>
       $(PrepareResourceNamesDependsOn);
       EnsurePbtPath
@@ -43,14 +52,14 @@
       (d) This is all done prior to the first ever use of a task from within this assembly by Microsoft.WinFx.targets
   -->
   <Target Name="EnsurePbtPath"
-          Condition="'$(InternalMarkupCompilation)'=='true'"
+          Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)')"
           DependsOnTargets="$(EnsurePbtPathDependsOn)"
           BeforeTargets="ResolveProjectReferences">
     <MakeDir Condition="!Exists('$(PbtDir)')"
              Directories="$(PbtDir)" />
     
     <MSBuild Projects="$(WpfSourceDir)PresentationBuildTasks\PresentationBuildTasks.csproj"
-             Condition="!Exists('$(_PresentationBuildTasksAssembly)')"
+             Condition="!Exists('$(_PresentationBuildTasksAssembly)') And Exists('$(LocalMicrosoftWinFXTargets)')"
              Properties="CopyTransitiveReferences=true;PublishDir=$(PbtDir);TargetFramework=$(PbtTfm);Platform=AnyCPU"
              Targets="Clean;Build;Publish" />
   </Target>
@@ -73,6 +82,14 @@
     </ItemGroup>
   </Target>
 
+  <!-- 
+    If local PresentationBuildTasks project is present, then import WinFX.targets from local sources;
+    otherwise import Microsoft.NET.Sdk.WindowsDesktop.targets from Microsoft.NET.Sdk.WindowsDesktop
+  -->
   <Import Project="$(WpfSourceDir)PresentationBuildTasks\Microsoft.WinFX.targets" 
-          Condition="'$(InternalMarkupCompilation)'=='true'"/>
+          Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)') "/>
+  
+  <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
+          Project="../targets/Microsoft.NET.Sdk.WindowsDesktop.targets"
+          Condition="'$(InternalMarkupCompilation)'=='true' And !Exists('$(LocalMicrosoftWinFXTargets)') "/>
 </Project>


### PR DESCRIPTION
Adding fallbacks for building WPF projects that use PresentationBuildTasks.dll and Microsoft.WinFX.targets for markup compilation

When PresentationBuildTasks (PBT) moves to [dotnet/wpf](https://github.com/dotnet/wpf) from [dotnet-wpf-int](https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int), internal builds will need to consume PBT via a transport package instead of using the local source copy of `Microsoft.WinFX.targets` and local build output of PresentationBuildTasks.dll. 

Since we already produce and MSBuild Sdk containing these files - `Microsoft.NET.Sdk.WindowsDesktop` (which will also move alongwith PBT to dotnet/wpf - they go together) - we will simply leverage this Sdk package as our _transport package_  for internal builds. 

===
This fix also contains an unrealted fixup to Packaging.targets that was inadvertently missing production of version.txt. 