### PR TITLE
Fix bug where x:Static argument is treated as member of 'SystemParameters' by mistake

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1509,9 +1509,7 @@ namespace System.Windows.Markup
                     Debug.Assert(targetType != null && memberName != null);
 
                     MemberInfo memberInfo = XamlTypeMapper.GetStaticMemberInfo(targetType, memberName, false);
-                    if (memberInfo is PropertyInfo &&
-                        targetType.Assembly == XamlTypeMapper.AssemblyPF &&
-                        targetType.FullName == "System.Windows.SystemParameters")
+                    if (memberInfo is PropertyInfo)
                     {
                         // see if the value is a static SystemResourceKey property from the themes
                         memberId = SystemResourceKey.GetBamlIdBasedOnSystemResourceKeyId(targetType, memberName);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1509,7 +1509,9 @@ namespace System.Windows.Markup
                     Debug.Assert(targetType != null && memberName != null);
 
                     MemberInfo memberInfo = XamlTypeMapper.GetStaticMemberInfo(targetType, memberName, false);
-                    if (memberInfo is PropertyInfo)
+                    if (memberInfo is PropertyInfo &&
+                        targetType.Assembly == XamlTypeMapper.AssemblyPF &&
+                        targetType.FullName == "System.Windows.SystemParameters")
                     {
                         // see if the value is a static SystemResourceKey property from the themes
                         memberId = SystemResourceKey.GetBamlIdBasedOnSystemResourceKeyId(targetType, memberName);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
@@ -364,6 +364,7 @@ namespace System.Windows
             short memberId = 0;
             string srkField = null;
             bool isKey = false;
+            bool found = true;
 
             if (memberName.EndsWith("Key", false, TypeConverterHelper.InvariantEnglishUS))
             {
@@ -382,9 +383,14 @@ namespace System.Windows
             {
                 srkField = memberName;
             }
+#if PBTCOMPILER
+            
+            found &= targetType.Assembly == XamlTypeMapper.AssemblyPF &&
+                targetType.FullName == "System.Windows.SystemParameters";
+                
+#endif
 
-            if (targetType.Assembly == XamlTypeMapper.AssemblyPF &&
-                targetType.FullName == "System.Windows.SystemParameters" &&
+            if (found &&
                 Enum.TryParse(srkField, out SystemResourceKeyID srkId))
             {
                 bool isExtended = ((short)srkId > SystemResourceKeyIDExtendedStart &&

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
@@ -390,14 +390,7 @@ namespace System.Windows
             if (targetType.Assembly == XamlTypeMapper.AssemblyPF &&
                 targetType.FullName == "System.Windows.SystemParameters")
             {
-                try
-                {
-                    srkId = (SystemResourceKeyID)Enum.Parse(typeof(SystemResourceKeyID), srkField);
-                }
-                catch (ArgumentException)
-                {
-                    found = false;
-                }
+                found = Enum.TryParse(srkField, out srkId);
             }
 
             if (found)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
@@ -387,13 +387,17 @@ namespace System.Windows
                 srkField = memberName;
             }
 
-            try
+            if (targetType.Assembly == XamlTypeMapper.AssemblyPF &&
+                targetType.FullName == "System.Windows.SystemParameters")
             {
-                srkId = (SystemResourceKeyID)Enum.Parse(typeof(SystemResourceKeyID), srkField);
-            }
-            catch (ArgumentException)
-            {
-                found = false;
+                try
+                {
+                    srkId = (SystemResourceKeyID)Enum.Parse(typeof(SystemResourceKeyID), srkField);
+                }
+                catch (ArgumentException)
+                {
+                    found = false;
+                }
             }
 
             if (found)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResourceKey.cs
@@ -364,10 +364,6 @@ namespace System.Windows
             short memberId = 0;
             string srkField = null;
             bool isKey = false;
-            bool found = true;
-
-            // Initialization needed to keep compiler happy!
-            SystemResourceKeyID srkId = SystemResourceKeyID.InternalSystemColorsStart;
 
             if (memberName.EndsWith("Key", false, TypeConverterHelper.InvariantEnglishUS))
             {
@@ -388,12 +384,8 @@ namespace System.Windows
             }
 
             if (targetType.Assembly == XamlTypeMapper.AssemblyPF &&
-                targetType.FullName == "System.Windows.SystemParameters")
-            {
-                found = Enum.TryParse(srkField, out srkId);
-            }
-
-            if (found)
+                targetType.FullName == "System.Windows.SystemParameters" &&
+                Enum.TryParse(srkField, out SystemResourceKeyID srkId))
             {
                 bool isExtended = ((short)srkId > SystemResourceKeyIDExtendedStart &&
                                    (short)srkId < SystemResourceKeyIDExtendedEnd);


### PR DESCRIPTION
Fixes #679

The issue is that the original code forgets to check `memberInfo`'s declaring type. When there's a property which shares a same member name of `SystemParameters` or `SystemResourceKeyID`, it'll be treated as member of `SystemParameters`.

The following content is a part of compiled baml of issue demo. Generated by dnSpy.

Before:
```
ElementStart [TypeId=0xff02, Flags=0x00]
    ContentProperty [AttributeId=0xff2b]
    LineNumberAndPosition [LineNumber=0x0000000f, LinePosition=0x0000000a]
    ElementStart [TypeId=0xffc9, Flags=0x00]
        PropertyWithExtension [AttributeId=0xfff2, Flags=0x025a, ValueId=0xfe52]
        LinePosition [LinePosition=0x00000011]
    ElementEnd
ElementEnd
```
After:
```
ElementStart [TypeId=0xff02, Flags=0x00]
    ContentProperty [AttributeId=0xff2b]
    LineNumberAndPosition [LineNumber=0x0000000f, LinePosition=0x0000000a]
    ElementStart [TypeId=0xffc9, Flags=0x00]
        TypeInfo [TypeId=0x0001, AssemblyId=0x0000, TypeFullName="XamlBugs.StaticProperties.FooClass"]
        AttributeInfo [AttributeId=0x0001, OwnerTypeId=0x0001, AttributeUsage=0x00, Name="Border"]
        PropertyWithExtension [AttributeId=0xfff2, Flags=0x025a, ValueId=0x0001]
        LinePosition [LinePosition=0x00000011]
    ElementEnd
ElementEnd
```