### PR TITLE
Set TargetingPackVersion intentionally

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,8 @@
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>f977a22b418447e1a42d04a61ab29c289465146f</Sha>
     </Dependency>
+  </ProductDependencies>
+  <ToolsetDependencies>
     <Dependency Name="Microsoft.Win32.Registry" Version="4.6.0-preview5.19218.1" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>82eedbff6b767c0bd9297d3dd27c89d925a28e93</Sha>
@@ -57,8 +59,6 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>82eedbff6b767c0bd9297d3dd27c89d925a28e93</Sha>
     </Dependency>
-  </ProductDependencies>
-  <ToolsetDependencies>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27618-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>4d6087136f8af1c076f706f59441f6de9795980b</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27617-01">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>3abca437fee294811fca2f81e9e5118a5b4c45fe</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Private.Winforms" Version="4.8.0-preview5.19208.4">
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>fd52f87e309d708ce4491f7c65b892f29091346f</Sha>
@@ -63,6 +59,10 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27617-01">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>3abca437fee294811fca2f81e9e5118a5b4c45fe</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19217.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4e21d52dabbb9f5705a90f097acb1465a0354c0d</Sha>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true'">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true' And $(TargetFramework.StartsWith('netcoreapp3.')) ">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -6,14 +6,20 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Platforms" 
                       Version="$(MicrosoftNETCorePlatformsVersion)" 
-                      Condition="'$(MSBuildProjectExtension)'!='.vcxproj' And '$(IsTestProject)'!='true'"/>
+                      Condition="'$(MSBuildProjectExtension)'!='.vcxproj' And '$(WpfTest)'!='true'"/>
+    
     <AdditionalPackageReference Include="Microsoft.NETCore.Platforms" 
                                 Version="$(MicrosoftNETCorePlatformsVersion)" 
-                                Condition="'$(ManagedCxx)'=='true'"/>
+                                Condition="'$(ManagedCxx)'=='true' And '$(WpfTest)'!='true'"/>
+    
+    <FrameworkReference Update="Microsoft.NETCore.App"
+                      Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true' And $(TargetFramework.StartsWith('netcoreapp3.')) And '$(MSBuildProjectExtension)'!='.vcxproj' And '$(WpfTest)'!='true'">
+      <TargetingPackVersion>$(MicrosoftNETCoreAppVersion)</TargetingPackVersion>
+    </FrameworkReference>
   </ItemGroup>
 
   <PropertyGroup>
     <!-- If TargetFramework is not netcoreapp3.x, then reset RuntimeFrameworkVersion -->
-    <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('netcoreapp3.'))" />
+    <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('netcoreapp3.')) And '$(WpfTest)'=='true'" />
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is part-2 of setting `RuntimeFrameworkVersion` intentionally. 

For now, tests are opted-out of `RuntimeFrameworkVersion` and `TargetingPackVersion`. Some tests continue to use `Sdk=Microsoft.NET.Sdk.WindowsDesktop `- we need to move them to use `Sdk=Microsoft.NET.Sdk` instead, and opt-them also into using `RuntimeFrameworkVersion`. We will do this after https://github.com/dotnet/arcade/pull/2343 is merged and becomes available generally. 

We are not updating global.json tools.dotnet and sdk.version yet - we'll keep slightly older versions there as well until we make relevant changes to tests. 