### PR TITLE
Public key tokens of .NET core WPF assemblies and .NET Framework WPF assemblies need to match

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -21,8 +21,6 @@
     <LangVersion Condition="'$(LangVersion)'==''">8.0</LangVersion>
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
     <IncludeDllSafeSearchPathAttribute Condition="'$(IncludeDllSafeSearchPathAttribute )'==''">true</IncludeDllSafeSearchPathAttribute>
-
-    <StrongNameKeyId Condition="'$(StrongNameKeyId)'=='' And '$(IsTestProject)'!='true'">Open</StrongNameKeyId>
   </PropertyGroup>
 
   <Import Project="$(WpfArcadeSdkToolsDir)SystemResources.props"/>

--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -34,6 +34,8 @@
   <Import Project="$(WpfArcadeSdkToolsDir)CodeAnalysis.props" />
   <Import Project="$(WpfArcadeSdkToolsDir)Redist.props" />
   <Import Project="$(WpfArcadeSdkToolsDir)Pbt.props" />
+  <Import Project="$(WpfArcadeSdkToolsDir)Signing.props" />
+
 
   <PropertyGroup>
     <DebugType>full</DebugType>

--- a/eng/WpfArcadeSdk/Sdk/Sdk.targets
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.targets
@@ -16,7 +16,6 @@
   <Import Project="$(WpfArcadeSdkToolsDir)ExtendedAssemblyInfo.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)Redist.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)WpfProjectReference.targets" />
-  <Import Project="$(WpfArcadeSdkToolsDir)Signing.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)Wpf.Cpp.targets" Condition="'$(MSBuildProjectExtension)'=='.vcxproj'"/>
   <Import Project="$(NoTargetsTargets)" Condition="'$(NoTargets)'=='true'"/>
   

--- a/eng/WpfArcadeSdk/Sdk/Sdk.targets
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.targets
@@ -1,4 +1,7 @@
 <Project>
+  <!-- Import Signing.targets before Microsoft.DotNet.Arcade.Sdk -->
+  <Import Project="$(WpfArcadeSdkToolsDir)Signing.targets" />
+  
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(WpfArcadeSdkToolsDir)InlineTasks.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)ShippingProjects.targets" />
@@ -19,10 +22,4 @@
   <!-- PresentationBuildTasks related targets files -->
   <Import Project="$(WpfArcadeSdkToolsDir)Pbt.targets" Condition="'$(InternalMarkupCompilation)'=='true'"/>
   <Import Project="$(WpfArcadeSdkToolsDir)NoInternalTypeHelper.targets" />
-
-  <!-- Set the public key token after everything else has been imported -->
-  <PropertyGroup>
-    <StrongNameKeyId Condition="'$(StrongNameKeyId)'=='' And '$(IsShipping)'=='true'">ECMA</StrongNameKeyId>
-    <StrongNameKeyId Condition="'$(StrongNameKeyId)'=='' And '$(IsShipping)'!='true'">Open</StrongNameKeyId>
-  </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/Sdk/Sdk.targets
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.targets
@@ -16,6 +16,7 @@
   <Import Project="$(WpfArcadeSdkToolsDir)ExtendedAssemblyInfo.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)Redist.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)WpfProjectReference.targets" />
+  <Import Project="$(WpfArcadeSdkToolsDir)Signing.targets" />
   <Import Project="$(WpfArcadeSdkToolsDir)Wpf.Cpp.targets" Condition="'$(MSBuildProjectExtension)'=='.vcxproj'"/>
   <Import Project="$(NoTargetsTargets)" Condition="'$(NoTargets)'=='true'"/>
   

--- a/eng/WpfArcadeSdk/Sdk/Sdk.targets
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.targets
@@ -19,4 +19,10 @@
   <!-- PresentationBuildTasks related targets files -->
   <Import Project="$(WpfArcadeSdkToolsDir)Pbt.targets" Condition="'$(InternalMarkupCompilation)'=='true'"/>
   <Import Project="$(WpfArcadeSdkToolsDir)NoInternalTypeHelper.targets" />
+
+  <!-- Set the public key token after everything else has been imported -->
+  <PropertyGroup>
+    <StrongNameKeyId Condition="'$(StrongNameKeyId)'=='' And '$(IsShipping)'=='true'">ECMA</StrongNameKeyId>
+    <StrongNameKeyId Condition="'$(StrongNameKeyId)'=='' And '$(IsShipping)'!='true'">Open</StrongNameKeyId>
+  </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/ShippingProjects.props
+++ b/eng/WpfArcadeSdk/tools/ShippingProjects.props
@@ -55,21 +55,83 @@
       PresentationBuildTasks
     </WindowsDesktopSdkProject>
     
+    <CycleBreakerProjects>
+        PresentationFramework-PresentationUI-api-cycle;
+        PresentationFramework-ReachFramework-impl-cycle;
+        PresentationFramework-System.Printing-api-cycle;
+        PresentationFramework-System.Printing-impl-cycle;
+        PresentationUI-PresentationFramework-impl-cycle;
+        ReachFramework-PresentationFramework-api-cycle;
+        ReachFramework-System.Printing-api-cycle;
+        System.Printing-PresentationFramework-api-cycle
+    </CycleBreakerProjects>
+    <HandCraftedReferenceProjects>
+        System.Printing-ref
+    </HandCraftedReferenceProjects>
+
+    <HelperProjects>
+      $(CycleBreakerProjects);
+      $(HandCraftedReferenceProjects)
+    </HelperProjects>
+
+    <!--
+      These assemblies have the public key id 31bf3856ad364e35 (MicrosoftShared)
+    -->
+    <UseMicrosoftSharedKeyId>
+      DirectWriteForwarder;
+      PresentationBuildTasks;
+      PresentationCore;
+      PresentationFramework;
+      PresentationFramework.Aero;
+      PresentationFramework.Aero2;
+      PresentationFramework.AeroLite;
+      PresentationFramework.Classic;
+      PresentationFramework.Luna;
+      PresentationFramework.Royale;
+      PresentationUI;
+      ReachFramework;
+      System.Printing;
+      UIAutomationClient;
+      UIAutomationClientsideProviders;
+      UIAutomationProvider;
+      UIAutomationTypes;
+      WindowsBase;
+      WindowsFormsIntegration;
+      PresentationFramework-PresentationUI-api-cycle;
+      PresentationFramework-ReachFramework-impl-cycle;
+      PresentationFramework-System.Printing-api-cycle;
+      PresentationFramework-System.Printing-impl-cycle;
+      ReachFramework-PresentationFramework-api-cycle;
+      ReachFramework-System.Printing-api-cycle;
+      System.Printing-PresentationFramework-api-cycle;
+      PresentationUI-PresentationFramework-impl-cycle;
+      System.Printing-ref
+    </UseMicrosoftSharedKeyId>
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- 
+      Some WPF product assemblies, like System.Windows.Controls.Ribbon, require markup compilation.
+      At present, a temporary project is created on the disk during markup-compilation with a name like 
+          <ProjectName>_random_wpftmp.csproj
+      Normalizing $(MSBuildProjectName) allows us to ensure that temporary projects of this nature are also
+      correctly treated as IsShipping=true
+    -->
+    <NormalizedMSBuildProjectName Condition="!$(MSBuildProjectName.EndsWith('_wpftmp'))">$(MSBuildProjectName)</NormalizedMSBuildProjectName>
+    <NormalizedMSBuildProjectName Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">$(MSBuildProjectName.SubString(0, $(MSBuildProjectName.IndexOf('_'))))</NormalizedMSBuildProjectName>
+    
     <IsShipping>false</IsShipping>
-    <IsShipping Condition="$(ShippingProjects.Contains('$(MSBuildProjectName)'))">true</IsShipping>
+    <IsShipping Condition="$(ShippingProjects.Contains('$(NormalizedMSBuildProjectName)'))">true</IsShipping>
     <IsShipping Condition="'$(IsPackagingProject)'=='true'">true</IsShipping>
 
     <EnableXlfLocalization>false</EnableXlfLocalization>
-    <EnableXlfLocalization Condition="'$(IsShipping)'=='true' And !$(ExcludeFromXlfLocalization.Contains('$(MSBuildProjectName)'))">true</EnableXlfLocalization>
+    <EnableXlfLocalization Condition="'$(IsShipping)'=='true' And !$(ExcludeFromXlfLocalization.Contains('$(NormalizedMSBuildProjectName)'))">true</EnableXlfLocalization>
 
-    <RepoLocation Condition="$(InternalShippingProjects.Contains('$(MSBuildProjectName)'))">Internal</RepoLocation>
-    <RepoLocation Condition="$(ExternalShippingProjects.Contains('$(MSBuildProjectName)'))">External</RepoLocation>
+    <RepoLocation Condition="$(InternalShippingProjects.Contains('$(NormalizedMSBuildProjectName)'))">Internal</RepoLocation>
+    <RepoLocation Condition="$(ExternalShippingProjects.Contains('$(NormalizedMSBuildProjectName)'))">External</RepoLocation>
     
     <!-- WindowsDesktopSdk overrides Internal, External etc. -->
-    <RepoLocation Condition="$(WindowsDesktopSdkProject.Contains('$(MSBuildProjectName)'))">WindowsDesktopSdk</RepoLocation>
+    <RepoLocation Condition="$(WindowsDesktopSdkProject.Contains('$(NormalizedMSBuildProjectName)'))">WindowsDesktopSdk</RepoLocation>
   </PropertyGroup>
   
 </Project>

--- a/eng/WpfArcadeSdk/tools/Signing.props
+++ b/eng/WpfArcadeSdk/tools/Signing.props
@@ -1,0 +1,17 @@
+<Project>
+  <!-- 
+    This should be imported after ShippingProjects.props
+  -->
+  <PropertyGroup>
+    <UseEcmaKey>false</UseEcmaKey>
+    <UseEcmaKey Condition="'$(IsShipping)'=='true' And !$(UseMicrosoftSharedKeyId.Contains('$(NormalizedMSBuildProjectName)'))">true</UseEcmaKey>
+    <UseEcmaKey Condition="$(HelperProjects.Contains('$(MSBuildProjectName)')) And !$(UseMicrosoftSharedKeyId.Contains('$(NormalizedMSBuildProjectName)'))">true</UseEcmaKey>
+
+    <UseMicrosoftSharedKey>false</UseMicrosoftSharedKey>
+    <UseMicrosoftSharedKey Condition="'$(IsShipping)'=='true' And $(UseMicrosoftSharedKeyId.Contains('$(NormalizedMSBuildProjectName)'))">true</UseMicrosoftSharedKey>
+    <UseMicrosoftSharedKey Condition="$(HelperProjects.Contains('$(MSBuildProjectName)')) And $(UseMicrosoftSharedKeyId.Contains('$(NormalizedMSBuildProjectName)'))">true</UseMicrosoftSharedKey>
+
+    <StrongNameKeyId Condition="'$(UseEcmaKey)'=='true'">ECMA</StrongNameKeyId>
+    <StrongNameKeyId Condition="'$(UseMicrosoftSharedKey)'=='true'">MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+</Project>

--- a/eng/WpfArcadeSdk/tools/Signing.targets
+++ b/eng/WpfArcadeSdk/tools/Signing.targets
@@ -1,10 +1,6 @@
-<Project>
-  <!-- Set the public key token after everything else has been imported -->
-  <PropertyGroup>
-    <!-- 
-      StrongNameKeyId is initialized by the Arcade SDK to MicrosoftShared. It is rarely ever set to ''
-    -->
-    <StrongNameKeyId Condition="('$(StrongNameKeyId)'=='' Or '$(StrongNameKeyId)'=='MicrosoftShared') And '$(IsShipping)'=='true'">ECMA</StrongNameKeyId>
-    <StrongNameKeyId Condition="('$(StrongNameKeyId)'=='' Or '$(StrongNameKeyId)'=='MicrosoftShared') And '$(IsShipping)'!='true'">Open</StrongNameKeyId>
-  </PropertyGroup>
+<Project InitialTargets="ValidateUniqueKeyIdRequest">
+  <Target Name="ValidateUniqueKeyIdRequest">
+    <Error Condition="'$(UseEcmaKey)'=='true' And '$(UseMicrosoftSharedKey)'=='true'"
+           Message="Both UseEcmaKey and UseMicrosoftSharedKey are set to true. Only one of these can be enabled at any one time"/>
+  </Target>
 </Project>

--- a/eng/WpfArcadeSdk/tools/Signing.targets
+++ b/eng/WpfArcadeSdk/tools/Signing.targets
@@ -1,0 +1,10 @@
+<Project>
+  <!-- Set the public key token after everything else has been imported -->
+  <PropertyGroup>
+    <!-- 
+      StrongNameKeyId is initialized by the Arcade SDK to MicrosoftShared. It is rarely ever set to ''
+    -->
+    <StrongNameKeyId Condition="('$(StrongNameKeyId)'=='' Or '$(StrongNameKeyId)'=='MicrosoftShared') And '$(IsShipping)'=='true'">ECMA</StrongNameKeyId>
+    <StrongNameKeyId Condition="('$(StrongNameKeyId)'=='' Or '$(StrongNameKeyId)'=='MicrosoftShared') And '$(IsShipping)'!='true'">Open</StrongNameKeyId>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Wpf/src/Directory.Build.Props
+++ b/src/Microsoft.DotNet.Wpf/src/Directory.Build.Props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <StrongNameKeyId>ECMA</StrongNameKeyId>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Build.Tasks.Windows
         /// <returns></returns>
         public override bool Execute()
         {
+            System.Diagnostics.Debugger.Launch();
+
             TaskHelper.DisplayLogo(Log, SR.Get(SRID.MarkupCompilePass1Task));
 
             bool bSuccess = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -102,8 +102,6 @@ namespace Microsoft.Build.Tasks.Windows
         /// <returns></returns>
         public override bool Execute()
         {
-            System.Diagnostics.Debugger.Launch();
-
             TaskHelper.DisplayLogo(Log, SR.Get(SRID.MarkupCompilePass1Task));
 
             bool bSuccess = true;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Directory.Build.Props
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Directory.Build.Props
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AssemblyKey>ECMA</AssemblyKey>
     <IsWPF>true</IsWPF>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -9,9 +9,6 @@
     <DefineConstants>$(DefineConstants);OLDRESOURCES;SYSTEM_XAML</DefineConstants>
   </PropertyGroup>
 
-    
-    
-  
   <ItemGroup>
     <Compile Include="$(WpfSharedDir)System\Windows\Markup\TypeConverterHelper.cs">
       <Link>Common\WPF\System\Windows\Markup\TypeConverterHelper.cs</Link>
@@ -87,8 +84,6 @@
     <Compile Remove="System\Xaml\MS\Impl\ConcurrentDictionary.cs" />
     <Compile Remove="System\Xaml\MS\Impl\XamlPropertyInfoKey.cs" />
     
-    
-    <!-- <Compile Remove="" /> -->
    </ItemGroup>
     
   <ItemGroup>


### PR DESCRIPTION
This is the public half of a two part change. The original fix (adding StrongNameKeyId=Ecma to WPF assembly projects) was insufficient. After help from @nguerrera and more investigation of which PKTs were contained in which NETFX assemblies, @vatsan-madhavan provided a much more comprehensive fix that also fixed other regressions introduced during Arcade onboarding. @vatsan-madhavan's complete fix is included here. 

- WPF assemblies are incompatible with each other in 3.0.0-alpha-27128-4 #208 (fixes issue #208)

- Could not find assembly 'System.Xaml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' #508 (fixes issue #508)

This internal half of this change will be committed after the darc update containing this change reaches dotnet-wpf-int.  Thanks. 

