### PR TITLE
Some changes to Versions.props and Versions.Details.xml to make them easier to work in 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27609-17">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>9e195d41f604e38fb227eaed017c9292c884149c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.0-preview5.19208.4">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>fd52f87e309d708ce4491f7c65b892f29091346f</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
     </Dependency>
@@ -13,7 +25,19 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
     </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
+    </Dependency>
+      <Dependency Name="System.Drawing.Common" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
+    </Dependency>
     <Dependency Name="System.Reflection.Emit" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
     </Dependency>
@@ -36,34 +60,6 @@
     <Dependency Name="System.Windows.Extensions" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
-    </Dependency>
-    <Dependency Name="System.CodeDom" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
-    </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
-      <SourceBuildId>5589</SourceBuildId>
-    </Dependency>
-    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.0-preview5.19208.4">
-      <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>fd52f87e309d708ce4491f7c65b892f29091346f</Sha>
-      <SourceBuildId>6173</SourceBuildId>
-    </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
-      <SourceBuildId>5589</SourceBuildId>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="4.6.0-preview5.19209.12" CoherentParentDependency="Microsoft.NETCore.App">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>5b6a71f295e5b7dcdff4fae98f1301c6a5772c7d</Sha>
-      <SourceBuildId>5589</SourceBuildId>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27609-17">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>9e195d41f604e38fb227eaed017c9292c884149c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,6 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
   <!-- NuGet Package Versions -->
-  <!-- Packages that come from https://github.com/dotnet/winforms -->
   <PropertyGroup>
     <MicrosoftPrivateWinformsVersion>4.8.0-preview5.19208.4</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
@@ -45,7 +44,7 @@
     <SystemCodeDomPackageVersionForPresentationBuildTasks>4.4.0</SystemCodeDomPackageVersionForPresentationBuildTasks>
   </PropertyGroup>
   <!-- Other Packages that require manual updating-->
-  </PropertyGroup>
+  <PropertyGroup>
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
     <StrawberryPerlVersion>5.28.1.1-1</StrawberryPerlVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,17 +4,24 @@
     <VersionPrefix>4.8.0</VersionPrefix>
     <PreReleaseVersionLabel>preview5</PreReleaseVersionLabel>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <SystemReflectionMetadataLoadContextVersion>4.6.0-preview5.19209.12</SystemReflectionMetadataLoadContextVersion>
-    <MicrosoftPrivateWinformsVersion>4.8.0-preview5.19208.4</MicrosoftPrivateWinformsVersion>
-    <SystemDrawingCommonVersion>4.6.0-preview5.19209.12</SystemDrawingCommonVersion>
-    <SystemDirectoryServicesVersion>4.6.0-preview5.19209.12</SystemDirectoryServicesVersion>
-    <MicrosoftNETCoreAppVersion>3.0.0-preview5-27609-17</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCorePlatformsVersion>3.0.0-preview5.19209.12</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
   <!-- NuGet Package Versions -->
+  <!-- Packages that come from https://github.com/dotnet/winforms -->
   <PropertyGroup>
-    <!-- Packages that come from https://github.com/dotnet/corefx -->
+    <MicrosoftPrivateWinformsVersion>4.8.0-preview5.19208.4</MicrosoftPrivateWinformsVersion>
+  </PropertyGroup>
+  <!-- Packages that come from https://github.com/dotnet/core-setup -->
+  <PropertyGroup>
+    <MicrosoftNETCoreAppVersion>3.0.0-preview5-27609-17</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCorePlatformsVersion>3.0.0-preview5.19209.12</MicrosoftNETCorePlatformsVersion>
+    <SystemDrawingCommonVersion>4.6.0-preview5.19209.12</SystemDrawingCommonVersion>
+    <SystemDirectoryServicesVersion>4.6.0-preview5.19209.12</SystemDirectoryServicesVersion>
+    <SystemReflectionMetadataLoadContextVersion>4.6.0-preview5.19209.12</SystemReflectionMetadataLoadContextVersion>
+  </PropertyGroup>
+  <!-- Packages that come from https://github.com/dotnet/corefx via core-setup coherency parent dependency -->
+  <PropertyGroup>
     <MicrosoftWin32RegistryPackageVersion>4.6.0-preview5.19209.12</MicrosoftWin32RegistryPackageVersion>
+    <SystemCodeDomPackageVersion>4.6.0-preview5.19209.12</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>4.6.0-preview5.19209.12</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>4.6.0-preview5.19209.12</SystemDiagnosticsEventLogPackageVersion>
     <SystemReflectionEmitPackageVersion>4.6.0-preview5.19209.12</SystemReflectionEmitPackageVersion>
@@ -24,20 +31,27 @@
     <SystemSecurityPermissionsPackageVersion>4.6.0-preview5.19209.12</SystemSecurityPermissionsPackageVersion>
     <SystemSecurityPrincipalWindowsPackageVersion>4.6.0-preview5.19209.12</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>4.6.0-preview5.19209.12</SystemWindowsExtensionsPackageVersion>
-    <SystemCodeDomPackageVersion>4.6.0-preview5.19209.12</SystemCodeDomPackageVersion>
-    <!-- Packages that come from https://github.com/dotnet/arcade -->
+  </PropertyGroup>
+  <!-- Packages that come from https://github.com/dotnet/arcade -->
+  <PropertyGroup>
     <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19209.2</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <!-- Packages that come from https://github.com/dotnet/corefxlab -->
+  </PropertyGroup>
+  <!-- Packages that come from https://github.com/dotnet/corefxlab -->
+  <PropertyGroup>
     <SystemReflectionTypeLoaderPackageVersion>0.1.0-preview2-181205-2</SystemReflectionTypeLoaderPackageVersion>
-    <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
+  </PropertyGroup>
+  <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
+  <PropertyGroup>
     <SystemCodeDomPackageVersionForPresentationBuildTasks>4.4.0</SystemCodeDomPackageVersionForPresentationBuildTasks>
-    <!-- Other Packages that require manual updating-->
+  </PropertyGroup>
+  <!-- Other Packages that require manual updating-->
+  </PropertyGroup>
     <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
     <StrawberryPerlVersion>5.28.1.1-1</StrawberryPerlVersion>
-    <XUnitRunnerConsoleVersion>2.4.0</XUnitRunnerConsoleVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.0</XUnitRunnerVisualStudioVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
+    <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
+    <XUnitRunnerVisualStudioVersion>$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>


### PR DESCRIPTION
* separate out version.props into different property groups by source to ease merging
* alphabetize version.props inside each property group
* alphabetize versions.details.xml by dependency name
* remove source ids
* make all xunit dependencies the same number

@vatsan-madhavan 