### PR TITLE
Recognize Application.xaml as well as App.xaml

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -5,6 +5,10 @@
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml')">
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
+    <ApplicationDefinition Include="Application.xaml"
+                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/Application.xaml')">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
 
     <None Remove="@(ApplicationDefinition)"
           Condition="'$(EnableDefaultApplicationDefinition)' != 'false'" />

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -2,11 +2,11 @@
 
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true'">
     <ApplicationDefinition Include="App.xaml"
-                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml')">
+                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
     <ApplicationDefinition Include="Application.xaml"
-                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/Application.xaml')">
+                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/Application.xaml') And '$(MSBuildProjectExtension)' == '.vbproj'">
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
 
@@ -22,7 +22,7 @@
     <None Remove="@(Page)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true" />
   </ItemGroup>


### PR DESCRIPTION
VB projects, by convention, use Application.xaml for the name of their ApplicationDefinition file. Without this change, we run into the problem described at https://github.com/dotnet/wpf/issues/500. Fixes #550.