### PR TITLE
Fix ResX Code Generation

### DIFF
--- a/eng/WpfArcadeSdk/tools/SystemResources.props
+++ b/eng/WpfArcadeSdk/tools/SystemResources.props
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+
+  <PropertyGroup>
+    <!-- 
+         Arcade requires us to set this property in order for it to appropriately update
+         GenerateSource in our EmbeddedResource items.  Without this, no code generation
+         will take place for any of our resx files.
+         See GenerateResxSource.targets in Arcade.
+    -->
+    <GenerateResxSource>true</GenerateResxSource>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <EmbeddedResource>
       <GenerateSource>true</GenerateSource>


### PR DESCRIPTION
Due to a change in Arcade in GenerateResxSource.targets, we need to set GenerateResxSource to true so that codegen runs on our EmbeddedResources.  This is blocking some DARC PRs with the latest Arcade changes.

fixes #662 