### PR TITLE
Fix packaging to place RID specific binaries under runtimes\<rid>\native

### DIFF
--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -7,7 +7,7 @@
     <LibFolder Condition="'$(LibFolder)'==''">lib</LibFolder>
     
     <!-- 
-      Architecture-specific assembies go under runtimes\<rid>\ 
+      Architecture-specific assemblies go under runtimes\<rid>\native\ 
       https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks
     -->
   </PropertyGroup>

--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -10,7 +10,6 @@
       Architecture-specific assembies go under runtimes\<rid>\ 
       https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks
     -->
-    <RuntimesFolder>runtimes</RuntimesFolder>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <!-- Projects can override the name of the 'lib' folder to something else - for e.g., 'tools'-->
     <LibFolder Condition="'$(LibFolder)'==''">lib</LibFolder>
+    
+    <!-- 
+      Architecture-specific assembies go under runtimes\<rid>\ 
+      https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks
+    -->
+    <RuntimesFolder>runtimes</RuntimesFolder>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -74,21 +80,20 @@ $(PreparePackageAssetsDependsOn):
           Returns="@(PackageAsset)"
           Condition="'$(PackageName)'!=''">
 
-    <!-- Identify $(TargetFrameworkOrRuntimeIdentifier) property -->
     <PropertyGroup>
-      <TargetFrameworkOrRuntimeIdentifier Condition="'$(TargetFrameworkOrRuntimeIdentifier)'=='' and '$(TargetFramework)'!=''">$(TargetFramework)</TargetFrameworkOrRuntimeIdentifier>
+      <DestinationSubFolder Condition="'$(DestinationSubFolder)'=='' and '$(TargetFramework)'!=''">$(LibFolder)\$(TargetFramework)\</DestinationSubFolder>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(TargetFrameworkOrRuntimeIdentifier)'==''">
-      <TargetFrameworkOrRuntimeIdentifier Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">win-x86</TargetFrameworkOrRuntimeIdentifier>
-      <TargetFrameworkOrRuntimeIdentifier Condition="'$(Platform)'=='x64'">win-x64</TargetFrameworkOrRuntimeIdentifier>
+    <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(DestinationSubFolder)'==''">
+      <DestinationSubFolder Condition="'$(Platform)'=='AnyCPU' or '$(Platform)'=='x86' or '$(Platform)'=='Win32'">runtimes\win-x86\native\</DestinationSubFolder>
+      <DestinationSubFolder Condition="'$(Platform)'=='x64'">runtimes\win-x64\native\</DestinationSubFolder>
     </PropertyGroup>
 
     <!--
-        Instead of showing an error when $(TargetFrameworkOrRuntimeIdentifier) cannot be identified
+        Instead of showing an error when $(TargetFramework) or $(RuntimeIdentifier) cannot be identified
         we simply do no further work
 
-        Include all the DLL's, EXE's and PDB's under lib\
+        Include all the DLL's, EXE's and PDB's under $(DestinationSubFolder), i.e., either under lib\$(TargetFramework) or runtimes\$(RuntimeIdentifier)\native
         Include all reference assemblies under ref\
         Include all content files under content\
 
@@ -97,37 +102,37 @@ $(PreparePackageAssetsDependsOn):
     
     The CreateItem tasks below is equivalent to this: 
     
-    <ItemGroup Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true'">
-      <PackageAsset Include="$(OutDir)*.dll" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\lib\$(TargetFrameworkOrRuntimeIdentifier)"/>
-      <PackageAsset Include="$(OutDir)*.exe" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\lib\$(TargetFrameworkOrRuntimeIdentifier)"/>
-      <PackageAsset Include="$(OutDir)*.pdb" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\lib\$(TargetFrameworkOrRuntimeIdentifier)"/>
-      <PackageAsset Include="$(ReferenceAssemblyDir)*.dll" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\ref\$(TargetFrameworkOrRuntimeIdentifier)"/>
+    <ItemGroup Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true'">
+      <PackageAsset Include="$(OutDir)*.dll" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\$(DestinationSubFolder)"/>
+      <PackageAsset Include="$(OutDir)*.exe" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\$(DestinationSubFolder)"/>
+      <PackageAsset Include="$(OutDir)*.pdb" RelativePath="$(ArtifactsPackagingDir)$(PackageName)\$(DestinationSubFolder)"/>
+      <PackageAsset Include="$(ReferenceAssemblyDir)*.dll" RelativePath="$(ArtifactsPackagingDir)\$(DestinationSubFolder)"/>
     </ItemGroup>
     -->
     <CreateItem Include="$(OutDir)*.dll"
-                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\$(TargetFrameworkOrRuntimeIdentifier)"
-                Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'==''">
+                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)"
+                Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'==''">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
     <CreateItem Include="$(OutDir)*.exe"
-                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\$(TargetFrameworkOrRuntimeIdentifier)"
-                Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'==''">
+                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)"
+                Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'==''">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
     <CreateItem Include="$(OutDir)*.pdb"
-                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\$(TargetFrameworkOrRuntimeIdentifier)"
-                Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true' and '$(ExcludePdbs)'!='true' and '@(PackagingAssemblyContent)'==''">
+                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)"
+                Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '$(ExcludePdbs)'!='true' and '@(PackagingAssemblyContent)'==''">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
     <CreateItem Include="$(ReferenceAssemblyDir)*.dll"
-                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\ref\$(TargetFrameworkOrRuntimeIdentifier)"
-                Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true' and '$(ExcludeRefAssemblies)'!='true'">
+                AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\ref\$(TargetFramework)"
+                Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '$(ExcludeRefAssemblies)'!='true'">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
 
     <CreateItem Include="$(OutDir)%(PackagingAssemblyContent.Identity)"
-            AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\$(TargetFrameworkOrRuntimeIdentifier)"
-            Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'!=''">
+            AdditionalMetadata="RelativePath=$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)"
+            Condition="'$(DestinationSubFolder)'!='' and '$(IsPackagingProject)'!='true' and '@(PackagingAssemblyContent)'!=''">
       <Output ItemName="PackageAsset" TaskParameter="Include"/>
     </CreateItem>
     <!-- 
@@ -144,10 +149,10 @@ $(PreparePackageAssetsDependsOn):
       <PackageAssetCultures Include="$(XlfLanguages)" />
 
       <PackageAsset Include="$(OutDir)%(PackageAssetCultures.Identity)\*.dll"
-                    RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\$(TargetFrameworkOrRuntimeIdentifier)\%(PackageAssetCultures.Identity)" />
+                    RelativePath="$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(DestinationSubFolder)\%(PackageAssetCultures.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkOrRuntimeIdentifier)'!=''">
+    <ItemGroup Condition="'$(DestinationSubFolder)'!=''">
 
       <!-- %(PackagingContent.SubFolder) not StartsWith 'root' -->
       <PackageAsset Condition="'%(PackagingContent.SubFolder)'!='' And !$([System.String]::Copy(&quot;%(PackagingContent.SubFolder)&quot;).StartsWith(&quot;root&quot;))"
@@ -273,6 +278,24 @@ $(PreparePackageAssetsDependsOn):
          Condition="('$(CreateArchNeutralPackage)'!='true' Or '$(IncludeAssembliesInArchNeutralPackage)'== 'true') and Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\$(LibFolder)\')" >
         <Pack>true</Pack>
         <PackagePath>$(LibFolder)</PackagePath>
+      </Content>
+
+      <Content Include="$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\**\*.dll"
+         Condition="('$(CreateArchNeutralPackage)'!='true' Or '$(IncludeAssembliesInArchNeutralPackage)'== 'true') and Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\')" >
+        <Pack>true</Pack>
+        <PackagePath>runtimes</PackagePath>
+      </Content>
+
+      <Content Include="$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\**\*.exe"
+         Condition="('$(CreateArchNeutralPackage)'!='true' Or '$(IncludeAssembliesInArchNeutralPackage)'== 'true') and Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\')" >
+        <Pack>true</Pack>
+        <PackagePath>runtimes</PackagePath>
+      </Content>
+
+      <Content Include="$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\**\*.pdb"
+         Condition="('$(CreateArchNeutralPackage)'!='true' Or '$(IncludeAssembliesInArchNeutralPackage)'== 'true') and Exists('$(ArtifactsPackagingDir)$(NormalizedPackageName)\runtimes\')" >
+        <Pack>true</Pack>
+        <PackagePath>runtimes</PackagePath>
       </Content>
 
       <Content Include="$(ArtifactsPackagingDir)$(NormalizedPackageName)\ref\**\*.dll"


### PR DESCRIPTION
WPF's internal transport packages currently place RID specific binaries under lib\<RID> folder. 

This change moves them under runtimes\<RID>native\ folder, per spec at [Supporting Multiple .NET Versions](https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks). 

When referencing one of these packages from a test, we noticed that the native assemblies were not getting included in `deps.json`, which lead to the identification of this problem. Placing the binaries under the correct location remedies the `deps.json` creation errors. 