### PR TITLE
Fix build failures (issue #638) and remove private C++ toolset workaround

### DIFF
--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true' And $(TargetFramework.StartsWith('netcoreapp3.')) ">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true' And $(TargetFramework.StartsWith('netcoreapp3.')) And '$(WpfTest)'!='true'">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -16,6 +16,13 @@
                       Condition="'$(MicrosoftNETCoreAppVersion)'!='' And '$(NoTargets)'!='true' And $(TargetFramework.StartsWith('netcoreapp3.')) And '$(MSBuildProjectExtension)'!='.vcxproj' And '$(WpfTest)'!='true'">
       <TargetingPackVersion>$(MicrosoftNETCoreAppVersion)</TargetingPackVersion>
     </FrameworkReference>
+
+    <!-- 
+      Workaround - this should be removed when our tests are converted from Microsoft.NET.Sdk.WindowsDesktop => Microsoft.NET.Sdk
+      project
+    -->
+    <KnownFrameworkReference Remove="Microsoft.AspNetCore.App"
+                             Condition="'$(WpfTest)'=='true'" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -65,22 +65,24 @@
   <Target
     Name="LimitNetCoreAppReferences"
     AfterTargets="ResolveTargetingPacks"
-    Returns="@(ReferencePath)"
-    Condition="'$(PkgMicrosoft_NETCore_App)'=='' And '@(NetCoreReference)'!='' and '@(ReferencePath)' != ''">
+    Returns="@(Reference)"
+    Condition="'$(PkgMicrosoft_NETCore_App)'=='' And '@(NetCoreReference)'!='' and '@(Reference)' != ''">
     <!--
       Example
       <NetCoreReference Include="Microsoft.CSharp" />
     -->
 
     <!--
-       Save Microsoft.NETCore.App.Ref assemblies, and remove those from @(ReferencePath)
+       Save Microsoft.NETCore.App.Ref assemblies, and remove those from @(Reference)
      -->
     <ItemGroup>
       <_netCoreAppSdkReference Remove="@(_netCoreAppSdkReference)" />
-      <_netCoreAppSdkReference Include="@(ReferencePath)"
-                               Condition="'%(ReferencePath.NuGetPackageId)'=='Microsoft.NETCore.App.Ref'" />
+      <_netCoreAppSdkReference Include="@(Reference)"
+                               Condition="'%(Reference.NuGetPackageId)'=='Microsoft.NETCore.App.Ref'">
+        <OriginalPath>%(Reference.Identity)</OriginalPath>
+      </_netCoreAppSdkReference>
 
-      <ReferencePath Remove="@(_netCoreAppSdkReference)" />
+      <Reference Remove="@(_netCoreAppSdkReference)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -94,7 +96,7 @@
     </FilterItem1ByItem2>
 
     <ItemGroup>
-      <ReferencePath Include="@(_netCoreAppReferences->'%(OriginalItemSpec)')" />
+      <Reference Include="@(_netCoreAppReferences->'%(OriginalPath)')" />
     </ItemGroup>
   </Target>
 
@@ -116,22 +118,24 @@
 
   <Target Name="LimitWindowsDesktopAppReferences"
         AfterTargets="ResolveTargetingPacks"
-        Returns="@(ReferencePath)"
-        Condition="'$(PkgMicrosoft_WindowsDesktop_App)'=='' And '@(WindowsDesktopReference)'!='' and '@(ReferencePath)' != ''">
+        Returns="@(Reference)"
+        Condition="'$(PkgMicrosoft_WindowsDesktop_App)'=='' And '@(WindowsDesktopReference)'!='' and '@(Reference)' != ''">
     <!--
       Example
       <WindowsDesktopReference Include="PresentationCore" />
     -->
 
     <!--
-       Save Microsoft.WindowsDesktop.App.Ref assemblies, and remove those from @(ReferencePath)
+       Save Microsoft.WindowsDesktop.App.Ref assemblies, and remove those from @(Reference)
      -->
     <ItemGroup>
       <_windowsDesktopAppSdkReference Remove="@(_windowsDesktopAppSdkReference)" />
-      <_windowsDesktopAppSdkReference Include="@(ReferencePath)"
-                                      Condition="'%(ReferencePath.NuGetPackageId)'=='Microsoft.WindowsDesktop.App.Ref'" />
+      <_windowsDesktopAppSdkReference Include="@(Reference)"
+                                      Condition="'%(Reference.NuGetPackageId)'=='Microsoft.WindowsDesktop.App.Ref'">
+        <OriginalPath>%(Reference.Identity)</OriginalPath>
+      </_windowsDesktopAppSdkReference>
 
-      <ReferencePath Remove="@(_windowsDesktopAppSdkReference)" />
+      <Reference Remove="@(_windowsDesktopAppSdkReference)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -145,7 +149,7 @@
     </FilterItem1ByItem2>
 
     <ItemGroup>
-      <ReferencePath Include="@(_windowsDesktopAppReferences->'%(OriginalItemSpec)')" />
+      <Reference Include="@(_windowsDesktopAppReferences->'%(OriginalPath)')" />
     </ItemGroup>
   </Target>
 

--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -64,7 +64,7 @@
 
   <Target
     Name="LimitNetCoreAppReferences"
-    AfterTargets="ResolveAssemblyReferences"
+    AfterTargets="ResolveTargetingPacks"
     Returns="@(ReferencePath)"
     Condition="'$(PkgMicrosoft_NETCore_App)'=='' And '@(NetCoreReference)'!='' and '@(ReferencePath)' != ''">
     <!--
@@ -115,7 +115,7 @@
   </Target>
 
   <Target Name="LimitWindowsDesktopAppReferences"
-        AfterTargets="ResolveAssemblyReferences"
+        AfterTargets="ResolveTargetingPacks"
         Returns="@(ReferencePath)"
         Condition="'$(PkgMicrosoft_WindowsDesktop_App)'=='' And '@(WindowsDesktopReference)'!='' and '@(ReferencePath)' != ''">
     <!--

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -89,11 +89,20 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <UsePrivateFrontEnd Condition="'$(UsePrivateFrontEnd)'==''">true</UsePrivateFrontEnd>
+    <!-- 
+      If there is ever need to use a private C++ compiler front-end, use the logic in the commented section below,
+      and update global.json with the corresponding version of msvcurt-c1xx
+      
+      There is also a corresponding section (also commented out) in Wpf.Cpp.targets.
+      
+      msvcurt-c1xx should reference a blob hosted in azure storage that contains
+      msvcurt[d]_netcore.lib and c1xx.dll 
+    -->
+    <!-- <UsePrivateFrontEnd Condition="'$(UsePrivateFrontEnd)'==''">true</UsePrivateFrontEnd> --> 
     <!-- Also update in global.json -->
-    <MsvcurtC1xxVersion>0.0.0.4</MsvcurtC1xxVersion>
-    <MsvcurtC1xxToolsPath>$(RepoRoot).tools\native\bin\msvcurt-c1xx\$(MsvcurtC1xxVersion)\$(Architecture)\</MsvcurtC1xxToolsPath>
-    <MsvcurtNetCoreLib>$(MsvcurtC1xxToolsPath)msvcurt$(LibSuffix)_netcore.lib</MsvcurtNetCoreLib>
+    <!--<MsvcurtC1xxVersion>0.0.0.4</MsvcurtC1xxVersion>-->
+    <!--<MsvcurtC1xxToolsPath>$(RepoRoot).tools\native\bin\msvcurt-c1xx\$(MsvcurtC1xxVersion)\$(Architecture)\</MsvcurtC1xxToolsPath>-->
+    <!--<MsvcurtNetCoreLib>$(MsvcurtC1xxToolsPath)msvcurt$(LibSuffix)_netcore.lib</MsvcurtNetCoreLib>-->
   </PropertyGroup>
   
   <ItemDefinitionGroup Condition="'$(UsePrivateFrontEnd)'=='true' And '$(ManagedCxx)'=='true' and '$(ExplicitCrts)'=='true'">

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
 
+  <!-- 
+    See comment about UsePrivateFrontEnd in Wpf.Cpp.props
+  -->
+  <!-- 
   <PropertyGroup>
     <FrontEndPath Condition="'$(VCToolArchitecture)'=='Native32Bit'">$(MsvcurtC1xxToolsPath)HostX86\c1xx.dll</FrontEndPath>
     <FrontEndPath Condition="'$(VCToolArchitecture)'=='Native64Bit'">$(MsvcurtC1xxToolsPath)HostX64\c1xx.dll</FrontEndPath>
@@ -17,7 +21,7 @@
       <AdditionalOptions>%(AdditionalOptions) /fe:"$(FrontEndPath)"</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
-
+  --> 
 
   <ItemDefinitionGroup>
     <ClCompile>

--- a/global.json
+++ b/global.json
@@ -1,18 +1,17 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview-010024",
+    "dotnet": "3.0.100-preview5-011568",
     "vs": {
-      "version": "16.0"
+      "version": "16.1"
     }
   },
   "sdk": {
-    "version": "3.0.100-preview-010024"
+    "version": "3.0.100-preview5-011568"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19252.2"
   },
   "native-tools": {
-    "strawberry-perl": "5.28.1.1-1",
-    "msvcurt-c1xx": "0.0.0.4"
+    "strawberry-perl": "5.28.1.1-1"
   }
 }

--- a/src/Microsoft.DotNet.Wpf/test/DRT/DrtXaml/DrtXaml/XamlTestFrameWork/TestFinder.cs
+++ b/src/Microsoft.DotNet.Wpf/test/DRT/DrtXaml/DrtXaml/XamlTestFrameWork/TestFinder.cs
@@ -189,17 +189,25 @@ namespace DrtXaml.XamlTestFramework
 
         public static bool IsATestType(Type type)
         {
-            if (!type.GetCustomAttributes(typeof(TestClassAttribute), false).Any())
+            try
             {
+                if (!type.GetCustomAttributes(typeof(TestClassAttribute), false).Any())
+                {
+                    return false;
+                }
+
+                if (type.GetCustomAttributes(typeof(TestDisabledAttribute), false).Any())
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            catch (TypeLoadException e) when (e.TypeName == "System.Runtime.CompilerServices.SuppressMergeCheckAttribute")
+            {
+                // Temporary workaround for missing type in System.Runtime
                 return false;
             }
-
-            if (type.GetCustomAttributes(typeof(TestDisabledAttribute), false).Any())
-            {
-                return false;
-            }
-
-            return true;
         }
 
         public static bool IsTestMethod(MethodInfo method)


### PR DESCRIPTION
- Fixes build break by changing when `LimitNetCoreAppReferences` runs
- Removes dependence on private C++/CLI tooling in favor of tools that are now present in Dev16.1 P2 builds (that are already on our build servers)
- Add a workaround in tests for a type missing from System.Runtime