### PR TITLE
Fix DebugType in Release builds

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -38,6 +38,8 @@
 
   <PropertyGroup>
     <DebugType>full</DebugType>
+    <DebugType Condition="'$(Configuration)'=='Release'">pdbonly</DebugType>
+    
     <PerlCommand>"$(RepoRoot).tools\native\bin\strawberry-perl\$(StrawberryPerlVersion)\portableshell.bat"</PerlCommand>
     
     <WpfCppProps>$(WpfArcadeSdkToolsDir)Wpf.Cpp.props</WpfCppProps>


### PR DESCRIPTION
We were using DebugType=Full for all build configurations.  This can place undo burden on the JIT for Release builds.  In Release, we still want to emit a PDB, but we want as much optimization as possible so we should use pdbonly.

fixes #693 