### PR TITLE
Clean up code in System.Xaml

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/BuildTopDownAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/BuildTopDownAttribute.cs
@@ -7,13 +7,11 @@ namespace System.Windows.Markup
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class UsableDuringInitializationAttribute : Attribute
     {
-        bool _usable;
-
         public UsableDuringInitializationAttribute(bool usable)
         {
-            _usable = usable;
+            Usable = usable;
         }
 
-        public bool Usable { get { return _usable; } }
+        public bool Usable { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -54,12 +54,7 @@ namespace System.Windows.Markup
         public override bool CanConvertToString(object value, IValueSerializerContext context)
         {
             // Validate the input type
-            if ( !(value is DateTime))
-            {
-                return false;
-            }
-            
-            return true;
+            return value is DateTime;
         }
 
         /// <summary>
@@ -119,10 +114,10 @@ namespace System.Windows.Markup
                 throw GetConvertToException( value, typeof(string) );
             }
             
-            DateTime dateTime = (DateTime)value;
+            var dateTime = (DateTime)value;
 
             // Build up the format string to be used in DateTime.ToString()
-            StringBuilder formatString = new StringBuilder("yyyy-MM-dd");
+            var formatString = new StringBuilder("yyyy-MM-dd");
             
             if (dateTime.TimeOfDay == TimeSpan.Zero)
             {
@@ -164,10 +159,7 @@ namespace System.Windows.Markup
             // We've finally got our format string built, we can create the string.
 
             return dateTime.ToString(formatString.ToString(), TypeConverterHelper.InvariantEnglishUS );
-
         }
-
     }
-
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
@@ -39,21 +39,12 @@ namespace System.Windows.Markup
         /// </summary>
         public UidPropertyAttribute(string name)
         {
-            _name = name;
+            Name = name;
         }
 
         /// <summary>
         ///     The name of the property that is designated to accept the x:Uid value
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
-
-        // The name of the property that is designated to accept the x:Uid value
-        private string _name = null;
+        public string Name { get; }
     }    
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
@@ -6,30 +6,15 @@ namespace System.Xaml
 {
     public class AttachableMemberIdentifier : IEquatable<AttachableMemberIdentifier>
     {
-        readonly Type declaringType;
-        readonly string memberName;
-
         public AttachableMemberIdentifier(Type declaringType, string memberName)
         {
-            this.declaringType = declaringType;
-            this.memberName = memberName;
+            DeclaringType = declaringType;
+            MemberName = memberName;
         }
 
-        public string MemberName
-        {
-            get
-            {
-                return memberName;
-            }
-        }
+        public string MemberName { get; }
 
-        public Type DeclaringType
-        {
-            get
-            {
-                return this.declaringType;
-            }
-        }
+        public Type DeclaringType { get; }
 
         public static bool operator !=(AttachableMemberIdentifier left, AttachableMemberIdentifier right)
         {
@@ -57,24 +42,24 @@ namespace System.Xaml
                 return false;
             }
 
-            return this.declaringType == other.declaringType && this.memberName == other.memberName;
+            return this.DeclaringType == other.DeclaringType && this.MemberName == other.MemberName;
         }
 
         public override int GetHashCode()
         {
-            int a = this.declaringType == null ? 0 : this.declaringType.GetHashCode();
-            int b = this.memberName == null ? 0 : this.memberName.GetHashCode();
+            int a = this.DeclaringType == null ? 0 : this.DeclaringType.GetHashCode();
+            int b = this.MemberName == null ? 0 : this.MemberName.GetHashCode();
             return ((a << 5) + a) ^ b;
         }
 
         public override string ToString()
         {
-            if (this.declaringType == null)
+            if (this.DeclaringType == null)
             {
-                return this.memberName;
+                return this.MemberName;
             }
 
-            return this.declaringType.ToString() + "." + memberName;
+            return this.DeclaringType.ToString() + "." + MemberName;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/SavedContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/SavedContext.cs
@@ -10,28 +10,24 @@ namespace System.Xaml
 
     internal class XamlSavedContext
     {
-        private XamlSchemaContext _context;
-        private XamlContextStack<ObjectWriterFrame> _stack;
-        private SavedContextType _savedContextType;
-
         public XamlSavedContext(SavedContextType savedContextType, ObjectWriterContext owContext, XamlContextStack<ObjectWriterFrame> stack)
         {
             //We should harvest all information necessary from the xamlContext so that we can answer all ServiceProvider based questions.
-            _savedContextType = savedContextType;
-            _context = owContext.SchemaContext;
-            _stack = stack;
+            SaveContextType = savedContextType;
+            SchemaContext = owContext.SchemaContext;
+            Stack = stack;
 
             // Null out CurrentFrameValue in case of template to save on survived allocations
             if (savedContextType == SavedContextType.Template)
             {
                 stack.CurrentFrame.Instance = null;
             }
-            this.BaseUri = owContext.BaseUri;
+            BaseUri = owContext.BaseUri;
         }
 
-        public SavedContextType SaveContextType { get { return _savedContextType; } }
-        public XamlContextStack<ObjectWriterFrame> Stack { get { return _stack; } }
-        public XamlSchemaContext SchemaContext { get { return _context; } }
-        public Uri BaseUri { get; private set; }
+        public SavedContextType SaveContextType { get; }
+        public XamlContextStack<ObjectWriterFrame> Stack { get; }
+        public XamlSchemaContext SchemaContext { get; }
+        public Uri BaseUri { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
@@ -94,20 +94,11 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
             return false;
         }
 
-        IContainer ITypeDescriptorContext.Container
-        {
-            get { return null; }
-        }
+        IContainer ITypeDescriptorContext.Container => null;
 
-        object ITypeDescriptorContext.Instance
-        {
-            get { return null; }
-        }
+        object ITypeDescriptorContext.Instance => null;
 
-        PropertyDescriptor ITypeDescriptorContext.PropertyDescriptor
-        {
-            get { return null; }
-        }
+        PropertyDescriptor ITypeDescriptorContext.PropertyDescriptor => null;
         #endregion
 
         #region IXamlTypeResolver Members
@@ -232,32 +223,17 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
         #endregion
 
         #region IXamlSchemaContextProvider Members
-        XamlSchemaContext IXamlSchemaContextProvider.SchemaContext
-        {
-            get { return _xamlContext.SchemaContext; }
-        }
+        XamlSchemaContext IXamlSchemaContextProvider.SchemaContext => _xamlContext.SchemaContext;
         #endregion
 
         #region IProvideValueTarget Members
-        object IProvideValueTarget.TargetObject
-        {
-            get { return _xamlContext.ParentInstance; }
-        }
+        object IProvideValueTarget.TargetObject => _xamlContext.ParentInstance;
 
-        object IProvideValueTarget.TargetProperty
-        {
-            get { return ContextServices.GetTargetProperty(this._xamlContext); }
-        }
+        object IProvideValueTarget.TargetProperty => ContextServices.GetTargetProperty(_xamlContext);
         #endregion
 
         #region IRootObjectProvider Members
-        object IRootObjectProvider.RootObject
-        {
-            get
-            {
-                return _xamlContext.RootInstance;
-            }
-        }
+        object IRootObjectProvider.RootObject => _xamlContext.RootInstance;
         #endregion
 
         #region IXamlNamespaceResolver Members
@@ -275,10 +251,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
 
         #region IXamlNameResolver Members
 
-        bool IXamlNameResolver.IsFixupTokenAvailable
-        {
-            get { return !_xamlContext.NameResolutionComplete; }
-        }
+        bool IXamlNameResolver.IsFixupTokenAvailable => !_xamlContext.NameResolutionComplete;
 
         object IXamlNameResolver.Resolve(string name)
         {
@@ -407,20 +380,11 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
 
         #region IXamlLineInfo Members
 
-        public bool HasLineInfo
-        {
-            get { return _xamlContext.LineNumber != 0 || _xamlContext.LinePosition != 0; }
-        }
+        public bool HasLineInfo => _xamlContext.LineNumber != 0 || _xamlContext.LinePosition != 0;
 
-        public int LineNumber
-        {
-            get { return _xamlContext.LineNumber; }
-        }
+        public int LineNumber => _xamlContext.LineNumber;
 
-        public int LinePosition
-        {
-            get { return _xamlContext.LinePosition; }
-        }
+        public int LinePosition => _xamlContext.LinePosition;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
@@ -14,19 +14,15 @@ namespace MS.Internal.Xaml
 {
     internal abstract class XamlContext
     {
-        private XamlSchemaContext _schemaContext;
         private Func<string, string> _resolvePrefixCachedDelegate;
         protected Assembly _localAssembly;
 
         protected XamlContext(XamlSchemaContext schemaContext)
         {
-            _schemaContext = schemaContext;
+            SchemaContext = schemaContext;
         }
 
-        public XamlSchemaContext SchemaContext
-        {
-            get { return _schemaContext; }
-        }
+        public XamlSchemaContext SchemaContext { get; }
 
         /// <SecurityNote>
         /// Note: not SecurityCritical. Should be used only for convenience filtering, not for security decisions.
@@ -260,7 +256,7 @@ namespace MS.Internal.Xaml
             Debug.Assert(typeName != null, "typeName cannot be null and should have been checked before now");
             Debug.Assert(typeName.Name != null, "typeName.Name cannot be null and should have been checked before now");
             Debug.Assert(typeName.Namespace != null);
-            XamlType xamlType = _schemaContext.GetXamlType(typeName);
+            XamlType xamlType = SchemaContext.GetXamlType(typeName);
             if (xamlType != null && !skipVisibilityCheck && !xamlType.IsVisibleTo(LocalAssembly))
             {
                 xamlType = null;
@@ -274,7 +270,7 @@ namespace MS.Internal.Xaml
                     typeArgs = ArrayHelper.ConvertArrayType<XamlTypeName, XamlType>(
                         typeName.TypeArguments, GetXamlTypeOrUnknown);
                 }
-                xamlType = new XamlType(typeName.Namespace, typeName.Name, typeArgs, this.SchemaContext);
+                xamlType = new XamlType(typeName.Namespace, typeName.Name, typeArgs, SchemaContext);
             }
             return xamlType;
         }
@@ -367,7 +363,7 @@ namespace MS.Internal.Xaml
         {
             XamlType[] typeArgArray = new XamlType[typeArguments.Count];
             typeArguments.CopyTo(typeArgArray, 0);
-            XamlType xamlType = _schemaContext.GetXamlType(ns, name, typeArgArray);
+            XamlType xamlType = SchemaContext.GetXamlType(ns, name, typeArgArray);
             if (xamlType != null && !xamlType.IsVisibleTo(LocalAssembly))
             {
                 xamlType = null;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
@@ -256,20 +256,11 @@ namespace MS.Internal.Xaml.Context
             set { _stack.CurrentFrame.ForcedToUseConstructor = value; }
         }
 
-        public bool CurrentInItemsProperty
-        {
-            get { return _stack.CurrentFrame.Member == XamlLanguage.Items; }
-        }
+        public bool CurrentInItemsProperty => _stack.CurrentFrame.Member == XamlLanguage.Items;
 
-        public bool CurrentInInitProperty
-        {
-            get { return _stack.CurrentFrame.Member == XamlLanguage.Initialization; }
-        }
+        public bool CurrentInInitProperty => _stack.CurrentFrame.Member == XamlLanguage.Initialization;
 
-        public bool CurrentInUnknownContent
-        {
-            get { return _stack.CurrentFrame.Member == XamlLanguage.UnknownContent; }
-        }
+        public bool CurrentInUnknownContent => _stack.CurrentFrame.Member == XamlLanguage.UnknownContent;
 
         public bool CurrentInImplicitArray
         {
@@ -299,9 +290,6 @@ namespace MS.Internal.Xaml.Context
             return CurrentMember.IsWriteVisibleTo(LocalAssembly, allowProtectedForType);
         }
 
-        public bool CurrentTypeIsRoot
-        {
-            get { return _stack.CurrentFrame.XamlType != null && _stack.Depth == 1; }
-        }
+        public bool CurrentTypeIsRoot => _stack.CurrentFrame.XamlType != null && _stack.Depth == 1;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
@@ -25,16 +25,13 @@ namespace System.Xaml
 
     public class AmbientPropertyValue
     {
-        XamlMember _property;
-        object _value;
-
         public AmbientPropertyValue(XamlMember property, object value)
         {
-            _property = property;
-            _value = value;
+            RetrievedProperty = property;
+            Value = value;
         }
 
-        public object Value { get { return _value; } }
-        public XamlMember RetrievedProperty { get { return _property; }  }
+        public object Value { get; }
+        public XamlMember RetrievedProperty { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
@@ -39,15 +39,9 @@ namespace System.Xaml
             _deferredTreeDepth = -1;
         }
 
-        public bool Handled
-        {
-            get { return _handled; }
-        }
+        public bool Handled => _handled;
 
-        public DeferringMode Mode
-        {
-            get { return _mode; }
-        }
+        public DeferringMode Mode => _mode;
 
         public XamlNodeList CollectTemplateList()
         {
@@ -300,10 +294,7 @@ namespace System.Xaml
             }
         }
 
-        public bool ShouldProvideLineInfo
-        {
-            get { return true; }
-        }
+        public bool ShouldProvideLineInfo => true;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlReaderSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlReaderSettings.cs
@@ -45,14 +45,7 @@ namespace System.Xaml
         private void InitializeProvideLineInfo()
         {
             //By default, _provideLineInfo is true if the currently executing process is running in debug mode
-            if (Debugger.IsAttached)
-            {
-                ProvideLineInfo = true;
-            }
-            else
-            {
-                ProvideLineInfo = false;
-            }
+            ProvideLineInfo = Debugger.IsAttached;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -338,59 +338,29 @@ namespace System.Xaml
             return !IsEof;
         }
 
-        public override XamlNodeType NodeType
-        {
-            get { return _current.NodeType; }
-        }
+        public override XamlNodeType NodeType => _current.NodeType;
 
-        public override bool IsEof
-        {
-            get { return _current.IsEof; }
-        }
+        public override bool IsEof => _current.IsEof;
 
-        public override NamespaceDeclaration Namespace
-        {
-            get { return _current.NamespaceDeclaration; }
-        }
+        public override NamespaceDeclaration Namespace => _current.NamespaceDeclaration;
 
-        public override XamlType Type
-        {
-            get { return _current.XamlType; }
-        }
+        public override XamlType Type => _current.XamlType; 
 
-        public override object Value
-        {
-            get { return _current.Value; }
-        }
+        public override object Value => _current.Value;
 
-        public override XamlMember Member
-        {
-            get { return _current.Member; }
-        }
+        public override XamlMember Member => _current.Member;
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get { return _context.SchemaContext; }
-        }
+        public override XamlSchemaContext SchemaContext => _context.SchemaContext;
 
         #endregion
 
         #region IXamlLineInfo Members
 
-        public bool HasLineInfo
-        {
-            get { return _mergedSettings.ProvideLineInfo; }
-        }
+        public bool HasLineInfo => _mergedSettings.ProvideLineInfo;
 
-        public int LineNumber
-        {
-            get { return _currentLineInfo.LineNumber; }
-        }
+        public int LineNumber => _currentLineInfo.LineNumber;
 
-        public int LinePosition
-        {
-            get { return _currentLineInfo.LinePosition; }
-        }
+        public int LinePosition => _currentLineInfo.LinePosition;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -11,22 +11,15 @@ namespace System.Xaml.MS.Impl
     internal class AssemblyNamespacePair
     {
         WeakReference _assembly;
-        String _clrNamespace;
 
         public AssemblyNamespacePair(Assembly asm, String clrNamespace)
         {
             _assembly = new WeakReference(asm);
-            _clrNamespace = clrNamespace;
+            ClrNamespace = clrNamespace;
         }
 
-        public Assembly Assembly
-        {
-            get { return (Assembly)_assembly.Target; }
-        }
+        public Assembly Assembly => (Assembly)_assembly.Target;
 
-        public string ClrNamespace
-        {
-            get { return _clrNamespace; }
-        }
+        public string ClrNamespace { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NamespaceDeclaration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NamespaceDeclaration.cs
@@ -9,30 +9,14 @@ namespace System.Xaml
     [DebuggerDisplay("Prefix={Prefix} Namespace={Namespace}")]
     public class NamespaceDeclaration
     {
-        private string prefix;
-        
-        private string ns;
-
         public NamespaceDeclaration(string ns, string prefix)
         {
-            this.ns = ns;
-            this.prefix = prefix;
+            this.Namespace = ns;
+            this.Prefix = prefix;
         }
 
-        public string Prefix
-        {
-            get
-            {
-                return prefix;
-            }
-        }
+        public string Prefix { get; }
         
-        public string Namespace
-        {
-            get
-            {
-                return ns;
-            }
-        }
+        public string Namespace { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
@@ -37,11 +37,11 @@ namespace MS.Internal.Xaml.Parser
             _pushedBackSymbol = GenericTypeNameScannerToken.NONE;
         }
 
-        public GenericTypeNameScannerToken Token { get { return _token; } }
+        public GenericTypeNameScannerToken Token => _token;
 
-        public string MultiCharTokenText { get { return _tokenText; } }
+        public string MultiCharTokenText => _tokenText;
 
-        public char ErrorCurrentChar { get { return _lastChar; } }
+        public char ErrorCurrentChar => _lastChar;
 
         public void Read()
         {
@@ -331,15 +331,9 @@ namespace MS.Internal.Xaml.Parser
             _idx = 0;
         }
 
-        protected char CurrentChar
-        {
-            get { return _inputText[_idx]; }
-        }
+        protected char CurrentChar => _inputText[_idx];
 
-        public bool IsAtEndOfInput
-        {
-            get { return (_idx >= _inputText.Length); }
-        }
+        public bool IsAtEndOfInput => _idx >= _inputText.Length;
 
         protected bool Advance()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
@@ -433,16 +433,9 @@ namespace MS.Internal.Xaml.Parser
             _tokenizer.Read();
         }
 
-        private int LineNumber
-        {
-            get { return _tokenizer.LineNumber; }
-        }
+        private int LineNumber => _tokenizer.LineNumber;
 
-
-        private int LinePosition
-        {
-            get { return _tokenizer.LinePosition; }
-        }
+        private int LinePosition => _tokenizer.LinePosition;
 
         // ================================================
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -60,7 +60,6 @@ namespace MS.Internal.Xaml.Parser
         string _tokenText;
         StringState _state;
         bool _hasTrailingWhitespace;
-        int _lineNumber;
         int _startPosition;
         private string _currentParameterName;
         private SpecialBracketCharacters _currentSpecialBracketCharacters;
@@ -69,7 +68,7 @@ namespace MS.Internal.Xaml.Parser
         {
             _context = context;
             _inputText = text;
-            _lineNumber = lineNumber;
+            LineNumber = lineNumber;
             _startPosition = linePosition;
             _idx = -1;
             _state = StringState.Value;
@@ -77,10 +76,7 @@ namespace MS.Internal.Xaml.Parser
             _currentSpecialBracketCharacters = null;
         }
 
-        public int LineNumber
-        {
-            get { return _lineNumber; }
-        }
+        public int LineNumber { get; }
 
         public int LinePosition
         {
@@ -91,25 +87,13 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        public string Namespace
-        {
-            get { return _tokenNamespace; }
-        }
+        public string Namespace => _tokenNamespace;
 
-        public MeTokenType Token
-        {
-            get { return _token; }
-        }
+        public MeTokenType Token => _token;
 
-        public XamlType TokenType
-        {
-            get { return _tokenXamlType; }
-        }
+        public XamlType TokenType => _tokenXamlType;
 
-        public XamlMember TokenProperty
-        {
-            get { return _tokenProperty; }
-        }
+        public XamlMember TokenProperty => _tokenProperty;
 
         // FxCop says this is never called
         //  (but _tokenNamespace is used internally in the Scanner)
@@ -118,20 +102,11 @@ namespace MS.Internal.Xaml.Parser
         //    get { return _tokenNamespace; }
         //}
 
-        public string TokenText
-        {
-            get { return _tokenText; }
-        }
+        public string TokenText => _tokenText;
 
-        public bool IsAtEndOfInput
-        {
-            get { return (_idx >= _inputText.Length); }
-        }
+        public bool IsAtEndOfInput => _idx >= _inputText.Length;
 
-        public bool HasTrailingWhitespace
-        {
-            get { return _hasTrailingWhitespace; }
-        }
+        public bool HasTrailingWhitespace => _hasTrailingWhitespace;
 
         public void Read()
         {
@@ -527,10 +502,7 @@ namespace MS.Internal.Xaml.Parser
             return result;
         }
 
-        private char CurrentChar
-        {
-            get { return _inputText[_idx]; }
-        }
+        private char CurrentChar =>_inputText[_idx];
 
         private char NextChar
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -105,15 +105,9 @@ namespace MS.Internal.Xaml
 
         #region IEnumerator<XamlNode> Members
 
-        public XamlNode Current
-        {
-            get { return _current; }
-        }
+        public XamlNode Current => _current;
 
-        object IEnumerator.Current
-        {
-            get { return _current; }
-        }
+        object IEnumerator.Current => _current;
 
         public bool MoveNext()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
@@ -101,15 +101,9 @@ namespace MS.Internal.Xaml.Parser
         //}
 
         // These properties are only defined if this Xml-Attribute is a XmlNs definition.
-        public string XmlNsPrefixDefined
-        {
-            get { return _xmlnsDefinitionPrefix; }
-        }
+        public string XmlNsPrefixDefined => _xmlnsDefinitionPrefix;
 
-        public string XmlNsUriDefined
-        {
-            get { return _xmlnsDefinitionUri; }
-        }
+        public string XmlNsUriDefined => _xmlnsDefinitionUri;
 
         //  ========================== internal ================================
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
@@ -12,7 +12,8 @@ namespace MS.Internal.Xaml.Parser
         public const char UnderScore = '_';
         public const char Dot = '.';
 
-        public string Name { get; protected set; }
+        protected string _prefix;
+        protected string _namespace = null;
 
         protected XamlName() : this(string.Empty) { }
 
@@ -27,13 +28,13 @@ namespace MS.Internal.Xaml.Parser
             _prefix = prefix ?? string.Empty;
         }
 
+        public string Name { get; protected set; }
+
         public abstract string ScopedName { get; }
 
-        protected string _prefix;
-        protected string _namespace = null;
+        public string Prefix => _prefix;
 
-        public string Prefix { get { return _prefix; } }
-        public string Namespace { get { return _namespace; } }
+        public string Namespace => _namespace;
 
         public static bool ContainsDot(string name)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
@@ -72,29 +72,10 @@ namespace MS.Internal.Xaml.Parser
             return propName;
         }
 
-        public override string ScopedName
-        {
-            get
-            {
-                return IsDotted ?
-                    Owner.ScopedName + "." + Name :
-                    Name;
-            }
-        }
+        public override string ScopedName => IsDotted ? $"{Owner.ScopedName}.{Name}" : Name;
 
-        public string OwnerName
-        {
-            get
-            {
-                return IsDotted ?
-                    Owner.Name :
-                    string.Empty;
-            }
-        }
+        public string OwnerName => IsDotted ? Owner.Name : string.Empty;
 
-        public bool IsDotted
-        {
-            get { return Owner != null; }
-        }
+        public bool IsDotted => Owner != null;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
@@ -739,20 +739,11 @@ namespace MS.Internal.Xaml.Parser
 
         // ---------- Private properties  ---------------
 
-        private int LineNumber
-        {
-            get { return _xamlScanner.LineNumber; }
-        }
+        private int LineNumber => _xamlScanner.LineNumber;
 
-        private int LinePosition
-        {
-            get { return _xamlScanner.LinePosition; }
-        }
+        private int LinePosition => _xamlScanner.LinePosition;
 
-        private bool ProvideLineInfo
-        {
-            get { return _settings.ProvideLineInfo; }
-        }
+        private bool ProvideLineInfo => _settings.ProvideLineInfo;
 
         // =================== Logic Functions ========================
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
@@ -79,73 +79,31 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        public ScannerNodeType NodeType
-        {
-            get { return _currentNode.NodeType; }
-        }
+        public ScannerNodeType NodeType => _currentNode.NodeType;
 
-        public XamlType Type
-        {
-            get { return _currentNode.Type; }
-        }
+        public XamlType Type => _currentNode.Type;
 
-        public XamlMember PropertyAttribute
-        {
-            get { return _currentNode.PropertyAttribute; }
-        }
+        public XamlMember PropertyAttribute => _currentNode.PropertyAttribute;
 
-        public XamlText PropertyAttributeText
-        {
-            get { return _currentNode.PropertyAttributeText; }
-        }
+        public XamlText PropertyAttributeText => _currentNode.PropertyAttributeText;
 
-        public bool IsCtorForcingMember
-        {
-            get { return _currentNode.IsCtorForcingMember; }
-        }
+        public bool IsCtorForcingMember => _currentNode.IsCtorForcingMember;
 
-        public XamlMember PropertyElement
-        {
-            get { return _currentNode.PropertyElement; }
-        }
+        public XamlMember PropertyElement => _currentNode.PropertyElement;
 
-        public XamlText TextContent
-        {
-            get { return _currentNode.TextContent; }
-        }
+        public XamlText TextContent => _currentNode.TextContent;
 
-        public bool IsXDataText
-        {
-            get { return _currentNode.IsXDataText; }
-        }
+        public bool IsXDataText => _currentNode.IsXDataText;
 
-        public bool HasKeyAttribute
-        {
-            get
-            {
-                return _hasKeyAttribute;
-            }
-        }
+        public bool HasKeyAttribute => _hasKeyAttribute;
 
-        public string Prefix
-        {
-            get { return _currentNode.Prefix; }
-        }
+        public string Prefix => _currentNode.Prefix;
 
-        public string Namespace
-        {
-            get { return _currentNode.TypeNamespace; }
-        }
+        public string Namespace => _currentNode.TypeNamespace;
 
-        public int LineNumber
-        {
-            get { return _currentNode.LineNumber; }
-        }
+        public int LineNumber => _currentNode.LineNumber;
 
-        public int LinePosition
-        {
-            get { return _currentNode.LinePosition; }
-        }
+        public int LinePosition => _currentNode.LinePosition;
 
         // ===================================================================
 
@@ -223,10 +181,7 @@ namespace MS.Internal.Xaml.Parser
             _accumulatedText = null;
         }
 
-        private bool HaveAccumulatedText
-        {
-            get { return _accumulatedText != null && !_accumulatedText.IsEmpty; }
-        }
+        private bool HaveAccumulatedText => _accumulatedText != null && !_accumulatedText.IsEmpty;
 
         // ============= Element Processing ==================================
 
@@ -729,10 +684,7 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        private bool HaveUnprocessedAttributes
-        {
-            get { return _attributes != null; }
-        }
+        private bool HaveUnprocessedAttributes => _attributes != null;
 
         private void EnqueueAnotherAttribute(bool isEmptyTag)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
@@ -46,20 +46,11 @@ namespace MS.Internal.Xaml.Parser
             _stack.Pop();
         }
 
-        public int Depth
-        {
-            get { return _stack.Count - 1; }
-        }
+        public int Depth => _stack.Count - 1;
 
-        public XamlType CurrentType
-        {
-            get { return (_stack.Count == 0) ? null : _stack.Peek().XamlType; }
-        }
+        public XamlType CurrentType => _stack.Count == 0 ? null : _stack.Peek().XamlType;
 
-        public string CurrentTypeNamespace
-        {
-            get { return (_stack.Count == 0) ? null : _stack.Peek().TypeNamespace; }
-        }
+        public string CurrentTypeNamespace => _stack.Count == 0 ? null : _stack.Peek().TypeNamespace;
 
         public XamlMember CurrentProperty
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
@@ -36,18 +36,9 @@ namespace MS.Internal.Xaml.Parser
             _isWhiteSpaceOnly = true;
         }
 
-        public bool IsEmpty
-        {
-            get { return _sb.Length==0; }
-        }
+        public bool IsEmpty => _sb.Length==0;
 
-        public string Text
-        {
-            get
-            {
-                return _sb.ToString();
-            }
-        }
+        public string Text => _sb.ToString();
 
         public string AttributeText
         {
@@ -62,15 +53,9 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        public bool IsSpacePreserved
-        {
-            get { return _isSpacePreserve; }
-        }
+        public bool IsSpacePreserved => _isSpacePreserve;
 
-        public bool IsWhiteSpaceOnly
-        {
-            get { return _isWhiteSpaceOnly; }
-        }
+        public bool IsWhiteSpaceOnly => _isWhiteSpaceOnly;
 
         public void Paste(string text, bool trimLeadingWhitespace, bool convertCRLFtoLF=true)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Permissions/XamlAccessLevel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Permissions/XamlAccessLevel.cs
@@ -36,7 +36,7 @@ namespace System.Xaml.Permissions
             {
                 throw new ArgumentNullException(nameof(assemblyName));
             }
-            ValidateAssemblyName(assemblyName, "assemblyName");
+            ValidateAssemblyName(assemblyName, nameof(assemblyName));
             return new XamlAccessLevel(assemblyName.FullName, null);
         }
 
@@ -64,7 +64,7 @@ namespace System.Xaml.Permissions
             string typeName = assemblyQualifiedTypeName.Substring(0, nameBoundary).Trim();
             string assemblyFullName = assemblyQualifiedTypeName.Substring(nameBoundary + 1).Trim();
             AssemblyName assemblyName = new AssemblyName(assemblyFullName);
-            ValidateAssemblyName(assemblyName, "assemblyQualifiedTypeName");
+            ValidateAssemblyName(assemblyName, nameof(assemblyQualifiedTypeName));
             
             return new XamlAccessLevel(assemblyName.FullName, typeName);
         }
@@ -76,10 +76,7 @@ namespace System.Xaml.Permissions
         // Type references, because permissions can be serialized, and we don't want to force an
         // assembly load on deserialization in a different AppDomain.
         
-        public AssemblyName AssemblyAccessToAssemblyName
-        {
-            get { return new AssemblyName(AssemblyNameString); }
-        }
+        public AssemblyName AssemblyAccessToAssemblyName => new AssemblyName(AssemblyNameString);
 
         public string PrivateAccessToTypeName { get; private set; }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/LineInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/LineInfo.cs
@@ -6,29 +6,14 @@ namespace System.Xaml
 {
     internal class LineInfo
     {
-        #region Fields
-        private int _lineNumber;
-        private int _linePosition;
-        #endregion
-
-        #region Constructors
         internal LineInfo(int lineNumber, int linePosition)
         {
-            _lineNumber = lineNumber;
-            _linePosition = linePosition;
-        }
-        #endregion
-
-        #region Public Properties
-        public int LineNumber
-        {
-            get { return _lineNumber; }
+            LineNumber = lineNumber;
+            LinePosition = linePosition;
         }
 
-        public int LinePosition
-        {
-            get { return _linePosition; }            
-        }
-        #endregion
+        public int LineNumber { get; }
+
+        public int LinePosition { get; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderBaseDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderBaseDelegate.cs
@@ -15,7 +15,6 @@ namespace System.Xaml
         protected XamlSchemaContext _schemaContext;
         protected XamlNode _currentNode;
         protected LineInfo _currentLineInfo;
-        protected bool _hasLineInfo;
 
         protected ReaderBaseDelegate(XamlSchemaContext schemaContext)
         {
@@ -26,85 +25,24 @@ namespace System.Xaml
             _schemaContext = schemaContext;            
         }
 
-        public override XamlNodeType NodeType
-        {
-            get { return _currentNode.NodeType; }
-        }
+        public override XamlNodeType NodeType => _currentNode.NodeType;
 
-        public override bool IsEof
-        {
-            get { return _currentNode.IsEof; }
-        }
+        public override bool IsEof => _currentNode.IsEof;
 
-        public override NamespaceDeclaration  Namespace
-        {
-            get { return _currentNode.NamespaceDeclaration; }
-        }
+        public override NamespaceDeclaration  Namespace => _currentNode.NamespaceDeclaration;
 
-        public override XamlType Type
-        {
-            get { return _currentNode.XamlType; }
-        }
+        public override XamlType Type => _currentNode.XamlType;
 
-        public override object Value
-        {
-            get { return _currentNode.Value; }
-        }
+        public override object Value => _currentNode.Value;
 
-        public override XamlMember Member
-        {
-            get { return _currentNode.Member; }
-        }
+        public override XamlMember Member => _currentNode.Member;
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get { return _schemaContext; }
-        }
+        public override XamlSchemaContext SchemaContext => _schemaContext;
 
-        #region IXamlLineInfo Members
+        public bool HasLineInfo { get; set; }
 
-        public bool HasLineInfo
-        {
-            get
-            {
-                return _hasLineInfo;
-            }
-            set
-            {
-                _hasLineInfo = value;
-            }
-        }
+        public int LineNumber =>_currentLineInfo != null ? _currentLineInfo.LineNumber : 0;
 
-        public int LineNumber
-        {
-            get 
-            {
-                if (_currentLineInfo != null)
-                {
-                    return _currentLineInfo.LineNumber;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-        }
-
-        public int LinePosition
-        {
-            get
-            {
-                if (_currentLineInfo != null)
-                {
-                    return _currentLineInfo.LinePosition;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-        }
-
-        #endregion
+        public int LinePosition => _currentLineInfo != null ? _currentLineInfo.LinePosition : 0;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderDelegate.cs
@@ -20,7 +20,7 @@ namespace System.Xaml
             _nextDelegate = next;
             _currentNode = new XamlNode(XamlNode.InternalNodeType.StartOfStream);
             _currentLineInfo = null;
-            _hasLineInfo = hasLineInfo;
+            HasLineInfo = hasLineInfo;
         }
 
         public override bool Read()

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderMultiIndexDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/ReaderMultiIndexDelegate.cs
@@ -33,7 +33,7 @@ namespace System.Xaml
             _idx = -1;
             _currentNode = s_StartOfStream;
             _currentLineInfo = null;
-            _hasLineInfo = hasLineInfo;
+            HasLineInfo = hasLineInfo;
         }
 
         public override bool Read()
@@ -72,7 +72,7 @@ namespace System.Xaml
             return !IsEof;
         }
 
-        public int Count { get { return _count; } }
+        public int Count => _count;
 
         public int CurrentIndex
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
@@ -109,15 +109,9 @@ namespace System.Xaml
             }
         }
 
-        internal bool IncomingFull
-        {
-            get { return _inIdx >= _incoming.Length; }
-        }
+        internal bool IncomingFull => _inIdx >= _incoming.Length;
 
-        internal bool OutgoingEmpty
-        {
-            get { return _outIdx >= _outValid; }
-        }
+        internal bool OutgoingEmpty => _outIdx >= _outValid;
 
         private void SwapBuffers()
         {
@@ -267,59 +261,29 @@ namespace System.Xaml
             return _internalReader.Read();
         }
 
-        public override XamlNodeType NodeType
-        {
-            get { return _internalReader.NodeType; }
-        }
+        public override XamlNodeType NodeType => _internalReader.NodeType;
 
-        public override bool IsEof
-        {
-            get { return _internalReader.IsEof; }
-        }
+        public override bool IsEof => _internalReader.IsEof;
 
-        public override NamespaceDeclaration Namespace
-        {
-            get { return _internalReader.Namespace; }
-        }
+        public override NamespaceDeclaration Namespace => _internalReader.Namespace;
 
-        public override XamlType Type
-        {
-            get { return _internalReader.Type; }
-        }
+        public override XamlType Type => _internalReader.Type;
 
-        public override object Value
-        {
-            get { return _internalReader.Value; }
-        }
+        public override object Value => _internalReader.Value;
 
-        public override XamlMember Member
-        {
-            get { return _internalReader.Member; }
-        }
+        public override XamlMember Member => _internalReader.Member;
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get { return _internalReader.SchemaContext; }
-        }
+        public override XamlSchemaContext SchemaContext => _internalReader.SchemaContext;
 
         #endregion
 
         #region IXamlLineInfo Members
 
-        public bool HasLineInfo
-        {
-            get { return _wrappedReaderHasLineInfo; }
-        }
+        public bool HasLineInfo => _wrappedReaderHasLineInfo;
 
-        public int LineNumber
-        {
-            get { return _lineNumber; }
-        }
+        public int LineNumber => _lineNumber;
 
-        public int LinePosition
-        {
-            get { return _linePosition; }
-        }
+        public int LinePosition => _linePosition;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
@@ -52,10 +52,7 @@ namespace System.Xaml
             _writer = new WriterDelegate(Add, AddLineInfo, schemaContext);
         }
 
-        public XamlWriter Writer
-        {
-            get { return _writer; }
-        }
+        public XamlWriter Writer => _writer;
 
         public XamlReader GetReader()
         {
@@ -119,9 +116,6 @@ namespace System.Xaml
             _readMode = false;      // go back to write mode.
         }
 
-        public int Count
-        {
-            get { return _nodeList.Count; }
-        }
+        public int Count => _nodeList.Count;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeQueue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeQueue.cs
@@ -44,20 +44,11 @@ namespace System.Xaml
             }
         }
 
-        public XamlWriter Writer
-        {
-            get { return _writer; }
-        }
+        public XamlWriter Writer => _writer;
 
-        public bool IsEmpty
-        {
-            get { return _nodeQueue.Count == 0; }
-        }
+        public bool IsEmpty => _nodeQueue.Count == 0;
 
-        public int Count
-        {
-            get { return _nodeQueue.Count; }
-        }
+        public int Count => _nodeQueue.Count;
 
         // ======================================
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlSubreader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlSubreader.cs
@@ -37,81 +37,29 @@ namespace System.Xaml
             return true;
         }
 
-        private bool IsEmpty { get { return _done || _firstRead; } }
+        private bool IsEmpty => _done || _firstRead;
 
-        public override XamlNodeType NodeType
-        {
-            get { return IsEmpty ? XamlNodeType.None : _reader.NodeType; }
-        }
+        public override XamlNodeType NodeType => IsEmpty ? XamlNodeType.None : _reader.NodeType;
 
-        public override bool IsEof
-        {
-            get { return IsEmpty ? true : _reader.IsEof; }
-        }
+        public override bool IsEof => IsEmpty ? true : _reader.IsEof;
 
-        public override NamespaceDeclaration Namespace
-        {
-            get { return IsEmpty ? null : _reader.Namespace; }
-        }
+        public override NamespaceDeclaration Namespace => IsEmpty ? null : _reader.Namespace;
 
-        public override XamlType Type
-        {
-            get { return IsEmpty ? null : _reader.Type; }
-        }
+        public override XamlType Type => IsEmpty ? null : _reader.Type;
 
-        public override object Value
-        {
-            get { return IsEmpty ? null : _reader.Value; }
-        }
+        public override object Value => IsEmpty ? null : _reader.Value;
 
-        public override XamlMember Member
-        {
-            get { return IsEmpty ? null : _reader.Member; }
-        }
+        public override XamlMember Member => IsEmpty ? null : _reader.Member;
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get { return _reader.SchemaContext; }
-        }
+        public override XamlSchemaContext SchemaContext => _reader.SchemaContext;
 
         #region IXamlLineInfo Members
 
-        public bool HasLineInfo
-        {
-            get
-            {
-                if (_lineInfoReader == null)
-                {
-                    return false;
-                }
-                return _lineInfoReader.HasLineInfo;
-            }
+        public bool HasLineInfo => _lineInfoReader != null && _lineInfoReader.HasLineInfo;
 
-        }
+        public int LineNumber =>_lineInfoReader == null ? 0 : _lineInfoReader.LineNumber;
 
-        public int LineNumber
-        {
-            get
-            {
-                if (_lineInfoReader == null)
-                {
-                    return 0;
-                }
-                return _lineInfoReader.LineNumber;
-            }
-        }
-
-        public int LinePosition
-        {
-            get
-            {
-                if (_lineInfoReader == null)
-                {
-                    return 0;
-                }
-                return _lineInfoReader.LinePosition;
-            }
-        }
+        public int LinePosition => _lineInfoReader == null ? 0 : _lineInfoReader.LinePosition;
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeValueSerializerContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeValueSerializerContext.cs
@@ -24,15 +24,9 @@ namespace System.Xaml.Replacements
         }
 
 
-        public IContainer Container
-        {
-            get { return null; }
-        }
+        public IContainer Container => null;
 
-        public object Instance
-        {
-            get { return null; }
-        }
+        public object Instance => null;
 
         public void OnComponentChanged()
         {
@@ -43,10 +37,7 @@ namespace System.Xaml.Replacements
             return false;
         }
 
-        public PropertyDescriptor PropertyDescriptor
-        {
-            get { return null; }
-        }
+        public PropertyDescriptor PropertyDescriptor => null;
 
         public object GetService(Type serviceType)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/Reference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/Reference.cs
@@ -25,9 +25,9 @@ namespace System.Windows.Markup
         {
             if (serviceProvider == null)
             {
-                throw new ArgumentNullException("serviceProvider");
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
-            IXamlNameResolver nameResolver = serviceProvider.GetService(typeof(IXamlNameResolver)) as IXamlNameResolver;
+            var nameResolver = serviceProvider.GetService(typeof(IXamlNameResolver)) as IXamlNameResolver;
             if (nameResolver == null)
             {
                 throw new InvalidOperationException(SR.Get(SRID.MissingNameResolver));

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
@@ -22,10 +22,7 @@ namespace System.Xaml.Schema
             _factory = factory;
         }
 
-        internal override bool IsPublic
-        {
-            get { return true; }
-        }
+        internal override bool IsPublic => true;
 
         protected override TConverterBase CreateInstance()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
@@ -12,14 +12,13 @@ namespace System.Xaml
 {
     public class XamlDirective : XamlMember
     {
-        private AllowedMemberLocations _allowedLocation;
         private readonly IList<string> _xamlNamespaces;
 
         internal XamlDirective(IEnumerable<string> xamlNamespaces, string name, AllowedMemberLocations allowedLocation, MemberReflector reflector)
             : base(name, reflector) 
         {
             _xamlNamespaces = GetReadOnly(xamlNamespaces);
-            _allowedLocation = allowedLocation;
+            AllowedLocation = allowedLocation;
         }
 
         public XamlDirective(IEnumerable<string> xamlNamespaces, string name, XamlType xamlType,
@@ -32,17 +31,17 @@ namespace System.Xaml
             }
 
             _xamlNamespaces = GetReadOnly(xamlNamespaces);
-            _allowedLocation = allowedLocation;
+            AllowedLocation = allowedLocation;
         }
 
         public XamlDirective(string xamlNamespace, string name)
             :base(name, null)
         {
             _xamlNamespaces = GetReadOnly(xamlNamespace);
-            _allowedLocation = AllowedMemberLocations.Any;
+            AllowedLocation = AllowedMemberLocations.Any;
         }
 
-        public AllowedMemberLocations AllowedLocation { get { return _allowedLocation; } }
+        public AllowedMemberLocations AllowedLocation { get; }
 
         public override int GetHashCode()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
@@ -48,15 +48,9 @@ namespace System.Xaml.Schema
             }
         }
 
-        public MethodInfo UnderlyingGetter
-        {
-            get { return IsUnknown ? null : _member.Getter; }
-        }
+        public MethodInfo UnderlyingGetter => IsUnknown ? null : _member.Getter;
 
-        public MethodInfo UnderlyingSetter
-        {
-            get { return IsUnknown ? null : _member.Setter; }
-        }
+        public MethodInfo UnderlyingSetter => IsUnknown ? null : _member.Setter;
 
         public virtual object GetValue(object instance)
         {
@@ -201,10 +195,7 @@ namespace System.Xaml.Schema
         }
         // ^^^^^----- End of unused members.  -----^^^^^
 
-        private bool IsUnknown
-        {
-            get { return _member == null || _member.UnderlyingMember == null; }
-        }
+        private bool IsUnknown => _member == null || _member.UnderlyingMember == null;
 
         private void ThrowIfUnknown()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -19,7 +19,7 @@ namespace System.Xaml.Schema
         private ConcurrentDictionary<string, XamlType> _typeCache;
         private ICollection<XamlType> _allPublicTypes;
 
-        public bool IsClrNamespace { get; private set; }
+        public bool IsClrNamespace { get; }
 
         public XamlNamespace(XamlSchemaContext schemaContext)
         {
@@ -46,10 +46,7 @@ namespace System.Xaml.Schema
             _typeCache = XamlSchemaContext.CreateDictionary<string, XamlType>();
         }
 
-        public bool IsResolved
-        {
-            get { return (null != _assemblyNamespaces); }
-        }
+        public bool IsResolved => null != _assemblyNamespaces;
 
         public ICollection<XamlType> GetAllXamlTypes()
         {
@@ -176,12 +173,9 @@ namespace System.Xaml.Schema
 
         #endregion
 
-        internal int RevisionNumber
-        {
-            // The only external mutation we allow is adding new namespaces. So the count of
-            // namespaces also serves as a revision number.
-            get { return (_assemblyNamespaces != null) ? _assemblyNamespaces.Count : 0; }
-        }
+        // The only external mutation we allow is adding new namespaces. So the count of
+        // namespaces also serves as a revision number.
+        internal int RevisionNumber => _assemblyNamespaces != null ? _assemblyNamespaces.Count : 0;
 
         // ================ Internal Static functions ======================================
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferLoadAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferLoadAttribute.cs
@@ -7,9 +7,6 @@ namespace System.Windows.Markup
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class XamlDeferLoadAttribute : Attribute
     {
-        string _contentTypeName;
-        string _loaderTypeName;
-
         public XamlDeferLoadAttribute(Type loaderType, Type contentType)
         {
             if (loaderType == null)
@@ -20,8 +17,8 @@ namespace System.Windows.Markup
             {
                 throw new ArgumentNullException(nameof(contentType));
             }
-            _loaderTypeName = loaderType.AssemblyQualifiedName;
-            _contentTypeName = contentType.AssemblyQualifiedName;
+            LoaderTypeName = loaderType.AssemblyQualifiedName;
+            ContentTypeName = contentType.AssemblyQualifiedName;
             LoaderType = loaderType;
             ContentType = contentType;
         }
@@ -36,21 +33,16 @@ namespace System.Windows.Markup
             {
                 throw new ArgumentNullException(nameof(contentType));
             }
-            _loaderTypeName = loaderType;
-            _contentTypeName = contentType;
+            LoaderTypeName = loaderType;
+            ContentTypeName = contentType;
         }
 
-        public string LoaderTypeName
-        {
-            get { return _loaderTypeName; }
-        }
+        public string LoaderTypeName { get; }
 
-        public string ContentTypeName
-        {
-            get { return _contentTypeName; }
-        }
+        public string ContentTypeName { get; }
 
         public Type LoaderType { get; private set; }
+
         public Type ContentType { get; private set; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -44,13 +44,7 @@ namespace System.Xaml
             base.Dispose(disposing);
         }
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get
-            {
-                return this.xamlXmlWriter.SchemaContext;
-            }
-        }
+        public override XamlSchemaContext SchemaContext => xamlXmlWriter.SchemaContext;
 
         public void Reset()
         {
@@ -64,30 +58,11 @@ namespace System.Xaml
         // It should be called after calling the final WriteEndObject().
         // If MarkupExtensionString is not called before writing the next markup extension string
         // in curly syntax, the previous markup extension string is lost.
-        public string MarkupExtensionString
-        {
-            get
-            {
-                if (this.nodes.Count == 0)
-                {
-                    return sb.ToString();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        public string MarkupExtensionString => nodes.Count == 0 ? sb.ToString() : null;
 
         // This is set to true when the Markup Extension Writer fails to write
         // the given node stream in curly form.
-        public bool Failed
-        {
-            get
-            {
-                return failed;
-            }
-        }
+        public bool Failed => failed;
 
         string LookupPrefix(XamlType type)
         {
@@ -183,26 +158,10 @@ namespace System.Xaml
 
         class Node
         {
-            public XamlMember XamlProperty
-            {
-                get;
-                set;
-            }
-            public XamlPropertySet Members
-            {
-                get;
-                set;
-            }
-            public XamlNodeType NodeType
-            {
-                get;
-                set;
-            }
-            public XamlType XamlType
-            {
-                get;
-                set;
-            }
+            public XamlMember XamlProperty { get; set; }
+            public XamlPropertySet Members { get; set; }
+            public XamlNodeType NodeType { get; set; }
+            public XamlType XamlType { get; set; }
         }
 
         abstract class WriterState
@@ -297,10 +256,7 @@ namespace System.Xaml
             Start()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
             public override void WriteStartObject(XamlMarkupExtensionWriter writer, XamlType type)
             {
@@ -323,10 +279,7 @@ namespace System.Xaml
             {
             }
 
-            public abstract string Delimiter
-            {
-                get;
-            }
+            public abstract string Delimiter { get; }
 
             public override void WriteEndObject(XamlMarkupExtensionWriter writer)
             {
@@ -431,10 +384,7 @@ namespace System.Xaml
             InObjectBeforeMember()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
             public override string Delimiter
             {
@@ -461,15 +411,9 @@ namespace System.Xaml
             InObjectAfterMember()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
-            public override string Delimiter
-            {
-                get { return ", "; }
-            }
+            public override string Delimiter => ", ";
 
             public override void WriteStartMember(XamlMarkupExtensionWriter writer, XamlMember property)
             {
@@ -484,10 +428,7 @@ namespace System.Xaml
             {
             }
 
-            public abstract string Delimiter
-            {
-                get;
-            }
+            public abstract string Delimiter { get; }
 
             public override void WriteValue(XamlMarkupExtensionWriter writer, string value)
             {
@@ -510,15 +451,9 @@ namespace System.Xaml
             InPositionalParametersBeforeValue()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
-            public override string Delimiter
-            {
-                get { return " "; }
-            }
+            public override string Delimiter => " ";
         }
 
         class InPositionalParametersAfterValue : InPositionalParameters
@@ -527,15 +462,9 @@ namespace System.Xaml
             InPositionalParametersAfterValue()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
-            public override string Delimiter
-            {
-                get { return ", "; }
-            }
+            public override string Delimiter => ", ";
 
             public override void WriteEndMember(XamlMarkupExtensionWriter writer)
             {
@@ -555,10 +484,7 @@ namespace System.Xaml
             InMember()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
             public override void WriteValue(XamlMarkupExtensionWriter writer, string value)
             {
@@ -591,10 +517,7 @@ namespace System.Xaml
             InMemberAfterValueOrEndObject()
             {
             }
-            public static WriterState State
-            {
-                get { return state; }
-            }
+            public static WriterState State => state;
 
             public override void WriteEndMember(XamlMarkupExtensionWriter writer)
             {
@@ -617,10 +540,6 @@ namespace System.Xaml
 
     internal class XamlMarkupExtensionWriterSettings
     {
-        public bool ContinueWritingWhenPrefixIsNotFound
-        {
-            get;
-            set;
-        }
+        public bool ContinueWritingWhenPrefixIsNotFound { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -256,7 +256,7 @@ namespace System.Xaml
             get { return IsWritePublicIgnoringType && (_declaringType == null || _declaringType.IsPublic); }
         }
 
-        public string Name { get { return _name; } }
+        public string Name => _name;
 
         public bool IsNameValid
         {
@@ -384,27 +384,15 @@ namespace System.Xaml
             get { return _underlyingMember; }
         }
 
-        public bool IsReadOnly
-        {
-            get { return GetFlag(BoolMemberBits.ReadOnly); }
-        }
+        public bool IsReadOnly => GetFlag(BoolMemberBits.ReadOnly);
 
-        public bool IsWriteOnly
-        {
-            get { return GetFlag(BoolMemberBits.WriteOnly); }
-        }
+        public bool IsWriteOnly => GetFlag(BoolMemberBits.WriteOnly);
 
-        public bool IsAttachable
-        {
-            get { return _memberType == MemberType.Attachable; }
-        }
+        public bool IsAttachable => _memberType == MemberType.Attachable;
 
-        public bool IsEvent
-        {
-            get { return GetFlag(BoolMemberBits.Event); }
-        }
+        public bool IsEvent => GetFlag(BoolMemberBits.Event);
 
-        public bool IsDirective { get { return _memberType == MemberType.Directive; } }
+        public bool IsDirective => _memberType == MemberType.Directive;
 
         public virtual IList<string> GetXamlNamespaces()
         {
@@ -430,10 +418,7 @@ namespace System.Xaml
             }
         }
 
-        public bool IsAmbient
-        {
-            get { return GetFlag(BoolMemberBits.Ambient); }
-        }
+        public bool IsAmbient => GetFlag(BoolMemberBits.Ambient);
 
         public DesignerSerializationVisibility SerializationVisibility
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -121,69 +121,21 @@ namespace System.Xaml
             return true;
         }
 
-        public override XamlNodeType NodeType
-        {
-            get
-            {
-                return this.currentXamlNode.NodeType;
-            }
-        }
+        public override XamlNodeType NodeType => currentXamlNode.NodeType;
 
-        public override NamespaceDeclaration Namespace
-        {
-            get
-            {
-                return this.currentXamlNode.NamespaceDeclaration;
-            }
-        }
+        public override NamespaceDeclaration Namespace => currentXamlNode.NamespaceDeclaration;
 
-        public override XamlType Type
-        {
-            get
-            {
-                return this.currentXamlNode.XamlType;
-            }
-        }
+        public override XamlType Type => currentXamlNode.XamlType;
 
-        public override XamlMember Member
-        {
-            get
-            {
-                return this.currentXamlNode.Member;
-            }
-        }
+        public override XamlMember Member => currentXamlNode.Member;
 
-        public override object Value
-        {
-            get
-            {
-                return this.currentXamlNode.Value;
-            }
-        }
+        public override object Value => currentXamlNode.Value;
 
-        public override XamlSchemaContext SchemaContext
-        {
-            get
-            {
-                return this.schemaContext;
-            }
-        }
+        public override XamlSchemaContext SchemaContext => schemaContext;
 
-        public override bool IsEof
-        {
-            get
-            {
-                return this.currentXamlNode.IsEof;
-            }
-        }
+        public override bool IsEof => currentXamlNode.IsEof;
 
-        public virtual object Instance
-        {
-            get
-            {
-                return this.currentXamlNode.NodeType == XamlNodeType.StartObject ? this.currentInstance : null;
-            }
-        }
+        public virtual object Instance =>currentXamlNode.NodeType == XamlNodeType.StartObject ? currentInstance : null;
 
         internal static DesignerSerializationVisibility GetSerializationVisibility(XamlMember member)
         {
@@ -263,13 +215,7 @@ namespace System.Xaml
                 return children;
             }
 
-            public bool IsAtomic
-            {
-                get
-                {
-                    return (this.children.Count == 1) && (this.children[0] is ValueMarkupInfo);
-                }
-            }
+            public bool IsAtomic => children.Count == 1 && children[0] is ValueMarkupInfo;
 
             public bool IsAttributableMarkupExtension
             {
@@ -966,20 +912,16 @@ namespace System.Xaml
 
         class EndObjectMarkupInfo : MarkupInfo
         {
-            static EndObjectMarkupInfo instance = new EndObjectMarkupInfo();
-
             EndObjectMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndObject); }
 
-            public static EndObjectMarkupInfo Instance { get { return instance; } }
+            public static EndObjectMarkupInfo Instance { get; } = new EndObjectMarkupInfo();
         }
 
         class EndMemberMarkupInfo : MarkupInfo
         {
-            static EndMemberMarkupInfo instance = new EndMemberMarkupInfo();
-
             EndMemberMarkupInfo() { XamlNode = new XamlNode(XamlNodeType.EndMember); }
 
-            public static EndMemberMarkupInfo Instance { get { return instance; } }
+            public static EndMemberMarkupInfo Instance { get; } = new EndMemberMarkupInfo();
         }
 
         class NamespaceMarkupInfo : MarkupInfo
@@ -996,7 +938,7 @@ namespace System.Xaml
             List<MarkupInfo> properties = new List<MarkupInfo>();
             bool? isAttributableMarkupExtension = null;
 
-            public List<MarkupInfo> Properties { get { return this.properties; } }
+            public List<MarkupInfo> Properties => properties;
             public string Name { get; set; }
             //public object Scope { get; set; }
             //public bool? ShouldWriteAsReference { get; set; }


### PR DESCRIPTION
This PR cleans up code in different files of System.Xaml.

Mainly
- expression bodied properties for one-line getters
- var where type is obvious from assignment
- nameof instead of string
- Use readonly auto properties where possible