### PR TITLE
BamlMapTable should always reinitialize KnownAssemblyInfoRecord

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -72,20 +72,17 @@ namespace System.Windows.Markup
 
 #region Constructor
 
-        static BamlMapTable()
-        {
-            // Setup the assembly record for the known types of controls
-            KnownAssemblyInfoRecord = new BamlAssemblyInfoRecord();
-            KnownAssemblyInfoRecord.AssemblyId = -1;
-            KnownAssemblyInfoRecord.Assembly = ReflectionHelper.LoadAssembly(_frameworkAssembly, string.Empty);
-            KnownAssemblyInfoRecord.AssemblyFullName = KnownAssemblyInfoRecord.Assembly.FullName;
-        }
-
         internal BamlMapTable(XamlTypeMapper xamlTypeMapper)
         {
             Debug.Assert(null != xamlTypeMapper);
 
             _xamlTypeMapper = xamlTypeMapper;
+
+            // Setup the assembly record for the known types of controls
+            KnownAssemblyInfoRecord = new BamlAssemblyInfoRecord();
+            KnownAssemblyInfoRecord.AssemblyId = -1;
+            KnownAssemblyInfoRecord.Assembly = ReflectionHelper.LoadAssembly(_frameworkAssembly, string.Empty);
+            KnownAssemblyInfoRecord.AssemblyFullName = KnownAssemblyInfoRecord.Assembly.FullName;
         }
 
 #endregion Constructor


### PR DESCRIPTION
NETFX Regression: No longer can set name property to MarkupExtension in certain places #378.

Move KnownAssemblyInfoRecord initialization out of BamlMapTable's static constructor to its constructor. (Fixes #378)