### PR TITLE
Default NetCore references for internal markup compilation should include System and TypeConverter

### DIFF
--- a/eng/WpfArcadeSdk/tools/Pbt.targets
+++ b/eng/WpfArcadeSdk/tools/Pbt.targets
@@ -29,6 +29,8 @@
   -->
   <ItemGroup Condition="'$(InternalMarkupCompilation)'=='true'">
     <NetCoreReference Include="mscorlib" />
+    <NetCoreReference Include="System" />
+    <NetCoreReference Include="System.ComponentModel.TypeConverter" />
     <NetCoreReference Include="System.Runtime" />
   </ItemGroup>
   


### PR DESCRIPTION
Required for the internal change that reduces PresentationBuildTasks reflection-only probing targets during build time to the reference list. Duplicate NetCoreReferences are benign.