### PR TITLE
LOC CHECKIN | Add PresentationBuildTasks xlf localization

### DIFF
--- a/eng/WpfArcadeSdk/tools/ShippingProjects.props
+++ b/eng/WpfArcadeSdk/tools/ShippingProjects.props
@@ -46,7 +46,6 @@
     </ShippingProjects>
 
     <ExcludeFromXlfLocalization>
-      PresentationBuildTasks;
       D3DCompiler;
       VCRuntime
     </ExcludeFromXlfLocalization>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <EnablePInvokeAnalyzer>true</EnablePInvokeAnalyzer>
-    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <EnableXlfLocalization>True</EnableXlfLocalization>
 
     <!-- 
       Clear AssemblyVersion => it will ensure that the AssemblyVersion is > 4.0.0.0.
@@ -24,11 +23,8 @@
 
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <AssemblyName>PresentationBuildTasks</AssemblyName>
-    <OutputType>Library</OutputType>
     <DefineConstants>$(DefineConstants);PBTCOMPILER;PARSERM8BC;NEWLOADER;IGNORABLESUPPORT;ONLYMARKUPEXTENSIONS</DefineConstants>
-    <ProjectGuid>{4216C2EA-E2B9-4FB2-9803-F73FDC64CAC4}</ProjectGuid>
     <BinPlaceRuntime>false</BinPlaceRuntime>
-    <DebugType>full</DebugType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <Platforms>AnyCPU;x64</Platforms>
@@ -74,11 +70,7 @@
 
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx">
-      <ManifestResourceName>Strings</ManifestResourceName>
-      <StronglyTypedClassName>MS.Utility</StronglyTypedClassName>
-      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
-    </EmbeddedResource>
+      <EmbeddedResource Include="Resources\Strings.resx" />
   </ItemGroup>
 
   <ItemGroup>
@@ -321,15 +313,4 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
   </ItemGroup>
 
-
-  <PropertyGroup>
-    <!-- 
-        Resource Generation 
-           * GenerateResourcesSource must be added as a dependent compilation target 
-   -->
-    <CoreCompileDependsOn>
-      GenerateResourcesSource;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
-  </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <EnablePInvokeAnalyzer>true</EnablePInvokeAnalyzer>
-    <EnableXlfLocalization>True</EnableXlfLocalization>
 
     <!-- 
       Clear AssemblyVersion => it will ensure that the AssemblyVersion is > 4.0.0.0.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.de.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Analyseergebnis: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: ApplicationDefinition-Element kann von Bibliotheksprojektdatei nicht angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Eingabe: Markup ApplicationDefinition-Datei: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: "{0}" kann nicht für das "{1}:{2}"-Tag festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: Unbekannter UidManager-Aufgabenname "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Uids in Datei "{0}" werden geprüft...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Lokalisierungsdirektivendatei wurde generiert: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Lokalisierungsdirektivendatei wird generiert: "{0}"...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Markupkompilierung abgeschlossen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">BAML- oder Quellcodedateien wurden erfolgreich von "MarkupCompilePass1" generiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">BAML- oder Quellcodedateien wurden erfolgreich von "MarkupCompilePass2" generiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: Ereignis "{0}" besitzt den generischen Ereignishandler-Delegattyp "{1}". Die Typparameter von "{1}" können nicht an ein geeignetes Typargument gebunden werden, da es sich bei dem enthaltenen Tag "{2}" nicht um ein generisches Tag handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Aktuelles Projektverzeichnis: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: Nur ein Stammtag kann Attribut "{0}:{1}" angeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: "{0}:{1}" kann nicht als Stammelement angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: "{0}:{1}" enthält "{2}". "{0}:{1}" kann nur einen CDATA- oder einen Textabschnitt enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Markupkompilierung wurde gestartet.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" ist ungültig. Der Wert des Ereignisattributs "{0}" darf keine leere Zeichenfolge sein oder nur Leerzeichen enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: "{0}:FieldModifier" kann nicht für dieses Tag angegeben werden, da entweder kein "{0}:Name" oder Name-Attribut festgelegt ist, oder da das Tag lokal definiert wurde und ein nicht zulässiges Name-Attribut besitzt.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: Die Datei "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">Die Eingabedatei "{0}" wurde zu einem neuen relativen Pfad "{1}" im Verzeichnis "{2}" aufgelöst.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: Fehler bei der Uid-Prüfung von {0} Dateien.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Uids gültig in {0} Dateien.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Uids entfernt aus {0} Dateien.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Uids aktualisiert in {0} Dateien.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">BAML-Datei wurde generiert: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Codedatei wurde generiert: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: "{0}:{1}" enthält "{2}". "{0}:{1}" darf keine geschachtelten Inhalte enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: Das Verzeichnis "{0}" ist nicht vorhanden und kann nicht erstellt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">Die InternalTypeHelper-Klasse ist für dieses Projekt nicht erforderlich, leeren Sie die Datei "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: Klassenname "{0}" ist für das lokal definierte XAML-Stammelement ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: Namespace "{0}" ist für das lokal definierte XAML-Stammelement "{1}" ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" ist ungültig. "{2}" ist kein gültiger {3}-Klassenname.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: Der in der Projektdatei festgelegte UICulture-Wert "{0}" ist ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: Vom Serialisierungsprogramm werden keine benutzerdefinierten BAML-Serialisierungsvorgänge unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: Vom Serialisierungsprogramm werden keine Convert-Vorgänge unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: Der Name "{0}" ist im Standardnamespace "{1}" ungültig. Korrigieren Sie in der Projektdatei den RootNamespace-Tagwert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" ist ungültig. "{1}" ist kein gültiger Methodenname für den Ereignishandler. Gültig sind nur Instanzmethoden für die generierte Klasse bzw. für die Code-Behind-Klasse.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: Die Zieleigenschaft für den Lokalisierungskommentar ist ungültig in der Zeichenfolge "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: Der Wert des Lokalisierungskommentars ist ungültig für die Zieleigenschaft "{0}" in der Zeichenfolge "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: Die Einstellung "{0}" für das Lokalisierbarkeitsattribut ist ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: Die Markupdatei ist ungültig. Geben Sie eine Quellmarkupdatei mit der Erweiterung ".xaml" an.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" ist ungültig. "{2}" ist kein gültiger Typnamenverweis für das generische Argument an Position "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: "{0}"- XML ist nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: Da "{0}" in derselben Assembly implementiert ist, muss statt des Name-Attributs das Attribut "{1}:Name" festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Eingabe: Die lokale Verweismarkupdatei für "ApplicationDefinition" ist "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">BAML-Datei wurde generiert: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Eingabe: Lokale Verweismarkupdatei für "Page": "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: Ereignis "{0}" besitzt den generischen Ereignishandler-Delegattyp "{1}". Der Typparameter "{2}" für "{1}" entspricht keinem der im generischen Tag "{3}" enthaltenen Typparameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: Für das Stammattribut "{0}" ist ein {1}:Class-Attribut erforderlich, da "{2}" ein {1}:Code-Tag enthält. Entfernen Sie entweder {1}:Code und dessen Inhalt, oder fügen Sie dem Stammelement ein {1}:Class-Attribut hinzu.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: Für das Stammelement "{0}" ist ein {1}:Class-Attribut erforderlich, damit Ereignishandler in der XAML-Datei unterstützt werden. Entfernen Sie entweder den Ereignishandler für das {2}-Ereignis, oder fügen Sie dem Stammelement ein {1}:Class-Attribut hinzu.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: Das Stammelement "{0}" ist ein generischer Typ und erfordert ein {1}:Class-Attribut, damit das für das Stammelementtag angegebene {1}:TypeArguments-Attribut unterstützt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: Das {0}:FieldModifier-Attribut kann nicht angegeben werden, da zum Generieren eines Namensfeldes mit dem angegebenen Zugriffsmodifizierer auch ein {0}:Class-Attribut erforderlich ist. Fügen Sie für das Stammtag entweder ein {0}:Class-Attribut hinzu, oder entfernen Sie das {0}:FieldModifier-Attribut.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: Das {0}:ClassModifier-Attribut kann für das Stammtag nicht angegeben werden, da auch ein {0}:Class-Attribut erforderlich ist. Fügen Sie entweder ein {0}:Class-Attribut hinzu, oder entfernen Sie das {0}:ClassModifier-Attribut.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: Fehlendes {0}:Class-Attribut. Das Attribut ist erforderlich, wenn ein {0}:Subclass-Attribut angegeben ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: Von "ResourcesGenerator" kann immer nur eine .resources-Datei gleichzeitig generiert werden. Die OutputResourcesFile-Eigenschaft in der Projektdatei muss auf eine Datei festgelegt sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: In der Projektdatei kann nur ein SplashScreen-Element angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: Die Uid "{0}" für das Element "{1}" ist nicht eindeutig.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: Von der Projektdatei kann höchstens ein ApplicationDefinition-Element angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Ein "{0}" hat den Namen "{1}". Benennen Sie ResourceDictionary-Inhalte nicht, da ihre Instanziierung zurückgestellt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: Unbekannte CLS-Ausnahme.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: Beim Verarbeiten der Initialisierungszeichenfolge "{0}" ist ein TypeConverter-Syntaxfehler aufgetreten. Eigenschaftselemente sind für Objekte, die über "TypeConverter" erstellt wurden, nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: Die Assembly "{0}" kann nicht geladen werden, da eine andere Version der gleichen Assembly "{1}" geladen ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: Das AsyncRecords-Attribut muss für das Stammtag festgelegt sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: Die angefügte Eigenschaft "{0}" ist für "{1}" oder eine der Basisklassen nicht definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: Für "{0}" wurden zu viele Attribute angegeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: Für "{0}" wurden nicht genügend Attribute angegeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: Die Eigenschaft "{0}" muss sich im Standardnamespace oder im Elementnamespace "{1}" befinden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Von "Mapper.SetAssemblyPath" kann kein leerer "assemblyName" angenommen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Von "Mapper.SetAssemblyPath" kann kein leerer "assemblyPath" angenommen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: Ein Element vom Typ "{0}" kann nicht für die komplexe Eigenschaft "{1}" festgelegt werden, da es sich hierbei um nicht kompatible Typen handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: Es wurde kein Public-Konstruktor für "{0}" gefunden, von dem {1}-Argumente angenommen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: Wörterbuchschlüssel dürfen nicht vom Typ "{0}" sein. Es werden nur String-, TypeExtension- und StaticExtension-Typen unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: Member "{0}" ist nicht gültig, da er nicht über einen qualifizierenden Typnamen verfügt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: Der Wert der Name-Eigenschaft "{0}" ist ungültig. Namen müssen mit einem Buchstaben oder Unterstrich beginnen und dürfen nur Buchstaben, Zahlen und Unterstriche enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: Zeichenfolgenwert "{0}" kann nicht in Typ "{1}" konvertiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: Der Eigenschaftswert für "SynchronousMode" ist ungültig. Gültige Werte sind "Async" und "Sync".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: Das Objekt, das der Array-Eigenschaft hinzugefügt wird, ist kein gültiger Typ. Das Array ist vom Typ "{0}", das hinzugefügte Objekt ist jedoch vom Typ "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: "MarkupExtensions" sind nicht zulässig für die Eigenschaftswerte "Uid" oder "Name", daher ist "{0}" nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: Das Objekt "{0}" besitzt bereits ein untergeordnetes Objekt, weshalb "{1}" nicht hinzugefügt werden kann. Von "{0}" kann nur ein einzelnes untergeordnetes Objekt angenommen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: Einem Objekt vom Typ "{0}" kann kein Inhalt hinzugefügt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: Bei "{0}" handelt es sich um eine schreibgeschützte Eigenschaft vom Typ "IList" oder "IDictionary", die nicht festgelegt werden kann, weil sie über keinen öffentlichen oder internen get-Accessor verfügt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: "{0} '{1}'" kann nicht festgelegt werden, da kein {2}-Accessor vorhanden ist, auf den zugegriffen werden kann.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: Die Inhaltseigenschaft "{0}" kann nicht für das Element "{1}" festgelegt werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: "{0}" kann nicht als Wert eines Property-Attributs eines Trigger festgelegt werden, da kein öffentlicher oder interner get-Accessor vorhanden ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: Zwei neue Namespaces können nicht mit demselben früheren Namespace kompatibel sein, wenn dieser ein XmlnsCompatibility-Attribut verwendet.�Der Namespace "{0}" ist bereits als mit "{1}" kompatibel markiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: Eigenschaftselemente dürfen nicht in der Mitte von Elementinhalten enthalten sein, sondern müssen sich vor oder nach dem Inhalt befinden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: Ein Code-Tag aus dem xaml-Namespace wurde in der XAML-Datei gefunden. Führen Sie zum Öffnen der Datei eine Kompilierung durch.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: Der Elementtyp "{0}" verfügt nicht über einen zugehörigen "TypeConverter", um die Zeichenfolge "{1}" zu analysieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: Daten in einem versiegelten "XmlnsDictionary" können nicht geändert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: Der Wörterbuchschlüssel "{0}" wird bereits verwendet. Key-Attribute werden beim Einfügen von Objekten in das Wörterbuch als Schlüssel verwendet und müssen eindeutig sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: Die Eigenschaft "{0}" wurde für diese Markuperweiterung bereits festgelegt und kann nicht mehrmals festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: Die Eigenschaft "{0}" wurde bereits festgelegt und kann nicht mehrmals festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: Die Eigenschaften "{0}" und "{1}" verweisen auf dieselbe Eigenschaft. Doppelte Eigenschaftseinstellungen sind nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: Das Eigenschaftselement "{0}" darf nicht leer sein. Es muss untergeordnete Elemente oder Text enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: "EntityReference &amp;{0};" ist unbekannt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: Auf den Delegattyp "{0}" für das {1}-Ereignis kann nicht zugegriffen werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: Bei der Eigenschaft "{0}" handelt es sich um eine schreibgeschützte IEnumerable-Eigenschaft. Das bedeutet, dass "IAddChild" von "{1}" implementiert werden muss.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: "ContentPropertyAttribute" für den Typ "{0}" ist ungültig, die Eigenschaft "{1}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">Bekannter Typwert {0}="{1}" ist kein gültiger bekannter Typ.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: Der statische Member "{0}" wurde nicht im Typ "{1}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: Bei Schlüsseln und Werten in "XmlnsDictionary" muss es sich um Zeichenfolgen handeln.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Zeile {0} Position {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: "XmlNamespace", "Assembly" oder "ClrNamespace" fehlt in Mapping-Anweisung.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">Der zuweisende URI "{0}" ist ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: Das Format ist für "MarkupExtension", von der die Konstruktor-Argumente in "{0}" angegeben werden, nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: Bei Markuperweiterungen ist ein einzelnes "=" zwischen Name und Wert sowie ein einzelnes "," zwischen Konstruktorparametern und Name/Wert-Paaren erforderlich. Die Argumente "{0}" sind ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: "{0}" ist ungültig. Bei Markuperweiterungen sind zwischen dem Namen der Markuperweiterung und dem ersten Parameter lediglich Leerstellen erforderlich. Vor dem ersten Parameter sind keine Kommas oder Gleichheitszeichen zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: Schließendes BracketCharacter-Objekt "{0}" in Zeilennummer "{1}" und an Zeilenposition "{2}" ohne entsprechendes öffnendes BracketCharacter-Objekt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: BracketCharacter "{0}" in Zeilennummer "{1}" und an Zeilenposition "{2}" verfügt nicht über ein entsprechendes öffnendes/schließendes BracketCharacter-Objekt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: MarkupExtension-Ausdrücke müssen mit "}" enden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: Name/Wert-Paare in "MarkupExtensions" müssen das Format "Name = Wert" aufweisen. Die einzelnen Paare werden durch Kommas getrennt. Dieses Format gilt nicht für "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: Namen und Werte von "MarkupExtension" dürfen keine Anführungszeichen enthalten. MarkupExtension-Argumente vom Typ "{0}" sind ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: Der Text "{1}" ist nach Abschluss-{0} eines MarkupExtension-Ausdrucks nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: Beim Analysieren einer Markup Extension wurde für den Typ "{1}" die unbekannte Eigenschaft "{0}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: Unbekanntes Attribut "{0}" im Namespace "{1}". Beachten Sie, dass in diesem Namespace derzeit nur das Key-Attribut unterstützt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: Interner Parserfehler - Es können nicht gleichzeitig mehrere schreibbare BAML-Datensätze verwendet werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">Das Eigenschaftselement "{0}" kann nicht direkt innerhalb eines anderen Eigenschaftselements geschachtelt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: Attribute können nicht in Array-Tags platziert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: Beim Kompilieren von XAML-Dateien wird asynchrones Laden nicht unterstützt, weshalb "SynchronousMode" von "{0}" nicht zulässig ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: Elementinhalte werden vom Typ "{0}" nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: Alle zu "IDictionary" hinzugefügten Elemente müssen über ein Key-Attribut oder einen anderen ihnen zugeordneten Schlüsseltyp verfügen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Das Key-Attribut kann nur für Tags verwendet werden, die sich in einem Dictionary (beispielsweise in "ResourceDictionary") befinden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: "{1}" kann nicht als Wert für "{0}" verwendet werden. Zahlen sind keine gültigen Aufzählungswerte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: Die Eigenschaftselementsyntax kann nicht zum Angeben des Ereignishandlers "{0}" verwendet werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: Die XAML-Datei, in der Ereignisse enthalten sind, muss kompiliert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: Der Typ "{0}" darf kein Name-Attribut besitzen. Werttypen und Typen ohne Standardkonstruktor können innerhalb von "ResourceDictionary" als Elemente verwendet werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: Der Wert "{0}" des Name-Attributs kann für das Element "{1}" nicht festgelegt werden. "{1}" befindet sich im Bereich des Elements "{2}", für das bereits ein Name registriert wurde, als es in einem anderen Bereich definiert wurde.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: Für das Objekt "{0}" wurde kein "NamespaceURI" definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: XML-Dateninseln können nicht geschachtelt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: Eigenschaften können nicht für Eigenschaftselemente festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: Benutzerdefiniertes Serialisierungsprogramm kann für "{0}" nicht gefunden und deshalb nicht analysiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: Von Set-Accessoren für den Stil werden keine untergeordneten Elemente unterstützt. Tags vom Typ "{0}" sind nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: Der Typ "{0}"wurde nicht gefunden. Beachten Sie, dass bei Typnamen die Groß- und Kleinschreibung berücksichtigt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: Beim Wert "{0}" handelt es sich nicht um einen gültigen MarkupExtension-Ausdruck. "{1}" kann im Namespace "{2}" nicht aufgelöst werden. "{1}" muss eine Unterklasse von "MarkupExtension" sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: Das XML-Namespacepräfix "{0}" wird keinem "NamespaceURI" zugeordnet, weshalb das Element "{1}" nicht aufgelöst werden kann.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: Das XML-Namespacepräfix "{0}" ist keinem Namespace-URI zugeordnet. Daher kann die Eigenschaft "{1}" nicht aufgelöst werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: Die Eigenschaft "{0}" besitzt keinen Wert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: Innerhalb eines Markups können ausschließlich öffentliche oder interne Klassen verwendet werden. Der Typ "{0}" ist weder öffentlich noch intern.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: Die Eigenschaft "{0}" ist schreibgeschützt und kann nicht von einem Markup aus festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: Von dem Typverweis kann kein öffentlicher Typ mit dem Namen "{0}" gefunden werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: Auf den statischen Member "{0}" im Typ "{1}" kann nicht verwiesen werden, da auf ihn nicht zugegriffen werden kann.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: Das SynchronousMode-Attribut muss sich im Stammtag befinden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: Innerhalb eines Eigenschaftselements dürfen nicht gleichzeitig der Text "{0}" und das untergeordnete Element "{1}" vorhanden sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: Text ist ungültig in einer IDictionary- oder Array-Eigenschaft.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: Von einer einzelnen XAML-Datei kann nicht auf mehr als 4.096 verschiedene Assemblys verwiesen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: Unmittelbar nach der TypeConverter-Initialisierungszeichenfolge "{0}" muss ein Endtag folgen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: Beim Verarbeiten der Initialisierungszeichenfolge "{0}" ist ein TypeConverter-Syntaxfehler aufgetreten. Elementattribute sind für Objekte, die über "TypeConverter" erstellt wurden, nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: Bei "{0}" handelt es sich um einen nicht deklarierten Namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: Die Eigenschaft "{0}" ist im XML-Namespace "{1}" nicht vorhanden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: Das Attribut "{0}" ist im XML-Namespace "http://schemas.microsoft.com/winfx/2006/xaml" nicht vorhanden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: Das Tag "{0}" ist im XML-Namespace "{1}" nicht vorhanden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: Beim Bestimmen, ob es sich beim aktuellen Tag um ein Eigenschaftselement handelt, wurde der unbekannte XML-Knotentyp "{0}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: Für das übergeordnete Element oder die Eigenschaft "{0}" ist eine XML-Dateninsel erforderlich. Umschließen Sie XML-Dateninseln mit &lt;x:XData&gt; ... &lt;/x:XData&gt;, um die XML-Inseln von umgebenden XAMLs zu unterscheiden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: Das Element oder die Eigenschaft "{0}" kann keine XML-Dateninsel enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: Vom XmlLangProperty-Attribut muss ein Eigenschaftsname angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: "IXmlLineInfo" wird von der Klasse "{0}" nicht implementiert. Dies ist erforderlich, um Positionsinformationen für die XAML-Datei zu erhalten, das gerade analysiert wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: Unerwartetes Token "{0}" an Position "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: Token ist ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Markupkompilierung wird vorbereitet...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: Der Typname "{0}" besitzt nicht das erwartete Format "className, Assembly".</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Resource-Datei "{0}" wird gelesen...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Neukompilierte XAML-Datei: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Eingabe: Assembly Reference-Datei: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">Die Ressourcen-ID lautet "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: Die Eingaberessourcendatei "{0}" überschreitet die maximale Größe von {1} Byte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">.resources-Datei "{0}" wurde generiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">.resources-Datei "{0}" wird generiert...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" ist ungültig. "{1}" muss ein RoutedEvent sein, das mit einem Namen registriert wurde, der mit dem Schlüsselwort "Event" endet.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: Der Aufgabe müssen Markupdateien übergeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: Die SourceName-Eigenschaft kann nicht innerhalb eines Style.Triggers-Abschnitts festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style unterstützt nicht gleichzeitig {0}-Tags und Style.{1}-Eigenschaftstags in einem einzelnen Style. Verwenden Sie nicht beide gleichzeitig.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: Das Styleeigenschaftstag "{0}" kann nur direkt in einem Styletag angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: Style {0} "{1}" wurde in Typ "{2}" nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: Style {0} "{1}" kann nicht aufgelöst werden. Stellen Sie sicher, dass der besitzende Typ "TargetType" von "Style" ist, oder verwenden Sie die Class.Property-Syntax, um {0} anzugeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Der Style darf kein untergeordnetes {0}-Objekt enthalten. Bei dem untergeordneten Styleobjekt muss es sich um einen Setter-Accessor handeln, da das Objekt der Setters-Sammlung hinzugefügt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: Tags vom Typ "{0}" werden in Abschnitten vom Typ Style nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: Das Ereignis "{0}" kann für ein Target-Tag in einem Style nicht angegeben werden. Verwenden Sie stattdessen "EventSetter".</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: Der Text "{0}" ist an dieser Stelle innerhalb eines Abschnitts vom Typ Style nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: Die Eigenschaft "{0}" kann für den Style nicht festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: Bei "{0}" darf es sich nicht um den Stamm einer XAML-Datei handeln, da beim Definieren XAML verwendet wurde.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: Der Target-Typ "{0}" wird von dieser Aufgabe nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: TargetName-Eigenschaft kann nicht für einen "Style Setter" festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Buildaufgabe "{0}" Version {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Alle Rechte vorbehalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Der Name "{0}" wurde bereits definiert. Namen müssen eindeutig sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: Der Stamm eines Vorlageninhaltsabschnitts kann kein Element vom Typ "{0}" enthalten. Nur die Typen "FrameworkElement" und "FrameworkContentElement" sind gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: Das Vorlageneigenschaftstag "{0}" kann nur direkt nach einem ControlTemplate-Tag angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: Vorlagen dürfen nur ein einzelnes Stammelement besitzen. "{0}" ist nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: Vorlageneigenschaft "{0}" wurde nicht im Typ "{1}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: Vorlageneigenschaft "{0}" kann nicht aufgelöst werden. Stellen Sie sicher, dass der besitzende Typ "TargetType" von "Style" ist, oder verwenden Sie die Class.Property-Syntax, um die Eigenschaft anzugeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: Trigger-Ziel "{0}" wurde nicht gefunden. (Das Ziel muss vor allen Setters, Triggers oder Conditions erscheinen, die es verwenden.)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: Tags vom Typ "{0}" werden in Vorlagenabschnitten nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: Der Text "{0}" ist an dieser Stelle innerhalb eines Vorlagenabschnitts nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: Die Eigenschaft "{0}" kann nicht als Eigenschaftselement für die Vorlage festgelegt werden. Als Eigenschaftselemente sind nur Elemente vom Typ "Triggers" oder "Storyboards" zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: Beim Analysieren wurde ein leeres Token gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: Beim Analysieren wurden nach dem Token zusätzliche Daten gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: Beim Analysieren des Tokens wurde erkannt, dass ein abschließendes Anführungszeichen fehlt.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: Es wurde ein vorzeitiger Zeichenfolgenabschluss erkannt.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: Die Uid fehlt für das Element "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Unbekannter Buildfehler, "{0}" </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" ist für die Sprache {2} ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: Im Namespace "http://schemas.microsoft.com/winfx/2006/xaml" befindet sich das unbekannte Tag "{0}:{1}". Beachten Sie, dass bei Tagnamen die Groß- und Kleinschreibung berücksichtigt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: "{1}" ist ungültig. "{0}" ist kein Ereignis für "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" ist für die Sprache {2} ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments="{1}" ist für das Tag "{2}" ungültig. Entweder handelt es sich bei "{2}" nicht um einen generischen Typ oder die im Attribut enthaltene Anzahl von Type-Argumenten ist falsch. Entfernen Sie das {0}:TypeArguments-Attribut, da es nur für generische Typen zulässig ist, oder korrigieren Sie dessen Wert, sodass er der Stelligkeit des generischen Typs "{2}" entspricht.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: "{0}" ist auf diesem Computer nicht ordnungsgemäß installiert. "{0}" muss im &lt;compilers&gt;-Abschnitt von "machine.config" aufgeführt sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Unbekannter Pfadvorgang.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: Der Lokalisierungskommentar besitzt keinen festgelegten Wert für die Zieleigenschaft: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: Die Komponenten der Haupt- und Nebenversionsnummer können nicht negativ sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: Die Projektdatei muss die .NET Framework-Assembly "{0}" in der Verweisliste enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: Der Wert für die LocalizationDirectivesToLocFile-Eigenschaft ist ungültig und muss zu "None" oder "CommentsOnly" bzw. für die MarkupCompilePass1-Aufgabe zu "All" geändert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: Die Projektdatei enthält einen ungültigen Eigenschaftswert.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: "Choice" kann nicht auf "Fallback" folgen.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: "AlternateContent" muss mindestens ein Choice-Element enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: "Choice" ist nur gültig in "AlternateContent".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: Der Namespace "{0}" ist mithilfe von "XmlnsCompatibilityAttribute" als mit sich selbst kompatibel markiert. Ein Namespace kann nicht direkt oder indirekt von sich selbst überschrieben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: Doppelte Preserve-Deklaration für das Element "{1}" im Namespace "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: Doppelte ProcessContent-Deklaration für das Element "{1}" in Namespace "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: Doppelte Preserve-Deklaration mit Platzhalterzeichen für den Namespace "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: Doppelte ProcessContent-Deklaration mit Platzhalterzeichen für den Namespace "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: "Fallback" ist nur gültig in "AlternateContent".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: Das Element "{0}" ist kein gültiges untergeordnetes Element von "AlternateContent". Nur Elemente vom Typ "Choice" und "Fallback" sind gültige untergeordnete Elemente für AlternateContent-Elemente.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: Das Attribut "{0}" ist für das Element "{1}" nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: Ungültiges {0}-Format.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: Für den Namespace "{0}" dürfen nicht gleichzeitig eine spezifische und eine Preserve-Deklaration mit Platzhalterzeichen vorhanden sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: Für den Namespace "{0}" dürfen nicht gleichzeitig eine spezifische und eine ProcessContent-Deklaration mit Platzhalterzeichen vorhanden sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Das Requires-Attribut muss ein gültiges Namespacepräfix enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: Der Attributwert "{0}" ist kein gültiger XML-Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: "AlternateContent" darf nur ein einzelnes Fallback-Element enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: Fehler bei der MustUnderstand-Bedingung für den Namespace "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: Der Namespace "{0}" besitzt Elemente, für die eine Aufbewahrung deklariert ist, die jedoch nicht als ignorierbar deklariert sind.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: Der Namespace "{0}" ist zwar als "ProcessContent", jedoch nicht als "Ignorable" deklariert.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: "Choice" muss ein Requires-Attribut enthalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: Das Präfix "{0}" ist nicht definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: Nicht erkanntes Kompatibilitätsattribut "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: Unbekanntes Kompatibilitätselement "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: Die Zeichenfolge mit der Feature-ID darf nicht die Länge Null besitzen.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Resultado del análisis: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: el archivo de proyecto de biblioteca no puede especificar el elemento ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Entrada: archivo ApplicationDefinition de marcado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: no se puede establecer '{0}' en la etiqueta '{1}:{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: nombre de tarea UidManager '{0}' no reconocido.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Comprobando el Uid en el archivo '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Archivo de directivas de localización generado: '{0}' .</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Generando archivo de directivas de localización: '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Compilación de marcado finalizada.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 generó correctamente los archivos BAML o de código fuente.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 generó correctamente los archivos BAML o de código fuente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: el evento '{0}' tiene un tipo delegado de controlador de eventos genérico '{1}'. Los parámetros de tipo de '{1}' no se pueden enlazar con un argumento de tipo apropiado porque la etiqueta contenedora '{2}' no es de tipo genérico.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">El directorio del proyecto actual es '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: sólo una etiqueta raíz puede especificar el atributo '{0}:{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: no se puede especificar '{0}:{1}' como elemento raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' contiene '{2}'. '{0}:{1}' sólo puede contener una sección CDATA o de texto.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Comenzó la compilación de marcado.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" no es válido. El valor de atributo de evento '{0}' no puede ser una cadena vacía ni tener sólo espacios en blanco.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: no se puede especificar {0}:FieldModifier en esta etiqueta porque no tiene establecido el atributo {0}:Name o Name, o bien la etiqueta está definida localmente y tiene un atributo Name establecido, que no está permitido.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: no se encuentra el archivo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">El archivo de entrada '{0}' se resuelve en una ruta de acceso relativa '{1}' en el directorio '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: error al comprobar los Uid en {0} archivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Uid válidos en {0} archivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Uid quitados de {0} archivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Uid actualizados en {0} archivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Archivo BAML generado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Archivo de código generado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' contiene '{2}'. '{0}:{1}' no puede tener contenido anidado.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: el directorio '{0}' no existe y no se puede crear.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">No se requiere la clase InternalTypeHelper para este proyecto, vacíe el archivo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: el nombre de clase '{0}' no es válido para el elemento raíz XAML definido localmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: el espacio de nombres '{0}' no es válido para el elemento raíz XAML '{1}' definido localmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" no es válido. '{2}' no es un nombre de {3}clase válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: el valor de UICulture '{0}' establecido en el archivo de proyecto no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: el serializador no admite operaciones de serialización BAML personalizadas.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: el serializador no admite operaciones Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: el nombre '{0}' no es válido en el espacio de nombres predeterminado '{1}'. Corrija el valor de la etiqueta RootNamespace en el archivo de proyecto.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" no es válido. '{1}' no es un nombre de método de controlador de eventos válido. Sólo son válidos los métodos de instancia de la clase generada o de código subyacente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: la propiedad de destino del comentario de localización no es válida en la cadena '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: el valor de comentario de localización no es válido para la propiedad de destino '{0}' en la cadena '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: el valor del atributo de localización '{0}' no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: el archivo de marcado no es válido. Especifique un archivo de marcado de origen con la extensión .xaml.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" no es válido. '{2}' no es una referencia de nombre de tipo válida para el argumento genérico en la posición '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: el elemento XML '{0}' no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: puesto que '{0}' está implementado en el mismo ensamblado, debe establecer el atributo {1}:Name, en lugar del atributo Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Entrada: el archivo ApplicationDefinition de marcado de referencia local es '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Archivo BAML generado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Entrada: el archivo Page de marcado de referencia local es: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: el evento '{0}' tiene un tipo delegado de controlador de eventos genérico '{1}'. El parámetro de tipo '{2}' de '{1}' no coincide con ningún parámetro de tipo de la etiqueta genérica contenedora '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: el elemento raíz '{0}' requiere un atributo {1}:Class porque '{2}' contiene una etiqueta {1}:Code. Quite {1}:Code y su contenido o agregue un atributo {1}:Class al elemento raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: el elemento raíz '{0}' requiere un atributo {1}:Class para admitir controladores de eventos en el archivo XAML. Quite el controlador de eventos del evento {2} o agregue un atributo {1}:Class al elemento raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: el elemento raíz '{0}' es un tipo genérico y requiere un atributo {1}:Class para admitir el atributo {1}:TypeArguments especificado en la etiqueta del elemento raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: no se puede especificar el atributo {0}:FieldModifier porque se requiere también un atributo {0}:Class para generar un campo Name con el modificador de acceso especificado. Agregue un atributo {0}:Class en la etiqueta raíz o quite el atributo {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: no se puede especificar el atributo {0}:ClassModifier en la etiqueta raíz porque se requiere también un atributo {0}:Class. Agregue un atributo {0}:Class o quite el atributo {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: falta el atributo {0}:Class. Es necesario cuando se especifica un atributo {0}:Subclass.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator sólo puede generar un archivo .resources cada vez. La propiedad OutputResourcesFile del archivo de proyecto se debe establecer en un archivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: El archivo de proyecto no puede especificar más de un elemento SplashScreen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: el Uid "{0}" del elemento '{1}' no es único.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: el archivo de proyecto no puede especificar más de un elemento ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Un elemento '{0}' tiene el nombre '{1}'. No dé nombre al contenido de ResourceDictionary porque aplaza la creación de instancias del mismo.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: excepción de CLS desconocida.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType es '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: se encontró un error de sintaxis en TypeConverter al procesar la cadena de inicialización '{0}'. No se permiten elementos de propiedad en objetos creados con TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: no se puede cargar el ensamblado '{0}' porque una versión diferente del mismo ensamblado ya está cargada '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: se debe establecer el atributo AsyncRecords en la etiqueta raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: la propiedad '{0}' adjunta no está definida en '{1}' o alguna de sus clases base.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: hay demasiados atributos especificados para '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: no hay suficientes atributos especificados para '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: la propiedad '{0}' debe estar en el espacio de nombres predeterminado o en el espacio de nombres de elementos '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath no puede aceptar un elemento assemblyName vacío.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath no puede aceptar un elemento assemblyPath vacío.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: no se puede establecer un elemento de tipo '{0}' en la propiedad compleja '{1}'. No son tipos compatibles.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: no se encuentra un constructor público para '{0}' que tome {1} argumentos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: una clave de diccionario no puede ser de tipo '{0}'. Sólo se admiten String, TypeExtension y StaticExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: El miembro '{0}' no es válido porque no tiene un nombre de tipo calificador.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: el valor de la propiedad Name '{0}' no es válido. Name debe comenzar con una letra o un signo de subrayado y sólo puede contener letras, dígitos y signos de subrayado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: no se puede convertir el valor de cadena '{0}' al tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: el valor de la propiedad SynchronousMode no es válido. Los valores válidos son Async y Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: el objeto que se va a agregar a una propiedad de matriz no es de un tipo válido. La matriz es de tipo '{0}', pero el objeto que se va a agregar es de tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: no se permiten elementos MarkupExtension como valores de propiedad Uid y Name; por tanto, '{0}' no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: el objeto '{0}' tiene ya un elemento secundario y no puede agregar '{1}'. '{0}' sólo puede aceptar un elemento secundario.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: no se puede agregar contenido a un objeto de tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' es una propiedad de sólo lectura del tipo IList o IDictionary y no se puede establecer porque no tiene un descriptor de acceso get público o interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: {0} '{1}' no se puede establecer porque no tiene un descriptor de acceso {2} accesible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: No se puede establecer la propiedad de contenido '{0}' en el elemento '{1}'. '{0}' tiene un nivel de acceso incorrecto o su ensamblado no permite el acceso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: no se puede establecer '{0}' como valor de un atributo Property de un elemento Trigger porque no tiene un descriptor de acceso get público o interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: dos espacios de nombres nuevos no pueden ser compatibles con el mismo espacio de nombres antiguo usando un atributo XmlnsCompatibility.�El espacio de nombres '{0}' está ya marcado como compatible con '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: Los elementos de propiedad no pueden incluirse en la mitad del contenido de un elemento. Deben colocarse antes o después del contenido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: se encontró la etiqueta 'Code' del espacio de nombres xaml en el archivo XAML. Para cargar este archivo, debe compilarlo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: El tipo de Element '{0}' no tiene un elemento TypeConverter asociado para analizar la cadena '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: no se pueden modificar los datos de un elemento XmlnsDictionary sellado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: la clave de diccionario '{0}' está ya en uso. Los atributos de clave se usan como claves cuando se insertan objetos en un diccionario y deben ser únicos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: la propiedad '{0}' ya se ha establecido en esta extensión de marcado y sólo se puede establecer una vez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: la propiedad '{0}' ya se ha establecido y sólo se puede establecer una vez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: las propiedades '{0}' y '{1}' hacen referencia a la misma propiedad. La configuración de propiedades duplicadas no está permitida.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: el elemento de propiedad '{0}' no puede estar vacío. Debe contener texto o elementos secundarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: no se reconoce el elemento EntityReference &amp;{0};</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: no se puede obtener acceso al tipo delegado '{0}' para el evento '{1}'. '{0}' tiene un nivel de acceso incorrecto o su ensamblado no permite el acceso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: la propiedad '{0}' es una propiedad IEnumerable de sólo lectura, por lo que '{1}' debe implementar IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: ContentPropertyAttribute no válido en el tipo '{0}', propiedad '{1}' no encontrada.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">El valor de tipo conocido {0}='{1}' no es un tipo conocido válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: no se puede encontrar el miembro estático '{0}' en el tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: las claves y los valores de XmlnsDictionary deben ser cadenas.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Línea {0}, posición {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: falta un elemento XmlNamespace, Assembly o ClrNamespace en la instrucción Mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">El URI de asignación '{0}' no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: formato no válido para el elemento MarkupExtension que especifica los argumentos del constructor en '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: las extensiones de marcado requieren un solo signo '=' entre el nombre y el valor, y una sola coma (',') entre los parámetros del constructor y los pares nombre/valor. Los argumentos '{0}' no son válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' no es válido. Las extensiones de marcado requieren sólo espacios entre el nombre de la extensión de marcado y el primer parámetro. No pueden tener coma ni signos igual delante del primer parámetro.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: Se encontró un carácter de paréntesis de cierre '{0}' en el número de línea '{1}' y en la posición '{2}' de la línea sin un carácter de paréntesis de apertura correspondiente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: El carácter de paréntesis '{0}' en el número de línea '{1}' y en la posición '{2}' de la línea no tiene un carácter de paréntesis de apertura o cierre correspondiente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: las expresiones MarkupExtension deben terminar con '}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: los pares nombre/valor de las MarkupExtensions deben tener el formato 'Nombre = Valor' con cada par separado por una coma. '{0}' no se ajusta a este formato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: los nombres y valores de un elemento MarkupExtension no pueden contener comillas. Los argumentos de MarkupExtension '{0}' no son válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: no se permite el texto '{1}' después del '{0}' de cierre de una expresión MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: se encontró una propiedad '{0}' desconocida para el tipo '{1}' al analizar una expresión Markup Extension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: atributo '{0}' desconocido en el espacio de nombres '{1}'. Tenga en cuenta que, actualmente, sólo se admite el atributo Key en este espacio de nombres.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: error de analizador interno: no se pueden usar varios registros BAML de escritura al mismo tiempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">El elemento de propiedad '{0}' no se puede anidar directamente en otro elemento de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: no se pueden poner atributos en etiquetas Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: no se permite la carga asincrónica al compilar un archivo XAML; por tanto, no se permite un valor '{0}' para SynchronousMode.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: el tipo '{0}' no admite el contenido de elementos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: todos los objetos agregados a un elemento IDictionary deben tener un atributo Key o algún otro tipo de clave asociado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: el atributo Key sólo se puede usar en una etiqueta contenida en un elemento Dictionary (como ResourceDictionary).</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: no se puede usar '{1}' como valor para '{0}'. Los números no son valores de enumeración válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: no se puede usar la sintaxis de elemento de propiedad para especificar el controlador de eventos '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: se debe compilar el archivo XAML que contiene eventos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: el tipo '{0}' no puede tener un atributo Name. En un elemento ResourceDictionary, se pueden usar como elementos los tipos de valor y los tipos sin un constructor predeterminado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: no se puede establecer el valor del atributo Name '{0}' en el elemento '{1}'. '{1}' está dentro del ámbito del elemento '{2}', que ya tenía un nombre registrado cuando se definió en otro ámbito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: no se ha definido ningún elemento NamespaceURI para el objeto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: no se pueden anidar islas de datos XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: no se pueden establecer propiedades en elementos de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: no se encuentra ningún serializador personalizado para '{0}'; por tanto, no se puede analizar.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: los elementos Style Setter no admiten elementos secundarios. No se permite una etiqueta de tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: no se puede encontrar el tipo '{0}'. Tenga en cuenta que los nombres de tipo distinguen mayúsculas de minúsculas.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: el valor '{0}' no es una expresión MarkupExtension válida. No se puede resolver '{1}' en el espacio de nombres '{2}'. '{1}' debe ser una subclase de MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: el prefijo del espacio de nombres XML '{0}' no está asignado a un elemento NamespaceURI, por lo que no se puede resolver el elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: el prefijo del espacio de nombres XML '{0}' no está asignado a un URI de espacio de nombres, por lo que no puede resolver la propiedad '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: la propiedad '{0}' no tiene ningún valor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: sólo se pueden usar clases públicas o internas en el marcado. El tipo '{0}' no es público ni interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: la propiedad '{0}' es de sólo lectura y no se puede establecer desde el marcado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: la referencia de tipo no puede encontrar un tipo público con el nombre '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: no se puede hacer referencia al miembro estático '{0}' en el tipo '{1}' porque no está accesible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: el atributo SynchronousMode debe estar en la etiqueta raíz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: el elemento de texto '{0}' y el elemento secundario '{1}' no pueden estar presentes a la vez en un elemento de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: no se permite texto en una propiedad IDictionary o Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: un archivo XAML no puede hacer referencia a más de 4.096 ensamblados diferentes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: la etiqueta de cierre debe estar inmediatamente después de la cadena de inicialización de TypeConverter '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: se encontró un error de sintaxis de TypeConverter al procesar la cadena de inicialización '{0}'. Los atributos de elemento no están permitidos en objetos creados mediante TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' es un espacio de nombres no declarado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: la propiedad '{0}' no existe en el espacio de nombres XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: el atributo '{0}' no existe en el espacio de nombres XML 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: la etiqueta '{0}' no existe en el espacio de nombres XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: se encontró el tipo de nodo XML '{0}' no reconocido al determinar si la etiqueta actual es un elemento de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: el elemento primario o propiedad '{0}' requiere una isla de datos XML. Para distinguir una isla XML del XAML adyacente, incluya la isla de datos XML entre &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: el elemento o propiedad '{0}' no puede contener una isla de datos XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: el atributo XmlLangProperty debe especificar un nombre de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: la clase '{0}' no implementa IXmlLineInfo, que es necesario para obtener información de posición del XAML que se está analizando.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: símbolo (token) '{0}' inesperado en la posición '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: el símbolo (token) no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Preparando la compilación de marcado...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: el nombre de tipo '{0}' no tiene el formato esperado 'nombreDeClase, ensamblado'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Leyendo el archivo Resource: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Archivo XAML compilado de nuevo: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Entrada: archivo Reference de ensamblado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">El Id. de recurso es '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: el archivo de recursos de entrada '{0}' supera el tamaño máximo de {1} bytes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">Archivo .resources generado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Generando archivo .resources: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" no es válido. '{1}' debe ser un elemento RoutedEvent registrado con un nombre que termine con la palabra clave "Event".</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: debe pasar archivos de marcado a la tarea.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: no se puede establecer la propiedad SourceName en la sección Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style no admite etiquetas {0} y etiquetas de propiedad Style.{1} a la vez para un solo elemento Style. Use unas u otras.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: la etiqueta de propiedad Style '{0}' sólo se puede especificar directamente bajo una etiqueta Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: no se puede encontrar el elemento Style {0} '{1}' en el tipo '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: no se puede resolver Style {0} '{1}'. Compruebe que el tipo de propiedad sea TargetType de Style; o bien use la sintaxis Class.Property para especificar {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style no puede contener el elemento secundario '{0}'. El elemento secundario Style debe ser un elemento Setter porque se agrega a la colección de Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: no se admiten etiquetas de tipo '{0}' en secciones Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: no se puede especificar el evento '{0}' en una etiqueta Target en un Style. Use EventSetter en su lugar.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: no se permite el texto '{0}' en esta ubicación de una sección Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: no se puede establecer la propiedad '{0}' en Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: '{0}' no puede ser la raíz de un archivo XAML porque se definió con XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: el tipo de destino '{0}' no es compatible con esta tarea.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: no se puede establecer la propiedad TargetName en un Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Build Task '{0}' Versión '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Reservados todos los derechos.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Name '{0}' ya se ha definido. Los elementos Name deben ser únicos.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: la raíz de una sección de contenido Template no puede contener un elemento de tipo '{0}'. Sólo son válidos los tipos FrameworkElement y FrameworkContentElement.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: la etiqueta de propiedad de plantilla '{0}' sólo se puede especificar inmediatamente después de una etiqueta ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: una plantilla sólo puede tener un elemento raíz. No se permite '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: se puede encontrar la propiedad de plantilla '{0}' en el tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: no se puede resolver la propiedad de plantilla '{0}'. Compruebe que el tipo de propiedad sea TargetType de Style, o use la sintaxis Class.Property para especificar la propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: no se puede encontrar el destino Trigger '{0}'. (El destino debe aparecer delante de cualquier Setters, Triggers o Conditions que lo use).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: no se admiten etiquetas de tipo '{0}' en secciones de plantilla.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: no se permite el texto '{0}' en esta ubicación de una sección de plantilla.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: no se puede establecer la propiedad '{0}' como elemento de propiedad de una plantilla. Sólo se permite Triggers y Storyboards como elementos de propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: se encontró un símbolo (token) vacío durante el análisis.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: se encontraron datos adicionales después de un símbolo (token) durante el análisis.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: al analizar el símbolo (token) se detectó que falta la comilla final.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: se encontró un cierre de cadena prematuro.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: falta un Uid para el elemento '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Error de compilación desconocido: '{0}' </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" no es válido para el idioma {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: etiqueta '{0}:{1}' no reconocida en el espacio de nombres 'http://schemas.microsoft.com/winfx/2006/xaml'. Tenga en cuenta que los nombres de etiqueta distinguen mayúsculas de minúsculas.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' no es válido. '{0}' no es un evento en '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" no es válido para el idioma {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' no es válido en la etiqueta '{2}'. '{2}' no es de un tipo genérico o bien el número de argumentos Type del atributo es incorrecto. Quite el atributo {0}:TypeArguments, porque sólo se permite en tipos genéricos, o corrija su valor para que coincida con el del tipo genérico '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' no está instalado correctamente en este equipo. Debe aparecer en la sección &lt;compilers&gt; de machine.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Se intentó una operación de ruta de acceso desconocida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: el comentario de localización no tiene ningún valor establecido para la propiedad de destino: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: los componentes principal y secundario del número de versión no pueden ser negativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: el archivo de proyecto debe incluir el ensamblado '{0}' de .NET Framework en la lista de referencias.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: el valor de propiedad LocalizationDirectivesToLocFile no es válido y se debe cambiar a None, CommentsOnly o All para la tarea MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: el archivo de proyecto contiene un valor de propiedad no válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice no puede ir después de un elemento Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent debe contener uno o varios elementos Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice sólo es válido en AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: El espacio de nombres '{0}' está marcado como compatible con sí mismo con XmlnsCompatibilityAttribute. Un espacio de nombres no puede invalidarse a sí mismo directa ni indirectamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: declaración Preserve duplicada para el elemento '{1}' en el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: declaración ProcessContent duplicada para el elemento '{1}' en el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: declaración Preserve de comodín duplicada para el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: declaración ProcessContent de comodín duplicada para el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback sólo es válido en AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: el elemento '{0}' no es un elemento secundario válido de AlternateContent. Sólo Choice y Fallback son elementos secundarios válidos de un elemento AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: el atributo '{0}' no es válido para el elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: el formato de '{0}' no es válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: no se pueden tener una declaración Preserve específica y otra de comodín para el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: no se pueden tener una declaración ProcessContent específica y otra de comodín para el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: el atributo Requires debe contener un prefijo de espacio de nombres válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: el valor del atributo '{0}' no es un nombre XML válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent sólo debe contener un elemento Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: error de la condición MustUnderstand en el espacio de nombres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: el espacio de nombres '{0}' tiene elementos declarados para conservarlos, pero no está declarado como Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: el espacio de nombres '{0}' está declarado como ProcessContent, pero no como Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice debe contener un atributo Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: el prefijo '{0}' no está definido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: atributo de compatibilidad '{0}' no reconocido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: elemento de compatibilidad '{0}' no reconocido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: la cadena de Id. de la característica no puede tener longitud 0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Résultat de l'analyse : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002 : le fichier de projet de bibliothèque ne peut pas spécifier un élément ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Entrée : fichier ApplicationDefinition de balisage : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015 : impossible de définir '{0}' sur la balise '{1}:{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001 : nom de tâche UidManager non reconnu '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Contrôle des Uid du fichier '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Fichier de directives de localisation généré : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Génération du fichier de directives de localisation : '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Compilation du balisage terminée.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 a généré avec succès les fichiers BAML ou de code source.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 a généré avec succès les fichiers BAML ou de code source.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011 : l'événement '{0}' possède un type délégué de gestionnaires d'événements générique '{1}'. Les paramètres type de '{1}' ne peuvent pas être liés à un argument type approprié car la balise contenante '{2}' n'est pas un type générique.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Le répertoire projet actuel est '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022 : seule une balise racine peut spécifier l'attribut '{0}:{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010 : impossible de spécifier '{0}:{1}' comme élément racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004 : '{0}:{1}' contient '{2}'. '{0}:{1}' ne peut contenir qu'une section CDATA ou texte.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Démarrage de la compilation du balisage.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030 : {0}="{1}" n'est pas valide. La valeur de l'attribut d'événement '{0}' ne peut pas être une chaîne vide ou ne comportant que des espaces.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021 : {0}:FieldModifier ne peut pas être spécifié sur cette balise car il n'a pas d'attribut {0}:Name ou Name défini, ou la balise est localement définie et possède un attribut Name défini, ce qui n'est pas autorisé.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002 : impossible de trouver le fichier '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">Résolution du fichier d'entrée '{0}' en nouveau chemin relatif '{1}' au répertoire '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004 : échec du contrôle des Uid des fichiers {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Uid valides dans les fichiers {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Uid supprimées des fichiers {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Uid mises à jour dans les fichiers {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Fichier BAML généré : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Fichier code généré : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003 : '{0}:{1}' contient '{2}'. '{0}:{1}' ne peut pas comporter un contenu imbriqué.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006 : le répertoire '{0}' n'existe pas et ne peut pas être créé.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">Classe InternalTypeHelper non obligatoire pour ce projet, fichier Make '{0}' vide.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018 : nom de classe '{0}' non valide pour l'élément racine XAML défini localement.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019 : espace de noms '{0}' non valide pour l'élément racine XAML défini localement '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027 : {0}:{1}="{2}" non valide. '{2}' n'est pas un nom de classe {3} valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001 : la valeur UICulture '{0}' définie dans le fichier projet n'est pas valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402 : le sérialiseur ne prend pas en charge les opérations de sérialisation BAML personnalisées.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401 : le sérialiseur ne prend pas en charge les opérations Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029 : nom '{0}' non valide dans l'espace de noms par défaut '{1}'. Corrigez la valeur de la balise RootNamespace dans le fichier projet.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005 : {0}="{1}" n'est pas valide. '{1}' n'est pas un nom valide de méthode de gestionnaire d'événement. Seules les méthodes d'instance de la classe générée ou code-behind sont valides.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001 : la propriété cible des commentaires de localisation n'est pas valide dans la chaîne '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002 : la valeur des commentaires de localisation n'est pas valide pour la propriété cible '{0}' de la chaîne '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004 : paramétrage de l'attribut Localizability '{0}' non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001 : fichier de balisage non valide. Spécifiez un fichier de balisage source avec une extension .xaml.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" n'est pas valide. '{2}' n'est pas une référence de nom de type valide pour l'argument générique à la position '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000 : XML '{0}' non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023 : comme '{0}' est implémenté dans le même assembly, vous devez définir l'attribut {1}:Name à la place de l'attribut Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Entrée : le fichier ApplicationDefinition de balisage de référence local est '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Fichier BAML généré : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Entrée : fichier Page de balisage de référence local : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012 : l'événement '{0}' possède un type délégué de gestionnaires d'événements générique '{1}'. Le paramètre type '{2}' de '{1}' ne correspond pas aux paramètres type de la balise générique contenante '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026 : l'élément racine '{0}' nécessite un attribut {1}:Class car '{2}' contient une balise {1}:Code. Supprimez {1}:Code et son contenu, ou ajoutez un attribut {1}:Class à l'élément racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024 : l'élément racine '{0}' nécessite un attribut {1}:Class pour prendre en charge les gestionnaires d'événements du fichier XAML. Supprimez le gestionnaire d'événements de l'événement {2} ou ajoutez un attribut {1}:Class à l'élément racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025 : l'élément racine '{0}' est un type générique et nécessite un attribut {1}:Class pour prendre en charge l'attribut {1}:TypeArguments spécifié sur la balise de l'élément racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031 : l'attribut {0}:FieldModifier ne peut pas être spécifié car un attribut {0}:Class est également obligatoire pour générer un champ Name avec le modificateur d'accès spécifié. Ajoutez un attribut {0}:Class sur la balise racine ou supprimez l'attribut {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009 : l'attribut {0}:ClassModifier ne peut pas être spécifié sur la balise racine car un attribut {0}:Class est également obligatoire. Ajoutez un attribut {0}:Class sur la balise racine ou supprimez l'attribut {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016 : l'attribut {0}:Class est manquant. Il est obligatoire quand un attribut {0}:Subclass est spécifié.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002 : ResourcesGenerator ne peut générer qu'un seul fichier .resources à la fois. La propriété OutputResourcesFile du fichier projet doit être définie avec un seul fichier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004 : le fichier projet ne peut pas spécifier plus d'un élément SplashScreen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002 : l'Uid "{0}" de l'élément '{1}' n'est pas unique.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003 : le fichier projet ne peut pas spécifier plusieurs éléments ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Un '{0}' est appelé '{1}'. N'attribuez pas de nom au contenu ResourceDictionary, car son installation est différée.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001 : exception CLS inconnue.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType est '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: erreur de syntaxe TypeConverter rencontrée lors du traitement de la chaîne d'initialisation '{0}'. Les éléments de propriété ne sont pas autorisés sur les objets créés via TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099 : impossible de charger l'assembly '{0}', car une autre version du même assembly est chargée '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002 : l'attribut AsyncRecords doit être défini sur la balise racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015 : la propriété jointe '{0}' n'est pas définie sur '{1}' ou l'une de ses classes de base.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003 : trop d'attributs spécifiés pour '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004 : nombre d'attributs spécifié pour '{0}' insuffisant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005 : la propriété '{0}' doit être dans l'espace de noms par défaut ou dans l'espace de noms de l'élément '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006 : Mapper.SetAssemblyPath ne peut pas accepter un assemblyName vide.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007 : Mapper.SetAssemblyPath ne peut pas accepter un assemblyPath vide.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008 : un élément de type '{0}' ne peut pas être défini sur la propriété complexe '{1}'. Les types ne sont pas compatibles.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009 : impossible de trouver un constructeur public pour '{0}' qui accepte {1} arguments.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012 : une clé de dictionnaire ne peut pas être de type '{0}'. Seuls les types String, TypeExtension et StaticExtension sont pris en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029 : le membre '{0}' n'est pas valide, car il ne possède pas un nom de type qualifiant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010 : valeur '{0}' de la propriété Name non valide. Name doit commencer par une lettre ou un trait de soulignement et ne peut contenir que des lettres, des chiffres ou des traits de soulignement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094 : impossible de convertir la valeur de chaîne '{0}' en type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013 : la valeur de la propriété SynchronousMode n'est pas valide. Les valeurs valides sont Async et Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014 : le type de l'objet ajouté à une propriété de tableau n'est pas valide. Le tableau est de type '{0}' alors que l'objet ajouté est de type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079 : les expressions MarkupExtension n'étant pas autorisées pour les valeurs des propriétés Uid ou Name, '{0}' n'est pas valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089 : l'objet '{0}' possède déjà un enfant et ne peut pas ajouter '{1}'. '{0}' ne peut accepter qu'un seul enfant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028 : impossible d'ajouter un contenu à un objet de type '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081 : '{0}' est une propriété en lecture seule de type IList ou IDictionary et ne peut pas être définie car elle ne possède pas d'accesseur get public ou interne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080 : impossible de définir {0} '{1}' en l'absence d'un accesseur {2} accessible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087 : impossible de définir la propriété de contenu '{0}' sur l'élément '{1}'. '{0}' possède un niveau d'accès incorrect ou son assembly n'autorise pas l'accès.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082 : impossible de définir '{0}' comme valeur de l'attribut Property d'un Trigger, car il ne possède pas un accesseur get public ou interne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016 : deux nouveaux espaces de noms ne peuvent pas être compatibles avec le même espace de noms antérieur à l'aide d'un attribut XmlnsCompatibility.� L'espace de noms '{0}' est déjà marqué comme compatible avec '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088 : les éléments de propriétés ne peuvent pas se trouver au milieu du contenu d'un élément. Ils doivent se trouver avant ou après le contenu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017 : balise 'Code' d'un espace de noms xaml trouvée dans le fichier XAML. Pour charger ce fichier, vous devez le compiler.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061 : le type Element '{0}' n'a pas de TypeConverter associé pour analyser la chaîne '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018 : impossible de modifier les données d'un XmlnsDictionary de type sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020 : clé de dictionnaire '{0}' déjà utilisée. Les attributs Key sont utilisés en tant que clés lors de l'insertion d'objets dans un dictionnaire et doivent être uniques.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033 : la propriété '{0}' a déjà été définie sur cette extension de balisage et ne peut être définie qu'une seule fois.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024 : la propriété '{0}' a déjà été définie et ne peut l'être qu'une seule fois.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025 : '{0}' et '{1}' font référence à la même propriété. Les valeurs de propriété en double ne sont pas autorisées.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026 : l'élément de propriété '{0}' ne peut pas être vide. Il doit contenir des éléments enfants ou du texte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027 : EntityReference &amp;{0}; non reconnue.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083 : impossible d'accéder au type délégué '{0}' pour l'événement '{1}'. '{0}' possède un niveau d'accès incorrect ou son assembly n'autorise pas l'accès.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030 : la propriété '{0}' est une propriété IEnumerable en lecture seule, ce qui signifie que '{1}' doit implémenter IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078 : ContentPropertyAttribute non valide sur le type '{0}', propriété '{1}' introuvable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">La valeur de type connu {0}='{1}' n'est pas un type connu valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011 : impossible de trouver le membre statique '{0}' sur le type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031 : les clés et les valeurs de XmlnsDictionary doivent être des chaînes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Ligne {0} Position {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037 : XmlNamespace, Assembly ou ClrNamespace absent de l'instruction Mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">URI de mappage '{0}' non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040 : format non valide pour MarkupExtension qui spécifie les arguments du constructeur dans '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041 : les extensions de balisage nécessitent un seul signe '=' entre le nom et la valeur et une seule ',' entre les paramètres du constructeur et les paires nom / valeur. Les arguments '{0}' ne sont pas valides.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091 : '{0}' n'est pas valide. Les extensions de balisage nécessitent uniquement des espaces entre le nom de l'extension de balisage et le premier paramètre. Impossible d'avoir une virgule ou un signe '=' avant le premier paramètre.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001 : BracketCharacter fermant '{0}' détecté au numéro de ligne '{1}' et à la position de ligne '{2}' sans correspondance avec un BracketCharacter ouvrant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002 : le BracketCharacter '{0}' détecté au numéro de ligne '{1}' et à la position de ligne '{2}' ne correspond à aucun BracketCharacter ouvrant/fermant.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038 : les expressions MarkupExtension doivent se terminer par une '}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042 : les paires nom / valeur d'une expression MarkupExtensions doivent obéir au format 'Name = Value' et chaque paire doit être séparée par une virgule. '{0}' ne respecte pas ce format.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043 : les noms et valeurs d'une expression MarkupExtension ne peuvent pas contenir de guillemets. Les arguments '{0}' de MarkupExtension ne sont pas valides.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044 : texte '{1}' non autorisé après la fermeture '{0}' d'une expression MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045 : propriété '{0}' inconnue pour le type '{1}' rencontrée lors de l'analyse d'une expression Markup Extension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046 : attribut '{0}' inconnu dans l'espace de noms '{1}'. Notez que seul l'attribut Key est actuellement pris en charge dans cet espace de noms.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047 : erreur d'analyse interne - impossible d'utiliser en même temps plusieurs enregistrements BAML accessibles en écriture.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">L'élément de propriété '{0}' ne peut pas être imbriqué directement dans un autre élément de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049 : impossible de placer des attributs sur les balises Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021 : le chargement asynchrone n'étant pas pris en charge lors de la compilation d'un fichier XAML, un SynchronousMode égal à '{0}' n'est pas autorisé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051 : le type '{0}' ne prend pas en charge le contenu de l'élément.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022 : tous les objets ajoutés à un IDictionary doivent avoir un attribut Key ou un autre type de clé associé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023 : l'attribut Key ne peut pas être utilisé sur une balise contenue dans un Dictionary (comme ResourceDictionary).</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032 : '{1}' ne peut pas être utilisé comme valeur de '{0}'. Les nombres ne sont pas des valeurs d'énumération valides.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053 : impossible d'utiliser la syntaxe de l'élément de propriété pour spécifier le gestionnaire d'événements '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052 : le fichier XAML qui contient les événements doit être compilé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054 : le type '{0}' ne peut pas avoir d'attribut Name. Les types valeur et les types sans constructeur par défaut peuvent être utilisés comme éléments au sein d'un ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093 : impossible de définir la valeur de l'attribut Name '{0}' sur l'élément '{1}'. '{1}' se trouve sous la portée de l'élément '{2}', qui avait déjà un nom inscrit quand il a été défini dans une autre portée.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056 : aucune définition de NamespaceURI pour l'objet '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084 : impossible d'imbriquer des îlots de données XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057 : impossible de définir des propriétés sur les éléments de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058 : comme il est impossible de trouver un sérialiseur personnalisé pour '{0}', il ne peut pas être analysé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059 : les Style Setters ne prennent pas en charge les éléments enfants. Une balise de type '{0}' n'est pas autorisée.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050 : impossible de trouver le type '{0}'. Notez que les noms de type respectent la casse.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048 : la valeur '{0}' n'est pas une expression MarkupExtension valide. Impossible de résoudre '{1}' en espace de noms '{2}'. '{1}' doit être une sous-classe de MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062 : comme le préfixe de l'espace de noms XML '{0}' ne correspond pas à un NamespaceURI, l'élément '{1}' ne peut pas être résolu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100 : comme le préfixe d'espace de noms '{0}' ne correspond pas à un URI d'espace de noms, la résolution de la propriété '{1}' n'est pas possible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063 : la propriété '{0}' n'a pas de valeur.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064 : seules les classes publiques ou internes peuvent être utilisées au sein du balisage. Le type '{0}' n'est ni public ni interne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065 : la propriété '{0}' est en lecture seule et ne peut pas être définie à partir du balisage.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066 : la référence de type ne peut pas trouver un type public nommé '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019 : impossible de référencer le membre statique '{0}' sur le type '{1}' car il n'est pas accessible.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067 : l'attribut SynchronousMode doit se trouver sur la balise racine.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069 : impossible d'avoir à la fois le texte '{0}' et l'élément enfant '{1}' dans un élément de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068 : texte non valide sous une propriété IDictionary ou Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070 : un même fichier XAML ne peut pas référencer plus de 4 096 assemblys différents.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095 : la balise de fermeture doit suivre immédiatement la chaîne d'initialisation TypeConverter '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090 : erreur de syntaxe TypeConverter rencontrée lors du traitement de la chaîne d'initialisation '{0}'. Les attributs d'élément ne sont pas autorisés sur les objets créés via TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071 : '{0}' est un espace de noms non déclaré.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072 : la propriété '{0}' n'existe pas dans l'espace de noms XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073 : l'attribut '{0}' n'existe pas dans l'espace de noms XML 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074 : la balise '{0}' n'existe pas dans l'espace de noms XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075 : type de nœud XML non identifié '{0}' rencontré pendant l'analyse visant à déterminer si la balise en cours est un élément de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086 : l'élément parent ou la propriété '{0}' nécessite un îlot de données XML. Pour distinguer un îlot XML du XAML environnant, incluez dans un wrapper l'îlot de données XML dans &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085 : la propriété ou l'élément '{0}' ne peut pas contenir d'îlot de données XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092 : l'attribut XmlLangProperty doit spécifier un nom de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077 : la classe '{0}' n'implémente pas IXmlLineInfo. Cette implémentation est obligatoire pour obtenir les informations de position du XAML en cours d'analyse.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098 : jeton inattendu '{0}' à la position '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096 : jeton non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Préparation de la compilation du balisage...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301 : le nom de type '{0}' n'a pas le format attendu, 'className, assembly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Lecture du fichier Resource : '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Fichier XAML recompilé : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Entrée : fichier Reference d'assembly : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">L'ID de ressource est '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001 : le fichier de ressources en entrée '{0}' dépasse la taille maximale ({1} octets).</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">Fichier .resources généré : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Génération du fichier .resources : '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006 : {0}.{1}="{2}" n'est pas valide. '{1}' doit être un événement RoutedEvent inscrit avec un nom qui se termine par le mot clé "Event".</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005 : vous devez passer les fichiers de balisage à la tâche.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110 : la propriété SourceName ne peut pas être définie au sein de la section Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001 : Style ne prend pas en charge à la fois les balises {0} et les balises de propriété Style.{1} pour un même Style. Utilisez l'une ou l'autre solution.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002 : la balise de propriété Style '{0}' ne peut être spécifiée directement que sous une balise Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005 : impossible de trouver le Style {0} '{1}' sur le type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003 : impossible de résoudre le Style {0} '{1}'. Vérifiez que le type propriétaire est le TargetType de Style ou utilisez la syntaxe Class.Property pour spécifier le {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004 : Style ne peut pas contenir d'enfant '{0}'. L'enfant Style doit être une méthode Setter car il est ajouté à la collection Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006 : les balises de type '{0}' ne sont pas prises en charge dans les sections Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007 : l'événement '{0}' ne peut pas être spécifié sur la balise Target d'un Style. Utilisez à la place un EventSetter.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008 : le texte '{0}' n'est pas autorisé à cet emplacement au sein d'une section Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009 : la propriété '{0}' ne peut pas être définie sur Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017 : '{0}' ne peut pas être la racine d'un fichier XAML, car sa définition a été faite à l'aide de XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004 : type Target '{0}' non pris en charge par cette tâche.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011 : la propriété TargetName ne peut pas être définie sur un Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Tous droits réservés.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101 : le Name '{0}' a déjà été défini. Chaque Name doit être unique.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108 : la racine d'une section de contenu Template ne peut pas contenir un élément de type '{0}'. Seuls les types FrameworkElement et FrameworkContentElement sont valides.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103 : la balise de propriété du modèle '{0}' ne peut être spécifiée qu'immédiatement après une balise ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107 : un modèle ne peut avoir qu'un seul élément racine. '{0}' n'est pas autorisé.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109 : impossible de trouver la propriété de modèle '{0}' sur le type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106 : impossible de résoudre la propriété de modèle '{0}'. Vérifiez que le type propriétaire est le TargetType de Style ou utilisez la syntaxe Class.Property pour spécifier la propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111 : impossible de trouver la cible Trigger '{0}'. (La cible doit figurer avant toute méthode Setter, Trigger ou Condition qui l'utilise.)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102 : les balises de type '{0}' ne sont pas prises en charge dans les sections de modèle.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105 : le texte '{0}' n'est pas autorisé à cet emplacement au sein d'une section de modèle.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104 : la propriété '{0}' ne peut pas être définie comme élément de propriété d'un modèle. Seuls les éléments Triggers et Storyboards sont autorisés comme éléments de propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004 : jeton vide rencontré lors de l'analyse.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003 : données supplémentaires rencontrées après l'analyse du jeton.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002 : absence de guillemet fermant rencontrée lors de l'analyse du jeton.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001 : fin de chaîne prématurée rencontrée.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003 : absence d'Uid pour l'élément '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Erreur de build inconnue, '{0}' </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013 : {0}:ClassModifier="{1}" non valide pour le langage {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002 : balise '{0}:{1}' non reconnue dans l'espace de noms 'http://schemas.microsoft.com/winfx/2006/xaml'. Notez que les noms de balise respectent la casse.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007 : '{1}' n'est pas valide. '{0}' n'est pas un événement sur '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014 : {0}:FieldModifier="{1}" n'est pas valide pour le langage {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020 : {0}:TypeArguments='{1}' n'est pas valide sur la balise '{2}'. '{2}' n'est pas un type générique ou le nombre d'arguments Type dans l'attribut est erroné. Supprimez l'attribut {0} :TypeArguments parce qu'il n'est autorisé que sur les types génériques ou corrigez sa valeur pour qu'elle corresponde à la parité du type générique '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008 : '{0}' n'est pas installé correctement sur cet ordinateur. Il doit être répertorié dans la section &lt;compilers&gt; de machine.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Tentative d'opération de chemin d'accès inconnu.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003 : les commentaires de localisation n'ont pas de valeur définie pour la propriété cible : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501 : les numéros de version majeure et de version mineure ne peuvent pas être négatifs.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000 : le fichier projet doit inclure l'assembly du .NET Framework '{0}' dans la liste de référence.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001 : la valeur de la propriété LocalizationDirectivesToLocFile n'est pas valide et doit être modifiée en None, CommentsOnly ou All pour la tâche MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003 : le fichier projet contient une valeur de propriété non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602 : un élément Choice ne peut pas suivre un élément Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606 : AlternateContent doit contenir un ou plusieurs éléments Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601 : élément Choice valide uniquement dans AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640 : l'espace de noms '{0}' est marqué comme compatible avec lui-même à l'aide de XmlnsCompatibilityAttribute. Un espace de noms ne peut pas directement ou indirectement se remplacer lui-même.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631 : déclaration Preserve en double pour l'élément '{1}' de l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617 : déclaration ProcessContent en double pour l'élément '{1}' de l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633 : déclaration Preserve générique en double pour l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619 : déclaration ProcessContent générique en double pour l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605 : élément Fallback valide uniquement dans AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610 : l'élément '{0}' n'est pas un enfant valide de AlternateContent. Seuls les éléments Choice et Fallback sont des enfants valides d'un élément AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608 : attribut '{0} non valide pour l'élément '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611 : format '{0}' non valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632 : impossible d'avoir une déclaration Preserve à la fois spécifique et générique pour l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618 : Impossible d'avoir à la fois une déclaration ProcessContent générique et spécifique pour l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604 : l'attribut Requires doit contenir un préfixe d'espace de noms valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634 : la valeur de l'attribut '{0}' n'est pas un nom XML valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607 : AlternateContent ne doit contenir qu'un seul élément Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626 : échec de la condition MustUnderstand sur l'espace de noms '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630 : l'espace de noms '{0}' possède des éléments déclarés avec Preserve, mais n'est pas déclaré lui-même Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615 : l'espace de noms '{0}' est déclaré ProcessContent, mais n'est pas déclaré Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603 : l'élément Choice doit comporter un attribut Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612 : le préfixe '{0}' n'est pas défini.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614 : attribut de compatibilité '{0}' non reconnu.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609 : élément de compatibilité '{0}' non reconnu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502 : la chaîne d'identification de la fonctionnalité ne peut pas avoir une longueur nulle.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Risultato analisi: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: impossibile specificare l'elemento ApplicationDefinition nel file di progetto della libreria.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Input: file ApplicationDefinition markup: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: impossibile impostare '{0}' nel tag '{1}:{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: nome di attività UidManager non riconosciuto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Controllo degli Uids nel file '{0}' in corso...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">File di direttive di localizzazione generato: '{0}' .</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Generazione del file di direttive di localizzazione '{0}' in corso...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Compilazione del markup completata.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">Generazione dei file BAML o di codice sorgente completata da MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">Generazione dei file BAML o di codice sorgente completata da MarkupCompilePass2.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: all'evento '{0}' è associato un tipo delegato generico di gestore eventi '{1}'. Impossibile associare i parametri di tipo di '{1}' a un argomento di tipo appropriato perché il tag contenitore '{2}' non è un tipo generico.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Directory di progetto corrente: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: l'attributo '{0}:{1}' può essere specificato solo in un tag radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: impossibile specificare '{0}:{1}' come elemento radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' contiene '{2}'. '{0}:{1}' può contenere solo una sezione CDATA o di testo.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Compilazione del markup avviata.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" non è valido. Il valore dell'attributo dell'evento '{0}' non può essere una stringa vuota o composta solo da spazi vuoti.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: impossibile specificare {0}:FieldModifier in questo tag perché non è impostato l'attributo {0}:Name o Name oppure il tag è definito localmente con un attributo Name impostato e questa condizione non è consentita.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: il file '{0}' non è stato trovato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">File di input '{0}' risolto in un nuovo percorso relativo '{1}' nella directory '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: controllo Uid non riuscito per {0} file.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Uids validi in {0} file.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Uids rimossi da {0} file.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Uids aggiornati in {0} file.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">File BAML generato: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">File di codice generato: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' contiene '{2}'. '{0}:{1}' non può includere contenuto annidato.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: la directory '{0}' non esiste e non può essere creata.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">La classe InternalTypeHelper non è richiesta per questo progetto, file make '{0}' vuoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: il nome di classe '{0}' non è valido per l'elemento radice XAML definito in locale.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: lo spazio dei nomi '{0}' non è valido per l'elemento radice XAML definito in locale '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" non è valido. '{2}' non è un nome di classe {3} valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: il valore UICulture '{0}' impostato nel file di progetto non è valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: il serializzatore non supporta operazioni di serializzazione BAML personalizzate.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: il serializzatore non supporta operazioni Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: il nome '{0}' non è valido nello spazio dei nomi predefinito '{1}'. Correggere il valore del tag RootNamespace nel file di progetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" non è valido. '{1}' non è un nome valido di metodo del gestore eventi. Sono validi solo i metodi di istanza nella classe generata o code-behind.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: la proprietà di destinazione del commento di localizzazione non è valida nella stringa '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: il valore del commento di localizzazione non è valido per la proprietà di destinazione '{0}' nella stringa '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: l'impostazione dell'attributo di localizzabilità '{0}' non è valida.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: file di markup non valido. Specificare un file di markup di origine con estensione .xaml.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" non valido. '{2}' non è un riferimento a un nome di tipo valido per l'argomento generico nella posizione '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: XML '{0}' non valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: '{0}' è implementato nello stesso assembly. È pertanto necessario impostare l'attributo {1}:Name anziché l'attributo Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Input: il file ApplicationDefinition del markup di riferimento locale è '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">File BAML generato: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Input: file Page del markup di riferimento locale: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: all'evento '{0}' è associato un tipo delegato generico del gestore eventi '{1}'. Il parametro del tipo '{2}' in '{1}' non corrisponde a nessun parametro del tipo nel tag generico contenitore '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: per l'elemento radice '{0}' è obbligatorio un attributo {1}:Class perché '{2}' contiene un tag {1}:Code. Rimuovere {1}:Code e il relativo contenuto oppure aggiungere un attributo {1}:Class all'elemento radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: per l'elemento radice '{0}' è necessario un attributo {1}:Class per il supporto dei gestori eventi nel file XAML. Rimuovere il gestore eventi per l'evento {2} oppure aggiungere un attributo {1}:Class all'elemento radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: l'elemento radice '{0}' è un tipo generico ed è necessario un attributo {1}:Class per il supporto dell'attributo {1}:TypeArguments specificato nel tag dell'elemento radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: impossibile specificare l'attributo {0}:FieldModifier perché è necessario anche un attributo {0}:Class per generare un campo Name con il modificatore di accesso specificato. Aggiungere un attributo {0}:Class nel tag radice oppure rimuovere l'attributo {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: impossibile specificare l'attributo {0}:ClassModifier nel tag radice perché è necessario anche un attributo {0}:Class. Aggiungere un attributo {0}:Class o rimuovere l'attributo {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: attributo {0}:Class mancante. L'attributo è necessario quando si specifica un attributo {0}:Subclass.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator supporta la generazione di un solo file con estensione resources alla volta. La proprietà OutputResourcesFile nel file di progetto .resources deve essere impostata su un solo file.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: impossibile specificare più di un elemento SplashScreen nel file di progetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: Uid "{0}" non univoco per l'elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: impossibile specificare più di un elemento ApplicationDefinition nel file di progetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Un elemento '{0}' è denominato '{1}'. Non assegnare al contenuto il nome ResourceDictionary perché la relativa creazione dell'istanza è posticipata.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: eccezione CLS sconosciuta.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: errore di sintassi TypeConverter rilevato durante l'elaborazione della stringa di inizializzazione '{0}'. Elementi proprietà non consentiti per gli oggetti creati tramite TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: non è possibile caricare l'assembly '{0}' perché è caricata una versione diversa dello stesso assembly '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: l'attributo AsyncRecords deve essere impostato nel tag radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: la proprietà associata '{0}' non è definita in '{1}' o in una delle classi di base corrispondenti.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: troppi attributi specificati per '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: attributi insufficienti specificati per '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: la proprietà '{0}' deve essere inclusa nello spazio dei nomi predefinito o nello spazio dei nomi dell'elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath non accetta un assemblyName vuoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath non accetta un assemblyPath vuoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: impossibile impostare un elemento di tipo '{0}' nella proprietà complessa '{1}'. Tipi non compatibili.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: impossibile trovare un costruttore pubblico per '{0}' che accetti {1} argomento/i.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: una chiave per un dizionario non può essere di tipo '{0}'. Sono supportati solo i tipi String, TypeExtension e StaticExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: il membro '{0}' non è valido perché non dispone di un nome di tipo valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: Il valore della proprietà Name '{0}' non è valido. Il valore Name deve iniziare con una lettera o un carattere di sottolineatura e può includere solo lettere, cifre e caratteri di sottolineatura.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: impossibile convertire il valore stringa '{0}' nel tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: il valore della proprietà SynchronousMode non è valido. I valori validi sono Async e Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: tentativo di aggiunta di un oggetto di tipo non valido a una proprietà di matrice. La matrice è di tipo '{0}' e l'oggetto è di tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: non è consentito l'utilizzo di MarkupExtension come valori per la proprietà Uid o Name, pertanto '{0}' non è valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: per l'oggetto '{0}' esiste già un oggetto figlio. Impossibile aggiungere '{1}'. '{0}' accetta un solo oggetto figlio.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: impossibile aggiungere contenuto all'oggetto di tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' è una proprietà di sola lettura di tipo IList o IDictionary. Impossibile impostarla perché non dispone di una funzione di accesso get interna o pubblica.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: impossibile impostare {0} '{1}' perché non dispone di una funzione di accesso {2} accessibile.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: non è possibile impostare la proprietà di contenuto '{0}' per l'elemento '{1}'. Il livello di accesso di '{0}' non è corretto oppure l'assembly corrispondente non consente l'accesso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: impossibile impostare '{0}' come valore dell'attributo Property di un Trigger perché non dispone di una funzione di accesso get interna o pubblica.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: impossibile contrassegnare due spazi dei nomi nuovi come compatibili con lo stesso spazio dei nomi precedente utilizzando un attributo XmlnsCompatibility.�Lo spazio dei nomi '{0}' è già contrassegnato come compatibile con '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: impossibile aggiungere elementi proprietà all'interno del contenuto di un elemento. Devono essere posizionati prima o dopo il contenuto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: trovato tag 'Code' dallo spazio dei nomi xaml nel file XAML. Per caricare il file, è necessario compilarlo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: per il tipo Element '{0}' non è disponibile un TypeConverter associato per analizzare la stringa '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: impossibile modificare i dati in un XmlnsDictionary sealed.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: la chiave del dizionario '{0}' è già in uso. Gli attributi Key vengono utilizzati come chiavi per l'inserimento di oggetti in un dizionario e devono essere univoci.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: la proprietà '{0}' è già impostata in questa estensione di markup e può essere impostata una sola volta.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: la proprietà '{0}' è già impostata e può essere impostata una sola volta.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: la proprietà '{0}' e '{1}' fanno riferimento alla stessa proprietà. Non sono consentite impostazioni di proprietà duplicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: l'elemento proprietà '{0}' non può essere vuoto. È necessario che contenga elementi figlio o testo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: EntityReference &amp;{0}; non riconosciuto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: non è possibile accedere al tipo delegato '{0}' per l'evento '{1}'. Il livello di accesso di '{0}' non è corretto oppure l'assembly corrispondente non consente l'accesso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: la proprietà '{0}' è una proprietà IEnumerable di sola lettura e ciò significa che '{1}' deve implementare IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: ContentPropertyAttribute non valido per il tipo '{0}'. Impossibile trovare la proprietà '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">Il valore di tipo noto {0}='{1}' non è un tipo noto valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: impossibile trovare il membro statico '{0}' nel tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: le chiavi e i valori in XmlnsDictionary devono essere stringhe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Riga {0}, posizione {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: XmlNamespace, Assembly o ClrNamespace mancante nell'istruzione Mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">URI di mapping '{0}' non valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: formato non valido per la MarkupExtension che specifica gli argomenti del costruttore in '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: per le estensioni di markup è necessario specificare un solo segno di uguale '=' tra il nome e il valore e una sola virgola ',' tra i parametri del costruttore e le coppie nome valore. Gli argomenti '{0}' non sono validi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' non è valido. Per le estensioni di markup sono consentiti solo spazi tra il nome dell'estensione di markup e il primo parametro. Impossibile aggiungere una virgola o un segno di uguale prima del primo parametro.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: in corrispondenza del numero di riga '{1}' e della posizione di riga '{2}' è stato rilevato un carattere di parentesi quadra di chiusura '{0}' per il quale non esiste un carattere di parentesi quadra di apertura corrispondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: per il carattere di parentesi quadra '{0}' al numero di riga '{1}' e alla posizione di riga '{2}' non esiste un carattere di parentesi quadra di apertura/chiusura corrispondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: le espressioni MarkupExtension devono terminare con una parentesi graffa '}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: il formato delle coppie nome valore in MarkupExtension deve essere 'Nome = Valore' e ogni coppia deve essere separata da una virgola. '{0}' non è conforme a questo formato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: i nomi e i valori in una MarkupExtension non possono contenere virgolette. Gli argomenti di MarkupExtension '{0}' non sono validi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: testo '{1}' non consentito dopo il carattere di chiusura '{0}' di un'espressione MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: rilevata proprietà sconosciuta '{0}' per il tipo '{1}' durante l'analisi di una Markup Extension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: attributo sconosciuto '{0}' nello spazio dei nomi '{1}'. Si noti che solo l'attributo Key è attualmente supportato in questo spazio dei nomi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: errore interno del parser - impossibile utilizzare contemporaneamente più record BAML scrivibili.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">Impossibile annidare l'elemento proprietà '{0}' direttamente all'interno di un altro elemento proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: non è possibile inserire attributi nei tag Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: caricamento asincrono non supportato per la compilazione di un file XAML. Il valore '{0}' per SynchronousMode non è pertanto consentito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: il tipo '{0}' non supporta contenuto di elementi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: a tutti gli oggetti aggiunti in un IDictionary deve essere associato un attributo Key o un altro tipo di chiave.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: è possibile utilizzare l'attributo Key solo in un tag contenuto in un Dictionary, ad esempio un ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: impossibile utilizzare '{1}' come valore per '{0}'. I numeri non sono valori di enumerazione validi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: impossibile utilizzare la sintassi degli elementi proprietà per specificare il gestore eventi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: è necessario compilare i file XAML che contengono eventi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: attributo Name non consentito per il tipo '{0}'. I tipi valore e i tipi senza un costruttore predefinito possono essere utilizzati come elementi in un ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: impossibile impostare il valore dell'attributo Name '{0}' per l'elemento '{1}'. '{1}' è compreso nell'ambito dell'elemento '{2}', per il quale è già stato registrato un nome al momento della definizione in un altro ambito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: nessun NamespaceURI definito per l'oggetto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: impossibile annidare isole di dati XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: impossibile impostare proprietà per gli elementi proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: impossibile trovare un serializzatore personalizzato per '{0}', pertanto impossibile eseguirne l'analisi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: i Style Setter non supportano elementi figlio. Non è consentito un tag di tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: impossibile trovare il tipo '{0}'. Si noti che per i nomi di tipo viene fatta distinzione tra maiuscole e minuscole.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: il valore '{0}' non rappresenta un'espressione MarkupExtension valida. Impossibile risolvere '{1}' nello spazio dei nomi '{2}'. '{1}' deve essere una sottoclasse di MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: il prefisso dello spazio dei nomi XML '{0}' non corrisponde a un NamespaceURI. Impossibile risolvere l'elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: il prefisso dello spazio dei nomi XML '{0}' non corrisponde a un URI di spazio dei nomi. Impossibile risolvere la proprietà '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: valore non disponibile per la proprietà '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: nel markup è consentito l'utilizzo solo di classi pubbliche o interne. Il tipo '{0}' non è pubblico né interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: la proprietà '{0}' è di sola lettura. Impossibile impostarla dal markup.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: impossibile trovare un tipo pubblico denominato '{0}' dal riferimento di tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: impossibile fare riferimento al membro statico '{0}' nel tipo '{1}' perché non è accessibile.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: l'attributo SynchronousMode deve essere inserito nel tag radice.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: impossibile inserire sia il testo '{0}' che l'elemento figlio '{1}' in un elemento proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: testo non valido in una proprietà IDictionary o Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: impossibile includere riferimenti a più di 4.096 assembly diversi in un singolo file XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: il tag di chiusura deve seguire immediatamente la stringa di inizializzazione del TypeConverter '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: errore di sintassi TypeConverter rilevato durante l'elaborazione della stringa di inizializzazione '{0}'. Attributi di elemento non consentiti per gli oggetti creati tramite TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' è uno spazio dei nomi non dichiarato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: la proprietà '{0}' non esiste nello spazio dei nomi XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: l'attributo '{0}' non esiste nello spazio dei nomi XML 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: il tag '{0}' non esiste nello spazio dei nomi XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: rilevato tipo di nodo XML '{0}' non riconosciuto durante il controllo del tag corrente per determinare se si tratta di un elemento proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: per l'elemento o la proprietà padre '{0}' è necessaria un'isola di dati XML. Per distinguere un'isola di dati XML dal codice XAML circostante, includere l'isola di dati XML tra tag &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: impossibile includere un'isola di dati XML nell'elemento o nella proprietà '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: l'attributo XmlLangProperty deve specificare un nome di proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: la classe '{0}' non implementa IXmlLineInfo, ma ciò è necessario per il recupero delle informazioni di posizione per il file XAML in corso di analisi.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: token imprevisto '{0}' nella posizione '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: token non valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Preparazione della compilazione del markup in corso...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: il nome di tipo '{0}' non è specificato nel formato previsto 'nomeClasse, assembly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Lettura del file Resource '{0}' in corso...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">File XAML ricompilato: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Input: file Reference assembly: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">ID risorsa: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: le dimensioni del file di risorse di input '{0}' superano il massimo consentito di {1} byte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">File con estensione .resources generato: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Generazione del file con estensione .resources '{0}' in corso...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" non è valido. '{1}' deve essere un RoutedEvent registrato con un nome che termina con la parola chiave "Event".</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: è necessario passare i file di markup all'attività.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: impossibile impostare la proprietà SourceName nella sezione Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: per Style non sono supportati sia i tag {0} che i tag di proprietà Style.{1} per un singolo Style. Utilizzare un tipo di tag o l'altro.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: è possibile specificare il tag di proprietà Style '{0}' solo direttamente in un tag Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: impossibile trovare lo Style {0} '{1}' nel tipo '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: impossibile risolvere lo Style {0} '{1}'. Verificare che il tipo proprietario sia il TargetType dello Style oppure utilizzare la sintassi Class.Property specificare lo stile {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style non può contenere l'elemento figlio '{0}'. L'elemento figlio Style deve essere un Setter perché viene aggiunto alla raccolta Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: i tag di tipo '{0}' non sono supportati nelle sezioni Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: impossibile specificare l'evento '{0}' in un tag Target in uno Style. Utilizzare un EventSetter in alternativa.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: testo '{0}' non consentito in questa posizione all'interno di una sezione Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: impossibile impostare la proprietà '{0}' per Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: '{0}' non può essere la radice di un file XAML perché è stato definito tramite XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: il tipo di destinazione '{0}' non è supportato da questa attività.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: impossibile impostare la proprietà TargetName in uno Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Attività Microsoft (R) Build '{0}' versione '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Tutti i diritti riservati.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Name '{0}' già definito. I valori Name devono essere univoci.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: la radice di una sezione di contenuto Template non può contenere un elemento di tipo '{0}'. Sono validi solo i tipi FrameworkElement e FrameworkContentElement.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: il tag della proprietà di modello '{0}' può essere specificato solo subito dopo un tag ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: un modello può includere un solo elemento radice. '{0}' non è consentito.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: impossibile trovare la proprietà di modello '{0}' nel tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: impossibile risolvere la proprietà di modello '{0}'. Verificare che il tipo proprietario sia il TargetType dello Style oppure utilizzare la sintassi Class.Property per specificare la proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: impossibile trovare la destinazione del Trigger '{0}'. La destinazione deve comparire prima di qualsiasi Setter, Trigger o Condition in cui è utilizzata.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: i tag di tipo '{0}' non sono supportati nelle sezioni modello.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: testo '{0}' non consentito in questa posizione all'interno di una sezione modello.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: impossibile impostare la proprietà '{0}' come elemento proprietà in un modello. Come elementi proprietà sono consentiti solo Triggers e Storyboards.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: rilevato token vuoto durante l'analisi.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: rilevati ulteriori dati dopo il token durante l'analisi.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: rilevata virgoletta finale mancante durante l'analisi del token.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: rilevata fine prematura della stringa.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: Uid mancante per l'elemento '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Errore di compilazione sconosciuto, '{0}' </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" non valido per il linguaggio {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: tag non riconosciuto '{0}:{1}' nello spazio dei nomi 'http://schemas.microsoft.com/winfx/2006/xaml'. Si noti che per i nomi di tag viene fatta distinzione tra maiuscole e minuscole.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' non è valido. '{0}' non è un evento in '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" non valido per il linguaggio {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' non è valido nel tag '{2}'. È possibile che '{2}' non sia un tipo generico oppure che il numero di argomenti Type nell'attributo non sia corretto. Rimuovere l'attributo {0}:TypeArguments perché è consentito solo per i tipi generici oppure correggere il valore in modo che corrisponda all'arità del tipo generico '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' non è installato in modo appropriato nel computer. Deve essere elencato nella sezione &lt;compilers&gt; del file machine.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Tentativo di esecuzione di un'operazione di percorso sconosciuta.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: per il commento di localizzazione non è disponibile un valore impostato per la proprietà di destinazione: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: i componenti del numero di versione principale e secondario non possono essere negativi.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: il file di progetto deve includere l'assembly .NET Framework '{0}' nell'elenco dei riferimenti.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: il valore della proprietà LocalizationDirectivesToLocFile non è valido e deve essere impostato su None, CommentsOnly o All per l'attività MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: il file di progetto contiene un valore di proprietà non valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice non può comparire dopo un Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent deve contenere uno o più elementi Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice è un elemento valido solo in AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: lo spazio dei nomi '{0}' è contrassegnato come compatibile con se stesso tramite XmlnsCompatibilityAttribute. Uno spazio dei nomi non può eseguire l'override diretto o indiretto di se stesso.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: dichiarazione Preserve duplicata per l'elemento '{1}' nello spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: dichiarazione ProcessContent duplicata per l'elemento '{1}' nello spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: dichiarazione Preserve duplicata con caratteri jolly per lo spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: dichiarazione ProcessContent duplicata con caratteri jolly per lo spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback è un elemento valido solo in AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: l'elemento '{0}' non è un elemento figlio valido di AlternateContent. Solo Choice e Fallback sono elementi figlio validi per un elemento AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: attributo '{0}' non valido per l'elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: formato '{0}' non valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: impossibile definire una dichiarazione Preserve sia specifica che con caratteri jolly per lo spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: impossibile definire una dichiarazione ProcessContent sia specifica che con caratteri jolly per lo spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: l'attributo Requires deve contenere un prefisso di spazio dei nomi valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: il valore dell'attributo '{0}' non è un nome XML valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent deve contenere un solo elemento Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: condizione MustUnderstand non riuscita nello spazio dei nomi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: lo spazio dei nomi '{0}' include elementi da mantenere secondo la dichiarazione Preserve, ma non è dichiarato come Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: lo spazio dei nomi '{0}' è dichiarato ProcessContent ma non Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice deve contenere un attributo Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: prefisso '{0}' non definito.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: attributo di compatibilità non riconosciuto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: elemento di compatibilità non riconosciuto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: la stringa dell'ID di funzionalità non può essere di lunghezza 0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">分析結果: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: ライブラリ プロジェクト ファイルは、ApplicationDefinition 要素を指定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">入力: ApplicationDefinition ファイルのマークアップ: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: '{0}' は、'{1}:{2}' タグでは設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: UidManager のタスク名 '{0}' を認識できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">ファイル '{0}' の Uid をチェックしています...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">ローカライズ ディレクティブ ファイル '{0}' を生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">ローカライズ ディレクティブ ファイル '{0}' を生成しています...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">マークアップのコンパイルが終了しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 は、正常に BAML またはソース コード ファイルを生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 は、正常に BAML またはソース コード ファイルを生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: '{0}' イベントは、ジェネリック イベント ハンドラー デリゲート型 '{1}' を保持しています。含まれているタグ '{2}' がジェネリック型ではないため、'{1}' の型パラメーターを適切な型の引数にバインドできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">現在のプロジェクト ディレクトリは '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: 属性 '{0}:{1}' は、ルート タグでのみ指定できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: '{0}:{1}' は、ルート要素として指定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' に '{2}' が含まれています。'{0}:{1}' は、CDATA またはテキスト セクションだけを含むことができます。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">マークアップのコンパイルを開始しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" は無効です。'{0}' イベント属性値に、空の文字列または空白だけの文字列を指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: {0}:FieldModifier をこのタグで指定することはできません。{0}:Name または Name 属性セットがないか、タグがローカルで定義され、Name 属性セットを保持しています。この処理は許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: ファイル '{0}' が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">入力ファイル '{0}' が、ディレクトリ '{2}' の新しい相対パス '{1}' に対して解決されています。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: {0} 個のファイルが、Uid チェックに失敗しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">{0} 個のファイルの Uid が有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">{0} 個のファイルから Uid が削除されました。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">{0} 個のファイルで Uid が更新されました。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">BAML ファイル '{0}' を生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">コード ファイル '{0}' を生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' に '{2}' が含まれています。'{0}:{1}' には、入れ子になっているコンテンツを含めることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: '{0}' ディレクトリは存在せず、作成することもできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">このプロジェクトには、InternalTypeHelper クラスは不要です。ファイル '{0}' を空にしてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: '{0}' クラス名は、ローカルで定義された XAML ルート要素に対して無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: '{0}' 名前空間は、ローカルで定義された XAML ルート要素 '{1}' に対して無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" は無効です。'{2}' は有効な {3} クラス名ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: プロジェクト ファイルで設定された UICulture 値 '{0}' は無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: シリアライザーは、カスタム BAML シリアル化操作をサポートしません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: シリアライザーは Convert 操作をサポートしません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: '{0}' 名は、既定の名前空間 '{1}' では無効です。プロジェクト ファイル内の RootNamespace タグの値を修正してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" は無効です。'{1}' は有効なイベント ハンドラー メソッド名ではありません。生成されたクラスまたは分離コード クラスのインスタンス メソッドだけが有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: ローカライズ コメントの対象プロパティが、文字列 '{0}' で無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: ローカライズ コメント値が、文字列 '{1}' の対象プロパティ '{0}' で無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: ローカライズ化属性の設定 '{0}' が無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: マークアップ ファイルが無効です。拡張子 .xaml を持つソース マークアップ ファイルを指定してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" は無効です。'{2}' は、位置 '{3}' のジェネリック引数に対して有効な型名の参照ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000:  '{0}' XML が無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: '{0}' が同じアセンブリに実装されているため、Name 属性ではなく {1}:Name 属性を設定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">入力: ローカル参照マークアップ ApplicationDefinition ファイルは '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">BAML ファイル '{0}' を生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">入力: ローカル参照マークアップ Page ファイルは '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: '{0}' イベントはジェネリック イベント ハンドラー デリゲート型 '{1}' を保持しています。'{1}' の型パラメーター '{2}' が、含まれているジェネリック タグ '{3}' のいずれの型パラメーターとも一致しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: '{2}' に {1}:Code タグが含まれているため、'{0}' ルート要素は {1}:Class 属性を必要とします。{1}:Code とそのコンテンツを削除するか、{1}:Class 属性をルート要素に追加してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: '{0}' ルート要素は、XAML ファイルでイベント ハンドラーをサポートするために、{1}:Class 属性を必要とします。{2} イベントのイベント ハンドラーを削除するか、{1}:Class 属性をルート要素に追加してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: '{0}' ルート要素はジェネリック型です。ルート要素タグで指定されている {1}:TypeArguments 属性をサポートするには {1}:Class 属性を必要とします。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: {0}:FieldModifier 属性を指定できません。指定されたアクセス修飾子を使用して Name フィールドを生成するには、{0}:Class 属性も必要です。{0}:Class 属性をルート タグに追加するか、{0}:FieldModifier 属性を削除してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: {0}:ClassModifier 属性はルート タグで指定できません。{0}:Class 属性も必要です。{0}:Class 属性を追加するか、{0}:ClassModifier 属性を削除してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: {0}:Class 属性がありません。{0}:Subclass 属性を指定するには、この属性が必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator は、一度に 1 つの .resources ファイルのみ生成できます。プロジェクト ファイルの OutputResourcesFile プロパティを、1 つのファイルに対して設定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: プロジェクト ファイルでは、複数の SplashScreen 要素を指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: 要素 '{1}' の Uid "{0}" が一意ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: プロジェクト ファイルでは、複数の ApplicationDefinition 要素を指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">'{0}' に '{1}' という名前が付いています。ResourceDictionary のコンテンツのインスタンス化は遅延されるため、これらのコンテンツには名前を付けないでください。</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: 不明な CLS 例外です。</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType が '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: 初期化文字列 '{0}' の処理中に TypeConverter 構文エラーが発生しました。TypeConverter によって作成されるオブジェクトでは、プロパティ要素は許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: アセンブリ '{0}' を読み込むことができません。同じアセンブリの異なるバージョン '{1}' が読み込まれているためです。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: AsyncRecords 属性は、ルート タグで設定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: 添付プロパティ '{0}' が、'{1}' またはその基本クラスの 1 つで定義されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: '{0}' に指定されている属性が多すぎます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: '{0}' に指定されている属性が不足しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: プロパティ '{0}' は、既定の名前空間または要素名前空間 '{1}' にある必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath は、空の assemblyName を受け入れません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath は、空の assemblyPath を受け入れません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: 複合プロパティ '{1}' に型 '{0}' の要素を設定することはできません。これらは互換性のある型ではありません</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: 引数 {1} を取る '{0}' のパブリック コンストラクターが見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: 辞書のキーに、型 '{0}' を使用することはできません。String、TypeExtension、および StaticExtension のみがサポートされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: 修飾型名がないため、'{0}' メンバーは無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: '{0}' Name プロパティ値が無効です。Name は文字またはアンダースコアから開始する必要があり、文字、数字、およびアンダースコアのみを使用することができます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: 文字列値 '{0}' を型 '{1}' に変換できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: SynchronousMode プロパティ値が無効です。有効な値は、Async および Sync です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: 配列プロパティに追加されるオブジェクトが無効な型です。配列は型 '{0}' ですが、追加されるオブジェクトは型 '{1}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: Uid および Name プロパティ値では MarkupExtensions が許可されていないため、'{0}' は無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: オブジェクト '{0}' には既に子があるため、'{1}' を追加できません。'{0}' では、1 つの子だけを使用できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: 型 '{0}' のオブジェクトにコンテンツを追加できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' は、型 IList または IDictionary の読み取り専用プロパティで、パブリックまたは内部の get アクセサーがないため設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: {0} '{1}' は、アクセス可能な {2} アクセサーがないので設定できません。。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: 要素 '{1}' のコンテンツ プロパティ '{0}' を設定できません。'{0}' のアクセス レベルが正しくないか、アセンブリでアクセスが許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: '{0}' は、パブリックまたは内部の get アクセサーがないため、Trigger の Property 属性の値として設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: XmlnsCompatibility 属性を使用して、2 つの新しい名前空間に同一の古い名前空間と互換性を持たせることはできません。�'{0}' 名前空間は既に '{1}' と互換性があるとマークされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: Property 要素は要素のコンテンツの中央に配置できません。Property 要素は、コンテンツの前または後ろになければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: xaml 名前空間からの 'Code' タグが XAML ファイルに存在します。このファイルを読み込むには、コンパイルする必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: 要素型 '{0}' には、文字列 '{1}' を解析するための TypeConverter が関連付けられていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: シールされた XmlnsDictionary のデータは変更できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: 辞書キー '{0}' は既に使用されています。キー属性は、オブジェクトを辞書に挿入するときにキーとして使用されます。これは一意である必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: プロパティ '{0}' は既にこのマークアップ拡張で設定されています。設定できるのは一度だけです。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: '{0}' プロパティは既に設定されています。設定できるのは一度だけです。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: プロパティ '{0}' と '{1}' は同じプロパティを参照しています。重複したプロパティ設定は許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: '{0}' プロパティ要素を空にすることはできません。子要素またはテキストを含んでいる必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: EntityReference &amp;{0}; は認識されません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: '{1}' イベントのデリゲート型 '{0}' にアクセスできません。'{0}' のアクセス レベルが正しくないか、アセンブリでアクセスが許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: '{0}' プロパティは読み取り専用の IEnumerable プロパティです。このため、'{1}' は IAddChild を実装する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: 型 '{0}' に、無効な ContentPropertyAttribute があります。プロパティ '{1}' が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">既知の型値 {0}='{1}' は、有効な既知の型ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: 型 '{1}' に静的メンバー '{0}' が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: XmlnsDictionary のキーと値は文字列でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">行 {0} 位置 {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: XmlNamespace、Assembly または ClrNamespace が Mapping 命令にありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">'{0}' URI マッピングが無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: '{0}' のコンストラクター引数を指定する MarkupExtension の形式が無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: マークアップ拡張では、単一の '=' が名前と値の間に必要です。また、単一の ',' がコンストラクター パラメーターと名前/値の組み合わせの間に必要です。引数 '{0}' は無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' は無効です。マークアップ拡張では、マークアップ拡張名と最初のパラメーターの間に空白だけを必要とします。コンマや等号を最初のパラメーターの前に使用することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: 終了の BracketCharacter '{0}' が行番号 '{1}' と行の位置 '{2}' に見つかりましたが、対応する開始の BracketCharacter がありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: 行番号 '{1}' と行の位置 '{2}' にある BracketCharacter '{0}' には、対応する開始/終了の BracketCharacter がありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: MarkupExtension 式の最後には、'}' が必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: MarkupExtension 内の名前/値の組み合わせは、'名前 = 値' の形式で、各組み合わせはコンマで区切られていなければなりません。'{0}' はこの形式に準拠していません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: MarkupExtension の名前と値に引用符を使用することはできません。MarkupExtension の引数 '{0}' は無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: MarkupExtension 式を閉じる '{0}' の後にテキスト '{1}' を使用することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: Markup Extension の解析時に、型 '{1}' に対する不明なプロパティ '{0}' が見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: 不明な属性 '{0}' が '{1}' 名前空間にあります。Key 属性だけが、この名前空間で現在サポートされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: 内部パーサー エラー - 同時に複数の書き込み可能な BAML レコードを使用することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">'{0}' プロパティ要素は、別のプロパティ要素内で直接入れ子にすることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: Array タグには属性を配置できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: XAML ファイルのコンパイル時は非同期読み込みはサポートされないため、'{0}' の SynchronousMode は使用できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: 型 '{0}' は要素のコンテンツをサポートしません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: IDictionary に追加されるすべてのオブジェクトは、Key 属性またはオブジェクトに関連する別の型のキーを保持している必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Key 属性は、Dictionary (ResourceDictionary など) に含まれているタグでのみ使用できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: '{1}' は、'{0}' の値として使用できません。数字は有効な列挙値ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: プロパティ要素の構文を使用してイベント ハンドラー '{0}' を指定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: イベントを含む XAML ファイルはコンパイルする必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: 型 '{0}' は Name 属性を持つことができません。値の型と既定のコンストラクターのない型を、ResourceDictionary 内で項目として使用できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: 要素 '{1}' で Name 属性値 '{0}' を設定することはできません。'{1}' は、要素 '{2}' のスコープ内にあり、この要素には、別のスコープで定義されたときに既に名前が登録されています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: オブジェクト '{0}' に対して NamespaceURI が定義されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: XML データ アイランドを入れ子にできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: プロパティ要素ではプロパティを設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: '{0}' のカスタム シリアライザーが見つからないため、解析できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: Style セッターは子要素をサポートしていません。型 '{0}' のタグは許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: 型 '{0}' が見つかりません。型名では大文字と小文字が区別されることに注意してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: '{0}' 値は有効な MarkupExtension 式ではありません。名前空間 '{2}' で '{1}' を解決できません。'{1}' は MarkupExtension のサブクラスである必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: '{0}' XML 名前空間のプレフィックスは NamespaceURI にマップされないため、要素 '{1}' を解決できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: '{0}' XML 名前空間プレフィックスは、名前空間 URI にマップされないため、プロパティ '{1}' を解決できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: プロパティ '{0}' には値がありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: パブリックまたは内部のクラスだけをマークアップ内で使用できます。'{0}' 型はパブリックでも内部でもありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: '{0}' プロパティは読み取り専用で、マークアップから設定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: 型参照は '{0}' という名前のパブリック型を見つけられません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: アクセスできないため、型 '{1}' の静的メンバー '{0}' を参照できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: SynchronousMode 属性はルート タグになければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: 1 つのプロパティ要素内に、テキスト '{0}' と子要素 '{1}' の両方を保持することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: テキストは、IDictionary または Array プロパティ内では無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: 単一の XAML ファイルは、4,096 個を超える異なるアセンブリを参照することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: TypeConverter 初期化文字列 '{0}' のすぐ後ろに終了タグが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: 初期化文字列 '{0}' の処理中に TypeConverter 構文エラーが発生しました。TypeConverter によって作成されるオブジェクトでは、要素属性は許可されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' は宣言されていない名前空間です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: プロパティ '{0}' は、XML 名前空間 '{1}' にありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: 属性 '{0}' は、XML 名前空間 'http://schemas.microsoft.com/winfx/2006/xaml' にありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: タグ '{0}' は、XML 名前空間 '{1}' にありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: 現在のタグがプロパティ要素かどうかを判断しているときに、認識不能な XML ノード型 '{0}' が見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: 親要素またはプロパティ '{0}' には XML データ アイランドが必要です。XML アイランドと周囲の XAML を区別するには、XML データ アイランドを &lt;x:XData&gt; ... &lt;/x:XData&gt; で囲んでください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: '{0}' 要素またはプロパティに XML データ アイランドを含めることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: XmlLangProperty 属性はプロパティ名を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: クラス '{0}' は IXmlLineInfo を実装しません。これは、解析する XAML の位置情報を取得するために必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: 位置 '{1}' に予期しないトークン '{0}' があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: トークンが無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">マークアップのコンパイルを準備しています...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: 型名 '{0}' には、予期された書式 'className, assembly' がありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Resource ファイル '{0}' を読み取っています...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">XAML ファイル '{0}' を再コンパイルしました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">入力: アセンブリ Reference ファイル: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">リソース ID は '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: 入力リソース ファイル '{0}' が、最大サイズの {1} バイトを超えました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">.resources ファイル '{0}' を生成しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">.resources ファイル '{0}' を生成しています...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" は無効です。'{1}' は、"Event" というキーワードで終わる名前で登録された RoutedEvent でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: マークアップ ファイルをタスクに渡す必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: SourceName プロパティは、Style.Triggers セクション内で設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style は、{0} タグと Style.{1} プロパティ タグの両方を単一の Style に対してサポートしていません。どちらか一方を使用してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: Style プロパティ タグ '{0}' は、Style タグ内でのみ直接指定できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: 型 '{2}' に Style {0} '{1}' が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: Style {0} '{1}' を解決できません。所有している型が Style の TargetType であることを確認するか、Class.Property 構文を使用して {0} を指定してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style に子 '{0}' を含めることはできません。Style の子は Setter コレクションに追加されるため、Setter でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: 型 '{0}' のタグは、Style セクションでサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: イベント '{0}' は、Style の Target タグでは指定できません。代わりに EventSetter を使用してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: テキスト '{0}' は、Style セクションのこの位置では使用できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: プロパティ '{0}' は、Style では設定できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: '{0}' は、XAML を使用して定義されているため、XAML ファイルのルートにすることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: 対象型 '{0}' は、このタスクではサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: Style Setter で TargetName プロパティを設定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft(R) Build Task '{0}' バージョン '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Name '{0}' は既に定義されています。Name は一意でなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: Template コンテンツ セクションのルートに型 '{0}' の要素を含めることはできません。FrameworkElement および FrameworkContentElement 型のみが有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: テンプレート プロパティ タグ '{0}' は、ControlTemplate タグの直後にのみ指定できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: テンプレートは、ルート要素を 1 つだけ保持できます。'{0}' は使用できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: 型 '{1}' にテンプレート プロパティ '{0}' が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: テンプレート プロパティ '{0}' を解決できません。所有している型が Style の TargetType であることを確認するか、Class.Property 構文を使用してプロパティを指定してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: Trigger ターゲット '{0}' が見つかりません (ターゲットは、それを使用する Setter、Trigger、または Condition の前になければなりません)。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: 型 '{0}' のタグは、テンプレート セクションでサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: テキスト '{0}' は、テンプレート セクションのこの位置では使用できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: プロパティ '{0}' は、テンプレートのプロパティ要素として設定できません。Triggers と Storyboards だけをプロパティ要素として使用できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: 解析中に空のトークンが見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: 解析中に、余分なデータがトークンの後に見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: トークンの解析中に、閉じる引用符の欠落が見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: 終了が不完全な文字列が見つかりました。</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: 要素 '{0}' の Uid がありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">不明なビルド エラー '{0}' が発生しました </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" は、言語 {2} では無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: 認識不能なタグ '{0}:{1}' が名前空間 'http://schemas.microsoft.com/winfx/2006/xaml' にあります。タグ名では大文字と小文字が区別されることに注意してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' は無効です。'{0}' は '{2}' のイベントではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" は、言語 {2} では無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' は、タグ '{2}' では無効です。'{2}' がジェネリック型でないか、属性の Type 引数の数が正しくありません。{0}:TypeArguments 属性はジェネリック型でのみ使用可能なため、これを削除するか、またはジェネリック型 '{2}' のアリティに合わせてその値を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' がこのコンピューターに正しくインストールされていません。これは、machine.config の &lt;compilers&gt; セクションに一覧表示されていなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">不明なパス操作が試行されました。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: ローカライズ コメントに、対象プロパティ '{0}' の値が設定されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: メジャーおよびマイナー バージョン番号コンポーネントは、負の値にできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: プロジェクト ファイルは、.NET Framework アセンブリ '{0}' を参照一覧に含んでいなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: LocalizationDirectivesToLocFile プロパティ値が無効です。MarkupCompilePass1 タスクでは、None、CommentsOnly、または All に変更する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: プロジェクト ファイルに、無効なプロパティ値が含まれています。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice を、Fallback に続けることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent には、1 つまたは複数の Choice 要素が必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice は、AlternateContent でのみ有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: 名前空間 '{0}' は、XmlnsCompatibilityAttribute を使用して、それ自身と互換性のある名前空間としてマークされています。名前空間は、自身を直接的または間接的にオーバーライドすることはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: 名前空間 '{0}' の要素 '{1}' の Preserve 宣言が重複しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: 名前空間 '{0}' の要素 '{1}' の ProcessContent 宣言が重複しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: 名前空間 '{0}' のワイルドカード Preserve 宣言が重複しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: 名前空間 '{0}' のワイルドカード ProcessContent 宣言が重複しています。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback は、AlternateContent 内でのみ有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: '{0}' 要素は、AlternateContent の有効な子ではありません。AlternateContent 要素の有効な子は、Choice および Fallback 要素のみです。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: '{0}' 属性は、要素 '{1}' に対して無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: '{0}' 形式は無効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: 名前空間 '{0}' の固有およびワイルドカードの Preserve 宣言の両方を指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: 名前空間 '{0}' の固有およびワイルドカードの ProcessContent 宣言の両方を指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Requires 属性には、有効な名前空間プレフィックスが含まれている必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: '{0}' 属性値は、無効な XML 名です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent には、Fallback 要素が 1 つだけ含まれている必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: 名前空間 '{0}' で、MustUnderstand 条件が失敗しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: 名前空間 '{0}' には、保持されると宣言されている項目がありますが、無視できるとは宣言されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: '{0}' 名前空間は ProcessContent と宣言されていますが、Ignorable とは宣言されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice には、Requires 属性が含まれている必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: '{0}' プレフィックスは定義されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: 認識できない互換性属性 '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: 認識できない互換性要素 '{0}' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: 機能 ID 文字列の長さは 0 にできません。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Wynik analizy: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: Plik biblioteki projektu nie może określić elementu ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Wejście: Plik znakowania ApplicationDefinition: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: Nie można ustawić elementu „{0}” dla tagu „{1}:{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: Nierozpoznana nazwa zadania UidManager „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Trwa sprawdzanie identyfikatorów Uid w pliku „{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Wygenerowano plik dyrektyw lokalizacyjnych „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Trwa generowanie pliku dyrektyw lokalizacyjnych „{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Zakończono kompilację znaczników.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">Zadanie MarkupCompilePass1 pomyślnie wygenerowało pliki BAML lub pliki zawierające kod źródłowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">Zadanie MarkupCompilePass2 pomyślnie wygenerowało pliki BAML lub pliki zawierające kod źródłowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: Zdarzenie „{0}” ma typ obiektu delegowanego obsługi zdarzeń rodzajowych „{1}”. Parametrów typu „{1}” nie można łączyć z odpowiednim argumentem typu, ponieważ tag zawierający „{2}” nie jest typu ogólnego.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Bieżący katalog projektu to „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: Tylko tag główny może określać atrybut „{0}:{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: Nie można określić atrybutu „{0}:{1}” jako elementu głównego.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: Atrybut „{0}:{1}” zawiera element „{2}”. Atrybut „{0}:{1}” może zawierać tylko element CDATA lub sekcję tekstową.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Rozpoczęto kompilację znaczników.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: Wartość {0}=„{1}” jest nieprawidłowa. Wartość atrybutu zdarzenia „{0}” nie może być ciągiem, który jest pusty lub zawiera tylko biały znak.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: Nie można określić elementu {0}:FieldModifier dla tego tagu, ponieważ nie ma on ustawionego atrybutu {0}:Name lub Name, albo tag jest zdefiniowany lokalnie i ma ustawiony atrybut Name, który jest niedozwolony.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: Nie można odnaleźć pliku „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">Plik wejściowy „{0}” rozpoznano jako nową względną ścieżkę dostępu „{1}” w katalogu „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: Liczba plików, w których sprawdzanie identyfikatorów Uid nie powiodło się, wynosi {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Liczba plików z prawidłowymi identyfikatorami Uid: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Liczba plików, z których usunięto identyfikatory Uid: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Liczba plików, w których zaktualizowano identyfikatory Uid: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Wygenerowany plik BAML: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Wygenerowany plik kodu: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: Atrybut „{0}:{1}” zawiera element „{2}”. Atrybut „{0}:{1}” nie może zawierać zawartości zagnieżdżonej.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: Katalog „{0}” nie istnieje i nie można go utworzyć.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">Klasa InternalTypeHelper nie jest wymagana dla tego projektu. Plik make „{0}” jest pusty.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: Nazwa klasy „{0}” jest nieprawidłowa dla zdefiniowanego lokalnie elementu głównego XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: Przestrzeń nazw „{0}” jest nieprawidłowa dla zdefiniowanego lokalnie elementu głównego XAML „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: Wartość {0}:{1}=„{2}” jest nieprawidłowa. „{2}” jest nieprawidłową nazwą klasy {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: Wartość UICulture „{0}” ustawiona w pliku projektu jest nieprawidłowa.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: Program szeregujący nie obsługuje niestandardowych operacji serializacji BAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: Program szeregujący nie obsługuje operacji typu Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: Nazwa „{0}” jest nieprawidłowa dla domyślnej przestrzeni nazw „{1}”. Należy poprawić wartość tagu RootNamespace w pliku projektu.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: Wyrażenie {0}=„{1}” jest nieprawidłowe. „{1}” jest nieprawidłową nazwą metody obsługi zdarzeń. Tylko metody wystąpień w klasie wygenerowanej lub klasie związanej z kodem są prawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: Docelowa właściwość komentarza lokalizacji jest nieprawidłowa w ciągu „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: Wartość komentarza lokalizacji jest nieprawidłowa dla docelowej właściwości „{0}” w ciągu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: Ustawienie atrybutu lokalizowalności „{0}” jest nieprawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: Plik znakowania jest nieprawidłowy. Określ źródłowy plik znakowania z rozszerzeniem .xaml</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: Nieprawidłowa wartość {0}:TypeArguments=„{1}”. Element „{2}” jest nieprawidłowym odwołaniem do nazwy typu dla rodzajowego argumentu na pozycji „{3}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: Prefiks „{0}” XML jest nieprawidłowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: Właściwość „{0}” jest zaimplementowana w tym samym zestawie, dlatego należy ustawić atrybut {1}:Name zamiast atrybutu Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Wejście: Lokalny plik znakowania referencji ApplicationDefinition to „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Wygenerowany plik BAML: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Wejście: Lokalny plik Page znakowania referencji to „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: Zdarzenie „{0}” ma typ obiektu delegowanego obsługi zdarzeń rodzajowych „{1}”. Parametr typu „{2}” w zdarzeniu „{1}” nie jest zgodny z żadnym z parametrów typu w zawierającym tagu rodzajowym „{3}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: Główny element „{0}” wymaga atrybutu {1}:Class, ponieważ element „{2}” zawiera tag {1}:Code. Usuń tag {1}:Code oraz jego składniki lub dodaj atrybut {1}:Class do elementu głównego.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: Element główny „{0}” wymaga atrybutu {1}:Class do obsługi zdarzeń w pliku XAML. Usuń procedurę obsługi dla zdarzenia {2} lub dodaj atrybut {1}:Class do elementu głównego.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: Element główny „{0}” jest typu ogólnego i wymaga atrybutu {1}:Class do obsługi atrybutu {1}:TypeArguments określonego w tagu elementu głównego.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: Nie można określić atrybutu {0}:FieldModifier, ponieważ do utworzenia pola Name z określonym modyfikatorem dostępu jest wymagany także atrybut {0}:Class. Dodaj atrybut {0}:Class w tagu głównym lub usuń atrybut {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: Atrybutu {0}:ClassModifier nie można określić w tagu głównym, ponieważ jest wymagany także atrybut {0}:Class. Dodaj atrybut {0}:Class lub usuń atrybut {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: Brak atrybutu {0}:Class. Jest on wymagany, gdy jest określony atrybut {0}:Subclass.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: Element ResourcesGenerator może utworzyć jednocześnie tylko jeden plik .resources. Właściwość OutputResourcesFile w pliku projektu musi być ustawiona na jeden plik.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: Plik projektu nie może określać więcej niż jednego elementu SplashScreen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: Identyfikator Uid „{0}” dla elementu „{1}” nie jest unikatowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: Plik projektu nie może określać więcej niż jednego elementu ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Elementowi {0} nadano nazwę {1}. Nie należy nadawać nazw elementom obiektu ResourceDictionary, ponieważ ich konkretyzacja została odroczona.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: Nieznany wyjątek CLS.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">Parametr OutputType: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: W czasie przetwarzania ciągu inicjalizacji „{0}” wystąpił błąd składni funkcji TypeConverter. Elementy właściwości są niedozwolone dla obiektów utworzonych za pomocą funkcji TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: Nie można załadować zestawu „{0}”, ponieważ jest załadowana inna wersja tego samego zestawu, „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: Atrybut AsyncRecords musi być ustawiony w tagu głównym.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: Dołączona właściwość „{0}” nie została zdefiniowana w klasie „{1}” lub w jednej ze swoich klas podstawowych.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: Zbyt dużo atrybutów określonych dla właściwości „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: Zbyt mało atrybutów określonych dla właściwości „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: Właściwość „{0}” musi występować w domyślnej przestrzeni nazw lub w przestrzeni nazw elementu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Klasa Mapper.SetAssemblyPath nie może zaakceptować pustego elementu assemblyName.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Klasa Mapper.SetAssemblyPath nie może zaakceptować pustego elementu assemblyPath.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: Dla właściwości złożonej „{1}” nie można ustawić elementu typu „{0}”. Te dwa typy są niezgodne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: Nie można znaleźć publicznego konstruktora dla funkcji „{0}”, która pobiera {1} argumentów.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: Klucz dla słownika nie może być typu „{0}”. Obsługiwane są tylko typy String, TypeExtension oraz StaticExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: Członek „{0}” jest nieprawidłowy, ponieważ nie ma on odpowiedniej nazwy typu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: Wartość właściwości Name „{0}” jest nieprawidłowa. Właściwość Name musi zaczynać się literą lub znakiem podkreślenia i może zawierać tylko litery, cyfry i znaki podkreślenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: Nie można przekonwertować wartości ciągu „{0}” na typ „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: Wartość właściwości SynchronousMode jest nieprawidłowa. Prawidłowe wartości to Async oraz Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: Obiekt dodawany do właściwości tablicy nie jest prawidłowym typem. Tablica jest typu „{0}”, a dodawany obiekt jest typu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: Wyrażenia MarkupExtension są niedozwolone dla wartości właściwości Uid lub Name, więc element „{0}” jest nieprawidłowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: Obiekt „{0}” ma już element podrzędny i nie można dodać elementu „{1}”. Obiekt „{0}” może zaakceptować tylko jeden element podrzędny.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: Nie można dodać zawartości do obiektu typu „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: Element „{0}” jest właściwością tylko do odczytu typu IList lub IDictionary i nie można go ustawić, ponieważ nie ma on publicznego ani wewnętrznego elementu dostępowego operacji get.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: Nie można ustawić właściwości {0} dla elementu „{1}”, ponieważ nie ma ona dostępnego {2} elementu dostępowego.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: Nie można ustawić właściwości zawartości „{0}” dla elementu „{1}”. Właściwość „{0}” ma nieprawidłowy poziom dostępu lub jej zestaw nie zezwala na uzyskanie dostępu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: Właściwość „{0}” nie może być ustawiona jako wartość atrybutu Property elementu Trigger, ponieważ nie ma ona publicznego ani wewnętrznego elementu dostępowego operacji get.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: Dwie nowe przestrzenie nazw nie mogą być zgodne z tą samą starą przestrzenią nazw używającą atrybutu XmlnsCompatibility.�Przestrzeń nazw „{0}” jest już oznaczona jako zgodna z przestrzenią „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: Elementy właściwości nie mogą znajdować się w środku zawartości elementu. Muszą znajdować się one przed lub za tą zawartością.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: W pliku XAML znaleziono tag „Code” pochodzący z przestrzeni nazw xaml. Aby załadować ten plik, należy go skompilować.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: Typ elementu „{0}” nie ma skojarzonego elementu funkcji TypeConverter do analizowania ciągu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: Nie można zmodyfikować danych w zapieczętowanym elemencie XmlnsDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: Klucz słownika „{0}” jest już używany. Atrybuty klucza są używane jako klucze przy wstawianiu obiektów do słownika i muszą być unikatowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: Właściwość „{0}” została już ustawiona w tym rozszerzeniu znakowania i można ją ustawić tylko raz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: Właściwość „{0}” została już ustawiona i można ustawić ją tylko raz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: Właściwości „{0}” i „{1}” odnoszą się do tej samej właściwości. Zduplikowane ustawienia właściwości są niedozwolone.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: Element właściwości „{0}” nie może być pusty. Musi on zawierać elementy podrzędne lub tekst.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: Element EntityReference &amp;{0}; nie został rozpoznany.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: Nie można uzyskać dostępu do typu obiektu delegowanego „{0}” dla zdarzenia „{1}”. Typ „{0}” ma nieprawidłowy poziom dostępu lub jego zestaw nie zezwala na uzyskanie dostępu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: Właściwość „{0}” jest właściwością IEnumerable tylko do odczytu, co oznacza, że element „{1}” musi implementować funkcję IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: Nieprawidłowy atrybut ContentPropertyAttribute dla typu „{0}”. Nie znaleziono właściwości „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">Wartość znanego typu {0}=„{1}” nie jest prawidłowym znanym typem.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: nie można znaleźć statycznego członka „{0}” dla typu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: Klucze i wartości w klasie XmlnsDictionary muszą być ciągami.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Wiersz {0} Pozycja {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: Brak parametru XmlNamespace, Assembly lub ClrNamespace w instrukcji Mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">Nieprawidłowy identyfikator URI mapowania „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: Nieprawidłowy format wyrażenia MarkupExtension, które określa argumenty konstruktora we właściwości „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: Rozszerzenia znakowania wymagają pojedynczego znaku „=” pomiędzy nazwą a wartością oraz pojedynczego znaku „,” pomiędzy parametrami konstruktora a parami nazw/wartości. Argumenty „{0}” są nieprawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: Element „{0}” jest nieprawidłowy. Rozszerzenia znakowania wymagają tylko pustych znaków pomiędzy nazwą rozszerzenia znakowania a pierwszym parametrem. Przed pierwszym parametrem nie może znajdować się przecinek ani znak równości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: Napotkano znak zamykania nawiasu „{0}” w wierszu numer „{1}” na pozycji „{2}” bez odpowiadającego znaku otwierania nawiasu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: Znak nawiasu „{0}” w wierszu numer „{1}” na pozycji „{2}” nie ma odpowiadającego znaku otwierania/zamykania nawiasu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: Wyrażenia MarkupExtension muszą kończyć się znakiem „}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: Pary nazw/wartości w wyrażeniach MarkupExtension muszą mieć format „Nazwa = Wartość” i każda para musi być oddzielona przecinkiem. Wyrażenie „{0}” nie jest w tym formacie.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: Nazwy oraz wartości w wyrażeniach MarkupExtension nie mogą zawierać cudzysłowów. Argumenty wyrażenia MarkupExtension „{0}” są nieprawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: Tekst „{1}” nie jest dozwolony po ciągu zamykającym „{0}” wyrażenia MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: Podczas analizowania wyrażenia Markup Extension napotkano nieznaną właściwość „{0}” dla typu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: Nieznany atrybut „{0}” w przestrzeni nazw „{1}”. Należy zwrócić uwagę, że w tej przestrzeni nazw jest obecnie obsługiwany tylko atrybut Key.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: Wewnętrzny błąd analizatora — nie można używać wielu zapisywalnych rekordów BAML w tym samym czasie.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">Element właściwości „{0}” nie może być bezpośrednio zagnieżdżony w innym elemencie właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: Nie można umieścić atrybutów w tagach właściwości Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: Ładowanie asynchroniczne nie jest obsługiwane podczas kompilowania pliku XAML, więc tryb SynchronousMode „{0}” jest niedozwolony.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: Typ „{0}” nie obsługuje zawartości elementu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: Wszystkie obiekty dodane do właściwości IDictionary muszą mieć ustawiony atrybut Key lub mieć skojarzony inny dowolny typ klucza.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Atrybutu Key może zostać użyty tylko w tagu zawartym w klasie Dictionary (takiej jak ResourceDictionary).</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: Nie można użyć elementu „{1}” jako wartości dla parametru „{0}”. Liczby nie są poprawnymi wartościami wyliczania.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: Do określania obsługi zdarzenia „{0}” nie można użyć składni elementu właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: Plik XAML zawierający zdarzenia musi być skompilowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: Typ „{0}” nie może mieć atrybutu Name. Typy wartości oraz typy bez konstruktora domyślnego mogą zostać użyte jako elementy w klasie ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: Nie można ustawić wartości atrybutu Name „{0}” dla elementu „{1}”. Element „{1}” należy do zakresu elementu „{2}”, który miał już zarejestrowaną nazwę, gdy został zdefiniowany w innym zakresie.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: Brak zdefiniowanego identyfikatora NamespaceURI dla obiektu „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: Nie można zagnieżdżać wysp danych XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: Nie można ustawić właściwości dla elementów właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: Nie można znaleźć niestandardowego programu szeregującego dla elementu „{0}”, więc nie można przeprowadzić jego analizy.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: Elementy ustawień stylu nie obsługują elementów podrzędnych. Tag typu „{0}” jest niedozwolony.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: Nie można znaleźć typu „{0}”. Uwaga: w nazwach typów jest uwzględniana wielkość liter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: Wartość „{0}” nie jest prawidłowym wyrażeniem MarkupExtension. Nie można rozpoznać elementu „{1}” w przestrzeni nazw „{2}”. Element „{1}” musi być podklasą wyrażenia MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: Prefiks przestrzeni nazw XML „{0}” nie jest mapowany do identyfikatora NamespaceURI, więc nie można rozpoznać elementu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: Prefiks przestrzeni nazw XML „{0}” nie jest zmapowany na identyfikator URI przestrzeni nazw, dlatego nie można rozpoznać właściwości „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: Właściwość „{0}” nie ma wartości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: Wewnątrz znakowania można używać tylko klas publicznych lub wewnętrznych. Typ „{0}” nie jest klasą publiczną ani wewnętrzną.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: Właściwość „{0}” jest tylko do odczytu i nie można jej ustawić za pomocą znakowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: Odwołanie do typu nie może odnaleźć typu publicznego nazywanego „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: Nie można odwołać się do statycznego członka „{0}” dla typu „{1}”, ponieważ jest on niedostępny.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: Atrybut SynchronousMode musi znajdować się w tagu głównym.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: Wewnątrz elementu właściwości nie mogą znajdować jednocześnie tekst „{0}” i element podrzędny „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: Nieprawidłowy tekst we właściwości IDictionary lub Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: Pojedynczy plik XAML nie może odwoływać się do więcej niż 4 096 różnych zestawów.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: Tag zamykający musi znajdować się za ciągiem inicjującym funkcji TypeConverter „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: Podczas przetwarzania ciągu inicjującego „{0}” wystąpił błąd składni funkcji TypeConverter. Atrybuty elementu nie są dozwolone dla obiektów utworzonych za pośrednictwem funkcji TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: „{0}” jest niezadeklarowaną przestrzenią nazw.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: Właściwość „{0}” nie istnieje w przestrzeni nazw XML „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: Atrybut „{0}” nie istnieje w przestrzeni nazw XML „http://schemas.microsoft.com/winfx/2006/xaml”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: Tag „{0}” nie istnieje w przestrzeni nazw XML „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: Podczas sprawdzania, czy bieżący tag jest elementem właściwości, znaleziono nierozpoznany węzeł XML typu „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: Element nadrzędny lub właściwość „{0}” wymagają wyspy danych XML. Aby odróżnić wyspę XML od otaczającego kodu XAML, umieść ją pomiędzy tagami &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: Element „{0}” lub właściwość nie mogą zawierać wyspy danych XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: Atrybut XmlLangProperty musi określać nazwę właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: Klasa „{0}” nie implementuje interfejsu IXmlLineInfo. Jest to wymagane do pobrania informacji o położeniu dla analizowanego kodu XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: Nieoczekiwany token „{0}” na pozycji „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: Nieprawidłowy token.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Trwa przygotowywanie do kompilacji znaczników...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: Nazwa typu „{0}” nie ma oczekiwanego formatu „nazwa_klasy, zestaw”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Trwa odczytywanie pliku Resource: „{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Ponownie skompilowany plik XAML: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Wejście: Plik Reference zestawu : „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">Identyfikator ID zasobu to: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: Wejściowy plik zasobów „{0}” przekracza maksymalny rozmiar {1} bajtów.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">Wygenerowano plik .resources: „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Trwa generowanie pliku .resources: „{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.Wyrażenie {1}="{2}" jest nieprawidłowe. „{1}” musi być zdarzeniem RoutedEvent zarejestrowanym z nazwą kończącą się słowem kluczowym „Event”.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: Musisz przekazać pliki znaczników do zadania.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: Właściwość SourceName nie może być ustawiona w sekcji Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style nie obsługuje jednocześnie tagów {0} i tagów właściwości Style.{1} dla pojedyńczego elementu Style. Użyj tagów jednego rodzaju.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: Tag „{0}” właściwości elementu Style „{0}” można określić jedynie bezpośrednio pod tagiem Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: Nie można odnaleźć elementu Style {0} „{1}” w typie „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: Nie można rozpoznać elementu Style {0} „{1}”. Sprawdź, czy typ będący właścicielem to typ TargetType elementu Style albo użyj składni Class.Property do określenia elementu {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Element Style nie może zawierać elementu podrzędnego „{0}”. Element podrzędny elementu Style musi być typu Setter, ponieważ jest dodawany do kolekcji Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: Tagi typu „{0}” nie są obsługiwane w sekcjach elementu Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: W tagu Target właściwości Style nie można określić zdarzenia „{0}”. Użyj zamiast tego elementu EventSetter.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: Tekst „{0}” jest niedozwolony w tej lokalizacji wewnątrz sekcji Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: W elemencie Style nie można ustawić właściwości „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: Element „{0}” nie może być elementem głównym pliku XAML ponieważ został zdefiniowany przy użyciu kodu XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: Typ docelowy „{0}” nie jest obsługiwany przez to zadanie.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: Nie można ustawić właściwości TargetName w znaczniku Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) — zadanie kompilacji „{0}” w wersji „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Wszelkie prawa zastrzeżone.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Element Name „{0}” już został zdefiniowany. Elementy Name muszą być unikatowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: Element główny sekcji zawartości szablonu nie może zawierać elementu typu „{0}”. Tylko typy FrameworkElement i FrameworkContentElement są prawidłowe.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: Tag „{0}” właściwości szablonu można określić jedynie bezpośrednio po tagu ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: Szablon może mieć tylko jeden element główny. Element „{0}” jest niedozwolony.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: Nie można odnaleźć właściwości szablonu „{0}” w typie„{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: Nie można rozpoznać właściwości szablonu „{0}”. Sprawdź, czy typ będący właścicielem to element TargetType elementu Style albo użyj składni Class.Property do określenia właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: Nie można odnaleźć elementu docelowego „{0}” elementu Trigger. Element docelowy musi pojawić się przed wszystkimi elementami Setter, Trigger, lub Condition, które go używają.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: Tagi typu „{0}” nie są obsługiwane w sekcjach Template.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: Tekst „{0}” nie jest dozwolony w tej lokalizacji wewnątrz sekcji szablonu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: Właściwość „{0}” nie może być ustawiona jako element właściwości w szablonie. Jako elementy właściwości dozwolone są tylko elementy Triggers i Storyboards.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: W trakcie analizy napotkano pusty token.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: W trakcie analizy napotkano dodatkowe dane po tokenie.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: W trakcie analizy tokenu napotkano brak cudzysłowu zamykającego.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: Napotkano przedwczesne zakończenie ciągu.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: Brakuje identyfikatora Uid dla elementu „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Nieznany błąd kompilacji, „{0}” </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: Modyfikator {0}:ClassModifier="{1}" jest niepoprawny dla języka {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: Nierozpoznany tag „{0}:{1}” w przestrzeni nazw „http://schemas.microsoft.com/winfx/2006/xaml”. Należy zwrócić uwagę, że w nazwach tagów uwzględniana jest wielkość liter.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: Element „{1}” jest nieprawidłowy. Zdarzenie „{0}” nie jest zdarzeniem w elemencie „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: Modyfikator {0}:FieldModifier="{1}" jest nieprawidłowy dla języka {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: Wartość {0}:TypeArguments=„{1}” jest niepoprawna w tagu „{2}”. Element „{2}” nie jest typem ogólnym lub liczba argumentów Type w atrybucie jest nieprawidłowa. Usuń atrybut {0}:TypeArguments, który jest dozwolony tylko dla ogólnych typów, albo popraw jego wartość tak, aby zgadzała się z liczbą argumentów wymaganą przez ogólny typ „{2}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: Element „{0}” nie jest poprawnie zainstalowany na tym komputerze. Musi znajdować się w sekcji &lt;compilers&gt; pliku machine.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Podjęto próbę wykonania nieznanej operacji na ścieżce.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: Komentarz lokalizacji nie ma ustawionej żadnej wartości dla właściwości docelowej „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: Główne i pomocnicze składniki numeru wersji nie mogą być ujemne.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: Plik projektu musi zawierać zestaw „{0}” .NET Framework na liście odwołań.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: Wartość właściwości LocalizationDirectivesToLocFile jest nieprawidłowa i należy ją zmienić na None, CommentsOnly lub All dla zadania MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: Plik projektu zawiera nieprawidłową wartość właściwości.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Element Choice nie może występować po elemencie Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: Obiekt AlternateContent musi zawierać jeden lub więcej elementów Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Element Choice jest prawidłowy tylko w bloku AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: Przestrzeń nazw {0} jest oznaczona jako zgodna sama z sobą za pomocą atrybutu XmlnsCompatibilityAttribute. Przestrzeń nazw nie może bezpośrednio ani pośrednio przesłaniać siebie.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: Zduplikowana deklaracja atrybutu Preserve dla elementu „{1}” w przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: Zduplikowana deklaracja atrybutu ProcessContent dla elementu „{1}” w przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: Zduplikowana deklaracja Preserve z symbolem wieloznacznym dla przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: Zduplikowana deklaracja atrybutu ProcessContent z symbolem wieloznacznym dla przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Element Fallback jest prawidłowy tylko w bloku AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: Element „{0}” jest nieprawidłowym elementem podrzędnym w elemencie AlternateContent. Tylko elementy Choice i Fallback są poprawnymi elementami podrzędnymi elementu AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: Atrybut „{0}” jest nieprawidłowy dla elementu „{1}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: Format „{0}” jest nieprawidłowy.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: Dla przestrzeni nazw „{0}” nie można mieć jednocześnie określonej i wieloznacznej deklaracji atrybutu Preserve.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: Nie można użyć jednocześnie deklaracji atrybutu ProcessContent konkretnej i z symbolem wieloznacznym dla przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Atrybut Requires musi zawierać prawidłowy prefiks przestrzeni nazw.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: Wartość atrybutu „{0}” nie jest prawidłową nazwą XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: Element AlternateContent musi zawierać tylko jeden element Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: Niespełniony warunek MustUnderstand w przestrzeni nazw „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: Przestrzeń nazw „{0}” zawiera elementy, które zostały zadeklarowane do zachowania, ale sama nie jest zadeklarowana jako ignorowalna.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: Przestrzeń nazw „{0}” ma zadeklarowany atrybut ProcessContent, ale nie ma atrybutu Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Element Choice musi zawierać atrybut Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: Prefiks „{0}” nie jest zdefiniowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: Nierozpoznany atrybut zgodności „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: Nierozpoznany element zgodności „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: Ciąg identyfikatora funkcji nie mieć zerowej długości.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Resultado da análise : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: o arquivo do projeto de biblioteca não pode especificar o elemento ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Entrada: arquivo de marcação ApplicationDefinition: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: '{0}' não pode ser definido na marca '{1}:{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: nome de tarefa UidManager não reconhecido '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Verificando Uids no arquivo '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Arquivo de diretivas de localização gerado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Gerando arquivo de diretivas de localização: '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Compilação da marcação concluída.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 gerou arquivos BAML ou de código-fonte com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 gerou arquivos BAML ou de código-fonte com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: o evento '{0}' tem um tipo delegado de manipulador de eventos genérico '{1}'. Os parâmetros de tipo de '{1}' não podem ser associados a um argumento de tipo adequado porque a marca pertencente '{2}' não é do tipo genérico.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">O diretório atual do projeto é '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: somente uma marca de raiz pode especificar o atributo '{0}:{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: '{0}:{1}' não pode ser especificado como elemento raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' contém '{2}'. '{0}:{1}' pode conter somente CDATA ou uma seção de texto.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Iniciada a compilação da marcação.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" não é válido. O valor do atributo de evento '{0}' não pode ser uma cadeia de caracteres vazia ou que tenha somente espaço em branco.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: {0}:FieldModifier não pode ser especificado nesta marca porque não possui {0}:Name ou conjunto de atributos Name, ou a marca foi definida localmente ou tem um conjunto de atributos Name, o que não é permitido.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: o arquivo '{0}' não pode ser encontrado.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">O arquivo de entrada '{0}' está resolvido para o novo caminho relativo '{1}' no diretório '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: {0} arquivos com falha na verificação de Uid.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Uids válidas em {0} arquivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Uids removidas de {0} arquivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Uids atualizadas em {0} arquivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Arquivo BAML gerado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Arquivo de código gerado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' contém '{2}'. '{0}:{1}' não pode apresentar conteúdo aninhado.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: o diretório '{0}' não existe e não pode ser criado.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">A classe InternalTypeHelper não é necessária para este projeto; esvazie o arquivo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: o nome da classe '{0}' não é válido para o elemento raiz XAML definido localmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: o namespace '{0}' não é válido para o elemento raiz XAML '{1}' definido localmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" não é válido. '{2}' não é um nome de classe{3} válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: o valor '{0}' de UICulture definido no arquivo de projeto não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: o serializador não oferece suporte às operações personalizadas de serialização de BAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: o serializador não oferece suporte às operações Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: o nome '{0}' não é válido no namespace '{1}' padrão. Corrija o valor da marca RootNamespace no arquivo de projeto.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" não é válido. '{1}' não é um nome de método do manipulador de eventos válido. Somente métodos de instância na classe gerada ou code-behind são válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: a propriedade de destino de comentário de localização não é válida na cadeia de caracteres '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: o valor do comentário de localização não é válido para a propriedade de destino '{0}' na cadeia de caracteres '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: a configuração do atributo de localização '{0}' não é válida.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: o arquivo de marcação não é válido. Especifique um arquivo de origem de marcação com uma extensão .xaml.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" não é válido. '{2}' não é uma referência de nome de tipo válida para o argumento genérico na posição '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: XML '{0}' não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: como '{0}' está implementado no mesmo assembly, você deve definir o atributo {1}:Name em vez do atributo Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Entrada: o arquivo ApplicationDefinition de marcação de referência local é '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Arquivo BAML gerado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Entrada: arquivo Page de marcação de referência local: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: o evento '{0}' tem um tipo delegado de manipulador de eventos genérico '{1}'. O parâmetro de tipo '{2}' em '{1}' não corresponde aos parâmetros de tipo na marca genérica pertencente '{3}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: o elemento raiz '{0}' requer um atributo {1}:Class porque '{2}' contém uma marca {1}:Code. Remova {1}:Code e seu conteúdo ou adicione um atributo {1}:Class ao elemento raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: o elemento '{0}' raiz requer que um atributo {1}:Class ofereça suporte aos manipuladores de eventos no arquivo XAML. Remova o manipulador de eventos do evento {2} ou adicione um atributo {1}:Class ao elemento raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: o elemento raiz '{0}' é um tipo genérico e requer que um atributo {1}:Class ofereça suporte ao atributo {1}:TypeArguments especificado na marca de elemento raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: o atributo {0}:FieldModifier não pode ser especificado porque um atributo {0}:Class também é necessário para gerar um campo Name com o modificador de acesso especificado. Adicione um atributo {0}:Class à marca raiz ou remova o atributo {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: o atributo {0}:ClassModifier não pode ser especificado na marca raiz porque um atributo {0}:Class também é necessário. Adicione um atributo {0}:Class ou remova o atributo  {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: o atributo {0}:Class está faltando. Ele é necessário quando um atributo {0}:Subclass é especificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator pode gerar somente um arquivo .resources de cada vez. A propriedade OutputResourcesFile do arquivo de projeto deve ser definida para um arquivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: o arquivo do projeto não pode especificar mais de um elemento de SplashScreen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: a Uid "{0}" do elemento '{1}' não é exclusiva.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: o arquivo do projeto não pode especificar mais de um elemento ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Um '{0}' está denominado '{1}'. Não nomeie o conteúdo de ResourceDictionary porque sua instanciação foi adiada.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: exceção CLS desconhecida.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType é '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: erro de sintaxe TypeConverter encontrado durante o processamento da cadeia de caracteres de inicialização '{0}'. Os elementos da propriedade não são permitidos nos objetos criados com TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: Não é possível carregar o assembly '{0}' porque uma versão diferente do mesmo assembly já está carregada '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: o atributo AsyncRecords deve ser definido na marca raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: a propriedade anexada '{0}' não está definida em '{1}' ou uma de suas classes base.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: muitos atributos foram especificados para '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: não há atributos suficientes especificados para '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: a propriedade '{0}' deve estar no namespace padrão ou no namespace do elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath não pode aceitar um assemblyName vazio.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath não pode aceitar um assemblyPath vazio.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: um elemento do tipo '{0}' não pode ser definido na propriedade complexa '{1}'. Eles não são tipos compatíveis.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: não é possível encontrar um construtor público para '{0}' que aceite {1} argumentos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: uma chave para um dicionário não pode ser do tipo '{0}'. Somente há suporte para String, TypeExtension e StaticExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: o membro '{0}' não é válido porque não tem um nome de tipo qualificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: o valor '{0}' da propriedade Name não é válido. Name deve começar com uma letra ou um sublinhado e pode conter somente letras, dígitos e sublinhados.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: não é possível converter o valor '{0}' da cadeia de caracteres no tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: o valor da propriedade SynchronousMode não é válido. Os valores válidos são Async e Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: o objeto que está sendo adicionado a uma propriedade de matriz não é um tipo válido. A matriz é do tipo '{0}', mas o objeto que está sendo adicionado é do tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: MarkupExtensions não são permitidos como valores de propriedade Uid ou Name; portanto, '{0}' não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: o objeto '{0}' já tem um filho e não pode adicionar '{1}'. '{0}' pode aceitar somente um filho.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: não é possível adicionar conteúdo ao objeto do tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' é uma propriedade somente leitura do tipo IList ou IDictionary e não pode ser definida porque não tem um acessador get público ou interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: {0} '{1}' não pode ser definido porque não tem um acessador {2} acessível.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: não é possível definir a propriedade de conteúdo '{0}' no elemento '{1}'. '{0}' tem nível de acesso incorreto ou seu assembly não permite acesso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: '{0}' não pode ser definido como o valor de um atributo Property de Trigger porque não tem um acessador get público ou interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: dois namespaces novos não podem ser compatíveis com o mesmo namespace antigo usando um atributo XmlnsCompatibility. O namespace �'{0}' já está marcado como compatível com '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: os elementos da propriedade não podem estar no meio do conteúdo de um elemento. Eles devem estar antes ou depois do conteúdo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: marca 'Code' do namespace de xaml encontrada no arquivo XAML. Para carregar esse arquivo, você deve compilá-lo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: o tipo '{0}' do Elemento não tem um TypeConverter associado para analisar a cadeia de caracteres '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: não é possível modificar dados em um XmlnsDictionary lacrado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: a chave de dicionário '{0}' já foi usada. Os atributos da chave são usados como chaves na inserção de objetos em um dicionário e devem ser exclusivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: a propriedade '{0}' já foi definida nesta extensão de marcação e somente pode ser definida uma vez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: a propriedade '{0}' já foi definida e somente pode ser definida uma vez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: '{0}' e '{1}' referem-se à mesma propriedade. Não são permitidas configurações de propriedade repetidas.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: o elemento da propriedade '{0}' não pode estar vazio. Ele deve conter elementos filho ou de texto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: EntityReference &amp;{0}; não é reconhecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: não é possível acessar o tipo delegado '{0}' para o evento '{1}'. '{0}' tem nível de acesso incorreto ou seu assembly não permite acesso.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: a propriedade '{0}' é do tipo IEnumerable somente leitura, o que significa que '{1}' deve implementar IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: propriedade ContentPropertyAttribute inválida no tipo '{0}'; propriedade '{1}' não encontrada.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">O valor de tipo conhecido {0}='{1}' não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: não é possível encontrar o membro estático '{0}' no tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: as chaves e os valores em XmlnsDictionary devem ser cadeias de caracteres.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Linha {0}, posição {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: XmlNamespace, Assembly ou ClrNamespace ausentes na instrução Mapping.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">O URI de mapeamento '{0}' não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: o formato não é válido para MarkupExtension, que especifica os argumentos do construtor em '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: as extensões de marcação requerem um único '=' entre nome e valor, e um único ',' entre os parâmetros do construtor e os pares nome-valor. Os argumentos '{0}' não são válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' não é válido. As extensões de marcação requerem somente espaços entre o nome da extensão da marcação e o primeiro parâmetro. Não é possível ter vírgula ou sinal de igual antes do primeiro parâmetro.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: Encontrado um BracketCharacter de fechamento '{0}' no Número de Linha '{1}' e Posição de Linha '{2}' sem um BracketCharacter de abertura correspondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: O BracketCharacter '{0}' no Número de Linha '{1}' e Posição de Linha '{2}' não tem um BracketCharacter de abertura/fechamento correspondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: as expressões MarkupExtension devem terminar com um '}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: os pares nome-valor em MarkupExtensions devem ter o formato 'Nome = Valor' e cada par é separado por uma vírgula. '{0}' não segue esse formato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: os nomes e valores em um MarkupExtension não podem conter aspas. Os argumentos '{0}' de MarkupExtension não são válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: o texto '{1}' não é permitido após o fechamento '{0}' de uma expressão MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: propriedade '{0}' desconhecida para o tipo '{1}' encontrada durante a análise de um Markup Extension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: atributo '{0}' desconhecido no namespace '{1}'. Observe que só há suporte atualmente para o atributo Key neste namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: erro interno do analisador - Não é possível utilizar vários registros BAML graváveis ao mesmo tempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">O elemento '{0}' da propriedade não pode ser aninhado diretamente dentro de outro elemento da propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: não é possível colocar atributos nas marcas de Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: não há suporte para o carregamento assíncrono durante a compilação de um arquivo XAML; portanto, SynchronousMode de '{0}' não é permitido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: o tipo '{0}' não oferece suporte ao conteúdo do elemento.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: todos os objetos adicionados a um IDictionary devem ter um atributo Key ou algum outro tipo de chave associada a eles.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: o atributo Key somente pode ser usado em uma marca contida em um Dictionary (como ResourceDictionary).</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: '{1}' não pode ser usado como valor de '{0}'. Os números não são valores válidos de enumeração.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: não é possível utilizar a sintaxe de elemento de propriedade para especificar o manipulador de eventos'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: o arquivo XAML que contém eventos deve ser compilado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: o tipo '{0}' não pode ter um atributo Name. Os tipos de valor e tipos sem um construtor padrão podem ser usados como itens em um ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: não é possível definir o valor de atributo Name '{0}' no elemento '{1}'. '{1}' está sob o escopo do elemento '{2}', que já tinha um nome registrado quando foi definido em outro escopo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: nenhum NamespaceURI está definido para o objeto '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: não é possível aninhar ilhas de dados XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: não é possível definir as propriedades nos elementos da propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: não é possível encontrar um serializador personalizado para '{0}'; portanto, ele não pode ser analisado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: os style setters não oferecem suporte aos elementos filho. Uma marca do tipo '{0}' não é permitida.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: não é possível encontrar o tipo '{0}'. Observe que os nomes de tipo diferenciam maiúsculas e minúsculas.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: o valor '{0}' não é uma expressão  MarkupExtension válida. Não é possível resolver '{1}' no namespace '{2}'. '{1}' deve ser uma subclasse de MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: o prefixo do namespace XML '{0}' não mapeia para um NamespaceURI; portanto, o elemento '{1}' não pode ser resolvido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: O prefixo do namespace XML '{0}' não mapeia para um URI de namespace; portanto, não é possível resolver a propriedade '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: a propriedade '{0}' não tem um valor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: somente classes públicas ou internas podem ser usadas na marcação. O tipo '{0}' não é público nem interno.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: a propriedade '{0}' é somente leitura e não pode ser definida da marcação.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: a referência ao tipo não pode encontrar um tipo público denominado '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: não é possível fazer referência ao membro estático '{0}' no tipo '{1}' uma vez que não está acessível.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: o atributo SynchronousMode deve estar na marca raiz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: não é possível ter o texto '{0}' e o elemento filho '{1}' no elemento da propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: o texto de IDictionary ou uma propriedade Array não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: um único arquivo XAML não pode fazer referência a mais de 4.096 assemblies diferentes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: a marca de fechamento deve seguir imediatamente a cadeia de caracteres de inicialização TypeConverter '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: erro de sintaxe TypeConverter encontrado durante o processamento da cadeia de caracteres de inicialização '{0}'. Os atributos de elemento não são permitidos em objetos criados com TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' é um namespace não declarado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: a propriedade '{0}' não existe no namespace XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: o atributo '{0}' não existe no namespace XML  'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: a marca '{0}' não existe no namespace XML '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: tipo de nó XML '{0}' não reconhecido encontrado ao determinar se a marca atual é um elemento de propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: o elemento ou a propriedade pai '{0}' requer uma ilha de dados XML. Para diferenciar uma ilha XML do XAML adjacente, coloque a ilha de dados XML entre &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: o elemento ou a propriedade '{0}' não podem conter uma ilha de dados XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: o atributo XmlLangProperty deve especificar um nome de propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: a classe '{0}' não implementa IXmlLineInfo. Isso é necessário para se obter as informações de posição do XAML em análise.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: Token '{0}' inesperado na posição '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: o token não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Preparando para a compilação da marcação...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: o nome do tipo '{0}' não tem o formato esperado 'className, assembly'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Lendo o arquivo Resource: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Arquivo XAML recompilado : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Entrada: arquivo Reference do assembly: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">A ID de recurso é '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: o arquivo de recurso de entrada '{0}' excede o tamanho máximo de {1} bytes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">Arquivo .resources gerado: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Gerando arquivo .resources: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" não é válido. '{1}' deve ser um RoutedEvent registrado com um nome que termina com a palavra-chave "Event".</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: você deve transferir os arquivos de marcação para a tarefa.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: a propriedade SourceName não pode ser definida na seção Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style não oferece suporte a {0} marcas e marcas de propriedade Style.{1} para um único Style. Use um ou outro.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: a marca de propriedade Style '{0}' somente pode ser especificada diretamente em uma marca Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: não é possível encontrar Style {0} '{1}' no tipo '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: não é possível resolver Style {0} '{1}'. Verifique se o tipo de propriedade é TargetType de Style ou use a sintaxe Class.Property para especificar {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style não pode conter '{0}' filho. O Style filho deve ser um Setter porque está anexado à coleção Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: as seções Style não oferecem suporte às marcas do tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: o evento '{0}' não pode ser especificado em uma marca Target em um Style. Use um EventSetter.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: o texto '{0}' não é permitido nesse local em uma seção Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: a propriedade '{0}' não pode ser definida em Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: '{0}' não pode ser a raiz de um arquivo XAML porque ele foi definido usando XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: esta tarefa não oferece suporte ao tipo de destino '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: a propriedade TargetName não pode ser definida em um Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Build Task '{0}' Versão '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. Todos os direitos reservados.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Name '{0}' já foi definido. Names devem ser exclusivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: a raiz de uma seção de conteúdo de Modelo não pode conter um elemento do tipo '{0}'. Somente os tipos FrameworkElement e FrameworkContentElement são válidos.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: a marca de propriedade de modelo '{0}' somente pode ser especificada imediatamente após uma marca ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: um modelo pode ter somente um único elemento raiz. '{0}' não é permitido.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: não é possível encontrar a Propriedade de Modelo '{0}' no tipo '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: não é possível resolver a Propriedade de Modelo '{0}'. Verifique se o tipo de propriedade é TargetType de Style, ou use a sintaxe Class.Property para especificar a propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: não é possível encontrar o destino Trigger '{0}'. (O destino deve aparecer antes de Setters, Triggers ou Conditions que o utilizem.)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: as seções de modelo não oferecem suporte às marcas de tipo '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: o texto '{0}' não é permitido neste local em uma seção de modelo.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: a propriedade '{0}' não pode ser definida como um elemento de propriedade no modelo. Somente Triggers e Storyboards são permitidos como elementos de propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: encontrado um token vazio durante a análise.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: dados adicionais encontrados após o token durante a análise.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: encontrada uma aspa de fechamento faltando durante a análise do token.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: encontrado um término prematuro da cadeia de caracteres.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: Uid ausente para elemento '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Erro de compilação desconhecido, '{0}' </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" não é válido para o idioma {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: marca não reconhecida '{0}:{1}' no namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Observe que os nomes de marca diferenciam maiúsculas e minúsculas.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' não é válido. '{0}' não é um evento em '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" não é válido para o idioma {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' não é válido na marca '{2}'. '{2}' não é um tipo genérico ou o número de argumentos Type no atributo está errado. Remova o atributo {0}:TypeArguments porque ele só é permitido em tipos genéricos, ou corrija o valor para corresponder à paridade do tipo genérico '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' não está instalado adequadamente nesta máquina. Ele deve ser listado na seção &lt;compilers&gt; de machine.config.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Tentativa de operação de caminho desconhecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: o comentário da localização não tem valor definido para a propriedade de destino: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: os componentes de número da versão maior e menor não podem ser negativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: o arquivo de propriedade deve incluir o assembly .NET Framework '{0}' na lista de referência.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: o valor de propriedade LocalizationDirectivesToLocFile não é válido e deve ser alterado para None, CommentsOnly ou All para a tarefa MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: o arquivo de projeto contém um valor de propriedade não válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice não pode seguir Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent deve conter um ou mais elementos Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice válido somente em AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: O namespace '{0}' está marcado como compatível com ele mesmo usando XmlnsCompatibilityAttribute. Um namespace não pode substituir a ele mesmo direta ou indiretamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: declaração Preserve duplicada para elemento '{1}' no namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: declaração ProcessContent duplicada para elemento '{1}' no namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: declaração Preserve curinga duplicada para namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: declaração ProcessContent curinga duplicada para namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback válido somente em AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: o elemento '{0}' não é um filho válido de AlternateContent. Somente os elementos Choice e Fallback são filhos válidos de um elemento AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: o atributo {0}' não é válido para o elemento '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: o formato '{0}' não é válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: não é possível ter uma declaração Preserve específica e curinga para namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: não é possível ter uma declaração ProcessContent específica e curinga para namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: o atributo Requires deve conter um prefixo de namespace válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: o valor de atributo '{0}' não é um nome XML válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent deve conter somente um elemento Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: falha na condição MustUnderstand no namespace '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: o namespace '{0}' tem itens declarados a serem preservados, mas não é declarado ignorável.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: o namespace '{0}' é declarado ProcessContent, mas não é declarado Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice deve conter um atributo Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: o prefixo '{0}' não está definido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: atributo de compatibilidade '{0}' não reconhecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: elemento de compatibilidade '{0}' não reconhecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: a cadeia de caracteres da ID do recurso não pode ter comprimento 0.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Результат анализа: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: в файле проекта библиотеки нельзя указывать элемент ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Входные данные: файл ApplicationDefinition разметки: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: нельзя задать "{0}" в теге "{1}:{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: нераспознанное имя задачи UidManager "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">Проверка кодов Uid в файле "{0}" ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Генерация файла директив локализации: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Генерация файла директив локализации: "{0}" ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">Компиляция разметки завершена.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">Успешная генерация файлов BAML или исходного кода в MarkupCompilePass1.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">Успешная генерация файлов BAML или исходного кода в MarkupCompilePass2.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: для события "{0}" имеется общий тип делегата обработчика событий "{1}". Параметры типа "{1}" не могут быть привязаны к аргументу подходящего типа, поскольку содержащий тег "{2}" не является общим типом.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Текущий каталог проекта: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: атрибут "{0}:{1}" может быть указан только в корневом теге.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: "{0}:{1}" не может быть указан как корневой элемент.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: "{0}:{1}" содержит "{2}". "{0}:{1}" может содержать только разделы CDATA или текстовый.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">Компиляция разметки начата.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: недопустимое значение {0}="{1}". Значение атрибута события "{0}" не может быть строкой, которая пуста или содержит только пробелы.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: невозможно задать {0}:FieldModifier в данном теге, так как у него либо не заданы {0}:Name или атрибут Name, либо тег определен локально и для него задан атрибут Name, что не допускается.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: не удается найти файл "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">Входной файл "{0}" сопоставлен с новым относительным путем "{1}" в каталоге "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: проверка Uid не прошла для следующего числа файлов: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">Допустимые коды Uid в {0} файлах.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">Коды Uid удалены из {0} файлов.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">Коды Uid обновлены в {0} файлах.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Сгенерирован файл BAML: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Сгенерирован файл кода: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: "{0}:{1}" содержит "{2}". В "{0}:{1}" не может быть вложенного содержимого.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: каталог "{0}" не существует и не может быть создан.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">Для данного проекта класс InternalTypeHelper не требуется, сделайте пустой файл "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: недопустимое имя класса "{0}" для локально определенного корневого элемента XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: недопустимое пространство имен "{0}" для локально определенного корневого элемента XAML "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: недопустимая строка {0}:{1}="{2}". "{2}" является недопустимым именем класса {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: в файле проекта задано недопустимое значение UICulture "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: сериализатор не поддерживает нестандартные операции сериализации BAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: сериализатор не поддерживает операции Convert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: недопустимое имя "{0}" в пространстве имен по умолчанию "{1}". Исправьте значение тега RootNamespace в файле проекта.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: недопустимая строка {0}="{1}". Недопустимое имя метода обработчика событий "{1}". Разрешены только методы экземпляра для сгенерированного класса или класса кода программной части.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: недопустимое конечное свойство примечания локализации в строке "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: недопустимое значение примечания локализации для конечного свойства "{0}" в строке "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: недопустимое значение атрибута возможности локализации "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: недопустимый файл разметки. Укажите исходный файл разметки с расширением .xaml.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: недопустимая строка {0}:TypeArguments="{1}". Недопустимая ссылка на имя типа "{2}" для общего аргумента в позиции "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: недопустимый код XML "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: реализация "{0}" сделана в той же сборке, поэтому необходимо задать атрибут {1}:Name, а не атрибут Name.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Входные данные: файл ApplicationDefinition для разметки локальных ссылок - "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Сгенерирован файл BAML: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Входные данные: файл Page для разметки локальных ссылок - "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: в событии "{0}" используется тип делегата "{1}" для общего обработчика событий. Параметр типа "{2}" для "{1}" не соответствует ни одному из параметров типа в содержащем общем теге "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: корневой элемент "{0}" требует атрибута {1}:Class, так как "{2}" содержит тег {1}:Code. Либо удалите тег {1}:Code и его содержимое, либо добавьте в корневой элемент атрибут {1}:Class.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: корневой элемент "{0}" требует атрибута {1}:Class для поддержки обработчиков событий в файле XAML. Либо удалите обработчик событий для события {2}, либо добавьте в корневой элемент атрибут {1}:Class.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: корневой элемент "{0}" имеет базовый тип и требует атрибута {1}:Class для поддержки атрибута {1}:TypeArguments, указанного в теге корневого элемента.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: невозможно указать атрибут {0}:FieldModifier, так как для генерации поля Name с указанным модификатором доступа требуется еще и атрибут {0}:Class. Либо добавьте атрибут {0}:Class для корневого тега, либо удалите атрибут {0}:FieldModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: невозможно указать атрибут {0}:ClassModifier для корневого тега, так как требуется еще и атрибут {0}:Class. Либо добавьте атрибут {0}:Class, либо удалите атрибут {0}:ClassModifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: отсутствует атрибут {0}:Class. Этот атрибут обязателен, когда указан атрибут {0}:Subclass.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator позволяет генерировать только по одному файлу .resources за раз. Для свойства OutputResourcesFile в файле проекта необходимо задать значение в один файл.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004. Невозможно указать более одного элемента SplashScreen в файле проекта.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: код Uid "{0}" для элемента "{1}" не является уникальным.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: в файле проекта нельзя указывать более одного элемента ApplicationDefinition.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">"{0}" имеет имя "{1}". Не именовать контент ResourceDictionary, поскольку его создание отложено.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: неизвестное исключение CLS.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">Тип OutputType равен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: при обработке строки инициализации "{0}" обнаружена синтаксическая ошибка TypeConverter. Использование элементов свойств не допускается в объектах, созданных посредством TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: невозможно загрузить сборку "{0}", поскольку другая версия этой же сборки уже загружена "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: необходимо задать атрибут AsyncRecords в корневом теге.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: присоединенное свойство "{0}" не определено в "{1}" или в одном из базовых классов.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: для "{0}" указано слишком много атрибутов.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: для "{0}" указано недостаточно атрибутов.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: свойство "{0}" должно лежать в пространстве имен по умолчанию или в пространстве имен элемента "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath не может принять пустое имя assemblyName.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath не может принять пустой путь assemblyPath.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: элемент типа "{0}" нельзя задать для сложного свойства "{1}". Типы несовместимы.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: для "{0}" не удается найти общий конструктор, принимающий аргументы {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: ключ словаря не может иметь тип "{0}". Поддерживаются только типы String, TypeExtension и StaticExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: член "{0}" не является допустимым, так как не имеет соответствующего имени типа.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: недопустимое значение свойства Name для "{0}". Имя Name может содержать только буквы, цифры и знаки подчеркивания, причем первой должна стоять буква или знак подчеркивания.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: не удается преобразовать строковое значение "{0}" в тип "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: недопустимое значение свойства SynchronousMode. Разрешены значения Async и Sync.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: недопустимый тип объекта, добавляемого в свойства массива. Массив имеет тип "{0}", а добавляемый объект имеет тип "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: MarkupExtensions не разрешены для значений свойства Uid или Name, поэтому значение "{0}" недопустимо.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: у объекта "{0}" уже есть дочерний объект, добавление "{1}" невозможно. "{0}" может иметь только один дочерний объект.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: не удается добавить содержимое в объект типа "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: "{0}" является свойством только для чтения типа IList или IDictionary и не может быть задано, так как у него нет общей или внутренней функции доступа get.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: невозможно задать {0} "{1}", так как отсутствует доступная функция доступа {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: невозможно задать свойство содержимого "{0}" для элемента "{1}", так как "{0}" имеет неверный уровень доступа или его сборке доступ не разрешен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: невозможно задать "{0}", так как у значения атрибута Property для Trigger нет общей или внутренней функции доступа get.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: два новых пространства имен не могут быть совместимыми с прежним пространством имен при использовании атрибута XmlnsCompatibility.�Пространство имен "{0}" уже помечено как совместимое с "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: элементы свойств не могут находиться в середине содержимого элемента. Они должны быть размещены до или после содержимого.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: в файле xaml обнаружен тег "Code" из пространства имен XAML. Для загрузки этого файла его необходимо скомпилировать.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: тип элемента "{0}" не имеет связанного TypeConverter для синтаксического анализа строки "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: изменение данных в запечатанном словаре XmlnsDictionary невозможно.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: ключ словаря "{0}" уже используется. Атрибуты Key используются в качестве ключей при вставке объектов в словарь и должны быть уникальными.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: свойство "{0}" уже задано в данном расширении разметки и может быть задано только один раз.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: свойство "{0}" уже задано и может быть задано только один раз.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: свойство "{0}" и "{1}" ссылаются на одно и то же свойство. Дублирование установок свойств не разрешается.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: элемент свойства "{0}" не может быть пустым. Он должен содержать дочерние элементы или текст.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: нераспознанная ссылка EntityReference &amp;{0};.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: нет доступа к делегированному типу "{0}" для события "{1}". "{0}" имеет неправильный уровень доступа или его сборке доступ не разрешен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: свойство "{0}" является свойством IEnumerable, доступным только для чтения, поэтому "{1}" должен реализовывать IAddChild.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: недопустимый атрибут ContentPropertyAttribute для типа "{0}", свойство "{1}" не найдено.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">Значение известного типа {0}="{1}" не является допустимым известным типом.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: не удается найти статический член "{0}" типа "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: ключи и значения в XmlnsDictionary должны быть строками.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Строка {0} позиция {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: в инструкции Mapping пропущены XmlNamespace, Assembly или ClrNamespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">Недопустимый "{0}", сопоставляющий URI.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: недопустимый формат для MarkupExtension, в котором аргументы конструктора заданы в "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: расширения разметки требуют одного знака равенства ("=") между именем и значением и одной запятой (",") между параметрами конструктора и парами имен и значений. Аргументы "{0}" недопустимы.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: недопустимый аргумент "{0}". Расширения разметки требуют только пробелов между именем расширения разметки и первым параметром. Наличие запятой или знака равенства до первого параметра не допускаются.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: обнаружен закрывающий символ BracketCharacter "{0}" в строке "{1}" и позиции "{2}" без соответствующего открывающего символа BracketCharacter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: символ BracketCharacter "{0}" в строке "{1}" и позиции "{2}" не имеет соответствующего открывающего или закрывающего символа BracketCharacter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: выражения MarkupExtension должны оканчиваться фигурной скобкой "}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: пары имен и значений в MarkupExtensions должны иметь формат "Имя = Значение", и каждая пара отделяется запятой. "{0}" не соответствует этому формату.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: имена и значения в MarkupExtension не могут содержать кавычки. Недопустимые аргументы MarkupExtension "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: текст "{1}" не разрешен после закрывающей "{0}" в выражении MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: обнаружено неизвестное свойство "{0}" для типа "{1}" при синтаксическом анализе Markup Extension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: неизвестный атрибут "{0}" в пространстве имен "{1}". В этом пространстве имен в настоящее время поддерживается только атрибут Key.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: внутренняя ошибка синтаксического анализатора - не удается одновременно использовать несколько записей BAML, доступных для записи.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">Элемент свойства "{0}" не может быть вложен непосредственно в другой элемент свойства.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: невозможно разместить атрибуты в тегах Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: асинхронная загрузка не поддерживается при компиляции файла XAML, поэтому значение SynchronousMode "{0}" не допускается.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: тип "{0}" не поддерживает содержимое элемента.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: все объекты, добавленные в IDictionary, должны иметь связанный с ними атрибут Key или другой тип ключа.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: атрибут Key можно использовать только в теге, содержащемся в Dictionary (например, ResourceDictionary).</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: "{1}" нельзя использовать в качестве значения для "{0}". Числа не являются допустимыми значениями перечисления.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: синтаксис элемента свойства нельзя использовать для задания обработчика событий "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: файл XAML, содержащий события, необходимо скомпилировать.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: тип "{0}" не может иметь атрибут Name. Типы значений и типы без заданного по умолчанию конструктора можно использовать как элементы внутри ResourceDictionary.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: значение атрибута Name "{0}" невозможно задать для элемента "{1}", так как он находится в области элемента "{2}", в котором уже были зарегистрированы имена в то время, когда он был определен в другой области.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: для объекта "{0}" не определен ни один NamespaceURI.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: вложение островов данных XML не допускается.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: задание свойств для элементов свойств не допускается.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: не удается найти нестандартный сериализатор для "{0}", синтаксический анализ невозможен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: присвоители стилей не поддерживают дочерние элементы. Тег типа "{0}" является недопустимым.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: не удается найти тип "{0}". Имена типов вводятся с учетом регистра букв.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: значение "{0}" не является допустимым расширением MarkupExtension. Не удается определить "{1}" в пространстве имен "{2}". "{1}" должно быть подклассом MarkupExtension.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: префикс пространства имен XML "{0}" не сопоставлен с NamespaceURI, поэтому не удается определить элемент "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: префикс пространства имен XML "{0}" не соотносится с URI пространства имен, поэтому не удается разрешить свойство "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: у свойства "{0}" нет значения.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: в разметке допускается использовать только общие или внутренние классы. Тип "{0}" не является общим или внутренним.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: свойство "{0}" доступно только для чтения, его невозможно задать из разметки.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: ссылке на тип не удается найти общий тип с именем "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: не удается сослаться на статический член "{0}" типа "{1}", так как он недоступен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: атрибут SynchronousMode необходимо указывать для корневого тега.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: невозможно одновременно включить текст "{0}" и дочерний элемент "{1}" в элемент свойства.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: недопустимый текст в свойстве IDictionary или Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: один файл XAML не может ссылаться на более чем 4096 различных сборок.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: закрывающий тег должен следовать сразу же за строкой инициализации "{0}" класса TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: при обработке строки инициализации "{0}" обнаружена синтаксическая ошибка TypeConverter. Использование атрибутов свойств не допускается в объектах, созданных посредством TypeConverter.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: "{0}" является необъявленным пространством имен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: свойство "{0}" не существует в пространстве имен XML "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: атрибут "{0}" не существует в пространстве имен XML "http://schemas.microsoft.com/winfx/2006/xaml".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: тег "{0}" не существует в пространстве имен XML "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: обнаружен нераспознанный тип узла XML "{0}" при попытке определить, является ли текущий тег элементом свойства.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: для родительского элемента или свойства "{0}" требуется область данных XML. Чтобы выделить область XML из окружающего текста XAML, заключите область данных XML в теги &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: элемент или свойство "{0}" не может содержаться в области данных XML.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: атрибут XmlLangProperty должен указывать имя свойства.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: в классе "{0}" нет реализации IXmlLineInfo. Она требуется для получения сведений о позиции в анализируемом документе XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: неожиданный маркер "{0}" в позиции "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: недопустимый маркер.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">Подготовка компиляции разметки...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: имя типа "{0}" не имеет ожидаемый формат "имя_класса, сборка".</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Чтение файла Resource: "{0}"...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">Перекомпилированный файл XAML: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Входное значение: файл Reference для сборки: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">Код ресурса - "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: входной файл ресурсов "{0}" превышает максимальную длину в {1} байт.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">Сгенерирован файл .resources: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">Генерация файла .resources: "{0}"...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: недопустимая строка {0}.{1}="{2}". Для применения этого синтаксиса {1} должно быть событием RoutedEvent, зарегистрированным с именем, оканчивающимся на ключевое слово "Event".</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: необходимо передать файлы разметки задаче.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: свойство SourceName невозможно задать в разделе Style.Triggers.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: одновременное использование в Style тегов {0} и тегов свойств Style.{1} для одного Style не поддерживается. Используйте одно из двух.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: тег свойства Style "{0}" можно указывать только непосредственно внутри тега Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: не удается найти Style {0} "{1}" типа "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: не удается разрешить Style {0} "{1}". Проверьте, что тип-владелец - TargetType объекта Style, или с помощью синтаксиса Class.Property задайте {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style не может содержать дочерние объекты "{0}". Дочерний объект для Style должен быть типа Setter, так как он добавляется в семейство Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: теги типа "{0}" не поддерживаются в разделах Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: невозможно указать событие "{0}" в теге Target внутри Style. Вместо этого используйте EventSetter.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: текст "{0}" не разрешен в этом месте в разделе Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: невозможно задать свойство "{0}" для Style.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: "{0}" не может быть корнем файла XAML, так как при его определении использовался язык XAML.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: конечный тип "{0}" не поддерживается данной задачей.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: свойство TargetName не может быть задано для типа Style Setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Build Task "{0}", версия "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">© Корпорация Майкрософт (Microsoft Corporation), 2005. Все права защищены.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: имя Name "{0}" уже было определено. Имена Name должны быть уникальными.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: тег элемента типа "{0}" не может содержаться в корне раздела содержимого шаблона. Допустимы только типы FrameworkElement и FrameworkContentElement.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: тег свойства шаблона "{0}" может быть указан только сразу после тега ControlTemplate.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: шаблон может иметь только один корневой элемент. "{0}" не является допустимым.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: не удается найти свойство шаблона "{0}" типа "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: не удается разрешить свойство шаблона "{0}". Проверьте, что тип-владелец - TargetType объекта Style, или с помощью синтаксиса Class.Property задайте данное свойство.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: не удается найти цель "{0}" для Trigger. (Цель должна быть указана раньше, чем любые Setters, Triggers или Conditions, которые ее используют.)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: теги типа "{0}" не поддерживаются в разделах шаблона.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: текст "{0}" не разрешен в данном месте в разделе шаблона.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: невозможно задать свойство "{0}" как элемент свойства в шаблоне. Элементами свойств могут быть только Triggers и Storyboards.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: при синтаксическом анализе обнаружена пустая лексема.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: при синтаксическом анализе обнаружены лишние данные после лексемы.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: при синтаксическом анализе лексемы обнаружена пропущенная закрывающая кавычка.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: обнаружено преждевременное завершение строки.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: для элемента "{0}" отсутствует Uid.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Неизвестная ошибка сборки, "{0}" </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: недопустимая строка {0}:ClassModifier="{1}" для языка {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: нераспознанный тег "{0}:{1}" в пространстве имен "http://schemas.microsoft.com/winfx/2006/xaml". Имена тегов вводятся с учетом регистра.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: недопустимое значение "{1}". "{0}" не является событием на "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: недопустимая строка {0}:FieldModifier="{1}" для языка {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: строка {0}:TypeArguments="{1}" является недопустимой для тега "{2}". Либо "{2}" не является универсальным типом, либо указано неправильное число аргументов Type в атрибуте. Удалите атрибут {0}:TypeArguments, так как он допустим только для универсальных типов, или исправьте их число, чтобы оно соответствовало арности универсального типа {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: установка "{0}" на данном компьютере выполнена некорректно. В разделе &lt;compilers&gt; файла machine.config должна быть соответствующая строка.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Попытка выполнения операции с неизвестным путем.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: в примечании локализации не задано значение конечного свойства: "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: компоненты номера основной и вспомогательной версии не могут быть отрицательными.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: в списке ссылок файла проекта должна быть включена сборка .NET Framework "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: значение свойства LocalizationDirectivesToLocFile для задачи MarkupCompilePass1 недопустимо и должно быть заменено на None, CommentsOnly или All.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: файл проекта содержит недопустимое значение свойства.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: элемент Choice не может стоять после элемента Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: элемент AlternateContent должен содержать не менее одного элемента Choice.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: элемент Choice допустим только в элементе AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: Пространство имен'{0}' помечено как совместимое с самим собой с использованием XmlnsCompatibilityAttribute. Пространство имен не может явным или неявным образом переопределять себя.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: повторяющееся объявление Preserve для элемента "{1}" в пространстве имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: повторяющееся объявление ProcessContent для элемента "{1}" в пространстве имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: повторяющееся объявление Preserve с подстановочными знаками для пространства имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: повторяющееся объявление ProcessContent с подстановочными знаками для пространства имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: элемент Fallback допустим только в элементе AlternateContent.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: элемент "{0}" не является допустимым дочерним элементом AlternateContent. Дочерними элементами для элемента AlternateContent могут быть только элементы Choice и Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: недопустимый атрибут "{0}" элемента "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: недопустимый формат "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: нельзя одновременно иметь объявления Preserve с подстановочными знаками и явное для пространства имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: нельзя одновременно иметь объявления ProcessContent с подстановочными знаками и явное для пространства имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: атрибут Requires должен содержать допустимый префикс пространства имен.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: значение атрибута "{0}" не является допустимым XML-именем.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: в AlternateContent должен содержаться только один элемент Fallback.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: сбой условия MustUnderstand на пространстве имен "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: в пространстве имен "{0}" есть объекты, объявленные как сохраняемые, но оно не объявлено как Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: пространство имен "{0}" объявлено как ProcessContent, но не объявлено как Ignorable.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice должен содержать атрибут Requires.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: префикс "{0}" не определен.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: нераспознанный атрибут совместимости "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: нераспознанный элемент совместимости "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: строка кода свойства не должна иметь нулевую длину.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">Çözümleme Sonucu : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: Kitaplık proje dosyası ApplicationDefinition öğesi belirtemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">Giriş: İşaretleme ApplicationDefinition dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: '{0}' '{1}:{2}' etiketinde ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: Tanınmayan UidManager görev adı '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">'{0}' dosyasındaki Uid'ler denetleniyor ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">Oluşturulan yerelleştirme yönergeleri dosyası: '{0}' .</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">Yerelleştirme yönergeleri dosyası oluşturuluyor: '{0}' ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">İşaretleme derlemesi tamamlandı.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1, BAML veya kaynak kodu dosyalarını başarıyla oluşturdu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 BAML veya kaynak kodu dosyalarını başarıyla oluşturdu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: '{0}' olayı genel bir olay işleyicisi temsilci türü '{1}' içeriyor. İçeren etiket '{2}' genel türde olduğundan, '{1}' tür parametreleri uygun bir tür bağımsız değişkenine bağlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">Geçerli proje dizini '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: Yalnızca bir kök etiket öznitelik belirtebilir '{0}:{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: '{0}:{1}' kök öğe olarak belirtilemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' öğesi '{2}' içeriyor. '{0}:{1}' yalnızca CDATA veya metin bölümü içerebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">İşaretleme derlemesi başlatıldı.</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" geçerli değil. '{0}' olay öznitelik değeri boş olan veya yalnızca boşluk içeren bir dize olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: {0}:Name veya Name özniteliği kümesi olmadığı ya da etiket yerel olarak tanımlanmadığı ve izin verilmeyen bir Name özniteliği kümesine sahip olduğu için {0}:FieldModifier bu etikette belirtilemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: '{0}' dosyası bulunamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">'{0}' giriş dosyası '{2}' dizininde yeni '{1}' göreli yoluna çözümlendi.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: {0} dosya Uid denetiminde başarısız oldu.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">{0} dosyadaki Uid'ler geçerli.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">{0} dosyadan Uid'ler kaldırıldı.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">{0} dosyada Uid'ler güncelleştirildi.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Oluşturulan BAML dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">Oluşturulan kod dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' öğesi '{2}' içeriyor. '{0}:{1}' iç içe geçmiş içerik içeremez.</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: '{0}' dizini yok ve oluşturulamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">InternalTypeHelper sınıfı bu proje için gerekli değil, '{0}' dosyasını boşaltın.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: '{0}' sınıf adı yerel olarak tanımlanmış XAML kök öğesi için geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: '{0}' ad alanı yerel olarak tanımlanmış XAML kök öğesi '{1}' için geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" geçerli değil. '{2}' geçerli bir {3}sınıf adı değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: Proje dosyasında belirlenen UICulture değeri '{0}' geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: Serileştirici özel BAML serileştirme işlemlerini desteklemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: Seri hale getirici Convert işlemlerini desteklemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: '{0}' adı '{1}' varsayılan ad alanında geçerli değil. Proje dosyasında RootNamespace etiket değerini düzeltin.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" geçerli değil. '{1}' geçerli bir olay işleyicisi metot adı değil. Yalnızca, oluşturulan veya kod ardında bulunan sınıftaki örnek metotları geçerlidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: Yerelleştirme açıklama hedefi özelliği '{0}' dizesinde geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: Yerelleştirme açıklaması değeri '{1}' dizesindeki '{0}' hedef özelliği için geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: Yerelleştirilebilirlik öznitelik ayarı '{0}' geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: İşaretleme dosyası geçerli değil. Uzantısı .xaml olan bir kaynak işaretleme dosyası belirtin.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" geçerli değil. '{2}', '{3}' konumundaki genel bağımsız değişken için geçerli bir tür adı başvurusu değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: '{0}' XML geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: '{0}' aynı bütünleştirilmiş kodda yürütüldüğü için, Name özniteliği yerine {1}:Name özniteliğini ayarlamanız gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">Giriş: Yerel başvuru işaretleme ApplicationDefinition dosyası '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">Oluşturulan BAML dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">Giriş: Yerel başvuru işaretleme Page dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: '{0}' olayı genel bir olay işleyicisi temsilci türü '{1}' içeriyor. '{1}' öğesindeki tür parametresi '{2}' içeren '{3}' genel etiketindeki herhangi bir tür parametresiyle eşleşmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: '{2}' bir {1}:Code etiketi içerdiğinden '{0}' kök öğesi için bir {1}:Class özniteliği gerekiyor. {1}:Code öğesini ve içeriğini kaldırın veya kök öğeye {1}:Class özniteliği ekleyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: '{0}' kök öğesinin XAML dosyasındaki olay işleyicilerini desteklemesi için {1}:Class özniteliği gerekiyor. {2} olayının olay işleyicisini kaldırın veya kök öğeye {1}:Class özniteliği ekleyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: '{0}' kök öğesi genel türde ve kök öğe etiketinde belirtilen {1}:TypeArguments özniteliğini desteklemesi için {1}:Class özniteliği gerekiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: Belirtilen erişim değiştiricisiyle bir Name alanı oluşturmak için bir {0}:Class özniteliği de gerektiğinden {0}:FieldModifier özniteliği belirtilemez. Kök etikete bir {0}:Class özniteliği ekleyin veya {0}:FieldModifier özniteliğini kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: Bir {0}:Class özniteliği de gerektiğinden {0}:ClassModifier özniteliği kök etikette belirtilemez. Bir {0}:Class özniteliği ekleyin veya {0}:ClassModifier özniteliğini kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: {0}:Class özniteliği eksik. Bu öznitelik bir {0}:Subclass özniteliği belirtildiğinde gereklidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator bir kerede yalnızca bir .resources dosyası oluşturabilir. Proje dosyasındaki OutputResourcesFile özelliği bir dosyaya ayarlanmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: Proje dosyası birden fazla SplashScreen öğesi belirtemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: '{1}' öğesi için "{0}" Uid'si benzersiz değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: Proje dosyası birden fazla ApplicationDefinition öğesi belirtemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">Bir '{0}' '{1}' olarak adlandırılmış. Örneklerinin oluşturulması gecikmeli olduğundan ResourceDictionary içeriğini adlandırmayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: Bilinmeyen CLS özel durumu.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: '{0}' dizesi başlatılırken TypeConverter sözdizimi hatasıyla karşılaşıldı. TypeConverter ile oluşturulan nesnelerde özellik öğelerine izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: Aynı bütünleştirilmiş kodun farklı bir sürümü yüklendiğinden '{0}' bütünleştirilmiş kodu yüklenemiyor '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: AsyncRecords özniteliği kök etikette ayarlanmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: Eklenen '{0}' özelliği '{1}' üzerinde veya temel sınıflarından birinde tanımlı değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: '{0}' için belirtilmiş çok fazla öznitelik var.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: '{0}' için belirtilmiş yeterli öznitelik yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: '{0}' özelliği varsayılan ad alanında veya '{1}' öğe ad alanında olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath boş bir assemblyName kabul edemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath boş bir assemblyPath kabul edemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: '{0}' türünde bir öğe '{1}' karmaşık özelliğinde ayarlanamaz. Bunlar uyumlu türler değildir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: '{0}' için {1} bağımsız değişken alan genel bir oluşturucu bulunamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: Bir sözlük anahtarı '{0}' türünde olamaz. Yalnızca String, TypeExtension ve StaticExtension desteklenir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: Niteleyici bir tür adı olmadığından '{0}' üyesi geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: '{0}' Name özellik değeri geçerli değil. Name bir harf veya alt çizgiyle başlamalıdır ve yalnızca harf, sayı ve alt çizgiler içerebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: '{0}' dize değeri '{1}' türüne dönüştürülemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: SynchronousMode özellik değeri geçerli değil. Geçerli değerler Async ve Sync değerleridir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: Bir dizi özelliğine eklenen nesne geçerli türde değil. Dizi '{0}' türünde, ancak eklenen nesne '{1}' türünde.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: Uid veya Name özellik değerleri için MarkupExtensions kullanılamaz, bu yüzden '{0}' geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: '{0}' nesnesinin zaten alt öğesi var ve '{1}' eklemez. '{0}' yalnızca bir alt öğe kabul edebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: '{0}' türünde nesneye içerik eklenemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' IList veya IDictionary türünde salt okunur bir özelliktir ve genel veya iç alma erişenine sahip olmadığı için ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: {0} '{1}' erişilebilir bir {2} erişenine sahip olmadığı için ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: '{1}' öğesinde '{0}' içerik özelliği ayarlanamaz. '{0}' yanlış erişim düzeyinde veya bütünleştirilmiş kodu erişime izin vermiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: '{0}' genel veya iç alma erişenine sahip olmadığı için bir Trigger Property özniteliği olarak ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: İki yeni ad alanı, XmlnsCompatibility özniteliğini kullanan aynı eski ad alanıyla uyumlu olamaz.�'{0}' ad alanı zaten '{1}' ile uyumlu olarak işaretlenmiş.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: Özellik öğeleri bir öğenin içeriğinin ortasında olamaz. İçerikten önce veya sonra gelmelidirler.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: XAML dosyasında xaml ad alanından 'Code' etiketi bulundu. Bu dosyayı yüklemek için, derlemeniz gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: '{0}' öğe türü '{1}' dizesini ayrıştırmak için ilişkilendirilmiş bir TypeConverter'a sahip değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: Korumalı bir XmlnsDictionary içindeki veriler değiştirilemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: '{0}' sözlük anahtarı zaten kullanılıyor. Anahtar öznitelikleri, bir sözlüğe nesne eklerken anahtar olarak kullanılırlar ve benzersiz olmaları gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: '{0}' özelliği bu işaretleme uzantısında zaten ayarlanmış durumda ve yalnızca bir kez ayarlanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: '{0}' özelliği zaten ayarlanmış ve yalnızca bir kez ayarlanabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: '{0}' ve '{1}' özelliği aynı özelliğe başvuruda bulunuyor. Yinelenen özellik ayarlarına izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: '{0}' özellik öğesi boş olamaz. Alt öğeler veya metin içermesi gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: EntityReference &amp;{0}; tanınmıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: '{1}' olayı için '{0}' temsilci türüne erişilemiyor. '{0}' yanlış erişim düzeyinde veya bütünleştirilmiş kodu erişime izin vermiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: '{0}' özelliği salt okunur bir IEnumerable özelliğidir ve buna göre '{1}' IAddChild uygulamalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: '{0}' türünde geçersiz ContentPropertyAttribute, özellik '{1}' bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">Bilinen tür değeri{0}='{1}' geçerli bir bilinen tür değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: '{1}' türünde statik üye '{0}' bulunamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: XmlnsDictionary içindeki anahtarlar ve değerler dize olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">Satır {0} Konum {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: Mapping yönergesinde XmlNamespace, Assembly veya ClrNamespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">'{0}' eşleme URI'si geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: '{0}' içinde oluşturucu bağımsız değişkenleri belirten MarkupExtension için biçim geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: İşaretleme uzantıları ad ve değer arasında tek bir '=' ve oluşturucu parametreleriyle ad/değer çiftleri arasında tek bir ',' gerektirir. '{0}' bağımsız değişkenleri geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' geçerli değil. İşaretleme uzantıları biçimlendirme uzantısı adıyla ilk parametre arasında yalnızca boşluklar olmasını gerektirir. İlk parametreden önce virgül veya eşittir işareti olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: '{1}' numaralı satırın '{2}' konumunda, karşılık gelen bir açılış ayracı olmayan '{0}' kapanış ayracı ile karşılaşıldı.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: '{1}' numaralı satırın '{2}' konumundaki '{0}' ayracı için karşılık gelen bir açılış/kapanış ayracı yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: MarkupExtension ifadelerinin sonunda a '}' olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: MarkupExtensions içindeki ad/değer çiftleri 'Ad = Değer' biçiminde olmalı ve her çift bir virgülle ayrılır. '{0}' bu biçime uymuyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: MarkupExtension içindeki Adlar ve Değerler tırnak işareti içeremez. MarkupExtension bağımsız değişkenleri '{0}' geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: MarkupExtension ifadesinin '{0}' kapanışından sonra '{1}' metnine izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: Markup Extension ayrıştırılırken '{1}' türü için bilinmeyen '{0}' özelliği bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: '{1}' ad alanında bilinmeyen '{0}' özelliği. Bu ad alanında şu anda yalnızca Key özniteliğinin desteklendiğini unutmayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: İç ayrıştırıcı hatası - Aynı anda birden fazla yazılabilir BAML kaydı kullanılamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">'{0}' özellik öğesi doğrudan başka bir özellik öğesinin içinde basamak durumunda olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: Array etiketlerine öznitelik yerleştirilemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: XAML dosyası derlenirken zaman uyumsuz yükleme desteklenmediği için, '{0}' türünde SynchronousMode'a izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: '{0}' türü öğe içeriğini desteklemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: Bir IDictionary öğesine eklenen tüm nesnelerin bir Key özniteliği veya kendilerine atanmış başka tür anahtarı olması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Key özniteliği yalnızca bir Dictionary içinde (örneğin ResourceDictionary) yer alan bir etikette kullanılabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: '{0}' için '{1}' değer olarak kullanılamaz. Sayılar geçerli sabit listesi değeri değildir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: '{0}' olay işleyicisini belirtmek için özellik öğesi sözdizimi kullanılamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: Olay içeren XAML dosyasının derlenmesi gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: '{0}' türü Name özniteliğine sahip olamaz. Değer türleri ve varsayılan oluşturucusu olmayan türler bir ResourceDictionary içinde öğe olarak kullanılabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: '{1}' öğesinde Name öznitelik değeri '{0}' ayarlanamaz. '{1}' öğesi, başka bir kapsamda tanımlandığı sırada zaten bir adı olan '{2}' öğesinin kapsamındadır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: '{0}' nesnesi için NamespaceURI tanımlanmadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: XML veri adaları iç içe yerleştirilemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: Özellik öğelerinde özellikler ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: '{0}' için özel bir seri hale getirici bulunamadığından ayrıştırılamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: Stil ayarlayıcılar alt öğeleri desteklemez. '{0}' türünde etikete izin verilmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: '{0}' türü bulunamıyor. Tür adlarında büyük/küçük harf ayrımı olduğunu unutmayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: '{0}' değeri geçerli bir MarkupExtension ifadesi değil. '{2}' ad alanında '{1}' çözümlenemiyor. '{1}' MarkupExtension'ın alt sınıfı olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: '{0}' XML ad alanı öneki bir NamespaceURI ile eşleşmediğinden '{1}' öğesi çözümlenemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: '{0}' XML ad alanı öneki bir ad alanı URI'siyle eşlemediğinden '{1}' özelliği çözümlenemiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: '{0}' özelliğinde değer yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: İşaretleme içinde yalnızca genel veya iç sınıflar kullanılabilir. '{0}' türü genel veya iç tür değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: '{0}' özelliği salt okunur ve işaretlemeden ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: Tür başvurusu '{0}' adında genel bir tür bulamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: '{1}' türündeki '{0}' statik üyesi erişilebilir durumda olmadığı için başvuruda bulunulamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: SynchronousMode özniteliği kök etikette olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: Bir özellik öğesi içinde '{0}' metni ile '{1}' alt öğesi birlikte bulunamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: Metin bir IDictionary veya Array özelliği altında geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: Tek bir XAML dosyası 4,096'dan fazla farklı derlemeye başvuruda bulunamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: Kapanış etiketi hemen TypeConverter başlatma dizesi '{0}' sonrasında olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: '{0}' dizesi başlatılırken TypeConverter sözdizimi hatasıyla karşılaşıldı. TypeConverter ile oluşturulan nesnelerde öğe özniteliklerine izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' bildirilmemiş bir ad alanıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: '{0}' özelliği '{1}' XML ad alanında yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: '{0}' özniteliği 'http://schemas.microsoft.com/winfx/2006/xaml' adresindeki XML ad alanında yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: '{0}' etiketi '{1}' XML ad alanında yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: Geçerli etiketin bir özellik öğesi olup olmadığı belirlenirken tanınmayan XML düğüm türü '{0}' bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: Üst öğe veya '{0}' özelliği için bir XML veri adası gerekiyor. Bir XML veri adasını, çevreleyen XAML'den ayırmak için, XML veri adasını &lt;x:XData&gt; ... &lt;/x:XData&gt; içine alın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: '{0}' öğesi veya özelliği XML veri adası içeremez.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: XmlLangProperty özniteliğinin bir özellik adı belirtmesi gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: '{0}' sınıfı IXmlLineInfo uygulamaz. Bu, ayrıştırılan XAML için konum bilgisi almak için gereklidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: '{1}' konumunda beklenmeyen '{0}' belirteci.</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: Belirteç geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">İşaretleme derlemesi için hazırlanıyor...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: '{0}' tür adı beklenen 'className, assembly' biçiminde değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">Resource dosyası okunuyor: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">XAML dosyası yeniden derlendi : '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">Giriş: Bütünleştirilmiş Kod Reference dosyası: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">Kaynak Kimliği '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: '{0}' giriş kaynak dosyası {1} baytlık en fazla boyut sınırını aşıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">.resources dosyası oluşturuldu: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">.resources dosyası oluşturuluyor: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" geçerli değil. '{1}' "Event" anahtar sözcüğüyle biten bir adla kaydedilmiş bir RoutedEvent olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: Göreve işaretleme dosyaları geçirmeniz gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: SourceName özelliği Style.Triggers bölümü içinde ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style, tek bir Style için {0} etiketlerinin ve Style.{1} özellik etiketlerinin ikisini birden destelemiyor. Birini veya diğerini kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: Style özellik etiketi '{0}' yalnızca doğrudan bir Style etiketi altında belirtilebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: '{2}' türünde Style {0} '{1}' bulunamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: Style {0} '{1}' çözümlenemiyor. Sahip olan türün Style'ın TargetType öğesi olduğunu doğrulayın veya {0} belirtmek için Class.Property sözdizimini kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style, '{0}' alt öğesini içeremez. Style alt öğesi Setters koleksiyonuna eklendiği için bir Setter olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: '{0}' türünde etiketler Style bölümlerinde desteklenmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: '{0}' olayı bir Style içinde Target etiketinde belirtilemez. Bunun yerine EventSetter kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: Bir Style bölümü içinde bu konumda '{0}' metnine izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: Style içinde '{0}' özelliği ayarlanamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: XAML kullanılarak tanımlandığı için, '{0}' bir XAML dosyasının kökü olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: '{0}' Hedef Türü bu görev tarafından desteklenmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: TargetName özelliği bir Style Setter içinde ayarlanamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) Build Task '{0}' Sürüm '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Telif hakkı (C) Microsoft Corporation 2005. Tüm hakları saklıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: Name '{0}' zaten tanımlanmış. Name değerleri benzersiz olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: Bir Template içerik bölümünün kökü '{0}' türünde öğe içeremez. Yalnızca FrameworkElement ve FrameworkContentElement türleri geçerlidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: '{0}' şablon özellik etiketi yalnızca bir ControlTemplate etiketinden hemen sonra belirtilebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: Bir şablonun yalnızca tek bir kök öğesi olabilir. '{0}' öğesine izin verilmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: '{1}' türünde '{0}' Şablon Özelliği bulunamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: '{0}' Şablon Özelliği çözümlenemiyor. Sahip olan türün Style'ın TargetType'ı olduğunu doğrulayın veya özelliği belirtmek için Class.Property sözdizimini kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: Trigger hedefi '{0}' bulunamıyor. (Hedef kendisini kullanan tüm Setter, Trigger veya Condition'lardan önce olmalıdır.)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: '{0}' türünde etiketler şablon bölümlerinde desteklenmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: Bir şablon bölümünde bu konumda '{0}' metnine izin verilmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: '{0}' özelliği şablonda özellik öğesi olarak ayarlanamaz. Özellik öğesi olarak yalnızca Triggers ve Storyboards'a izin verilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: Ayrıştırma sırasında boş belirteç bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: Ayrıştırma sırasında, belirteçten sonra fazladan veri bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: Belirteç ayrıştırılırken eksik bitiş tırnak işareti bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: Erken dize sonu bulundu.</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: '{0}' öğesi için Uid eksik.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">Bilinmeyen oluşturma hatası, '{0}' </target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" {2} dili için geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: 'http://schemas.microsoft.com/winfx/2006/xaml' ad alanında tanınmayan '{0}:{1}' etiketi. Etiket adlarında büyük/küçük harf ayrımı olduğunu unutmayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' geçerli değil. '{0}' '{2}' üzerinde bir olay değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" {2} dili için geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' '{2}' etiketinde geçerli değil. '{2}' genel türde değil veya öznitelikteki Type bağımsız değişkenlerinin sayısı yanlış. Yalnızca genel türlerde izin verildiğinden {0}:TypeArguments özniteliğini kaldırın ya da değerini '{2}' genel türünün eşliğine uygun şekilde düzeltin.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' bu makineye düzgün yüklenmedi. machine.config içinde &lt;compilers&gt; bölümünde listelenmesi gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">Bilinmeyen yol işlemi denendi.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: Yerelleştirme açıklamasında hedef özellik için ayarlanmış değer yok: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: Birincil ve ikincil sürüm numarası bileşenleri negatif olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: Proje dosyasının başvuru listesinde .NET Framework bütünleştirilmiş kodunu '{0}' içermesi gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: LocalizationDirectivesToLocFile özellik değeri geçerli değil ve MarkupCompilePass1 görevi için None, CommentsOnly veya All olarak değiştirilmesi gerekiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: Proje dosyası geçerli olmayan bir özellik değeri içeriyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice, bir Fallback'ten sonra olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent bir veya daha fazla Choice öğesi içermelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice yalnızca AlternateContent içinde geçerlidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: '{0}' ad alanı XmlnsCompatibilityAttribute kullanılarak kendiyle uyumlu olarak işaretlendi. Bir ad alanı doğrudan veya dolaylı olarak kendini geçersiz kılamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: '{0}' ad alanındaki '{1}' öğesi için yinelenen Preserve bildirimi.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: '{0}' ad alanındaki '{1}' öğesi için yinelenen ProcessContent bildirimi.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: '{0}' ad alanı için yinelenen joker karakterli Preserve bildirimi.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: '{0}' ad alanı için yinelenen joker karakterli ProcessContent bildirimi.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback yalnızca AlternateContent içinde geçerli.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: '{0}' öğesi AlternateContent'in geçerli bir alt öğesi değil. Yalnızca Choice ve Fallback bir AlternateContent öğesinin geçerli alt öğeleridir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: '{0}' özniteliği '{1}' öğesi için geçerli değildir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: '{0}' biçimi geçerli değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: '{0}' ad alanı için hem belirli, hem de joker Preserve bildirimi olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: '{0}' ad alanı için hem belirli, hem joker ProcessContent bildirimi olamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Requires özniteliği, geçerli bir ad alanı öneki içermelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: '{0}' özellik değeri geçerli bir XML adı değildir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent yalnızca bir Fallback öğesi içermelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: MustUnderstand koşulu '{0}' ad alanında başarısız oldu.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: '{0}' ad alanında korunması bildirilmiş öğeler var, ancak bunların yok sayılması bildirilmemiş.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: '{0}' ad alanı ProcessContent olarak bildirildi, ancak Ignorable olarak bildirilmedi.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice bir Requires özniteliği içermelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: '{0}' öneki tanımlı değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: Tanınmayan uyumluluk özniteliği '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: Tanınmayan uyumluluk öğesi '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: Özellik kimliği dizesinin uzunluğu 0 olamaz.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">分析结果:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: 库项目文件无法指定 ApplicationDefinition 元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">输入: 标记 ApplicationDefinition 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: 无法在“{1}:{2}”标记上设置“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: 无法识别的 UidManager 任务名“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">正在检查文件“{0}”中的 Uid ...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">生成的本地化指令文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">正在生成本地化指令文件:“{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">已完成标记编译。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 成功生成 BAML 或源代码文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 成功生成 BAML 或源代码文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011:“{0}”事件有一个通用的事件处理程序委托类型“{1}”。无法将“{1}”的类型参数与适当的类型参数绑定，因为所包含的标记“{2}”不是泛型类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">当前的项目目录是“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: 只有根标记可以指定特性“{0}:{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: 不能将“{0}:{1}”指定为根元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004:“{0}:{1}”包含“{2}”。“{0}:{1}”只能包含 CDATA 或文本部分。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">启动标记编译。</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}=“{1}”无效。“{0}”事件特性值不能为空字符串或只有空白。</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: 不能在该标记上指定 {0}:FieldModifier，因为它不具有 {0}:Name 或 Name 特性集，或者该标记是本地定义的且具有 Name 特性集，而这种情况是不允许的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: 无法找到文件“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">输入文件“{0}”在目录“{2}”处被解析为新的相对路径“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: {0} 文件无法进行 Uid 检查。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">在 {0} 文件中有效的 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">从 {0} 文件中移除的 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">在 {0} 文件中更新的 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">生成的 BAML 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">生成的代码文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003:“{0}:{1}”包含“{2}”。“{0}:{1}”不能包含嵌套内容。</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006:“{0}”目录不存在且无法创建。</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">该项目不需要 InternalTypeHelper 类，使文件“{0}”为空。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018:“{0}”类名对本地定义的 XAML 根元素无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019:“{0}”命名空间对本地定义的 XAML 根元素“{1}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}=“{2}”无效。“{2}”是无效的 {3} 类名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: 项目文件中的 UICulture 值“{0}”集无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: 序列化程序不支持自定义 BAML 序列化操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: 序列化程序不支持 Convert 操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029:“{0}”名称在默认命名空间“{1}”中无效。请更正项目文件中的 RootNamespace 标记值。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}=“{1}”无效。“{1}”不是有效的事件处理程序方法名。只有生成的类或代码隐藏类上的实例方法是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: 本地化注释目标属性在字符串“{0}”中无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: 本地化注释值对字符串“{1}”中的目标属性“{0}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: 可本地化特性设置“{0}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: 标记文件无效。请指定扩展名为 .xaml 的源标记文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments=“{1}”无效。对于位置“{3}”处的泛型实参，“{2}”不是有效的类型名引用。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000:“{0}”XML 无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: 由于“{0}”是在同一程序集中实现的，您必须设置 {1}:Name 特性而不是 Name 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">输入: 本地引用标记 ApplicationDefinition 文件是“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">生成的 BAML 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">输入: 本地引用标记 Page 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012:“{0}”事件具有通用事件处理程序委托类型“{1}”。“{1}”上的类型参数“{2}”与所包含的通用标记“{3}”上的任何类型参数不匹配。</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026:“{0}”根元素需要 {1}:Class 特性，因为“{2}”包含 {1}:Code 标记。请移除 {1}:Code 及其内容，或将 {1}:Class 特性添加到根元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024:“{0}”根元素需要 {1}:Class 特性来支持 XAML 文件中的事件处理程序。请移除 {2} 事件的事件处理程序，或将 {1}:Class 特性添加到根元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025:“{0}”根元素是泛型类型，且需要 {1}:Class 特性来支持根元素标记上指定的 {1}:TypeArguments 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: 无法指定 {0}:FieldModifier 特性，因为还需要 {0}:Class 特性来生成具有指定的访问修饰符的 Name 字段。请在根标记上添加 {0}:Class 特性或移除 {0}:FieldModifier 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: 无法在根标记上指定 {0}:ClassModifier 特性，因为还需要 {0}:Class 特性。请添加 {0}:Class 特性或移除 {0}:ClassModifier 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: 缺少 {0}:Class 特性。当已指定 {0}:Subclass 特性时该特性是必需的。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator 一次只能生成一个 .resources 文件。必须将项目文件中的 OutputResourcesFile 属性设置到一个文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: 项目文件不能指定多个 SplashScreen 元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: 元素“{1}”的 Uid“{0}”不是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: 项目文件不能指定多个 ApplicationDefinition 元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">某“{0}”已命名为“{1}”。请勿命名 ResourceDictionary 内容，因为已推迟此类内容的实例化。</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: 未知的 CLS 异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType 是“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: 在处理初始化字符串“{0}”时遇到 TypeConverter 语法错误。通过 TypeConverter 创建的对象上不允许属性元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: 无法加载程序集“{0}”，因为加载了同一程序集的其他版本“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: 根标记上必须设置 AsyncRecords 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015:“{1}”或其一个基类上未定义附加属性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: 为“{0}”指定了过多的特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: 为“{0}”指定的特性不足。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: 属性“{0}”必须位于默认的命名空间或元素命名空间“{1}”中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath 无法接受空 assemblyName。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath 无法接受空 assemblyPath。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: 无法在复杂属性“{1}”上设置类型“{0}”的元素。它们不是兼容的类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: 无法找到接受 {1} 参数的“{0}”的公共构造函数。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: 字典的密钥不能是“{0}”类型。仅支持 String、TypeExtension 和 StaticExtension。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029:“{0}”成员无效，因为它不具有限定的类型名。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010:“{0}”Name 属性值无效。Name 必须以字母或下划线开头，且只能包含字母、数字和下划线。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: 无法将字符串值“{0}”转换为类型“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: SynchronousMode 属性值无效。有效的值是 Async 和 Sync。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: 被添加到数组属性的对象为无效类型。该数组是“{0}”类型，但被添加的对象是“{1}”类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: Uid 或 Name 属性值不允许 MarkupExtensions，因此“{0}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: 对象“{0}”已经具有子级且无法添加“{1}”。“{0}”只能接受一个子级。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: 无法向“{0}”类型的对象添加内容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081:“{0}”是类型 IList 或 IDictionary 的一个只读属性，无法设置，因为它不具有公共或内部的 get 访问器。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: 无法设置 {0}“{1}”，因为它不具有可访问的 {2} 访问器。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: 无法设置元素“{1}”上的内容属性“{0}”。“{0}”具有不正确的访问级别，或者其程序集不允许访问。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: 无法将“{0}”设置为 Trigger 的 Property 特性的值，因为它不具有公共或内部的 get 访问器。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: 两个新命名空间无法使用 XmlnsCompatibility 特性与相同的旧命名空间兼容。�“{0}”命名空间已标记为与“{1}”兼容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: 属性元素不能位于元素内容的中间。它们必须位于内容之前或之后。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: xaml 命名空间的“Code”标记在 XAML 文件中找到。若要加载此文件，您必须编译它。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: 元素类型“{0}”不具有关联的 TypeConverter，无法分析字符串“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: 无法修改密封的 XmlnsDictionary 中的数据。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: 字典密钥“{0}”已使用。将对象插入字典时会将密钥特性用作密钥，并且必须是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: 该标记扩展名上已设置属性“{0}”，并且只能设置一次。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: 已设置“{0}”属性，并且只能设置一次。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: 属性“{0}”和“{1}”指的是同一属性。不允许重复的属性设置。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026:“{0}”属性元素不能为空。它必须包含子元素或文本。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: 无法识别 EntityReference &amp;{0};。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: 无法访问“{1}”事件的委托类型“{0}”。“{0}”具有错误的访问级别，或其程序集不允许访问。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030:“{0}”属性是只读的 IEnumerable 属性，这意味着“{1}”必须实现 IAddChild。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: 类型“{0}”上的 ContentPropertyAttribute 无效，未找到属性“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">已知类型值 {0}='{1}' 不是有效的已知类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: 无法找到类型“{1}”上的静态成员“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: XmlnsDictionary 中的密钥和值都必须是字符串。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">行 {0} 位置 {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: 缺少 Mapping 说明中的 XmlNamespace、Assembly 或 ClrNamespace。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">“{0}”mapping URI 无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: 在“{0}”中指定构造函数参数的 MarkupExtension 的格式无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: 标记扩展名在名称和值之间需要一个“=”，在构造函数参数和名称/值对之间需要一个“,”。参数“{0}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091:“{0}”无效。标记扩展在标记扩展名和第一个参数之间只需要空格。在第一个参数之前不能有逗号或等号。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: 行号 "{1}" 和行位置 "{2}" 处的右 BracketCharacter "{0}" 缺少对应的左 BracketCharacter。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: 行号 "{1}" 和行位置 "{2}" 处的 BracketCharacter "{0}" 缺少对应的左/右 BracketCharacter。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: MarkupExtension 表达式必须以一个“}”结束。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: MarkupExtensions 中的名称/值对必须具有“Name = Value”格式，并且每个对以逗号分隔。“{0}”不遵循此格式。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: MarkupExtension 中的名称和值不能含引号。MarkupExtension 参数“{0}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: 关闭 MarkupExtension 表达式的“{0}”之后，文本“{1}”是不允许的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: 分析 Markup Extension 时遇到类型“{1}”的未知属性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046:“{1}”命名空间中的特性“{0}”未知。请注意，当前该命名空间中仅支持 Key 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: 内部分析器错误 - 不能同时使用多个可写的 BAML 记录。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">“{0}”属性元素不能直接嵌套在另一属性元素内。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: 无法在 Array 标记上放置特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: 编译 XAML 文件时不支持异步加载，因此不允许“{0}”的 SynchronousMode。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: 类型“{0}”不支持元素内容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: 所有添加到 IDictionary 的对象必须具有 Key 特性，或有与这些对象相关的某些其他类型的密钥。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Key 特性只能用于包含在 Dictionary (如 ResourceDictionary)中的标记。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032:“{1}”无法用作“{0}”的值。数字不是有效的枚举值。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: 无法使用属性元素语法来指定事件处理程序“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: 必须编译包含事件的 XAML 文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: 类型“{0}”不能具有 Name 特性。值类型和没有默认构造函数的类型可以用作 ResourceDictionary 中的项。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: 无法对元素“{1}”设置 Name 特性值“{0}”。“{1}”在元素“{2}”的范围内，在另一范围内定义它时，已注册了名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: 未为对象“{0}”定义 NamespaceURI。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: 无法嵌套 XML 数据岛。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: 无法在属性元素上设置属性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: 无法找到“{0}”的自定义序列化程序，因此无法分析它。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: Style Setter 不支持子元素。不允许类型“{0}”的标记。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: 无法找到类型“{0}”。请注意，类型名区分大小写。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048:“{0}”值不是有效的 MarkupExtension 表达式。无法解析命名空间“{2}”中的“{1}”。“{1}”必须是 MarkupExtension 的子类。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062:“{0}”XML 命名空间前缀未映射到 NamespaceURI，因此无法解析元素“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100:“{0}”XML 命名空间前缀未映射到命名空间 URI，因此无法解析属性“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: 属性“{0}”不具有值。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: 只有公共或内部的类可在标记内使用。“{0}”类型不是公共或内部的类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065:“{0}”属性是只读的，且无法从标记设置。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: 类型引用无法找到名为“{0}”的公共类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: 无法引用类型“{1}”上的静态成员“{0}”，因为它不是可访问的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: SynchronousMode 特性必须位于根标记上。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: 无法在属性元素内同时包含文本“{0}”和子元素“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: IDictionary 或 Array 属性下的文本无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: 单个 XAML 文件无法引用 4,096 个以上的不同程序集。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: 关闭标记必须紧跟 TypeConverter 初始化字符串“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: 处理初始化字符串“{0}”时遇到 TypeConverter 语法错误。通过 TypeConverter 创建的对象上不允许元素特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071:“{0}”是未声明的命名空间。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: XML 命名空间“{1}”中不存在属性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: XML 命名空间“http://schemas.microsoft.com/winfx/2006/xaml”中不存在特性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: XML 命名空间“{1}”中不存在标记“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: 确定当前标记是否为属性元素时发现无法识别的 XML 节点类型“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: 父元素或属性“{0}”需要一个 XML 数据岛。若要区分 XML 岛和周围的 XAML，请将 XML 数据岛包装在 &lt;x:XData&gt; ... &lt;/x:XData&gt; 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085:“{0}”元素或属性不能包含 XML 数据岛。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: XmlLangProperty 特性必须指定属性名。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: 类“{0}”未实现 IXmlLineInfo。这是获取正在分析的 XAML 的位置信息所必需的。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: 位置“{1}”处的意外标记“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: 标记无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">正在准备标记编译...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: 类型名“{0}”不具有预期的格式“className, assembly”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">正在读取 Resource 文件:“{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">重新编译的 XAML 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">输入: 程序集 Reference 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">资源 ID 是“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: 输入的资源文件“{0}”超过 {1} 字节的最大大小。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">生成的 .resources 文件:“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">正在生成 .resources 文件:“{0}”...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}=“{2}”无效。“{1}”必须是使用以关键字“Event”结束的名称注册的 RoutedEvent。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: 您必须将标记文件传入到任务。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: Style.Triggers 部分内无法设置 SourceName 属性。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style 不同时支持单个 Style 的 {0} 标记和 Style.{1} 属性标记。请使用其中的一个或另一个。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: 只能直接在 Style 标记下指定 Style 属性标记“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: 无法在类型“{2}”上找到 Style {0}“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: 无法解析 Style {0}“{1}”。请确认拥有的类型是 Style 的 TargetType，或使用 Class.Property 语法指定 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style 不能包含子级“{0}”。Style 子级必须是 Setter，因为它被添加到 Setter 集合。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: Style 部分中不支持类型“{0}”的标记。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: 无法在 Style 中的 Target 标记上指定事件“{0}”。请使用 EventSetter。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: Style 部分中的该位置不允许文本“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: Style 上无法设置属性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017:“{0}”不能是 XAML 文件的根，因为它是使用 XAML 定义的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: 该任务不支持目标类型“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: 无法在 Style Setter 上设置 TargetName 属性。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) 生成任务“{0}”版本“{1}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">版权所有(C) Microsoft Corporation 2005。保留所有权利。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: 已定义 Name“{0}”。Name 必须是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: 模板内容部分的根不能包含“{0}”类型的元素。只有 FrameworkElement 和 FrameworkContentElement 类型是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: 只能在 ControlTemplate 标记之后紧跟着指定模板属性标记“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: 模板只能具有一个根元素。“{0}”是不允许的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: 无法在类型“{1}”上找到模板属性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: 无法解析模板属性“{0}”。请确认拥有的类型是 Style 的 TargetType，或使用 Class.Property 语法指定该属性。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: 无法找到 Trigger 目标“{0}”。(该目标必须出现在任何使用它的 Setter、Trigger 或 Condition 之前。)</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: 模板部分中不支持类型“{0}”的标记。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: 模板部分中的该位置不允许文本“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: 无法在模板上将属性“{0}”设置为属性元素。只允许将 Triggers 和 Storyboards 设置为属性元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: 分析时遇到空标记。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: 分析时在令牌后遇到额外数据。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: 分析标记时遇到缺少右引号。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: 遇到字符串过早终止的情况。</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: 缺少元素“{0}”的 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">未知的生成错误“{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier=“{1}”对语言 {2} 无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: 命名空间“http://schemas.microsoft.com/winfx/2006/xaml”中无法识别的标记“{0}:{1}”。请注意，标记名称区分大小写。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007:“{1}”无效。“{0}”不是“{2}”上的事件。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier=“{1}”对语言 {2} 无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: 标记“{2}”上的 {0}:TypeArguments='{1}' 无效。要么“{2}”不是泛型类型，要么特性中 Type 参数的数目错误。请移除 {0}:TypeArguments 特性，因为只在通用类型上允许该特性，或将其值修复为匹配泛型类型“{2}”的 arity。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: 未在该计算机上正确安装“{0}”。它必须在 machine.config 的 &lt;compilers&gt; 部分中列出。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">尝试未知的路径操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: 本地化注释没有目标属性:“{0}”的值集。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: 主要版本号组件和次要版本号组件不能为负数。</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: 项目文件必须在引用列表中包含 .NET Framework 程序集“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: LocalizationDirectivesToLocFile 属性值无效，必须针对 MarkupCompilePass1 任务将其更改为 None、CommentsOnly 或 All。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: 项目文件包含无效的属性值。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice 不能跟在 Fallback 之后。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent 必须包含一个或多个 Choice 元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice 仅在 AlternateContent 中有效。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: 已使用 XmlnsCompatibilityAttribute 将命名空间“{0}”标记为与自身兼容。命名空间不能直接或间接地重写自身。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: 命名空间“{0}”中元素“{1}”的重复 Preserve 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: 命名空间“{0}”中元素“{1}”的重复 ProcessContent 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: 命名空间“{0}”的重复通配符 Preserve 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: 命名空间“{0}”的重复通配符 ProcessContent 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback 仅在 AlternateContent 中有效。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610:“{0}”元素不是 AlternateContent 的有效子级。只有 Choice 和 Fallback 元素是 AlternateContent 元素的子级。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608:“{0}”特性对元素“{1}”无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611:“{0}”格式无效。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: 命名空间“{0}”不能同时具有特定的和通配符性质的 Preserve 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: 命名空间“{0}”不能同时具有特定的和通配符性质的 ProcessContent 声明。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Requires 特性必须包含有效的命名空间前缀。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634:“{0}”特性值不是有效的 XML 名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent 必须仅包含一个 Fallback 元素。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: MustUnderstand 条件在命名空间“{0}”上失败。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: 命名空间“{0}”具有声明为保留但未声明为可忽略的项。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615:“{0}”命名空间声明 ProcessContent 但未声明 Ignorable。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice 必须包含 Requires 特性。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: 未定义“{0}”前缀。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: 无法识别的兼容性特性“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: 无法识别的兼容性元素“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: 功能 ID 字符串不能具有长度 0。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,1242 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <trans-unit id="AnalysisResult">
+        <source>Analysis Result : '{0}'.</source>
+        <target state="new">Analysis Result : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AppDefIsNotRequired">
+        <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
+        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationDefinitionFile">
+        <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
+        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AttributeNotAllowedOnCodeTag">
+        <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
+        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BadUidTask">
+        <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
+        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CheckingUids">
+        <source>Checking Uids in file '{0}' ...</source>
+        <target state="new">Checking Uids in file '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerated">
+        <source>Generated localization directives file: '{0}' .</source>
+        <target state="new">Generated localization directives file: '{0}' .</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommentFileGenerating">
+        <source>Generating localization directives file: '{0}' ...</source>
+        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompilationDone">
+        <source>Markup compilation is done.</source>
+        <target state="new">Markup compilation is done.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass1">
+        <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CompileSucceed_Pass2">
+        <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
+        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainingTagNotGeneric">
+        <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
+        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CurrentDirectory">
+        <source>Current project directory is '{0}'.</source>
+        <target state="new">Current project directory is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionAttributeNotAllowed">
+        <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
+        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefinitionTagNotAllowedAtRoot">
+        <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
+        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefnTagsCannotBeNested">
+        <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
+        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoCompilation">
+        <source>Started the markup compilation.</source>
+        <target state="new">Started the markup compilation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EmptyEventStringNotAllowed">
+        <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
+        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FieldModifierNotAllowed">
+        <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
+        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileClassifierTask">
+        <source>FileClassifier</source>
+        <target state="new">FileClassifier</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotFound">
+        <source>BG1002: File '{0}' cannot be found.</source>
+        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileResolved">
+        <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
+        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesFailedUidCheck">
+        <source>UM1004: {0} files failed Uid check.</source>
+        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesPassedUidCheck">
+        <source>Uids valid in {0} files.</source>
+        <target state="new">Uids valid in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesRemovedUid">
+        <source>Uids removed from {0} files.</source>
+        <target state="new">Uids removed from {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesUpdatedUid">
+        <source>Uids updated in {0} files.</source>
+        <target state="new">Uids updated in {0} files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GeneratedCodeFile">
+        <source>Generated code file: '{0}'.</source>
+        <target state="new">Generated code file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GetWinFXPathTask">
+        <source>GetWinFXPath</source>
+        <target state="new">GetWinFXPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IllegalCDataTextScoping">
+        <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
+        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntermediateDirectoryError">
+        <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
+        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalTypeHelperNotRequired">
+        <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
+        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassName">
+        <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
+        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseClassNamespace">
+        <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
+        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidClassName">
+        <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
+        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCulture">
+        <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
+        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCustomSerialize">
+        <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
+        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDeSerialize">
+        <source>MC4401: Serializer does not support Convert operations.</source>
+        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDefaultCLRNamespace">
+        <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
+        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEventHandlerName">
+        <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
+        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentTarget">
+        <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
+        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocCommentValue">
+        <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
+        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidLocalizabilityValue">
+        <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
+        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMarkupFile">
+        <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
+        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTypeName">
+        <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
+        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidXml">
+        <source>MC3000: '{0}' XML is not valid.</source>
+        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalNamePropertyNotAllowed">
+        <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
+        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefAppDefFile">
+        <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
+        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefGeneratedBamlFile">
+        <source>Generated BAML file: '{0}'.</source>
+        <target state="new">Generated BAML file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalRefMarkupPage">
+        <source>Input: Local reference markup Page file: '{0}'.</source>
+        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass1Task">
+        <source>MarkupCompilePass1</source>
+        <target state="new">MarkupCompilePass1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MarkupCompilePass2Task">
+        <source>MarkupCompilePass2</source>
+        <target state="new">MarkupCompilePass2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchingTypeArgsNotFoundInRefType">
+        <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
+        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MergeLocalizationDirectivesTask">
+        <source>MergeLocalizationDirectives</source>
+        <target state="new">MergeLocalizationDirectives</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForCodeTag">
+        <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForEvent">
+        <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
+        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassDefinitionForTypeArgs">
+        <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
+        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithFieldModifier">
+        <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
+        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithModifier">
+        <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
+        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingClassWithSubClass">
+        <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
+        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MoreResourcesFiles">
+        <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
+        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleSplashScreenImages">
+        <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
+        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleUidUse">
+        <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
+        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MutlipleApplicationFiles">
+        <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
+        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NamedResDictItemWarning">
+        <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
+        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NonClsError">
+        <source>BG1001: Unknown CLS exception.</source>
+        <target state="new">BG1001: Unknown CLS exception.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputType">
+        <source>OutputType is '{0}'.</source>
+        <target state="new">OutputType is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAbandonedTypeConverterText">
+        <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAssemblyLoadVersionMismatch">
+        <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
+        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAsyncOnRoot">
+        <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
+        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttachedPropInheritError">
+        <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
+        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsHigh">
+        <source>MC3003: There are too many attributes specified for '{0}'.</source>
+        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeArgsLow">
+        <source>MC3004: There are not enough attributes specified for '{0}'.</source>
+        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserAttributeNamespaceMisMatch">
+        <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
+        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyName">
+        <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
+        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadAssemblyPath">
+        <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
+        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadChild">
+        <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
+        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadConstructorParams">
+        <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
+        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadKey">
+        <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
+        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadMemberReference">
+        <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
+        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadName">
+        <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
+        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadString">
+        <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
+        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadSyncMode">
+        <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
+        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadTypeInArrayProperty">
+        <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
+        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserBadUidOrNameME">
+        <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
+        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCanOnlyHaveOneChild">
+        <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
+        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCannotAddAnyChildren">
+        <source>MC3028: Cannot add content to object of type '{0}'.</source>
+        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantGetProperty">
+        <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetAttribute">
+        <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
+        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetContentProperty">
+        <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCantSetTriggerCondition">
+        <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
+        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserCompatDuplicate">
+        <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
+        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserContentMustBeContiguous">
+        <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
+        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefTag">
+        <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
+        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDefaultConverterElement">
+        <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
+        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDictionarySealed">
+        <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
+        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDupDictionaryKey">
+        <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
+        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateMarkupExtensionProperty">
+        <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
+        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty1">
+        <source>MC3024: '{0}' property has already been set and can be set only once.</source>
+        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserDuplicateProperty2">
+        <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
+        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEmptyComplexProp">
+        <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
+        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEntityReference">
+        <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
+        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserEventDelegateTypeNotAccessible">
+        <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
+        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserIEnumerableIAddChild">
+        <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
+        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidContentPropertyAttribute">
+        <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
+        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidKnownType">
+        <source>Known type value {0}='{1}' is not a valid known type.</source>
+        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserInvalidStaticMember">
+        <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
+        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserKeysAreStrings">
+        <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
+        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserLineAndOffset">
+        <source>Line {0} Position {1}</source>
+        <target state="new">Line {0} Position {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMapPIMissingKey">
+        <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
+        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMappingUriInvalid">
+        <source>'{0}' mapping URI is not valid.</source>
+        <target state="new">'{0}' mapping URI is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadConstructorParam">
+        <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
+        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionBadDelimiter">
+        <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
+        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
+        <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
+        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
+        <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
+        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
+        <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
+        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoEndCurlie">
+        <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
+        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoNameValue">
+        <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
+        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionNoQuotesInName">
+        <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
+        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionTrailingGarbage">
+        <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
+        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMarkupExtensionUnknownAttr">
+        <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
+        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMetroUnknownAttribute">
+        <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
+        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserMultiBamls">
+        <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
+        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNestedComplexProp">
+        <source>'{0}' property element cannot be nested directly inside another property element.</source>
+        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoAttrArray">
+        <source>MC3049: Cannot place attributes on Array tags.</source>
+        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoBamlAsync">
+        <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
+        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoChildrenTag">
+        <source>MC3051: The type '{0}' does not support element content.</source>
+        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryKey">
+        <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
+        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDictionaryName">
+        <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
+        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoDigitEnums">
+        <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
+        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEventTag">
+        <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
+        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoEvents">
+        <source>MC3052: XAML file that contains events must be compiled.</source>
+        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameOnType">
+        <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
+        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNameUnderDefinitionScopeType">
+        <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
+        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNamespace">
+        <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
+        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoNestedXmlDataIslands">
+        <source>MC3084: Cannot nest XML data islands.</source>
+        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoPropOnComplexProp">
+        <source>MC3057: Cannot set properties on property elements.</source>
+        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSerializer">
+        <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
+        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoSetterChild">
+        <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
+        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNoType">
+        <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
+        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserNotMarkupExtension">
+        <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
+        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSElement">
+        <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
+        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPrefixNSProperty">
+        <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
+        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPropNoValue">
+        <source>MC3063: Property '{0}' does not have a value.</source>
+        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserPublicType">
+        <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
+        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserReadOnlyProp">
+        <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
+        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserResourceKeyType">
+        <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
+        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserStaticMemberNotAllowed">
+        <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
+        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserSyncOnRoot">
+        <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
+        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInComplexProp">
+        <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
+        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTextInvalidInArrayOrDictionary">
+        <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
+        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTooManyAssemblies">
+        <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
+        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextNeedsEndElement">
+        <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
+        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserTypeConverterTextUnusable">
+        <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
+        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUndeclaredNS">
+        <source>MC3071: '{0}' is an undeclared namespace.</source>
+        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownAttribute">
+        <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownDefAttribute">
+        <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
+        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownTag">
+        <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
+        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserUnknownXmlType">
+        <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
+        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandMissing">
+        <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
+        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlIslandUnexpected">
+        <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
+        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlLangPropertyValueInvalid">
+        <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
+        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParserXmlReaderNoLineInfo">
+        <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
+        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parser_UnexpectedToken">
+        <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
+        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Parsers_IllegalToken">
+        <source>MC3096: Token is not valid.</source>
+        <target state="new">MC3096: Token is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PreparingCompile">
+        <source>Preparing for the markup compilation...</source>
+        <target state="new">Preparing for the markup compilation...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="QualifiedNameHasWrongFormat">
+        <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
+        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReadResourceFile">
+        <source>Reading Resource file: '{0}'...</source>
+        <target state="new">Reading Resource file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecompiledXaml">
+        <source>Recompiled XAML file : '{0}'.</source>
+        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferenceFile">
+        <source>Input: Assembly Reference file: '{0}'.</source>
+        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceId">
+        <source>Resource ID is '{0}'.</source>
+        <target state="new">Resource ID is '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourceTooBig">
+        <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
+        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerated">
+        <source>Generated .resources file: '{0}'.</source>
+        <target state="new">Generated .resources file: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGenerating">
+        <source>Generating .resources file: '{0}'...</source>
+        <target state="new">Generating .resources file: '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResourcesGeneratorTask">
+        <source>ResourcesGenerator</source>
+        <target state="new">ResourcesGenerator</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoutedEventNotRegistered">
+        <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
+        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFileNameNeeded">
+        <source>UM1005: You must pass markup files to the task.</source>
+        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceNameNotSupportedForStyleTriggers">
+        <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
+        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleImpliedAndComplexChildren">
+        <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
+        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleKnownTagWrongLocation">
+        <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
+        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoPropOrEvent">
+        <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
+        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTarget">
+        <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
+        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleNoTopLevelElement">
+        <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
+        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTagNotSupported">
+        <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
+        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTargetNoEvents">
+        <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
+        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleTextNotSupported">
+        <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
+        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StyleUnknownProp">
+        <source>MC4009: The property '{0}' cannot be set on Style.</source>
+        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SubSubClassingNotAllowed">
+        <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
+        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetIsNotSupported">
+        <source>BG1004: Target Type '{0}' is not supported by this task.</source>
+        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TargetNameNotSupportedForStyleSetters">
+        <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
+        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskLogo">
+        <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
+        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TaskRight">
+        <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
+        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateDupName">
+        <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
+        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateInvalidRootElementTag">
+        <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
+        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateKnownTagWrongLocation">
+        <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
+        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoMultipleRoots">
+        <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
+        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoProp">
+        <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
+        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTarget">
+        <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
+        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateNoTriggerTarget">
+        <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
+        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTagNotSupported">
+        <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
+        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateTextNotSupported">
+        <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
+        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateUnknownProp">
+        <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
+        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperEmptyToken">
+        <source>MC7004: Empty token encountered while parsing.</source>
+        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperExtraDataEncountered">
+        <source>MC7003: Extra data encountered after token while parsing.</source>
+        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperMissingEndQuote">
+        <source>MC7002: Missing end quote encountered while parsing token.</source>
+        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TokenizerHelperPrematureStringTermination">
+        <source>MC7001: Premature string termination encountered.</source>
+        <target state="new">MC7001: Premature string termination encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidManagerTask">
+        <source>UidManager</source>
+        <target state="new">UidManager</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UidMissing">
+        <source>UM1003: Uid is missing for element '{0}'.</source>
+        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownBuildError">
+        <source>Unknown build error, '{0}' </source>
+        <target state="new">Unknown build error, '{0}' </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownClassModifier">
+        <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownDefinitionTag">
+        <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
+        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownEventAttribute">
+        <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
+        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownFieldModifier">
+        <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
+        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownGenericType">
+        <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
+        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownLanguage">
+        <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
+        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnknownPathOperationType">
+        <source>Unknown path operation attempted.</source>
+        <target state="new">Unknown path operation attempted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnmatchedLocComment">
+        <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
+        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateManifestForBrowserApplicationTask">
+        <source>UpdateManifestForBrowserApplication</source>
+        <target state="new">UpdateManifestForBrowserApplication</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionNumberComponentNegative">
+        <source>MC4501: Major and minor version number components cannot be negative.</source>
+        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WinFXAssemblyMissing">
+        <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
+        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongLocalizationPropertySetting_Pass1">
+        <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
+        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WrongPropertySetting">
+        <source>BG1003: The project file contains a property value that is not valid.</source>
+        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceAfterFallback">
+        <source>MC4602: Choice cannot follow a Fallback.</source>
+        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceNotFound">
+        <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
+        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRChoiceOnlyInAC">
+        <source>MC4601: Choice valid only in AlternateContent.</source>
+        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRCompatCycle">
+        <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
+        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicatePreserve">
+        <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateProcessContent">
+        <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
+        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardPreserve">
+        <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRDuplicateWildcardProcessContent">
+        <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRFallbackOnlyInAC">
+        <source>MC4605: Fallback valid only in AlternateContent.</source>
+        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidACChild">
+        <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
+        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidAttribInElement">
+        <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
+        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidFormat">
+        <source>MC4611: '{0}' format is not valid.</source>
+        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidPreserve">
+        <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
+        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidProcessContent">
+        <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
+        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidRequiresAttribute">
+        <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
+        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRInvalidXMLName">
+        <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
+        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMultipleFallbackFound">
+        <source>MC4607: AlternateContent must contain only one Fallback element.</source>
+        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRMustUnderstandFailed">
+        <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
+        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSPreserveNotIgnorable">
+        <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
+        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRNSProcessContentNotIgnorable">
+        <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
+        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRRequiresAttribNotFound">
+        <source>MC4603: Choice must contain a Requires attribute.</source>
+        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUndefinedPrefix">
+        <source>MC4612: '{0}' prefix is not defined.</source>
+        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatAttrib">
+        <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
+        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="XCRUnknownCompatElement">
+        <source>MC4609: Unrecognized compatibility element '{0}'.</source>
+        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZeroLengthFeatureID">
+        <source>MC4502: The feature ID string cannot have length 0.</source>
+        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,1240 +1,1240 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
       <trans-unit id="AnalysisResult">
         <source>Analysis Result : '{0}'.</source>
-        <target state="new">Analysis Result : '{0}'.</target>
+        <target state="translated">分析結果: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="AppDefIsNotRequired">
         <source>MC1002: Library project file cannot specify ApplicationDefinition element.</source>
-        <target state="new">MC1002: Library project file cannot specify ApplicationDefinition element.</target>
+        <target state="translated">MC1002: 程式庫專案檔無法指定 ApplicationDefinition 項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="ApplicationDefinitionFile">
         <source>Input: Markup ApplicationDefinition file: '{0}'.</source>
-        <target state="new">Input: Markup ApplicationDefinition file: '{0}'.</target>
+        <target state="translated">輸入: 標記 ApplicationDefinition 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="AttributeNotAllowedOnCodeTag">
         <source>MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</source>
-        <target state="new">MC6015: '{0}' cannot be set on the '{1}:{2}' tag.</target>
+        <target state="translated">MC6015: 無法在 '{1}:{2}' 標記上設定 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="BadUidTask">
         <source>UM1001: Unrecognized UidManager task name '{0}'.</source>
-        <target state="new">UM1001: Unrecognized UidManager task name '{0}'.</target>
+        <target state="translated">UM1001: 無法識別的 UidManager 工作名稱 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="CheckingUids">
         <source>Checking Uids in file '{0}' ...</source>
-        <target state="new">Checking Uids in file '{0}' ...</target>
+        <target state="translated">正在檢查檔案 '{0}' 中的 Uid...</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerated">
         <source>Generated localization directives file: '{0}' .</source>
-        <target state="new">Generated localization directives file: '{0}' .</target>
+        <target state="translated">已產生的當地語系化指示詞檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommentFileGenerating">
         <source>Generating localization directives file: '{0}' ...</source>
-        <target state="new">Generating localization directives file: '{0}' ...</target>
+        <target state="translated">正在產生當地語系化指示詞檔案: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="CompilationDone">
         <source>Markup compilation is done.</source>
-        <target state="new">Markup compilation is done.</target>
+        <target state="translated">標記編譯完成。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass1">
         <source>MarkupCompilePass1 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass1 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass1 已順利產生 BAML 或原始程式碼檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="CompileSucceed_Pass2">
         <source>MarkupCompilePass2 successfully generated BAML or source code files.</source>
-        <target state="new">MarkupCompilePass2 successfully generated BAML or source code files.</target>
+        <target state="translated">MarkupCompilePass2 已順利產生 BAML 或原始程式碼檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainingTagNotGeneric">
         <source>MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</source>
-        <target state="new">MC6011: '{0}' event has a generic event handler delegate type '{1}'. The type parameters of '{1}' cannot be bound with an appropriate type argument because the containing tag '{2}' is not a generic type.</target>
+        <target state="translated">MC6011: '{0}' 事件具有泛用事件處理常式委派型別 '{1}'。'{1}' 的型別參數無法與適當的型別引數繫結，因為包含標記 '{2}' 不是泛型型別。</target>
         <note />
       </trans-unit>
       <trans-unit id="CurrentDirectory">
         <source>Current project directory is '{0}'.</source>
-        <target state="new">Current project directory is '{0}'.</target>
+        <target state="translated">目前的專案目錄是 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionAttributeNotAllowed">
         <source>MC6022: Only a root tag can specify attribute '{0}:{1}'.</source>
-        <target state="new">MC6022: Only a root tag can specify attribute '{0}:{1}'.</target>
+        <target state="translated">MC6022: 只有根標記可以指定屬性 '{0}:{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefinitionTagNotAllowedAtRoot">
         <source>MC6010: '{0}:{1}' cannot be specified as the root element.</source>
-        <target state="new">MC6010: '{0}:{1}' cannot be specified as the root element.</target>
+        <target state="translated">MC6010: 無法指定 '{0}:{1}' 做為根項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefnTagsCannotBeNested">
         <source>MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</source>
-        <target state="new">MC6004: '{0}:{1}' contains '{2}'. '{0}:{1}' can contain only a CDATA or text section.</target>
+        <target state="translated">MC6004: '{0}:{1}' 包含 '{2}'。'{0}:{1}' 只能包含 CDATA 或文字區段。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoCompilation">
         <source>Started the markup compilation.</source>
-        <target state="new">Started the markup compilation.</target>
+        <target state="translated">已開始進行標記編譯。</target>
         <note />
       </trans-unit>
       <trans-unit id="EmptyEventStringNotAllowed">
         <source>MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</source>
-        <target state="new">MC6030: {0}="{1}" is not valid. '{0}' event attribute value cannot be a string that is empty or has only white space.</target>
+        <target state="translated">MC6030: {0}="{1}" 無效。'{0}' 事件屬性值不可以是空字串或只包含空白字元的字串。</target>
         <note />
       </trans-unit>
       <trans-unit id="FieldModifierNotAllowed">
         <source>MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</source>
-        <target state="new">MC6021: {0}:FieldModifier cannot be specified on this tag because it has either no {0}:Name or Name attribute set, or the tag is locally defined and has a Name attribute set, which is not allowed.</target>
+        <target state="translated">MC6021: 無法在此標記上指定 {0}:FieldModifier，因為它並未設定 {0}:Name 或 Name 屬性，或是標記已在本機定義且已設定 Name 屬性，上述兩種情況都是不允許的。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileClassifierTask">
         <source>FileClassifier</source>
-        <target state="new">FileClassifier</target>
+        <target state="translated">FileClassifier</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>BG1002: File '{0}' cannot be found.</source>
-        <target state="new">BG1002: File '{0}' cannot be found.</target>
+        <target state="translated">BG1002: 找不到檔案 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileResolved">
         <source>Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</source>
-        <target state="new">Input file '{0}' is resolved to new relative path '{1}' at directory '{2}'.</target>
+        <target state="translated">輸入檔案 '{0}' 已解析為新的相對路徑 '{1}' (於目錄 '{2}')。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesFailedUidCheck">
         <source>UM1004: {0} files failed Uid check.</source>
-        <target state="new">UM1004: {0} files failed Uid check.</target>
+        <target state="translated">UM1004: 無法針對 {0} 檔案執行 Uid 檢查。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesPassedUidCheck">
         <source>Uids valid in {0} files.</source>
-        <target state="new">Uids valid in {0} files.</target>
+        <target state="translated">{0} 檔案中的 Uid 正確。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesRemovedUid">
         <source>Uids removed from {0} files.</source>
-        <target state="new">Uids removed from {0} files.</target>
+        <target state="translated">已從 {0} 檔案移除 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesUpdatedUid">
         <source>Uids updated in {0} files.</source>
-        <target state="new">Uids updated in {0} files.</target>
+        <target state="translated">已更新 {0} 檔案中的 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">已產生 BAML 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="GeneratedCodeFile">
         <source>Generated code file: '{0}'.</source>
-        <target state="new">Generated code file: '{0}'.</target>
+        <target state="translated">已產生程式碼檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="GetWinFXPathTask">
         <source>GetWinFXPath</source>
-        <target state="new">GetWinFXPath</target>
+        <target state="translated">GetWinFXPath</target>
         <note />
       </trans-unit>
       <trans-unit id="IllegalCDataTextScoping">
         <source>MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</source>
-        <target state="new">MC6003: '{0}:{1}' contains '{2}'. '{0}:{1}' cannot contain nested content.</target>
+        <target state="translated">MC6003: '{0}:{1}' 包含 '{2}'。'{0}:{1}' 不能包含巢狀內容。</target>
         <note />
       </trans-unit>
       <trans-unit id="IntermediateDirectoryError">
         <source>UM1006: '{0}' directory does not exist and cannot be created.</source>
-        <target state="new">UM1006: '{0}' directory does not exist and cannot be created.</target>
+        <target state="translated">UM1006: '{0}' 目錄不存在，且無法建立該目錄。</target>
         <note />
       </trans-unit>
       <trans-unit id="InternalTypeHelperNotRequired">
         <source>InternalTypeHelper class is not required for this project, make file '{0}' empty.</source>
-        <target state="new">InternalTypeHelper class is not required for this project, make file '{0}' empty.</target>
+        <target state="translated">對於此專案，InternalTypeHelper 類別不是必要項目，將檔案 '{0}' 清空。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassName">
         <source>MC6018: '{0}' class name is not valid for the locally defined XAML root element.</source>
-        <target state="new">MC6018: '{0}' class name is not valid for the locally defined XAML root element.</target>
+        <target state="translated">MC6018: 對於 XAML 根項目而言，在本機定義的 '{0}' 類別名稱是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseClassNamespace">
         <source>MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</source>
-        <target state="new">MC6019: '{0}' namespace is not valid for the locally defined XAML root element '{1}'.</target>
+        <target state="translated">MC6019: 對於在本機定義的 XAML 根項目 '{1}' 而言，'{0}' 命名空間是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidClassName">
         <source>MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</source>
-        <target state="new">MC6027: {0}:{1}="{2}" is not valid. '{2}' is not a valid {3}class name.</target>
+        <target state="translated">MC6027: {0}:{1}="{2}" 無效。'{2}' 不是有效的 {3} 類別名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCulture">
         <source>FC1001: The UICulture value '{0}' set in the project file is not valid.</source>
-        <target state="new">FC1001: The UICulture value '{0}' set in the project file is not valid.</target>
+        <target state="translated">FC1001: 在專案檔中設定的 UICulture 值 '{0}' 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCustomSerialize">
         <source>MC4402: Serializer does not support custom BAML serialization operations.</source>
-        <target state="new">MC4402: Serializer does not support custom BAML serialization operations.</target>
+        <target state="translated">MC4402: 序列化程式不支援自訂 BAML 序列化操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDeSerialize">
         <source>MC4401: Serializer does not support Convert operations.</source>
-        <target state="new">MC4401: Serializer does not support Convert operations.</target>
+        <target state="translated">MC4401: 序列化程式不支援 Convert 操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidDefaultCLRNamespace">
         <source>MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</source>
-        <target state="new">MC6029: '{0}' name is not valid in the default namespace '{1}'. Correct the RootNamespace tag value in the project file.</target>
+        <target state="translated">MC6029: 預設命名空間 '{1}' 中的 '{0}' 名稱無效。請更正專案檔中的 RootNamespace 標記值。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidEventHandlerName">
         <source>MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</source>
-        <target state="new">MC6005: {0}="{1}" is not valid. '{1}' is not a valid event handler method name. Only instance methods on the generated or code-behind class are valid.</target>
+        <target state="translated">MC6005: {0}="{1}" 無效。'{1}' 不是有效的事件處理常式方法名稱。只有已產生之類別或程式碼後置類別中的執行個體方法是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
         <source>LC1001: Localization comment target property is not valid in string '{0}'.</source>
-        <target state="new">LC1001: Localization comment target property is not valid in string '{0}'.</target>
+        <target state="translated">LC1001: '{0}' 字串中的當地語系化註解目標屬性無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentValue">
         <source>LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</source>
-        <target state="new">LC1002: Localization comment value is not valid for target property '{0}' in string '{1}'.</target>
+        <target state="translated">LC1002: '{1}' 字串中目標屬性 '{0}' 的當地語系化註解值無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocalizabilityValue">
         <source>LC1004: Localizability attribute setting '{0}' is not valid.</source>
-        <target state="new">LC1004: Localizability attribute setting '{0}' is not valid.</target>
+        <target state="translated">LC1004: 可當地語系化屬性設定 '{0}' 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMarkupFile">
         <source>MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</source>
-        <target state="new">MC6001: Markup file is not valid. Specify a source markup file with an .xaml extension.</target>
+        <target state="translated">MC6001: 標記檔案無效。請指定具有 .xaml 副檔名的來源標記檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidTypeName">
         <source>MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</source>
-        <target state="new">MC6028: {0}:TypeArguments="{1}" is not valid. '{2}' is not a valid type name reference for the generic argument at position '{3}'.</target>
+        <target state="translated">MC6028: {0}:TypeArguments="{1}" 無效。'{2}' 不是泛型引數 (位置 '{3}') 的有效型別名稱參考。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidXml">
         <source>MC3000: '{0}' XML is not valid.</source>
-        <target state="new">MC3000: '{0}' XML is not valid.</target>
+        <target state="translated">MC3000: '{0}' XML 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalNamePropertyNotAllowed">
         <source>MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</source>
-        <target state="new">MC6023: Because '{0}' is implemented in the same assembly, you must set the {1}:Name attribute rather than the Name attribute.</target>
+        <target state="translated">MC6023: 因為 '{0}' 是實作於相同的組件中，您必須設定 {1}:Name 屬性，而非 Name 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefAppDefFile">
         <source>Input: Local reference markup ApplicationDefinition file is '{0}'.</source>
-        <target state="new">Input: Local reference markup ApplicationDefinition file is '{0}'.</target>
+        <target state="translated">輸入: 本機參考標記 ApplicationDefinition 檔案是 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefGeneratedBamlFile">
         <source>Generated BAML file: '{0}'.</source>
-        <target state="new">Generated BAML file: '{0}'.</target>
+        <target state="translated">已產生的 BAML 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalRefMarkupPage">
         <source>Input: Local reference markup Page file: '{0}'.</source>
-        <target state="new">Input: Local reference markup Page file: '{0}'.</target>
+        <target state="translated">輸入: 本機參考標記 Page 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass1Task">
         <source>MarkupCompilePass1</source>
-        <target state="new">MarkupCompilePass1</target>
+        <target state="translated">MarkupCompilePass1</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupCompilePass2Task">
         <source>MarkupCompilePass2</source>
-        <target state="new">MarkupCompilePass2</target>
+        <target state="translated">MarkupCompilePass2</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchingTypeArgsNotFoundInRefType">
         <source>MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</source>
-        <target state="new">MC6012: '{0}' event has a generic event handler delegate type '{1}'. The type parameter '{2}' on '{1}' does not match any type parameters on the containing generic tag '{3}'.</target>
+        <target state="translated">MC6012: '{0}' 事件具有泛用事件處理常式委派型別 '{1}'。'{1}' 上的型別參數 '{2}' 不符合容器泛用標記 '{3}' 上的任何型別參數。</target>
         <note />
       </trans-unit>
       <trans-unit id="MergeLocalizationDirectivesTask">
         <source>MergeLocalizationDirectives</source>
-        <target state="new">MergeLocalizationDirectives</target>
+        <target state="translated">MergeLocalizationDirectives</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForCodeTag">
         <source>MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6026: '{0}' root element requires a {1}:Class attribute because '{2}' contains a {1}:Code tag. Either remove {1}:Code and its contents, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6026: '{0}' 根項目需要 {1}:Class 屬性，因為 '{2}' 包含 {1}:Code 標記。請移除 {1}:Code 與其內容，或新增 {1}:Class 屬性至根項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForEvent">
         <source>MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</source>
-        <target state="new">MC6024: '{0}' root element requires a {1}:Class attribute to support event handlers in the XAML file. Either remove the event handler for the {2} event, or add a {1}:Class attribute to the root element.</target>
+        <target state="translated">MC6024: '{0}' 根項目需要 {1}:Class 屬性，才能支援 XAML 檔案中的事件處理常式。請移除 {2} 事件的事件處理常式，或新增 {1}:Class 屬性至根項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassDefinitionForTypeArgs">
         <source>MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</source>
-        <target state="new">MC6025: '{0}' root element is a generic type and requires a {1}:Class attribute to support the {1}:TypeArguments attribute specified on the root element tag.</target>
+        <target state="translated">MC6025: '{0}' 根項目是泛型型別，且需要 {1}:Class 屬性，才能支援根項目標記中指定的 {1}:TypeArguments 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithFieldModifier">
         <source>MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</source>
-        <target state="new">MC6031: {0}:FieldModifier attribute cannot be specified because a {0}:Class attribute is also required to generate a Name field with the specified access modifier. Either add a {0}:Class attribute on the root tag or remove the {0}:FieldModifier attribute.</target>
+        <target state="translated">MC6031: 無法指定 {0}:FieldModifier 屬性，因為必須也要有 {0}:Class 屬性，才能使用指定的存取修飾詞產生 Name 欄位。請在根標記新增 {0}:Class 屬性，或移除 {0}:FieldModifier 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithModifier">
         <source>MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</source>
-        <target state="new">MC6009: {0}:ClassModifier attribute cannot be specified on the root tag because a {0}:Class attribute is also required. Either add a {0}:Class attribute or remove the {0}:ClassModifier attribute.</target>
+        <target state="translated">MC6009: 無法在根標記上指定 {0}:ClassModifier 屬性，因為也必須指定 {0}:Class 屬性。請新增 {0}:Class 屬性，或移除 {0}:ClassModifier 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingClassWithSubClass">
         <source>MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</source>
-        <target state="new">MC6016: {0}:Class attribute is missing. It is required when a {0}:Subclass attribute is specified.</target>
+        <target state="translated">MC6016: {0}:Class 屬性遺失。指定 {0}:Subclass 屬性時，也必須指定此屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreResourcesFiles">
         <source>RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</source>
-        <target state="new">RG1002: ResourcesGenerator can generate only one .resources file at a time. The OutputResourcesFile property in the project file must be set to one file.</target>
+        <target state="translated">RG1002: ResourcesGenerator 一次只能產生一個 .resources 檔案。專案檔中的 OutputResourcesFile 屬性必須設定至一個檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleSplashScreenImages">
         <source>MC1004: Project file cannot specify more than one SplashScreen element.</source>
-        <target state="new">MC1004: Project file cannot specify more than one SplashScreen element.</target>
+        <target state="translated">MC1004: 專案檔無法指定多個 SplashScreen 項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="MultipleUidUse">
         <source>UM1002: Uid "{0}" for element '{1}' is not unique.</source>
-        <target state="new">UM1002: Uid "{0}" for element '{1}' is not unique.</target>
+        <target state="translated">UM1002: 項目 '{1}' 的 Uid "{0}" 不是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="MutlipleApplicationFiles">
         <source>MC1003: Project file cannot specify more than one ApplicationDefinition element.</source>
-        <target state="new">MC1003: Project file cannot specify more than one ApplicationDefinition element.</target>
+        <target state="translated">MC1003: 專案檔無法指定多個 ApplicationDefinition 項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="NamedResDictItemWarning">
         <source>A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</source>
-        <target state="new">A '{0}' is named '{1}'. Do not name ResourceDictionary contents because their instantiation is deferred.</target>
+        <target state="translated">'{0}' 已命名為 '{1}'。請勿將 ResourceDictionary 內容命名，因為執行個體化已延後。</target>
         <note />
       </trans-unit>
       <trans-unit id="NonClsError">
         <source>BG1001: Unknown CLS exception.</source>
-        <target state="new">BG1001: Unknown CLS exception.</target>
+        <target state="translated">BG1001: 不明的 CLS 例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputType">
         <source>OutputType is '{0}'.</source>
-        <target state="new">OutputType is '{0}'.</target>
+        <target state="translated">OutputType 是 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAbandonedTypeConverterText">
         <source>MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3001: TypeConverter syntax error encountered while processing initialization string '{0}'. Property elements are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3001: 處理初始化字串 '{0}' 時發生 TypeConverter 語法錯誤。透過 TypeConverter 建立的物件上不允許屬性項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAssemblyLoadVersionMismatch">
         <source>MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</source>
-        <target state="new">MC3099: Cannot load assembly '{0}' because a different version of that same assembly is loaded '{1}'.</target>
+        <target state="translated">MC3099: 無法載入組件 '{0}'，因為已載入相同組件的不同版本 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAsyncOnRoot">
         <source>MC3002: The AsyncRecords attribute must be set on the root tag.</source>
-        <target state="new">MC3002: The AsyncRecords attribute must be set on the root tag.</target>
+        <target state="translated">MC3002: 必須在根標記上設定 AsyncRecords 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</source>
-        <target state="new">MC3015: The attached property '{0}' is not defined on '{1}' or one of its base classes.</target>
+        <target state="translated">MC3015: 附加的屬性 '{0}' 不是在 '{1}' 或它的其中一個基底類別上所定義。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsHigh">
         <source>MC3003: There are too many attributes specified for '{0}'.</source>
-        <target state="new">MC3003: There are too many attributes specified for '{0}'.</target>
+        <target state="translated">MC3003: 為 '{0}' 指定的屬性太多。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
         <source>MC3004: There are not enough attributes specified for '{0}'.</source>
-        <target state="new">MC3004: There are not enough attributes specified for '{0}'.</target>
+        <target state="translated">MC3004: 為 '{0}' 指定的屬性數目不足。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeNamespaceMisMatch">
         <source>MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</source>
-        <target state="new">MC3005: The property '{0}' must be in the default namespace or in the element namespace '{1}'.</target>
+        <target state="translated">MC3005: 屬性 '{0}' 必須位於預設的命名空間，或是位於項目命名空間 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyName">
         <source>MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</source>
-        <target state="new">MC3006: Mapper.SetAssemblyPath cannot accept an empty assemblyName.</target>
+        <target state="translated">MC3006: Mapper.SetAssemblyPath 無法接受空的 assemblyName。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadAssemblyPath">
         <source>MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</source>
-        <target state="new">MC3007: Mapper.SetAssemblyPath cannot accept an empty assemblyPath.</target>
+        <target state="translated">MC3007: Mapper.SetAssemblyPath 無法接受空的 assemblyPath。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</source>
-        <target state="new">MC3008: An element of type '{0}' cannot be set on the complex property '{1}'. They are not compatible types.</target>
+        <target state="translated">MC3008: 無法在複雜屬性 '{1}' 上設定型別為 '{0}' 的項目。它們不是相容的型別。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</source>
-        <target state="new">MC3009: Cannot find a public constructor for '{0}' that takes {1} arguments.</target>
+        <target state="translated">MC3009: 找不到取得 {1} 個引數之 '{0}' 的公用建構函式。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadKey">
         <source>MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</source>
-        <target state="new">MC3012: A key for a dictionary cannot be of type '{0}'. Only String, TypeExtension, and StaticExtension are supported.</target>
+        <target state="translated">MC3012: 字典的索引鍵型別不能是 '{0}'。只支援 String、TypeExtension 與 StaticExtension。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadMemberReference">
         <source>MC3029: '{0}' member is not valid because it does not have a qualifying type name.</source>
-        <target state="new">MC3029: '{0}' member is not valid because it does not have a qualifying type name.</target>
+        <target state="translated">MC3029: '{0}' 成員無效，因為它沒有合格的型別名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadName">
         <source>MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</source>
-        <target state="new">MC3010: '{0}' Name property value is not valid. Name must start with a letter or an underscore and can contain only letters, digits, and underscores.</target>
+        <target state="translated">MC3010: '{0}' Name 屬性值無效。Name 的開頭必須是字母或底線，而且只能包含字母、數字或底線。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
         <source>MC3094: Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="new">MC3094: Cannot convert string value '{0}' to type '{1}'.</target>
+        <target state="translated">MC3094: 無法將字串值 '{0}' 轉換為型別 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadSyncMode">
         <source>MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</source>
-        <target state="new">MC3013: SynchronousMode property value is not valid. Valid values are Async and Sync.</target>
+        <target state="translated">MC3013: SynchronousMode 屬性值無效。有效值是 Async 和 Sync。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadTypeInArrayProperty">
         <source>MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</source>
-        <target state="new">MC3014: The object being added to an array property is not a valid type. The array is of type '{0}' but the object being added is of type '{1}'.</target>
+        <target state="translated">MC3014: 要新增到陣列屬性之物件的型別無效。陣列型別為 '{0}'，但要新增之物件的型別為 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadUidOrNameME">
         <source>MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</source>
-        <target state="new">MC3079: MarkupExtensions are not allowed for Uid or Name property values, so '{0}' is not valid.</target>
+        <target state="translated">MC3079: Uid 或 Name 屬性值不允許 MarkupExtensions，因此 '{0}' 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCanOnlyHaveOneChild">
         <source>MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</source>
-        <target state="new">MC3089: The object '{0}' already has a child and cannot add '{1}'. '{0}' can accept only one child.</target>
+        <target state="translated">MC3089: 物件 '{0}' 已有子系，且無法新增 '{1}'。'{0}' 只能接受一個子系。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren">
         <source>MC3028: Cannot add content to object of type '{0}'.</source>
-        <target state="new">MC3028: Cannot add content to object of type '{0}'.</target>
+        <target state="translated">MC3028: 無法將內容新增至型別為 '{0}' 的物件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantGetProperty">
         <source>MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3081: '{0}' is a read-only property of type IList or IDictionary and cannot be set because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3081: '{0}' 是型別為 IList 或 IDictionary 的唯讀屬性且無法設定，因為它沒有公用或內部 get 存取子。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetAttribute">
         <source>MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</source>
-        <target state="new">MC3080: The {0} '{1}' cannot be set because it does not have an accessible {2} accessor.</target>
+        <target state="translated">MC3080: 無法新增 {0} '{1}'，因為它沒有可存取的 {2} 存取子。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetContentProperty">
         <source>MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3087: Cannot set content property '{0}' on element '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3087: 無法在 '{1}' 上設定內容屬性 '{0}'。'{0}' 具有不正確的存取層級，或其組件不允許存取。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantSetTriggerCondition">
         <source>MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</source>
-        <target state="new">MC3082: '{0}' cannot be set as the value of a Trigger's Property attribute because it does not have a public or internal get accessor.</target>
+        <target state="translated">MC3082: '{0}' 無法設定為 Trigger 之 Property 屬性的值，因為它沒有公用或內部 get 存取子。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCompatDuplicate">
         <source>MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</source>
-        <target state="new">MC3016: Two new namespaces cannot be compatible with the same old namespace using an XmlnsCompatibility attribute.�'{0}' namespace is already marked compatible with '{1}'.</target>
+        <target state="translated">MC3016: 兩個新的命名空間無法與使用 XmlnsCompatibility 屬性的相同舊版命名空間相容。�'{0}' 命名空間已標示為與 '{1}' 相容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserContentMustBeContiguous">
         <source>MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</source>
-        <target state="new">MC3088: Property elements cannot be in the middle of an element's content.  They must be before or after the content.</target>
+        <target state="translated">MC3088: 屬性項目不能位於項目內容的中間。它們必須位於內容的前面或後面。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
         <source>MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</source>
-        <target state="new">MC3017: 'Code' tag from xaml namespace found in XAML file. To load this file, you must compile it.</target>
+        <target state="translated">MC3017: 在 XAML 檔案中找到來自 xaml 命名空間的 'Code' 標記。若要載入此檔案，您必須將它編譯。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="new">MC3061: The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</target>
+        <target state="translated">MC3061: 項目型別 '{0}' 沒有關聯的 TypeConverter 可剖析字串 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDictionarySealed">
         <source>MC3018: Cannot modify data in a sealed XmlnsDictionary.</source>
-        <target state="new">MC3018: Cannot modify data in a sealed XmlnsDictionary.</target>
+        <target state="translated">MC3018: 無法修改已密封之 XmlnsDictionary 中的資料。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDupDictionaryKey">
         <source>MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</source>
-        <target state="new">MC3020: The dictionary key '{0}' is already used. Key attributes are used as keys when inserting objects into a dictionary and must be unique.</target>
+        <target state="translated">MC3020: 字典索引鍵 '{0}' 已使用。插入物件至字典時，會使用索引鍵屬性做為索引鍵，它們必須是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateMarkupExtensionProperty">
         <source>MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</source>
-        <target state="new">MC3033: The property '{0}' has already been set on this markup extension and can only be set once.</target>
+        <target state="translated">MC3033: 已在此標記延伸上設定屬性 '{0}'，且只能設定一次。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty1">
         <source>MC3024: '{0}' property has already been set and can be set only once.</source>
-        <target state="new">MC3024: '{0}' property has already been set and can be set only once.</target>
+        <target state="translated">MC3024: 已設定 '{0}' 屬性，且只能設定一次。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="new">MC3025: Property '{0}' and '{1}' refer to the same property. Duplicate property settings are not allowed.</target>
+        <target state="translated">MC3025: 屬性 '{0}' 與 '{1}' 代表相同屬性。不允許重複的屬性設定。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
         <source>MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</source>
-        <target state="new">MC3026: '{0}' property element cannot be empty. It must contain child elements or text.</target>
+        <target state="translated">MC3026: '{0}' 屬性項目不能是空的。它必須包含子項目或文字。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEntityReference">
         <source>MC3027: The EntityReference &amp;{0}; is not recognized.</source>
-        <target state="new">MC3027: The EntityReference &amp;{0}; is not recognized.</target>
+        <target state="translated">MC3027: 無法識別 EntityReference &amp;{0};。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="new">MC3083: Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</target>
+        <target state="translated">MC3083: 無法存取 '{1}' 事件的委派型別 '{0}'。'{0}' 具有不正確的存取層級，或其組件不允許存取。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</source>
-        <target state="new">MC3030: '{0}' property is a read-only IEnumerable property, which means that '{1}' must implement IAddChild.</target>
+        <target state="translated">MC3030: '{0}' 屬性是唯讀的 IEnumerable 屬性，這表示 '{1}' 必須實作 IAddChild。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="new">MC3078: Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</target>
+        <target state="translated">MC3078: 在型別 '{0}'，屬性 '{1}' 上找不到無效的 ContentPropertyAttribute。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidKnownType">
         <source>Known type value {0}='{1}' is not a valid known type.</source>
-        <target state="new">Known type value {0}='{1}' is not a valid known type.</target>
+        <target state="translated">已知型別值 {0}='{1}' 不是有效的已知型別。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidStaticMember">
         <source>MC3011: Cannot find the static member '{0}' on the type '{1}'.</source>
-        <target state="new">MC3011: Cannot find the static member '{0}' on the type '{1}'.</target>
+        <target state="translated">MC3011: 在型別 '{1}' 上找不到靜態成員 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserKeysAreStrings">
         <source>MC3031: Keys and values in XmlnsDictionary must be strings.</source>
-        <target state="new">MC3031: Keys and values in XmlnsDictionary must be strings.</target>
+        <target state="translated">MC3031: XmlnsDictionary 中的索引鍵與值必須是字串。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line {0} Position {1}</source>
-        <target state="new">Line {0} Position {1}</target>
+        <target state="translated">行 {0} 位置 {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingKey">
         <source>MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</source>
-        <target state="new">MC3037: Missing XmlNamespace, Assembly or ClrNamespace in Mapping instruction.</target>
+        <target state="translated">MC3037: Mapping 指示中遺失 XmlNamespace、Assembly 或 ClrNamespace。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMappingUriInvalid">
         <source>'{0}' mapping URI is not valid.</source>
-        <target state="new">'{0}' mapping URI is not valid.</target>
+        <target state="translated">'{0}' mapping URI 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadConstructorParam">
         <source>MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</source>
-        <target state="new">MC3040: Format is not valid for MarkupExtension that specifies constructor arguments in '{0}'.</target>
+        <target state="translated">MC3040: 在 '{0}' 中指定建構函式引數之 MarkupExtension 的格式不正確。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionBadDelimiter">
         <source>MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</source>
-        <target state="new">MC3041: Markup extensions require a single '=' between name and value, and a single ',' between constructor parameters and name/value pairs. The arguments '{0}' are not valid.</target>
+        <target state="translated">MC3041: 標記延伸要求名稱與值之間必須使用一個 '=' 來分隔; 而建構函式參數與名稱/值組之間則必須使用一個 ',' 來分隔。引數 '{0}' 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionDelimiterBeforeFirstAttribute">
         <source>MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</source>
-        <target state="new">MC3091: '{0}' is not valid. Markup extensions require only spaces between the markup extension name and the first parameter. Cannot have comma or equals sign before the first parameter.</target>
+        <target state="translated">MC3091: '{0}' 無效。標記延伸要求標記延伸名稱與第一個參數之間只能有一個空格。第一個參數之前不能有逗號或等號。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="new">MC8001: Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</target>
+        <target state="translated">MC8001: 在行號 '{1}' 與行位置 '{2}' 發生結尾 BracketCharacter '{0}' 而沒有相對應的開頭 BracketCharacter。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="new">MC8002: BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</target>
+        <target state="translated">MC8002: 行號 '{1}' 與行位置 '{2}' 的 BracketCharacter '{0}' 沒有相對應的開頭/結尾 BracketCharacter。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
         <source>MC3038: MarkupExtension expressions must end with a '}'.</source>
-        <target state="new">MC3038: MarkupExtension expressions must end with a '}'.</target>
+        <target state="translated">MC3038: MarkupExtension 運算式的結尾必須是 '}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoNameValue">
         <source>MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</source>
-        <target state="new">MC3042: Name/value pairs in MarkupExtensions must have the format 'Name = Value' and each pair is separated by a comma. '{0}' does not follow this format.</target>
+        <target state="translated">MC3042: MarkupExtensions 中的名稱/值組格式必須是 'Name = Value'，而每一組之間必須以逗號分則。'{0}' 未依照此格式。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoQuotesInName">
         <source>MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</source>
-        <target state="new">MC3043: Names and Values in a MarkupExtension cannot contain quotes. The MarkupExtension arguments '{0}' are not valid.</target>
+        <target state="translated">MC3043: MarkupExtension 中的名稱與值不能包含引號。MarkupExtension 引數 '{0}' 無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionTrailingGarbage">
         <source>MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</source>
-        <target state="new">MC3044: The text '{1}' is not allowed after the closing '{0}' of a MarkupExtension expression.</target>
+        <target state="translated">MC3044: MarkupExtension 運算式的右 '{0}' 之後不允許文字 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionUnknownAttr">
         <source>MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</source>
-        <target state="new">MC3045: Unknown property '{0}' for type '{1}' encountered while parsing a Markup Extension.</target>
+        <target state="translated">MC3045: 剖析 Markup Extension 時，發現型別 '{1}' 的未知屬性 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</source>
-        <target state="new">MC3046: Unknown attribute '{0}' in the '{1}' namespace. Note that only the Key attribute is currently supported in this namespace.</target>
+        <target state="translated">MC3046: 在 '{1}' 命名空間中發現未知屬性 '{0}'。請注意，目前此命名空間中只支援 Key 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
         <source>MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</source>
-        <target state="new">MC3047: Internal parser error - Cannot use multiple writable BAML records at the same time.</target>
+        <target state="translated">MC3047: 內部剖析器錯誤 - 無法同時使用多筆可寫入的 BAML 記錄。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNestedComplexProp">
         <source>'{0}' property element cannot be nested directly inside another property element.</source>
-        <target state="new">'{0}' property element cannot be nested directly inside another property element.</target>
+        <target state="translated">'{0}' 無法以巢狀結構方式直接放入另一個屬性項目中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoAttrArray">
         <source>MC3049: Cannot place attributes on Array tags.</source>
-        <target state="new">MC3049: Cannot place attributes on Array tags.</target>
+        <target state="translated">MC3049: 無法將屬性放置在 Array 標記上。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoBamlAsync">
         <source>MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</source>
-        <target state="new">MC3021: Asynchronous loading is not supported when compiling a XAML file, so a SynchronousMode of '{0}' is not allowed.</target>
+        <target state="translated">MC3021: 編譯 XAML 檔案時，不支援非同步載入，因此不允許 '{0}' 的 SynchronousMode。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoChildrenTag">
         <source>MC3051: The type '{0}' does not support element content.</source>
-        <target state="new">MC3051: The type '{0}' does not support element content.</target>
+        <target state="translated">MC3051: 型別 '{0}' 不支援項目內容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryKey">
         <source>MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</source>
-        <target state="new">MC3022: All objects added to an IDictionary must have a Key attribute or some other type of key associated with them.</target>
+        <target state="translated">MC3022: 新增至 IDictionary 的所有物件必須具有 Key 屬性 (或是與其關聯的某些型別的索引鍵)。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDictionaryName">
         <source>MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</source>
-        <target state="new">MC3023: The Key attribute can only be used on a tag contained in a Dictionary (such as a ResourceDictionary).</target>
+        <target state="translated">MC3023: Key 屬性只能用於包含在 Dictionary (例如 ResourceDictionary) 中的標記上。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="new">MC3032: '{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</target>
+        <target state="translated">MC3032: '{1}' 無法用做為 '{0}' 的值。數字不是有效的列舉值。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEventTag">
         <source>MC3053: Cannot use property element syntax to specify event handler '{0}'.</source>
-        <target state="new">MC3053: Cannot use property element syntax to specify event handler '{0}'.</target>
+        <target state="translated">MC3053: 無法使用屬性項目語法來指定事件處理常式 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoEvents">
         <source>MC3052: XAML file that contains events must be compiled.</source>
-        <target state="new">MC3052: XAML file that contains events must be compiled.</target>
+        <target state="translated">MC3052: 必須編譯包含事件的 XAML 檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameOnType">
         <source>MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</source>
-        <target state="new">MC3054: The type '{0}' cannot have a Name attribute. Value types and types without a default constructor can be used as items within a ResourceDictionary.</target>
+        <target state="translated">MC3054: 型別 '{0}' 不能具有 Name 屬性。沒有預設建構函式的實值型別與類型，可做為 ResourceDictionary 中的項目使用。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNameUnderDefinitionScopeType">
         <source>MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</source>
-        <target state="new">MC3093: Cannot set Name attribute value '{0}' on element '{1}'. '{1}' is under the scope of element '{2}', which already had a name registered when it was defined in another scope.</target>
+        <target state="translated">MC3093: 無法在項目 '{1}' 上設定 Name 屬性值 '{0}'。'{1}' 屬於項目 '{2}' 的範圍，當它在另一個範圍定義時，已經有已登錄的名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNamespace">
         <source>MC3056: No NamespaceURI is defined for the object '{0}'.</source>
-        <target state="new">MC3056: No NamespaceURI is defined for the object '{0}'.</target>
+        <target state="translated">MC3056: 尚未針對物件 '{0}' 定義 NamespaceURI。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoNestedXmlDataIslands">
         <source>MC3084: Cannot nest XML data islands.</source>
-        <target state="new">MC3084: Cannot nest XML data islands.</target>
+        <target state="translated">MC3084: 無法將 XML 資料島變更為巢狀結構。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoPropOnComplexProp">
         <source>MC3057: Cannot set properties on property elements.</source>
-        <target state="new">MC3057: Cannot set properties on property elements.</target>
+        <target state="translated">MC3057: 無法設定屬性項目的內容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSerializer">
         <source>MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</source>
-        <target state="new">MC3058: Cannot find a custom serializer for '{0}' so it cannot be parsed.</target>
+        <target state="translated">MC3058: 找不到 '{0}' 的自訂序列化程式，因此無法剖析。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoSetterChild">
         <source>MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</source>
-        <target state="new">MC3059: Style setters do not support child elements. A tag of type '{0}' is not allowed.</target>
+        <target state="translated">MC3059: 樣式設定者不支援子項目。不允許型別為 '{0}' 的標記。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoType">
         <source>MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</source>
-        <target state="new">MC3050: Cannot find the type '{0}'. Note that type names are case sensitive.</target>
+        <target state="translated">MC3050: 找不到型別 '{0}'。請注意，型別名稱會區分大小寫。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</source>
-        <target state="new">MC3048: '{0}' value is not a valid MarkupExtension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be a subclass of MarkupExtension.</target>
+        <target state="translated">MC3048: '{0}' 值不是有效的 MarkupExtension 運算式。無法解析命名空間 '{2}' 中的 '{1}'。'{1}' 必須是 MarkupExtension 的子類別。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSElement">
         <source>MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</source>
-        <target state="new">MC3062: '{0}' XML namespace prefix does not map to a NamespaceURI, so element '{1}' cannot be resolved.</target>
+        <target state="translated">MC3062: '{0}' XML 命名空間前置詞未對應到 NamespaceURI，因此無法解析項目 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPrefixNSProperty">
         <source>MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</source>
-        <target state="new">MC3100: '{0}' XML namespace prefix does not map to a namespace URI, so cannot resolve property '{1}'.</target>
+        <target state="translated">MC3100: '{0}' XML 命名空間未對應至命名空間 URI，因此無法解析屬性 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPropNoValue">
         <source>MC3063: Property '{0}' does not have a value.</source>
-        <target state="new">MC3063: Property '{0}' does not have a value.</target>
+        <target state="translated">MC3063: 屬性 '{0}' 沒有值。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserPublicType">
         <source>MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</source>
-        <target state="new">MC3064: Only public or internal classes can be used within markup. '{0}' type is not public or internal.</target>
+        <target state="translated">MC3064: 只能在標記中使用公用或內部類別。'{0}' 型別並非公用或內部。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserReadOnlyProp">
         <source>MC3065: '{0}' property is read-only and cannot be set from markup.</source>
-        <target state="new">MC3065: '{0}' property is read-only and cannot be set from markup.</target>
+        <target state="translated">MC3065: '{0}' 屬性是唯讀的，而且無法從標記設定。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserResourceKeyType">
         <source>MC3066: The type reference cannot find a public type named '{0}'.</source>
-        <target state="new">MC3066: The type reference cannot find a public type named '{0}'.</target>
+        <target state="translated">MC3066: 型別參考找不到名為 '{0}' 的公用型別。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserStaticMemberNotAllowed">
         <source>MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</source>
-        <target state="new">MC3019: Cannot reference the static member '{0}' on the type '{1}' as it is not accessible.</target>
+        <target state="translated">MC3019: 無法參考型別 '{1}' 上的靜態成員 '{0}'，因為它無法存取。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserSyncOnRoot">
         <source>MC3067: SynchronousMode attribute must be on the root tag.</source>
-        <target state="new">MC3067: SynchronousMode attribute must be on the root tag.</target>
+        <target state="translated">MC3067: 必須在根標記上設定 SynchronousMode 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInComplexProp">
         <source>MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</source>
-        <target state="new">MC3069: Cannot have both the text '{0}' and the child element '{1}' within a property element.</target>
+        <target state="translated">MC3069: 屬性項目中不能同時存在文字 '{0}' 與子項目 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTextInvalidInArrayOrDictionary">
         <source>MC3068: Text is not valid under an IDictionary or Array property.</source>
-        <target state="new">MC3068: Text is not valid under an IDictionary or Array property.</target>
+        <target state="translated">MC3068: 在 IDictionary 或 Array 屬性下，文字是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTooManyAssemblies">
         <source>MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</source>
-        <target state="new">MC3070: A single XAML file cannot reference more than 4,096 different assemblies.</target>
+        <target state="translated">MC3070: 單一 XAML 檔案無法參考超過 4,096 個不同的組件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextNeedsEndElement">
         <source>MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</source>
-        <target state="new">MC3095: Close tag must immediately follow TypeConverter initialization string '{0}'.</target>
+        <target state="translated">MC3095: 結束標記必須緊接在 TypeConverter 初始化字串 '{0}' 後方。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserTypeConverterTextUnusable">
         <source>MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</source>
-        <target state="new">MC3090: TypeConverter syntax error encountered while processing initialization string '{0}'.  Element attributes are not allowed on objects created via TypeConverter.</target>
+        <target state="translated">MC3090: 處理初始化字串時發生 TypeConverter 語法錯誤 '{0}'。透過 TypeConverter 建立的物件上不允許使用項目屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUndeclaredNS">
         <source>MC3071: '{0}' is an undeclared namespace.</source>
-        <target state="new">MC3071: '{0}' is an undeclared namespace.</target>
+        <target state="translated">MC3071: '{0}' 是未宣告的命名空間。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownAttribute">
         <source>MC3072: The property '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3072: The property '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3072: 屬性 '{0}' 不存在於 XML 命名空間 '{1}' 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownDefAttribute">
         <source>MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</source>
-        <target state="new">MC3073: The attribute '{0}' does not exist in XML namespace 'http://schemas.microsoft.com/winfx/2006/xaml'.</target>
+        <target state="translated">MC3073: 屬性 '{0}' 不存在於 XML 命名空間 'http://schemas.microsoft.com/winfx/2006/xaml' 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownTag">
         <source>MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</source>
-        <target state="new">MC3074: The tag '{0}' does not exist in XML namespace '{1}'.</target>
+        <target state="translated">MC3074: 標記 '{0}' 不存在於 XML 命名空間  '{1}' 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserUnknownXmlType">
         <source>MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</source>
-        <target state="new">MC3075: Unrecognized XML node type '{0}' found when determining if the current tag is a property element.</target>
+        <target state="translated">MC3075: 判斷目前的標記是否為屬性項目時，發現無法識別的 XML 節點類型 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandMissing">
         <source>MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</source>
-        <target state="new">MC3086: Parent element or property '{0}' requires an XML data island. To distinguish an XML island from surrounding XAML, wrap the XML data island in &lt;x:XData&gt; ... &lt;/x:XData&gt;.</target>
+        <target state="translated">MC3086: 父項目或屬性 '{0}' 需要 XML 資料島。為區分 XML 資料島與週邊 XAML，請將 XML 資料島包裝在 &lt;x:XData&gt; ... &lt;/x:XData&gt; 中。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlIslandUnexpected">
         <source>MC3085: '{0}' element or property cannot contain an XML data island.</source>
-        <target state="new">MC3085: '{0}' element or property cannot contain an XML data island.</target>
+        <target state="translated">MC3085: '{0}' 項目或屬性不能包含 XML 資料島。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlLangPropertyValueInvalid">
         <source>MC3092: XmlLangProperty attribute must specify a property name.</source>
-        <target state="new">MC3092: XmlLangProperty attribute must specify a property name.</target>
+        <target state="translated">MC3092: XmlLangProperty 屬性必須指定屬性名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserXmlReaderNoLineInfo">
         <source>MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</source>
-        <target state="new">MC3077: The class '{0}' does not implement IXmlLineInfo. This is required to get position information for the XAML being parsed.</target>
+        <target state="translated">MC3077: 類別 '{0}' 並未實作 IXmlLineInfo。必須實作，才能取得即將剖析之 XAML 的位置資訊。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parser_UnexpectedToken">
         <source>MC3098: Unexpected token '{0}' at position '{1}'.</source>
-        <target state="new">MC3098: Unexpected token '{0}' at position '{1}'.</target>
+        <target state="translated">MC3098: 非預期的語彙基元 '{0}'，位置 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="Parsers_IllegalToken">
         <source>MC3096: Token is not valid.</source>
-        <target state="new">MC3096: Token is not valid.</target>
+        <target state="translated">MC3096: 語彙基元無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreparingCompile">
         <source>Preparing for the markup compilation...</source>
-        <target state="new">Preparing for the markup compilation...</target>
+        <target state="translated">正在準備標記編譯...</target>
         <note />
       </trans-unit>
       <trans-unit id="QualifiedNameHasWrongFormat">
         <source>MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</source>
-        <target state="new">MC4301: Type name '{0}' does not have the expected format 'className, assembly'.</target>
+        <target state="translated">MC4301: 型別名稱 '{0}' 不是預期的格式 'className, assembly'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadResourceFile">
         <source>Reading Resource file: '{0}'...</source>
-        <target state="new">Reading Resource file: '{0}'...</target>
+        <target state="translated">正在讀取 Resource 檔案: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="RecompiledXaml">
         <source>Recompiled XAML file : '{0}'.</source>
-        <target state="new">Recompiled XAML file : '{0}'.</target>
+        <target state="translated">已重新編譯 XAML 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReferenceFile">
         <source>Input: Assembly Reference file: '{0}'.</source>
-        <target state="new">Input: Assembly Reference file: '{0}'.</target>
+        <target state="translated">輸入: 組件 Reference 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceId">
         <source>Resource ID is '{0}'.</source>
-        <target state="new">Resource ID is '{0}'.</target>
+        <target state="translated">資源識別碼是 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceTooBig">
         <source>RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</source>
-        <target state="new">RG1001: Input resource file '{0}' exceeds maximum size of {1} bytes.</target>
+        <target state="translated">RG1001: 輸入資源檔案 '{0}' 超過 {1} 位元組的大小上限。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerated">
         <source>Generated .resources file: '{0}'.</source>
-        <target state="new">Generated .resources file: '{0}'.</target>
+        <target state="translated">已產生 .resources 檔案: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGenerating">
         <source>Generating .resources file: '{0}'...</source>
-        <target state="new">Generating .resources file: '{0}'...</target>
+        <target state="translated">正在產生 .resources 檔案: '{0}'...</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesGeneratorTask">
         <source>ResourcesGenerator</source>
-        <target state="new">ResourcesGenerator</target>
+        <target state="translated">ResourcesGenerator</target>
         <note />
       </trans-unit>
       <trans-unit id="RoutedEventNotRegistered">
         <source>MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</source>
-        <target state="new">MC6006: {0}.{1}="{2}" is not valid. '{1}' must be a RoutedEvent registered with a name that ends with the keyword "Event".</target>
+        <target state="translated">MC6006: {0}.{1}="{2}" 無效。'{1}' 必須是以結尾是關鍵字 "Event" 之名稱登錄的 RoutedEvent。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFileNameNeeded">
         <source>UM1005: You must pass markup files to the task.</source>
-        <target state="new">UM1005: You must pass markup files to the task.</target>
+        <target state="translated">UM1005: 您必須將標記檔案傳遞給工作。</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceNameNotSupportedForStyleTriggers">
         <source>MC4110: SourceName property cannot be set within Style.Triggers section.</source>
-        <target state="new">MC4110: SourceName property cannot be set within Style.Triggers section.</target>
+        <target state="translated">MC4110: 無法在 Style.Triggers 區段中設定 SourceName 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</source>
-        <target state="new">MC4001: Style does not support both {0} tags and Style.{1} property tags for a single Style. Use one or the other.</target>
+        <target state="translated">MC4001: Style 無法同時支援 {0} 標記與 Style.{1} 屬性標記做為單一 Style。請使用其中一個。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleKnownTagWrongLocation">
         <source>MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</source>
-        <target state="new">MC4002: The Style property tag '{0}' can only be specified directly under a Style tag.</target>
+        <target state="translated">MC4002: 只能在 Style 標記下直接指定 Style 屬性標記 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoPropOrEvent">
         <source>MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</source>
-        <target state="new">MC4005: Cannot find the Style {0} '{1}' on the type '{2}'.</target>
+        <target state="translated">MC4005: 在型別 '{2}' 中找不到 Style {0} '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="new">MC4003: Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</target>
+        <target state="translated">MC4003: 無法解析 Style {0} '{1}'。請確定擁有者型別是 Style 的 TargetType，或使用 Class.Property 語法來指定 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTopLevelElement">
         <source>MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</source>
-        <target state="new">MC4004: Style cannot contain child '{0}'. Style child must be a Setter because it is added to the Setters collection.</target>
+        <target state="translated">MC4004: Style 不能包含子 '{0}'。Style 子項目必須是 Setter，因為它會新增到 Setters 集合。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTagNotSupported">
         <source>MC4006: Tags of type '{0}' are not supported in Style sections.</source>
-        <target state="new">MC4006: Tags of type '{0}' are not supported in Style sections.</target>
+        <target state="translated">MC4006: Style 區段中不支援型別為 '{0}' 的標記。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTargetNoEvents">
         <source>MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</source>
-        <target state="new">MC4007: The event '{0}' cannot be specified on a Target tag in a Style. Use an EventSetter instead.</target>
+        <target state="translated">MC4007: 無法在 Style 中的 Target 標記上指定事件 '{0}'。請使用 EventSetter 來替代。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
         <source>MC4008: The text '{0}' is not allowed at this location within a Style section.</source>
-        <target state="new">MC4008: The text '{0}' is not allowed at this location within a Style section.</target>
+        <target state="translated">MC4008: 不允許在 Style 區段中的此位置使用文字 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleUnknownProp">
         <source>MC4009: The property '{0}' cannot be set on Style.</source>
-        <target state="new">MC4009: The property '{0}' cannot be set on Style.</target>
+        <target state="translated">MC4009: 無法在 Style 上設定屬性 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="SubSubClassingNotAllowed">
         <source>MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</source>
-        <target state="new">MC6017: '{0}' cannot be the root of a XAML file because it was defined using XAML.</target>
+        <target state="translated">MC6017: '{0}' 無法做為 XAML 檔案的根，因為它是使用 XAML 定義。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetIsNotSupported">
         <source>BG1004: Target Type '{0}' is not supported by this task.</source>
-        <target state="new">BG1004: Target Type '{0}' is not supported by this task.</target>
+        <target state="translated">BG1004: 此工作不支援目標型別 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetNameNotSupportedForStyleSetters">
         <source>MC4011: TargetName property cannot be set on a Style Setter.</source>
-        <target state="new">MC4011: TargetName property cannot be set on a Style Setter.</target>
+        <target state="translated">MC4011: 無法在 Style Setter 上設定 TargetName 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskLogo">
         <source>Microsoft (R) Build Task '{0}' Version '{1}'.</source>
-        <target state="new">Microsoft (R) Build Task '{0}' Version '{1}'.</target>
+        <target state="translated">Microsoft (R) 建置工作 '{0}' 版本 '{1}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskRight">
         <source>Copyright (C) Microsoft Corporation 2005. All rights reserved.</source>
-        <target state="new">Copyright (C) Microsoft Corporation 2005. All rights reserved.</target>
+        <target state="translated">Copyright (C) Microsoft Corporation 2005. 著作權所有，並保留一切權利。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateDupName">
         <source>MC4101: The Name '{0}' has already been defined. Names must be unique.</source>
-        <target state="new">MC4101: The Name '{0}' has already been defined. Names must be unique.</target>
+        <target state="translated">MC4101: 已定義 Name '{0}'。名稱必須是唯一的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateInvalidRootElementTag">
         <source>MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</source>
-        <target state="new">MC4108: The root of a Template content section cannot contain an element of type '{0}'. Only FrameworkElement and FrameworkContentElement types are valid.</target>
+        <target state="translated">MC4108: Template 內容區段的根不能包含型別為 '{0}' 的項目。只有 FrameworkElement 與 FrameworkContentElement 型別是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateKnownTagWrongLocation">
         <source>MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</source>
-        <target state="new">MC4103: The template property tag '{0}' can only be specified immediately after a ControlTemplate tag.</target>
+        <target state="translated">MC4103: 樣板屬性標記 '{0}' 只能緊接在 ControlTemplate 標記之後指定。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoMultipleRoots">
         <source>MC4107: A template can have only a single root element. '{0}' is not allowed.</source>
-        <target state="new">MC4107: A template can have only a single root element. '{0}' is not allowed.</target>
+        <target state="translated">MC4107: 樣板只能有一個根項目。不允許 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoProp">
         <source>MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</source>
-        <target state="new">MC4109: Cannot find the Template Property '{0}' on the type '{1}'.</target>
+        <target state="translated">MC4109: 在型別 '{1}' 上找不到樣板屬性 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTarget">
         <source>MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</source>
-        <target state="new">MC4106: Cannot resolve the Template Property '{0}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the property.</target>
+        <target state="translated">MC4106: 無法解析樣板屬性 '{0}'。請確定擁有者型別是 Style 的 TargetType，或使用 Class.Property 語法來指定屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateNoTriggerTarget">
         <source>MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</source>
-        <target state="new">MC4111: Cannot find the Trigger target '{0}'.  (The target must appear before any Setters, Triggers, or Conditions that use it.)</target>
+        <target state="translated">MC4111: 找不到 Trigger 目標 '{0}' (目標必須出現在任何使用它的 Setters、Triggers 或 Conditions 前面)。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTagNotSupported">
         <source>MC4102: Tags of type '{0}' are not supported in template sections.</source>
-        <target state="new">MC4102: Tags of type '{0}' are not supported in template sections.</target>
+        <target state="translated">MC4102: 樣板區段不支援型別為 '{0}' 的標記。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
         <source>MC4105: The text '{0}' is not allowed at this location within a template section.</source>
-        <target state="new">MC4105: The text '{0}' is not allowed at this location within a template section.</target>
+        <target state="translated">MC4105: 不允許在樣板區段的此位置使用 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateUnknownProp">
         <source>MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</source>
-        <target state="new">MC4104: The property '{0}' cannot be set as a property element on template. Only Triggers and Storyboards are allowed as property elements.</target>
+        <target state="translated">MC4104: 無法在樣板上將屬性 '{0}' 設定為屬性項目。只允許將 Triggers 與 Storyboards 設定為屬性項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>MC7004: Empty token encountered while parsing.</source>
-        <target state="new">MC7004: Empty token encountered while parsing.</target>
+        <target state="translated">MC7004: 剖析時發現空白的語彙基元。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>MC7003: Extra data encountered after token while parsing.</source>
-        <target state="new">MC7003: Extra data encountered after token while parsing.</target>
+        <target state="translated">MC7003: 剖析時在語彙基元後發現額外資料。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
         <source>MC7002: Missing end quote encountered while parsing token.</source>
-        <target state="new">MC7002: Missing end quote encountered while parsing token.</target>
+        <target state="translated">MC7002: 剖析語彙基元時發現遺失結尾引號。</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperPrematureStringTermination">
         <source>MC7001: Premature string termination encountered.</source>
-        <target state="new">MC7001: Premature string termination encountered.</target>
+        <target state="translated">MC7001: 字串過早結束。</target>
         <note />
       </trans-unit>
       <trans-unit id="UidManagerTask">
         <source>UidManager</source>
-        <target state="new">UidManager</target>
+        <target state="translated">UidManager</target>
         <note />
       </trans-unit>
       <trans-unit id="UidMissing">
         <source>UM1003: Uid is missing for element '{0}'.</source>
-        <target state="new">UM1003: Uid is missing for element '{0}'.</target>
+        <target state="translated">UM1003: 項目 '{0}' 遺失 Uid。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBuildError">
         <source>Unknown build error, '{0}' </source>
-        <target state="new">Unknown build error, '{0}' </target>
+        <target state="translated">不明的建置錯誤 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownClassModifier">
         <source>MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6013: {0}:ClassModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6013: {0}:ClassModifier="{1}" 對於語言 {2} 而言是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownDefinitionTag">
         <source>MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</source>
-        <target state="new">MC6002: Unrecognized tag '{0}:{1}' in namespace 'http://schemas.microsoft.com/winfx/2006/xaml'. Note that tag names are case sensitive.</target>
+        <target state="translated">MC6002: 在命名空間 'http://schemas.microsoft.com/winfx/2006/xaml' 中發現無法識別的標記 '{0}:{1}'。請注意，標記名稱會區分大小寫。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownEventAttribute">
         <source>MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</source>
-        <target state="new">MC6007: '{1}' is not valid. '{0}' is not an event on '{2}'.</target>
+        <target state="translated">MC6007: '{1}' 無效。'{0}' 不是 '{2}' 上的事件。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownFieldModifier">
         <source>MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</source>
-        <target state="new">MC6014: {0}:FieldModifier="{1}" is not valid for the language {2}.</target>
+        <target state="translated">MC6014: {0}:FieldModifier="{1}" 對於語言 {2} 而言是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownGenericType">
         <source>MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</source>
-        <target state="new">MC6020: {0}:TypeArguments='{1}' is not valid on the tag '{2}'. Either '{2}' is not a generic type or the number of Type arguments in the attribute is wrong. Remove the {0}:TypeArguments attribute because it is allowed only on generic types, or fix its value to match the arity of the generic type '{2}'.</target>
+        <target state="translated">MC6020: {0}:TypeArguments='{1}' 在標記 '{2}' 上是無效的。'{2}' 不是泛型型別，或屬性中的 Type 引數數目錯誤。請移除 {0}:TypeArguments 屬性，因為它只能用於泛型型別; 或是修正此值以符合泛型型別 '{2}' 的引數數目要求。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownLanguage">
         <source>MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</source>
-        <target state="new">MC6008: '{0}' is not installed properly on this machine. It must be listed in the &lt;compilers&gt; section of machine.config.</target>
+        <target state="translated">MC6008: '{0}' 並未正確安裝在此電腦上。它必須列示於 machine.config 的 &lt;compilers&gt; 區段。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownPathOperationType">
         <source>Unknown path operation attempted.</source>
-        <target state="new">Unknown path operation attempted.</target>
+        <target state="translated">已嘗試不明的路徑操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="UnmatchedLocComment">
         <source>LC1003: Localization comment has no value set for target property: '{0}'.</source>
-        <target state="new">LC1003: Localization comment has no value set for target property: '{0}'.</target>
+        <target state="translated">LC1003: 未設定目標屬性的當地語系化註解: '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateManifestForBrowserApplicationTask">
         <source>UpdateManifestForBrowserApplication</source>
-        <target state="new">UpdateManifestForBrowserApplication</target>
+        <target state="translated">UpdateManifestForBrowserApplication</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionNumberComponentNegative">
         <source>MC4501: Major and minor version number components cannot be negative.</source>
-        <target state="new">MC4501: Major and minor version number components cannot be negative.</target>
+        <target state="translated">MC4501: 主要與次要版本號碼元件不能為負數。</target>
         <note />
       </trans-unit>
       <trans-unit id="WinFXAssemblyMissing">
         <source>MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</source>
-        <target state="new">MC6000: Project file must include the .NET Framework assembly '{0}' in the reference list.</target>
+        <target state="translated">MC6000: 專案檔必須在參考清單中包含 .NET Framework 組件 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongLocalizationPropertySetting_Pass1">
         <source>MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</source>
-        <target state="new">MC1001: The LocalizationDirectivesToLocFile property value is not valid and must be changed to None, CommentsOnly, or All for the MarkupCompilePass1 task.</target>
+        <target state="translated">MC1001: LocalizationDirectivesToLocFile 屬性值無效，而且必須針對 MarkupCompilePass1 工作變更為 None、CommentsOnly 或 All。</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongPropertySetting">
         <source>BG1003: The project file contains a property value that is not valid.</source>
-        <target state="new">BG1003: The project file contains a property value that is not valid.</target>
+        <target state="translated">BG1003: 專案檔包含無效的屬性值。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceAfterFallback">
         <source>MC4602: Choice cannot follow a Fallback.</source>
-        <target state="new">MC4602: Choice cannot follow a Fallback.</target>
+        <target state="translated">MC4602: Choice 不能緊接在 Fallback 後面。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceNotFound">
         <source>MC4606: AlternateContent must contain one or more Choice elements.</source>
-        <target state="new">MC4606: AlternateContent must contain one or more Choice elements.</target>
+        <target state="translated">MC4606: AlternateContent 必須包含一或多個 Choice 項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRChoiceOnlyInAC">
         <source>MC4601: Choice valid only in AlternateContent.</source>
-        <target state="new">MC4601: Choice valid only in AlternateContent.</target>
+        <target state="translated">MC4601: Choice 只在 AlternateContent 中是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRCompatCycle">
         <source>MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</source>
-        <target state="new">MC4640: Namespace '{0}' is marked as compatible with itself using XmlnsCompatibilityAttribute. A namespace cannot directly or indirectly override itself.</target>
+        <target state="translated">MC4640: 命名空間 '{0}' 已用 XmlnsCompatibilityAttribute 標記為與其本身相容。命名空間不能直接或間接覆寫本身。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicatePreserve">
         <source>MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4631: Duplicate Preserve declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4631: 在命名空間 '{0}' 中發現項目 '{1}' 的重複 Preserve 宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateProcessContent">
         <source>MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</source>
-        <target state="new">MC4617: Duplicate ProcessContent declaration for element '{1}' in namespace '{0}'.</target>
+        <target state="translated">MC4617: 在命名空間 '{0}' 中發現項目 '{1}' 的 ProcessContent 重複宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardPreserve">
         <source>MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4633: Duplicate wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4633: 發現命名空間 '{0}' 的重複萬用字元 Preserve 宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRDuplicateWildcardProcessContent">
         <source>MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4619: Duplicate wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4619: 發現命名空間 '{0}' 的重複萬用字元 ProcessContent 宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRFallbackOnlyInAC">
         <source>MC4605: Fallback valid only in AlternateContent.</source>
-        <target state="new">MC4605: Fallback valid only in AlternateContent.</target>
+        <target state="translated">MC4605: Fallback 只在 AlternateContent 中是有效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidACChild">
         <source>MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</source>
-        <target state="new">MC4610: '{0}' element is not a valid child of AlternateContent. Only Choice and Fallback elements are valid children of an AlternateContent element.</target>
+        <target state="translated">MC4610: '{0}' 項目不是 AlternateContent 的有效子項目。只有 Choice 與 Fallback 項目是 AlternateContent 項目的有效子項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidAttribInElement">
         <source>MC4608: '{0}' attribute is not valid for element '{1}'.</source>
-        <target state="new">MC4608: '{0}' attribute is not valid for element '{1}'.</target>
+        <target state="translated">MC4608: '{0}' 屬性對於項目 '{1}' 而言是無效的。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidFormat">
         <source>MC4611: '{0}' format is not valid.</source>
-        <target state="new">MC4611: '{0}' format is not valid.</target>
+        <target state="translated">MC4611: '{0}' 格式無效。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidPreserve">
         <source>MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</source>
-        <target state="new">MC4632: Cannot have both a specific and a wildcard Preserve declaration for namespace '{0}'.</target>
+        <target state="translated">MC4632: 無法為命名空間 '{0}' 同時指定特定與萬用字元 Preserve 宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidProcessContent">
         <source>MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</source>
-        <target state="new">MC4618: Cannot have both a specific and a wildcard ProcessContent declaration for namespace '{0}'.</target>
+        <target state="translated">MC4618: 無法為命名空間 '{0}' 同時指定特定與萬用字元 ProcessContent 宣告。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidRequiresAttribute">
         <source>MC4604: Requires attribute must contain a valid namespace prefix.</source>
-        <target state="new">MC4604: Requires attribute must contain a valid namespace prefix.</target>
+        <target state="translated">MC4604: Requires 屬性必須包含有效的命名空間前置詞。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRInvalidXMLName">
         <source>MC4634: '{0}' attribute value is not a valid XML name.</source>
-        <target state="new">MC4634: '{0}' attribute value is not a valid XML name.</target>
+        <target state="translated">MC4634: '{0}' 屬性值不是有效的 XML 名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMultipleFallbackFound">
         <source>MC4607: AlternateContent must contain only one Fallback element.</source>
-        <target state="new">MC4607: AlternateContent must contain only one Fallback element.</target>
+        <target state="translated">MC4607: AlternateContent 必須只包含一個 Fallback 項目。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRMustUnderstandFailed">
         <source>MC4626: MustUnderstand condition failed on namespace '{0}'.</source>
-        <target state="new">MC4626: MustUnderstand condition failed on namespace '{0}'.</target>
+        <target state="translated">MC4626: 在命名空間 '{0}' 上發生 MustUnderstand 條件失敗。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSPreserveNotIgnorable">
         <source>MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</source>
-        <target state="new">MC4630: Namespace '{0}' has items declared to be preserved but is not declared ignorable.</target>
+        <target state="translated">MC4630: 命名空間 '{0}' 包含已宣告為要保留的項目，但並非宣告為可略過。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRNSProcessContentNotIgnorable">
         <source>MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</source>
-        <target state="new">MC4615: '{0}' namespace is declared ProcessContent but is not declared Ignorable.</target>
+        <target state="translated">MC4615: '{0}' 命名空間已宣告 ProcessContent，但並非宣告為 Ignorable。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRRequiresAttribNotFound">
         <source>MC4603: Choice must contain a Requires attribute.</source>
-        <target state="new">MC4603: Choice must contain a Requires attribute.</target>
+        <target state="translated">MC4603: Choice 必須包含 Requires 屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUndefinedPrefix">
         <source>MC4612: '{0}' prefix is not defined.</source>
-        <target state="new">MC4612: '{0}' prefix is not defined.</target>
+        <target state="translated">MC4612: 未定義 '{0}' 前置詞。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatAttrib">
         <source>MC4614: Unrecognized compatibility attribute '{0}'.</source>
-        <target state="new">MC4614: Unrecognized compatibility attribute '{0}'.</target>
+        <target state="translated">MC4614: 無法識別的相容性屬性 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="XCRUnknownCompatElement">
         <source>MC4609: Unrecognized compatibility element '{0}'.</source>
-        <target state="new">MC4609: Unrecognized compatibility element '{0}'.</target>
+        <target state="translated">MC4609: 無法識別的相容性項目 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ZeroLengthFeatureID">
         <source>MC4502: The feature ID string cannot have length 0.</source>
-        <target state="new">MC4502: The feature ID string cannot have length 0.</target>
+        <target state="translated">MC4502: 功能識別碼的字串長度不能為 0。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
* Add initial xlf files for PresentationBuildTasks

* Bring PresentationBuildTasks translations over from NETFX

* Modify PresentationBuildTasks csproj to enable satellite assembly generation

* Don't exclude PresentationBuildTasks from xlf localization in ShippingProjects.props