### PR TITLE
Change DWriteForwarder to use __uuidof

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.cpp
@@ -24,26 +24,6 @@ extern void *GetDWriteCreateFactoryFunctionPointer();
 
 namespace MS { namespace Internal { namespace Text { namespace TextInterface
 {
-    /// <summary>
-    /// static ctor to initialize the GUID of IDWriteFactory interface.
-    /// </summary>
-    /// <SecurityNote>
-    /// Critical - Asserts unmanaged code permissions.
-    ///          - Assigns security critical _guidForIDWriteFactory
-    /// Safe     - The data used to initialize _guidForIDWriteFactory is const.
-    /// </SecurityNote>
-    [SecuritySafeCritical]
-#ifndef _CLR_NETCORE
-    [SecurityPermission(SecurityAction::Assert, UnmanagedCode=true)]
-#endif
-    static Factory::Factory()
-    {
-        System::Guid guid = System::Guid("b859ee5a-d838-4b5b-a2e8-1adc7d93db48");
-        _GUID* pGuidForIDWriteFactory = new _GUID();
-        *pGuidForIDWriteFactory = Native::Util::ToGUID(guid);
-        _guidForIDWriteFactory = gcnew NativePointerWrapper<_GUID>(pGuidForIDWriteFactory);  
-    }
-
     /// <SecurityNote>
     /// Critical - Calls security critical Factory ctor().
     /// </SecurityNote>
@@ -129,7 +109,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
         HRESULT hr = (*pfnDWriteCreateFactory)(
             DWriteTypeConverter::Convert(factoryType),
-            (REFIID)(*(_guidForIDWriteFactory->Value)),
+            __uuidof(IDWriteFactory),
             &factoryTemp
             );
         

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.h
@@ -30,16 +30,6 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
         private:
 
             /// <summary>
-            /// This variable stores the GUID of the IDWriteFactory interface.
-            /// The reason we are not using __uuidof(IDWriteFactory) is because the complier generates a global
-            /// variable and a static method to initialize it which is not annotated properly with security tags.
-            /// This makes the static method fail NGENing and causes Jitting which affects perf.
-            /// If the complier gets fixed then we can remove this scheme and use __uuidof(IDWriteFactory).
-            /// </summary>
-            [SecurityCritical]
-            static NativePointerWrapper<_GUID>^ _guidForIDWriteFactory;
-            
-            /// <summary>
             /// A pointer to the wrapped DWrite factory object.
             /// </summary>
             /// <SecurityNote>
@@ -47,12 +37,7 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
             /// </SecurityNote>
             [SecurityCritical]
             IDWriteFactory* _pFactory;
-
-            /// <summary>
-            /// static ctor to initialize the GUID of IDWriteFactory interface.
-            /// </summary>
-            static Factory();
-
+                      
             /// <summary>
             /// Constructs a factory object.
             /// </summary>


### PR DESCRIPTION
Removing use of GUID struct in initialization of the DWrite factory.  This is a workaround for a JIT bug that marshals incorrect GUID data, causing the cast to fail with E_NOINTERFACE.

fixes #725 