### PR TITLE
Adding a pinned version of S.Runtime.CompilerServices.Unsafe to PresentationBuildTasks.csproj

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -59,6 +59,7 @@
     <PackagingAssemblyContent Include="System.Numerics.Vectors.dll" />
     <PackagingAssemblyContent Include="System.Reflection.Metadata.dll" />
     <PackagingAssemblyContent Include="System.Reflection.MetadataLoadContext.dll" />
+    <PackagingAssemblyContent Include="System.Runtime.CompilerServices.Unsafe.dll" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <PackagingAssemblyContent Include="PresentationBuildTasks.dll" />
@@ -309,12 +310,18 @@
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
     
     <!-- 
-    
       Workaround for https://github.com/dotnet/corefx/issues/37943
     -->
     <PackageReference Include="System.Memory" Version="4.5.2">
       <NoWarn>$(NoWarn);NU1605</NoWarn>
     </PackageReference>
+    <!-- 
+      Provide S.R.CompilerServices.Unsafe with AssermblyVersion=4.0.4.1
+      System.Memory/v4.5.2/AssemblyVersion=4.0.1.0 depends on this. 
+      
+      This is also a consequence of https://github.com/dotnet/corefx/issues/37943
+    -->
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #773 
As a result of https://github.com/dotnet/corefx/issues/37943, we have a pinned version of System.Memory in PresentationBuildTasks.csproj.

Turns out that System.Memory v4.5.2 has a dependency on S.Runtime.CompilerServices.Unsafe v4.5.2/AssemblyVersion=4.0.4.1. Pinning this also to PresentationBuildTasks.csproj.