### PR TITLE
Revert PresentationFramework to .NET Framework translations for DE

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
       <trans-unit id="AXNohWnd">
@@ -54,7 +54,7 @@
       </trans-unit>
       <trans-unit id="AffectedByMsCtfIssue">
         <source>The security configuration of this computer is incompatible with certain features used by this application.\nFor more information, see {0}.\n\nContact your administrator to change the security configuration or to apply the available hotfix.</source>
-        <target state="translated">Die Sicherheitskonfiguration dieses Computers ist inkompatibel mit bestimmten von dieser Anwendung verwendeten Funktionen.\nWeitere Informationen finden Sie unter {0}.\n\nBitten Sie den Administrator, die Sicherheitskonfiguration zu ändern oder den verfügbaren Hotfix anzuwenden.</target>
+        <target state="needs-review-translation">Die Sicherheitskonfiguration dieses Computers ist inkompatibel mit bestimmten von dieser Anwendung verwendeten Funktionen.]A;Weitere Informationen finden Sie unter {0}.]A;]A;Bitten Sie den Administrator, die Sicherheitskonfiguration zu ändern oder den verfügbaren Hotfix anzuwenden.</target>
         <note />
       </trans-unit>
       <trans-unit id="AlreadyHasLogicalChildren">
@@ -74,22 +74,22 @@
       </trans-unit>
       <trans-unit id="Animation_InvalidAnimationUsingKeyFramesDuration">
         <source>'{0}' must have either a TimeSpan for its Duration or a TimeSpan for the KeyTime of its last KeyFrame. This '{0}' has a Duration of '{1}' and a KeyTime of '{2}' for its last KeyFrame, so the KeyTimes cannot be resolved.</source>
-        <target state="translated">"{0}" muss entweder einen TimeSpan-Wert für das Duration-Element oder einen TimeSpan-Wert für das KeyTime-Element des letzten KeyFrame-Objekts besitzen. Dieses {0}-Objekt besitzt den Duration-Wert "{1}" und den KeyTime-Wert "{2}" für das letzte KeyFrame-Objekt. Aus diesem Grund kann das KeyTimes-Objekt nicht aufgelöst werden.</target>
+        <target state="translated">"{0}" muss entweder einen TimeSpan-Wert für das Duration-Element oder einen TimeSpan-Wert für das KeyTime-Element des letzten KeyFrame-Objekts besitzen. Dieses "{0}"-Objekt besitzt den Duration-Wert "{1}" und den KeyTime-Wert "{2}" für das letzte KeyFrame-Objekt. Aus diesem Grund kann das KeyTimes-Objekt nicht aufgelöst werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="Animation_InvalidBaseValue">
         <source>'{0}' is not a valid '{1}' value for class '{2}'. This value might have been supplied by the base value of the property being animated or the output value of another animation applied to the same property.</source>
-        <target state="translated">"{0}" ist ein ungültiger {1}-Wert für die Klasse "{2}". Dieser Wert wurde möglicherweise vom Basiswert der animierten Eigenschaft oder dem Ausgabewert einer anderen Animation bereitgestellt, die auf die gleiche Eigenschaft angewendet wird.</target>
+        <target state="translated">"{0}" ist ein ungültiger {1}-Wert für Klasse "{2}". Dieser Wert wurde möglicherweise vom Basiswert der animierten Eigenschaft oder dem Ausgabewert einer anderen Animation bereitgestellt, die auf die gleiche Eigenschaft angewendet wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="Animation_InvalidResolvedKeyTimes">
         <source>Resolved KeyTime for key frame at index {1} cannot be greater than resolved KeyTime for key frame at index {4}. KeyFrames[{1}] has specified KeyTime '{2}', which resolves to time {3}; KeyFrames[{4}] has specified KeyTime '{5}', which resolves to time {6}. Some KeyTimes are resolved relative to Begin time of '{0}' and others relative to its Duration, so some sets of KeyTimes are not valid for all Durations.</source>
-        <target state="translated">Der aufgelöste KeyTime-Wert für den Keyframe an Index "{1}" kann nicht größer als der aufgelöste KeyTime-Wert für den Keyframe an Index "{4}" sein. Von "KeyFrames[{1}]" wurde der KeyTime-Wert "{2}" angegeben, der in die Zeit "{3}" aufgelöst wird. Von "KeyFrames[{4}]" wurde der KeyTime-Wert "{5}" angegeben, der in die Zeit "{6}" aufgelöst wird. Einige KeyTimes-Werte werden relativ zur Begin-Zeit von "{0}" und andere relativ zu den Duration-Werten aufgelöst, sodass einige Einstellungen von KeyTimes-Werten nicht für alle Duration-Werte gültig sind.</target>
+        <target state="needs-review-translation">Der aufgelöste KeyTime-Wert für den Keyframe an Index "{1}" kann nicht größer als der aufgelöste KeyTime-Wert für den Keyframe an Index "{4}" sein. Von "KeyFrames[{1}]5D;" wurde der KeyTime-Wert "{2}" angegeben, der für die Zeit "{3}" aufgelöst wird. Von "KeyFrames[{4}]5D;" wurde der KeyTime-Wert "{5}" angegeben, der für die Zeit "{6}" aufgelöst wird. Einige KeyTimes-Werte werden relativ zur Begin-Zeit von "{0}" und andere relativ zu den Duration-Werten aufgelöst, sodass einige Einstellungen von KeyTimes-Werten nicht für alle Duration-Werte gültig sind.</target>
         <note />
       </trans-unit>
       <trans-unit id="Animation_InvalidTimeKeyTime">
         <source>'{2}' KeyTime value is not valid for key frame at index {1} of this '{0}' because it is greater than animation's Duration value '{3}'.</source>
-        <target state="translated">Der KeyTime-Wert "{2}" ist nicht gültig für den KeyFrame-Wert am Index "{1}" dieses {0}-Objekts, weil er größer als der Duration-Wert "{3}" der Animation ist.</target>
+        <target state="translated">Der KeyTime-Wert "{2}" ist nicht gültig für den KeyFrame-Wert am Index "{1}" dieses {0}-Objekts, da er größer als der Duration-Wert "{3}" der Animation ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="Animation_Invalid_DefaultValue">
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ArgumentLengthMismatch">
         <source>Expected {0} argument(s) to method {1}.{2}.</source>
-        <target state="translated">Für die {1}-Methode wurde(n) {0} Argument(e) erwartet.{2}.</target>
+        <target state="translated">{0} Argument(e) für die {1}-Methode wurde(n) erwartet.{2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentPropertyMustNotBeNull">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="AxNoConnectionPointContainer">
         <source>Source object does not expose IConnectionPointContainer.</source>
-        <target state="translated">Das Quellobjekt macht IConnectionPointContainer nicht verfügbar.</target>
+        <target state="translated">"IConnectionPointContainer" wird vom Quellobjekt nicht verfügbar gemacht.</target>
         <note />
       </trans-unit>
       <trans-unit id="AxNoEventInterface">
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="AxNoSinkAdvise">
         <source>Cannot Advise event interface '{0}'. ('{1}')</source>
-        <target state="translated">"Advise" ist für die Ereignisschnittstelle "{0}" nicht möglich. ({1})</target>
+        <target state="translated">"Advise" ist für die Ereignisschnittstelle "{0}" nicht möglich. ("{1}")</target>
         <note />
       </trans-unit>
       <trans-unit id="AxNoSinkImplementation">
@@ -374,7 +374,7 @@
       </trans-unit>
       <trans-unit id="BindingGroup_ValueUnavailable">
         <source>The value for item '{0}' and property '{1}' is not available because a previous validation rule deemed the value invalid, or because the value could not be computed (e.g., conversion failure).</source>
-        <target state="translated">Der Wert für das Element "{0}" und die {1}-Eigenschaft ist nicht verfügbar, weil er von einer früheren Validierungsregel als ungültig angesehen wurde oder nicht berechnet werden konnte (z. B. aufgrund eines Konvertierungsfehlers).</target>
+        <target state="translated">Der Wert für das Element "{0}" und die {1}-Eigenschaft ist nicht verfügbar, weil er von einer früheren Validierungsregel als ungültig angesehen wurde oder nicht berechnet werden konnte (z.B. aufgrund eines Konvertierungsfehlers).</target>
         <note />
       </trans-unit>
       <trans-unit id="BindingListCanOnlySortByOneProperty">
@@ -389,7 +389,7 @@
       </trans-unit>
       <trans-unit id="BrowserHostingNotSupported">
         <source>Browser hosting of WPF applications is not supported on this platform.</source>
-        <target state="translated">Das Browserhosting von WPF-Anwendungen wird auf dieser Plattform nicht unterstützt.</target>
+        <target state="new">Browser hosting of WPF applications is not supported on this platform.</target>
         <note />
       </trans-unit>
       <trans-unit id="BufferOffsetNegative">
@@ -429,7 +429,7 @@
       </trans-unit>
       <trans-unit id="CalendarAutomationPeer_MonthMode">
         <source>Month</source>
-        <target state="translated">Monatsansicht</target>
+        <target state="translated">Monat</target>
         <note />
       </trans-unit>
       <trans-unit id="CalendarAutomationPeer_YearMode">
@@ -489,7 +489,7 @@
       </trans-unit>
       <trans-unit id="Calendar_UnSelectableDates">
         <source>Value is not valid.</source>
-        <target state="translated">Der Wert ist nicht gültig.</target>
+        <target state="translated">Ungültiger Wert.</target>
         <note />
       </trans-unit>
       <trans-unit id="CanOnlyHaveOneChild">
@@ -509,7 +509,7 @@
       </trans-unit>
       <trans-unit id="CancelledTitle">
         <source>Application Deployment Canceled</source>
-        <target state="translated">Die Anwendungsbereitstellung wurde abgebrochen.</target>
+        <target state="translated">Anwendungsbereitstellung abgebrochen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotBeInsidePopup">
@@ -539,7 +539,7 @@
       </trans-unit>
       <trans-unit id="CannotChangeLiveShaping">
         <source>Cannot set '{0}' property when '{1}' property is false.</source>
-        <target state="translated">Die {0}-Eigenschaft kann nicht festgelegt werden, wenn die {1}-Eigenschaft FALSE ist.</target>
+        <target state="translated">Die '{0}'-Eigenschaft kann nicht festgelegt werden, wenn die '{1}'-Eigenschaft "False" ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotChangeMainWindowInBrowser">
@@ -549,7 +549,7 @@
       </trans-unit>
       <trans-unit id="CannotConvertStringToType">
         <source>Cannot convert string value '{0}' to type '{1}'.</source>
-        <target state="translated">Der Zeichenfolgenwert "{0}" kann nicht in den Typ "{1}" konvertiert werden.</target>
+        <target state="translated">Der Zeichenfolgenwert "{0}" kann nicht in Typ "{1}" konvertiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotConvertType">
@@ -759,7 +759,7 @@
       </trans-unit>
       <trans-unit id="ChildHasWrongType">
         <source>'{0}' child does not have type '{1}' : '{2}'.</source>
-        <target state="translated">Das untergeordnete {0}-Element besitzt nicht den Typ "{1}": {2}.</target>
+        <target state="translated">Das untergeordnete {0}-Element besitzt nicht den Typ "'{1}" : "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ChildNameMustBeNonEmpty">
@@ -789,7 +789,7 @@
       </trans-unit>
       <trans-unit id="CircularOwnerChild">
         <source>'{0}' Window is already a child of Window '{1}'.</source>
-        <target state="translated">Window "{0}" ist bereits ein untergeordnetes Element von Window "{1}".</target>
+        <target state="translated">"Window '{0}''' ist bereits ein untergeordnetes Element von "Window '{1}'".</target>
         <note />
       </trans-unit>
       <trans-unit id="ClearHighlight">
@@ -809,7 +809,7 @@
       </trans-unit>
       <trans-unit id="CollectionAddEventMissingItem">
         <source>After a CollectionChange.Add event, Items collection does not contain the added item '{0}'.\n This could happen if the event sender supplied incorrect information in CollectionChangedEventArgs.</source>
-        <target state="translated">Nach einem CollectionChange.Add-Ereignis ist das hinzugefügte Element "{0}" in der Items-Sammlung nicht enthalten.\n Möglicherweise wurden vom Sender des Ereignisses in "CollectionChangedEventArgs" falsche Informationen bereitgestellt.</target>
+        <target state="needs-review-translation">Nach einem CollectionChange.Add-Ereignis ist das hinzugefügte Element "{0}" in der Items-Sammlung nicht enthalten.]A; Möglicherweise wurden vom Sender des Ereignisses in "CollectionChangedEventArgs" falsche Informationen bereitgestellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CollectionChangeIndexOutOfRange">
@@ -834,12 +834,12 @@
       </trans-unit>
       <trans-unit id="CollectionView_MissingSynchronizationCallback">
         <source>Synchronization callback for '{0}' collection is no longer available.\n This could happen if the callback is an anonymous method.</source>
-        <target state="translated">Der Synchronisierungsrückruf für die {0}-Sammlung ist nicht mehr verfügbar.\n Dies kann der Fall sein, wenn es sich beim Rückruf um eine anonyme Methode handelt.</target>
+        <target state="needs-review-translation">Der Synchronisierungsrückruf für die '{0}'-Sammlung ist nicht mehr verfügbar.]A; Dies kann der Fall sein, wenn es sich beim Rückruf um eine anonyme Methode handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CollectionView_NameTypeDuplicity">
         <source>Cannot get CollectionView of type '{0}' for CollectionViewSource that already uses type '{1}'.</source>
-        <target state="translated">CollectionView vom Typ "{0}" kann für "CollectionViewSource" nicht abgerufen werden, wenn bereits der Typ "{1}" verwendet wird.</target>
+        <target state="translated">"CollectionView" vom Typ "{0}" kann für "CollectionViewSource" nicht abgerufen werden, wenn bereits der Typ "{1}" verwendet wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="CollectionView_ViewTypeInsufficient">
@@ -854,7 +854,7 @@
       </trans-unit>
       <trans-unit id="Collection_BadType">
         <source>Cannot add instance of type '{1}' to a collection of type '{0}'. Only items of type '{2}' are allowed.</source>
-        <target state="translated">Die Instanz vom Typ "{1}" kann keiner Sammlung vom Typ "{0}" hinzugefügt werden. Es sind nur Elemente vom Typ "{2}" zulässig.</target>
+        <target state="translated">Instanz vom Typ "{1}" kann keiner Sammlung vom Typ "{0}" hinzugefügt werden. Es sind nur Objekte vom Typ "{2}" zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="Collection_CopyTo_ArrayCannotBeMultidimensional">
@@ -969,7 +969,7 @@
       </trans-unit>
       <trans-unit id="CreateRootPopup_ChildHasVisualParent">
         <source>'{0}' must be the root element of a tree, but has a visual parent '{1}'.</source>
-        <target state="translated">Bei "{0}" muss es sich um das Stammelement einer Struktur handeln, es ist jedoch ein visuelles übergeordnetes {1}-Objekt dafür vorhanden.</target>
+        <target state="translated">Bei "{0}" muss es sich um das Stammelement einer Struktur handeln, es ist jedoch ein visuelles {1}-Objekt dafür vorhanden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CreateTextNote">
@@ -1349,17 +1349,17 @@
       </trans-unit>
       <trans-unit id="DocumentStructureUnexpectedParameterType2">
         <source>Parameter of unexpected type '{0}'. Expected types are '{1}', '{2}'.</source>
-        <target state="translated">Der Typ "{0}" des Parameters ist unerwartet. Erwartete Typen: {1}, {2}.</target>
+        <target state="translated">Parameter des unerwarteten Typs "{0}". Erwartete Typen sind "{1}" und "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="DocumentStructureUnexpectedParameterType4">
         <source>Parameter of unexpected type '{0}'. Expected types are '{1}', '{2}', '{3}', '{4}'.</source>
-        <target state="translated">Der Typ "{0}" des Parameters ist unerwartet. Erwartete Typen: {1}, {2}, {3}, {4}.</target>
+        <target state="translated">Parameter des unerwarteten Typs "{0}". Erwartete Typen sind "{1}", "{2}", "{3}" und "{4}".</target>
         <note />
       </trans-unit>
       <trans-unit id="DocumentStructureUnexpectedParameterType6">
         <source>Parameter of unexpected type '{0}'. Expected types are '{1}', '{2}', '{3}', '{4}', '{5}', '{6}'.</source>
-        <target state="translated">Der Typ "{0}" des Parameters ist unerwartet. Erwartete Typen: {1}, {2}, {3}, {4}, {5}, {6}.</target>
+        <target state="translated">Der Typ "{0}" des Parameters ist unerwartet. Erwartete Typen sind "{1}", "{2}", "{3}", "{4}", "{5}" und "{6}".</target>
         <note />
       </trans-unit>
       <trans-unit id="DocumentViewerArgumentMustBeInteger">
@@ -1509,12 +1509,12 @@
       </trans-unit>
       <trans-unit id="EnumeratorNotStarted">
         <source>Enumeration has not started. Call MoveNext.</source>
-        <target state="translated">Die Enumeration wurde nicht gestartet. Rufen Sie "MoveNext" auf.</target>
+        <target state="translated">Der Auflistungsvorgang wurde nicht gestartet. Rufen Sie "MoveNext" auf.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumeratorReachedEnd">
         <source>Enumeration already finished.</source>
-        <target state="translated">Die Enumeration wurde bereits beendet.</target>
+        <target state="translated">Der Auflistungsvorgang wurde bereits abgeschlossen.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumeratorVersionChanged">
@@ -1524,7 +1524,7 @@
       </trans-unit>
       <trans-unit id="Enumerator_VerifyContext">
         <source>No current object to return.</source>
-        <target state="translated">Es ist kein aktuelles Objekt zum Zurückgeben vorhanden.</target>
+        <target state="translated">Es kann kein aktuelles Objekt zurückgegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="EventTriggerBadAction">
@@ -1579,7 +1579,7 @@
       </trans-unit>
       <trans-unit id="ExpectedBinaryContent">
         <source>Unexpected value. Deferrable content must be provided as a System.Stream or System.Byte[].</source>
-        <target state="translated">Unerwarteter Wert. Inhalt, der zurückgestellt werden kann, muss als System.Stream oder System.Byte[] bereitgestellt werden.</target>
+        <target state="needs-review-translation">Unerwarteter Wert. Inhalt, der zurückgestellt werden kann, muss als System.Stream oder System.Byte[]5D; bereitgestellt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExpectedResourceDictionaryTarget">
@@ -1609,17 +1609,17 @@
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
         <source>Too many files selected. Select fewer files and try again.</source>
-        <target state="translated">Zu viele Dateien ausgewählt. Wählen Sie weniger Dateien aus, und wiederholen Sie den Vorgang.</target>
+        <target state="translated">Es sind zu viele Dateien ausgewählt. Wählen Sie weniger Dateien aus, und versuchen Sie es erneut.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
         <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" ist nicht vorhanden.\r\nMöchten Sie das Element erstellen?</target>
+        <target state="needs-review-translation">'{0}' ist nicht vorhanden.]D;]A;Möchten Sie das Element erstellen?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
         <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" ist nicht vorhanden.\r\nÜberprüfen Sie den Dateinamen.</target>
+        <target state="needs-review-translation">'{0}' ist nicht vorhanden.]D;]A;Überprüfen Sie den Dateinamen.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1629,7 +1629,7 @@
       </trans-unit>
       <trans-unit id="FileDialogInvalidFilter">
         <source>Provided filter string is not valid. Filter string should contain a description of the filter, followed by a vertical bar and the filter pattern. Must also separate multiple filter description and pattern pairs by a vertical bar. Must separate multiple extensions in a filter pattern with a semicolon. Example: \"Image files (*.bmp, *.jpg)|*.bmp;*.jpg|All files (*.*)|*.*\"</source>
-        <target state="translated">Die bereitgestellte Filterzeichenfolge ist ungültig. Die Filterzeichenfolge muss eine Beschreibung des Filters enthalten, gefolgt von einem vertikalen Strich und dem Filtermuster. Weitere Paare aus Filterbeschreibung und Muster müssen ebenfalls durch einen vertikalen Strich getrennt werden. Mehrere Erweiterungen in Filtermustern werden mit einem Semikolon getrennt. Beispiel: "Bilddateien (*.bmp, *.jpg)|*.bmp;*.jpg|Alle Dateien (*.*)|*.*"</target>
+        <target state="needs-review-translation">Die bereitgestellte Filterzeichenfolge ist ungültig. Die Filterzeichenfolge muss eine Beschreibung des Filters enthalten, gefolgt von einem vertikalen Strich und dem Filtermuster. Weitere Filterbeschreibungen und Musterpaare müssen ebenfalls durch einen vertikalen Strich getrennt werden. Mehrfache Erweiterungen in Filtermustern werden mit einem Semikolon getrennt. Beispiel: "Bilddateien (*.bmp, *.jpg)|*.bmp;*.jpg|Alle Dateien (*.*)|*.*"</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFilterIndex">
@@ -1639,7 +1639,7 @@
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">"{0}" ist bereits vorhanden.\r\nMöchten Sie das Element ersetzen?</target>
+        <target state="needs-review-translation">'{0}' ist bereits vorhanden.]D;]A;Möchten Sie das Element ersetzen?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">
@@ -1794,7 +1794,7 @@
       </trans-unit>
       <trans-unit id="FlowDocumentReader_MultipleViewProvider_ScrollViewName">
         <source>Scroll</source>
-        <target state="translated">Schriftrolle</target>
+        <target state="translated">Blättern</target>
         <note />
       </trans-unit>
       <trans-unit id="FlowDocumentReader_MultipleViewProvider_TwoPageViewName">
@@ -1859,22 +1859,22 @@
       </trans-unit>
       <trans-unit id="Generator_CountIsWrong">
         <source>Accumulated count {0} is different from actual count {1}.  [Accumulated count is (Count at last Reset + #Adds - #Removes since last Reset).]</source>
-        <target state="translated">Die akkumulierte Anzahl {0} unterscheidet sich von der tatsächlichen Anzahl {1}. [Akkumulierte Anzahl ist (Anzahl bei letztem Zurücksetzen + Anzahl Hinzufügungen - Anzahl Entfernungen seit dem letzten Zurücksetzen).]</target>
+        <target state="needs-review-translation">Gesammelte Anzahl {0} unterscheidet sich von der tatsächlichen Anzahl {1}.  [Gesammelte Anzahl ist (Anzahl bei letztem Reset + #Adds - #Removes seit letztem Reset).]5D;</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_Inconsistent">
         <source>An ItemsControl is inconsistent with its items source.\n  See the inner exception for more information.</source>
-        <target state="translated">ItemsControl ist nicht konsistent mit der zugehörigen Elementquelle.\n  Weitere Informationen finden Sie in der inneren Ausnahme.</target>
+        <target state="needs-review-translation">Ein ItemsControl ist nicht konsistent mit seiner Elementquelle.]A; Weitere Informationen finden Sie in der inneren Ausnahme.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_ItemIsWrong">
         <source>At index {0}:  Generator's item '{1}' is different from actual item '{2}'.</source>
-        <target state="translated">Bei Index {0}: Das Generatorelement "{1}" unterscheidet sich vom tatsächlichen Element "{2}".</target>
+        <target state="translated">Bei Index {0}:  Generatorelement '{1}' unterscheidet sich von tatsächlichem Element '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_MoreErrors">
         <source>   (... {0} more instances ...)</source>
-        <target state="translated">   (... {0} weitere Instanzen ...)</target>
+        <target state="needs-review-translation">  (... {0} weitere Instanzen ...)</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_Readme0">
@@ -1884,7 +1884,7 @@
       </trans-unit>
       <trans-unit id="Generator_Readme1">
         <source>This exception was thrown because the generator for control '{0}' with name '{1}' has received sequence of CollectionChanged events that do not agree with the current state of the Items collection.</source>
-        <target state="translated">Die Ausnahme wurde ausgelöst, weil der Generator für das Steuerelement "{0}" mit dem Namen "{1}" eine Reihe von CollectionChanged-Ereignissen empfangen hat, die nicht mit dem aktuellen Status der Elementsammlung übereinstimmen.</target>
+        <target state="translated">Die Ausnahme wurde ausgelöst, da der Generator für Steuerelement '{0}' mit dem Namen '{1}' eine Reihe von CollectionChanged-Ereignissen empfangen hat, die nicht mit dem aktuellen Status der Elementsammlung übereinstimmen.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_Readme2">
@@ -1914,12 +1914,12 @@
       </trans-unit>
       <trans-unit id="Generator_Readme7">
         <source>To get a more timely exception, set the attached property '{0}' on the generator to value '{1}' and rerun the scenario.</source>
-        <target state="translated">Um eine zeitnahe Ausnahme zu erhalten, legen Sie die zugehörige Eigenschaft "{0}" für den Generator auf den Wert "{1}" fest und führen das Szenario erneut aus.</target>
+        <target state="translated">Um eine zeitnahe Ausnahme zu erhalten, legen Sie die zugehörige Eigenschaft '{0}' für den Generator auf den Wert '{1}' fest und führen das Szenario erneut aus.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_Readme8">
         <source>One way to do this is to run a command similar to the following:\n   {0}</source>
-        <target state="translated">Eine Möglichkeit dazu ist die Ausführung eines Befehls ähnlich dem folgenden:\n   {0}</target>
+        <target state="needs-review-translation">Eine Möglichkeit dazu ist die Ausführung eines Befehls ähnlich dem folgenden:]A;   {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="Generator_Readme9">
@@ -2024,7 +2024,7 @@
       </trans-unit>
       <trans-unit id="GridCollection_InOtherCollection">
         <source>'{0}' already belongs to another '{1}'.</source>
-        <target state="translated">"{0}" gehört bereits zu einem anderen {1}-Objekt.</target>
+        <target state="translated">"{0}" ist bereits im Besitz eines anderen {1}-Objekts.</target>
         <note />
       </trans-unit>
       <trans-unit id="GridCollection_MustBeCertainType">
@@ -2134,7 +2134,7 @@
       </trans-unit>
       <trans-unit id="InDifferentParagraphs">
         <source>'{0}' and '{1}' TextPointers are not in the same Paragraph.</source>
-        <target state="translated">Die TextPointers "{0}" und "{1}" befinden sich nicht im selben Absatz.</target>
+        <target state="translated">Die "TextPointers" "{0}" und "{1}" befinden sich nicht im selben "Paragraph".</target>
         <note />
       </trans-unit>
       <trans-unit id="InDifferentScope">
@@ -2144,7 +2144,7 @@
       </trans-unit>
       <trans-unit id="InDifferentTextContainers">
         <source>'{0}' and '{1}' TextPointers are not in the same document.</source>
-        <target state="translated">Die TextPointers "{0}" und "{1}" befinden sich nicht im selben Dokument.</target>
+        <target state="translated">Die "TextPointers" "{0}" und "{1}" befinden sich nicht im selben Dokument.</target>
         <note />
       </trans-unit>
       <trans-unit id="InavalidStartItem">
@@ -2164,7 +2164,7 @@
       </trans-unit>
       <trans-unit id="InconsistentBindingList">
         <source>IBindingList '{0}' has unexpected length after a '{1}' event.\nThis can happen if the IBindingList has been changed without raising a corresponding ListChanged event.</source>
-        <target state="translated">IBindingList "{0}" verfügt nach einem {1}-Ereignis über eine unerwartete Länge.\nDies kann der Fall sein, wenn die IBindingList verändert wurde, ohne dass ein entsprechendes ListChanged-Ereignis ausgelöst wurde.</target>
+        <target state="needs-review-translation">IBindingList '{0}' verfügt nach einem '{1}'-Ereignis über eine unerwartete Länge.]A;Dies kann der Fall sein, wenn die IBindingList verändert wurde, ohne dass ein entsprechendes ListChanged-Ereignis ausgelöst wurde.</target>
         <note />
       </trans-unit>
       <trans-unit id="IncorrectAnchorLength">
@@ -2189,12 +2189,12 @@
       </trans-unit>
       <trans-unit id="InkCanvasDeselectKey">
         <source>Esc</source>
-        <target state="translated">ESC</target>
+        <target state="translated">Esc</target>
         <note />
       </trans-unit>
       <trans-unit id="InkCanvasDeselectKeyDisplayString">
         <source>Esc</source>
-        <target state="translated">ESC</target>
+        <target state="translated">Esc</target>
         <note />
       </trans-unit>
       <trans-unit id="InputScopeAttribute_E_OUTOFMEMORY">
@@ -2354,7 +2354,7 @@
       </trans-unit>
       <trans-unit id="InvalidItemContainer">
         <source>'{0}' can only host a '{1}' or a '{2}'. '{3}' is an invalid container.</source>
-        <target state="translated">"{0}" kann nur "{1}" oder "{2}" hosten. "{3}" ist ein ungültiger Container.</target>
+        <target state="translated">'{0}' kann nur ein '{1}' oder ein '{2}' hosten. '{3}' ist ein ungültiger Container.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidLocCommentTarget">
@@ -2459,7 +2459,7 @@
       </trans-unit>
       <trans-unit id="InvalidSetterValue">
         <source>'{0}' is not a valid value for the '{1}.{2}' property on a Setter.</source>
-        <target state="translated">"{0}" ist kein gültiger Wert für die Eigenschaft "{1}.{2}" auf einem Setter.</target>
+        <target state="translated">"{0}" ist kein gültiger Wert für die Eigenschaft "{1}.{2}" auf einem "Setter".</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStartNodeForTextSelection">
@@ -2479,7 +2479,7 @@
       </trans-unit>
       <trans-unit id="InvalidStickyNoteTemplate">
         <source>IsExpanded template for StickyNoteControl of type '{0}' must contain element of type '{1}' with Name set to '{2}'.</source>
-        <target state="translated">Die IsExpanded-Vorlage für StickyNoteControl vom Typ "{0}" muss ein Element vom Typ "{1}" enthalten, dessen Name auf "{2}" festgelegt ist.</target>
+        <target state="translated">Die IsExpanded-Vorlage für "StickyNoteControl" vom Typ "{0}" muss ein Element vom Typ "{1}" enthalten, dessen Name auf "{2}" festgelegt ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidStoryFragmentsMarkup">
@@ -2589,7 +2589,7 @@
       </trans-unit>
       <trans-unit id="KeyAlignCenter">
         <source>Ctrl+E</source>
-        <target state="translated">Strg+E</target>
+        <target state="translated">Ctrl+E</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyAlignCenterDisplayString">
@@ -2599,7 +2599,7 @@
       </trans-unit>
       <trans-unit id="KeyAlignJustify">
         <source>Ctrl+J</source>
-        <target state="translated">Strg+B</target>
+        <target state="translated">Ctrl+B</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyAlignJustifyDisplayString">
@@ -2609,7 +2609,7 @@
       </trans-unit>
       <trans-unit id="KeyAlignLeft">
         <source>Ctrl+L</source>
-        <target state="translated">Strg+L</target>
+        <target state="translated">Ctrl+L</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyAlignLeftDisplayString">
@@ -2619,7 +2619,7 @@
       </trans-unit>
       <trans-unit id="KeyAlignRight">
         <source>Ctrl+R</source>
-        <target state="translated">Strg+R</target>
+        <target state="translated">Ctrl+R</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyAlignRightDisplayString">
@@ -2629,7 +2629,7 @@
       </trans-unit>
       <trans-unit id="KeyAltUndo">
         <source>Alt+Backspace</source>
-        <target state="translated">Alt+Rücktaste</target>
+        <target state="translated">Alt+Backspace</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyAltUndoDisplayString">
@@ -2639,7 +2639,7 @@
       </trans-unit>
       <trans-unit id="KeyApplyDoubleSpace">
         <source>Ctrl+2</source>
-        <target state="translated">Strg+2</target>
+        <target state="translated">Ctrl+2</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyApplyDoubleSpaceDisplayString">
@@ -2649,7 +2649,7 @@
       </trans-unit>
       <trans-unit id="KeyApplyOneAndAHalfSpace">
         <source>Ctrl+5</source>
-        <target state="translated">Strg+5</target>
+        <target state="translated">Ctrl+5</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyApplyOneAndAHalfSpaceDisplayString">
@@ -2659,7 +2659,7 @@
       </trans-unit>
       <trans-unit id="KeyApplySingleSpace">
         <source>Ctrl+1</source>
-        <target state="translated">Strg+1</target>
+        <target state="translated">Ctrl+1</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyApplySingleSpaceDisplayString">
@@ -2669,7 +2669,7 @@
       </trans-unit>
       <trans-unit id="KeyBackspace">
         <source>Backspace</source>
-        <target state="translated">Rücktaste</target>
+        <target state="translated">Backspace</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyBackspaceDisplayString">
@@ -2684,17 +2684,17 @@
       </trans-unit>
       <trans-unit id="KeyCopy">
         <source>Ctrl+C</source>
-        <target state="translated">STRG+C</target>
+        <target state="translated">Ctrl+C</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyCopyDisplayString">
         <source>Ctrl+C</source>
-        <target state="translated">STRG+C</target>
+        <target state="translated">Strg+C</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyCopyFormat">
         <source>Ctrl+Shift+C</source>
-        <target state="translated">Strg+Umschalt+C</target>
+        <target state="translated">Ctrl+Shift+C</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyCopyFormatDisplayString">
@@ -2704,7 +2704,7 @@
       </trans-unit>
       <trans-unit id="KeyCtrlInsert">
         <source>Ctrl+Insert</source>
-        <target state="translated">Strg+Einfg</target>
+        <target state="translated">Ctrl+Insert</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyCtrlInsertDisplayString">
@@ -2714,7 +2714,7 @@
       </trans-unit>
       <trans-unit id="KeyCut">
         <source>Ctrl+X</source>
-        <target state="translated">Strg+X</target>
+        <target state="translated">Ctrl+X</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyCutDisplayString">
@@ -2724,7 +2724,7 @@
       </trans-unit>
       <trans-unit id="KeyDecreaseFontSize">
         <source>Ctrl+OemOpenBrackets</source>
-        <target state="translated">Strg+OemOpenBrackets</target>
+        <target state="translated">Ctrl+OemOpenBrackets</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDecreaseFontSizeDisplayString">
@@ -2734,7 +2734,7 @@
       </trans-unit>
       <trans-unit id="KeyDecreaseIndentation">
         <source>Ctrl+Shift+T</source>
-        <target state="translated">Strg+Umschalt+T</target>
+        <target state="translated">Ctrl+Shift+T</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDecreaseIndentationDisplayString">
@@ -2744,12 +2744,12 @@
       </trans-unit>
       <trans-unit id="KeyDelete">
         <source>Delete</source>
-        <target state="translated">Löschen</target>
+        <target state="translated">Delete</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDeleteColumns">
         <source>Alt+Ctrl+Shift+D</source>
-        <target state="translated">Alt+Strg+Umschalt+D</target>
+        <target state="translated">Alt+Ctrl+Shift+D</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDeleteColumnsDisplayString">
@@ -2759,12 +2759,12 @@
       </trans-unit>
       <trans-unit id="KeyDeleteDisplayString">
         <source>Delete</source>
-        <target state="translated">Löschen</target>
+        <target state="translated">Entf</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDeleteNextWord">
         <source>Ctrl+Delete</source>
-        <target state="translated">Strg+Entf</target>
+        <target state="translated">Ctrl+Delete</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDeleteNextWordDisplayString">
@@ -2774,7 +2774,7 @@
       </trans-unit>
       <trans-unit id="KeyDeletePreviousWord">
         <source>Ctrl+Backspace</source>
-        <target state="translated">Strg+Rücktaste</target>
+        <target state="translated">Ctrl+Backspace</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyDeletePreviousWordDisplayString">
@@ -2784,7 +2784,7 @@
       </trans-unit>
       <trans-unit id="KeyEnterLineBreak">
         <source>Shift+Enter</source>
-        <target state="translated">Umschalt+Eingabetaste</target>
+        <target state="translated">Shift+Enter</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyEnterLineBreakDisplayString">
@@ -2794,7 +2794,7 @@
       </trans-unit>
       <trans-unit id="KeyEnterParagraphBreak">
         <source>Enter</source>
-        <target state="translated">Eingabetaste</target>
+        <target state="translated">Enter</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyEnterParagraphBreakDisplayString">
@@ -2804,7 +2804,7 @@
       </trans-unit>
       <trans-unit id="KeyIncreaseFontSize">
         <source>Ctrl+OemCloseBrackets</source>
-        <target state="translated">Strg+OemCloseBrackets</target>
+        <target state="translated">Ctrl+OemCloseBrackets</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyIncreaseFontSizeDisplayString">
@@ -2814,7 +2814,7 @@
       </trans-unit>
       <trans-unit id="KeyIncreaseIndentation">
         <source>Ctrl+T</source>
-        <target state="translated">Strg+T</target>
+        <target state="translated">Ctrl+T</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyIncreaseIndentationDisplayString">
@@ -2824,7 +2824,7 @@
       </trans-unit>
       <trans-unit id="KeyInsertColumns">
         <source>Alt+Ctrl+Shift+C</source>
-        <target state="translated">Alt+Strg+Umschalt+C</target>
+        <target state="translated">Alt+Ctrl+Shift+C</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyInsertColumnsDisplayString">
@@ -2834,7 +2834,7 @@
       </trans-unit>
       <trans-unit id="KeyInsertRows">
         <source>Alt+Ctrl+Shift+R</source>
-        <target state="translated">Alt+Strg+Umschalt+R</target>
+        <target state="translated">Alt+Ctrl+Shift+R</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyInsertRowsDisplayString">
@@ -2844,7 +2844,7 @@
       </trans-unit>
       <trans-unit id="KeyInsertTable">
         <source>Alt+Ctrl+Shift+T</source>
-        <target state="translated">Alt+Strg+Umschalt+T</target>
+        <target state="translated">Alt+Ctrl+Shift+T</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyInsertTableDisplayString">
@@ -2854,7 +2854,7 @@
       </trans-unit>
       <trans-unit id="KeyMergeCells">
         <source>Alt+Ctrl+Shift+M</source>
-        <target state="translated">Alt+Strg+Umschalt+M</target>
+        <target state="translated">Alt+Ctrl+Shift+M</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMergeCellsDisplayString">
@@ -2864,7 +2864,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveDownByLine">
         <source>Down</source>
-        <target state="translated">Nach-Unten</target>
+        <target state="translated">Down</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveDownByLineDisplayString">
@@ -2874,7 +2874,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveDownByPage">
         <source>PageDown</source>
-        <target state="translated">BildAb</target>
+        <target state="translated">PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveDownByPageDisplayString">
@@ -2884,7 +2884,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveDownByParagraph">
         <source>Ctrl+Down</source>
-        <target state="translated">Strg+Nach-Unten</target>
+        <target state="translated">Ctrl+Down</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveDownByParagraphDisplayString">
@@ -2894,7 +2894,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveLeftByCharacter">
         <source>Left</source>
-        <target state="translated">Nach-Links</target>
+        <target state="translated">Left</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveLeftByCharacterDisplayString">
@@ -2904,7 +2904,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveLeftByWord">
         <source>Ctrl+Left</source>
-        <target state="translated">Strg+Nach-Links</target>
+        <target state="translated">Ctrl+Left</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveLeftByWordDisplayString">
@@ -2914,7 +2914,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveRightByCharacter">
         <source>Right</source>
-        <target state="translated">Nach-Rechts</target>
+        <target state="translated">Right</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveRightByCharacterDisplayString">
@@ -2924,7 +2924,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveRightByWord">
         <source>Ctrl+Right</source>
-        <target state="translated">Strg+Nach-Rechts</target>
+        <target state="translated">Ctrl+Right</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveRightByWordDisplayString">
@@ -2934,7 +2934,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveToColumnEnd">
         <source>Alt+PageDown</source>
-        <target state="translated">Alt+BildAb</target>
+        <target state="translated">Alt+PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToColumnEndDisplayString">
@@ -2944,7 +2944,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveToColumnStart">
         <source>Alt+PageUp</source>
-        <target state="translated">Alt+BildAuf</target>
+        <target state="translated">Alt+PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToColumnStartDisplayString">
@@ -2954,7 +2954,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveToDocumentEnd">
         <source>Ctrl+End</source>
-        <target state="translated">Strg+Ende</target>
+        <target state="translated">Ctrl+End</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToDocumentEndDisplayString">
@@ -2964,7 +2964,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveToDocumentStart">
         <source>Ctrl+Home</source>
-        <target state="translated">Strg+Pos1</target>
+        <target state="translated">Ctrl+Home</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToDocumentStartDisplayString">
@@ -2974,27 +2974,27 @@
       </trans-unit>
       <trans-unit id="KeyMoveToLineEnd">
         <source>End</source>
-        <target state="translated">ENDE</target>
+        <target state="translated">End</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToLineEndDisplayString">
         <source>End</source>
-        <target state="translated">ENDE</target>
+        <target state="translated">Ende</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToLineStart">
         <source>Home</source>
-        <target state="translated">Startseite</target>
+        <target state="translated">Home</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToLineStartDisplayString">
         <source>Home</source>
-        <target state="translated">Startseite</target>
+        <target state="translated">Pos1</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToWindowBottom">
         <source>Alt+Ctrl+PageDown</source>
-        <target state="translated">Alt+Strg+BildAb</target>
+        <target state="translated">Alt+Ctrl+PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToWindowBottomDisplayString">
@@ -3004,7 +3004,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveToWindowTop">
         <source>Alt+Ctrl+PageUp</source>
-        <target state="translated">Alt+Strg+BildAuf</target>
+        <target state="translated">Alt+Ctrl+PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveToWindowTopDisplayString">
@@ -3014,7 +3014,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveUpByLine">
         <source>Up</source>
-        <target state="translated">Nach-Oben</target>
+        <target state="translated">Up</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveUpByLineDisplayString">
@@ -3024,7 +3024,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveUpByPage">
         <source>PageUp</source>
-        <target state="translated">BildAuf</target>
+        <target state="translated">PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveUpByPageDisplayString">
@@ -3034,7 +3034,7 @@
       </trans-unit>
       <trans-unit id="KeyMoveUpByParagraph">
         <source>Ctrl+Up</source>
-        <target state="translated">Strg+Nach-Oben</target>
+        <target state="translated">Ctrl+Up</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyMoveUpByParagraphDisplayString">
@@ -3044,7 +3044,7 @@
       </trans-unit>
       <trans-unit id="KeyPasteFormat">
         <source>Ctrl+Shift+V</source>
-        <target state="translated">Strg+Umschalt+V</target>
+        <target state="translated">Ctrl+Shift+V</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyPasteFormatDisplayString">
@@ -3054,7 +3054,7 @@
       </trans-unit>
       <trans-unit id="KeyRedo">
         <source>Ctrl+Y</source>
-        <target state="translated">Strg+Y</target>
+        <target state="translated">Ctrl+Y</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyRedoDisplayString">
@@ -3064,7 +3064,7 @@
       </trans-unit>
       <trans-unit id="KeyRemoveListMarkers">
         <source>Ctrl+Shift+R</source>
-        <target state="translated">Strg+Umschalt+R</target>
+        <target state="translated">Ctrl+Shift+R</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyRemoveListMarkersDisplayString">
@@ -3074,7 +3074,7 @@
       </trans-unit>
       <trans-unit id="KeyResetFormat">
         <source>Ctrl+Space</source>
-        <target state="translated">Strg+Leertaste</target>
+        <target state="translated">Ctrl+Space</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyResetFormatDisplayString">
@@ -3084,7 +3084,7 @@
       </trans-unit>
       <trans-unit id="KeySelectAll">
         <source>Ctrl+A</source>
-        <target state="translated">Strg+A</target>
+        <target state="translated">Ctrl+A</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectAllDisplayString">
@@ -3094,7 +3094,7 @@
       </trans-unit>
       <trans-unit id="KeySelectDownByLine">
         <source>Shift+Down</source>
-        <target state="translated">Umschalt+Nach-Unten</target>
+        <target state="translated">Shift+Down</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectDownByLineDisplayString">
@@ -3104,7 +3104,7 @@
       </trans-unit>
       <trans-unit id="KeySelectDownByPage">
         <source>Shift+PageDown</source>
-        <target state="translated">Umschalt+BildAb</target>
+        <target state="translated">Shift+PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectDownByPageDisplayString">
@@ -3114,7 +3114,7 @@
       </trans-unit>
       <trans-unit id="KeySelectDownByParagraph">
         <source>Ctrl+Shift+Down</source>
-        <target state="translated">Strg+Umschalt+Nach-Unten</target>
+        <target state="translated">Ctrl+Shift+Down</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectDownByParagraphDisplayString">
@@ -3124,7 +3124,7 @@
       </trans-unit>
       <trans-unit id="KeySelectLeftByCharacter">
         <source>Shift+Left</source>
-        <target state="translated">Umschalt+Nach-Links</target>
+        <target state="translated">Shift+Left</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectLeftByCharacterDisplayString">
@@ -3134,7 +3134,7 @@
       </trans-unit>
       <trans-unit id="KeySelectLeftByWord">
         <source>Ctrl+Shift+Left</source>
-        <target state="translated">Strg+Umschalt+Nach-Links</target>
+        <target state="translated">Ctrl+Shift+Left</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectLeftByWordDisplayString">
@@ -3144,7 +3144,7 @@
       </trans-unit>
       <trans-unit id="KeySelectRightByCharacter">
         <source>Shift+Right</source>
-        <target state="translated">Umschalt+Nach-Rechts</target>
+        <target state="translated">Shift+Right</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectRightByCharacterDisplayString">
@@ -3154,7 +3154,7 @@
       </trans-unit>
       <trans-unit id="KeySelectRightByWord">
         <source>Ctrl+Shift+Right</source>
-        <target state="translated">Strg+Umschalt+Nach-Rechts</target>
+        <target state="translated">Ctrl+Shift+Right</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectRightByWordDisplayString">
@@ -3164,7 +3164,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToColumnEnd">
         <source>Alt+Shift+PageDown</source>
-        <target state="translated">Alt+Umschalt+BildAb</target>
+        <target state="translated">Alt+Shift+PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToColumnEndDisplayString">
@@ -3174,7 +3174,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToColumnStart">
         <source>Alt+Shift+PageUp</source>
-        <target state="translated">Alt+Umschalt+BildAuf</target>
+        <target state="translated">Alt+Shift+PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToColumnStartDisplayString">
@@ -3184,7 +3184,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToDocumentEnd">
         <source>Ctrl+Shift+End</source>
-        <target state="translated">Strg+Umschalt+Ende</target>
+        <target state="translated">Ctrl+Shift+End</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToDocumentEndDisplayString">
@@ -3194,7 +3194,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToDocumentStart">
         <source>Ctrl+Shift+Home</source>
-        <target state="translated">Strg+Umschalt+Pos1</target>
+        <target state="translated">Ctrl+Shift+Home</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToDocumentStartDisplayString">
@@ -3204,7 +3204,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToLineEnd">
         <source>Shift+End</source>
-        <target state="translated">Umschalt+Ende</target>
+        <target state="translated">Shift+End</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToLineEndDisplayString">
@@ -3214,7 +3214,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToLineStart">
         <source>Shift+Home</source>
-        <target state="translated">Umschalt+Pos1</target>
+        <target state="translated">Shift+Home</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToLineStartDisplayString">
@@ -3224,7 +3224,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToWindowBottom">
         <source>Alt+Ctrl+Shift+PageDown</source>
-        <target state="translated">Alt+Strg+Umschalt+BildAb</target>
+        <target state="translated">Alt+Ctrl+Shift+PageDown</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToWindowBottomDisplayString">
@@ -3234,7 +3234,7 @@
       </trans-unit>
       <trans-unit id="KeySelectToWindowTop">
         <source>Alt+Ctrl+Shift+PageUp</source>
-        <target state="translated">Alt+Strg+Umschalt+BildAuf</target>
+        <target state="translated">Alt+Ctrl+Shift+PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectToWindowTopDisplayString">
@@ -3244,7 +3244,7 @@
       </trans-unit>
       <trans-unit id="KeySelectUpByLine">
         <source>Shift+Up</source>
-        <target state="translated">Umschalt+Nach-Oben</target>
+        <target state="translated">Shift+Up</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectUpByLineDisplayString">
@@ -3254,7 +3254,7 @@
       </trans-unit>
       <trans-unit id="KeySelectUpByPage">
         <source>Shift+PageUp</source>
-        <target state="translated">Umschalt+BildAuf</target>
+        <target state="translated">Shift+PageUp</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectUpByPageDisplayString">
@@ -3264,7 +3264,7 @@
       </trans-unit>
       <trans-unit id="KeySelectUpByParagraph">
         <source>Ctrl+Shift+Up</source>
-        <target state="translated">Strg+Umschalt+Nach-Oben</target>
+        <target state="translated">Ctrl+Shift+Up</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySelectUpByParagraphDisplayString">
@@ -3274,7 +3274,7 @@
       </trans-unit>
       <trans-unit id="KeyShiftBackspace">
         <source>Shift+Backspace</source>
-        <target state="translated">Umschalt+Rücktaste</target>
+        <target state="translated">Shift+Backspace</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyShiftBackspaceDisplayString">
@@ -3284,7 +3284,7 @@
       </trans-unit>
       <trans-unit id="KeyShiftDelete">
         <source>Shift+Delete</source>
-        <target state="translated">Umschalt+Entf</target>
+        <target state="translated">Shift+Delete</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyShiftDeleteDisplayString">
@@ -3294,7 +3294,7 @@
       </trans-unit>
       <trans-unit id="KeyShiftInsert">
         <source>Shift+Insert</source>
-        <target state="translated">Umschalt+Einfg</target>
+        <target state="translated">Shift+Insert</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyShiftInsertDisplayString">
@@ -3304,7 +3304,7 @@
       </trans-unit>
       <trans-unit id="KeyShiftSpace">
         <source>Shift+Space</source>
-        <target state="translated">Umschalt+Leerschritt</target>
+        <target state="translated">Shift+Space</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyShiftSpaceDisplayString">
@@ -3314,17 +3314,17 @@
       </trans-unit>
       <trans-unit id="KeySpace">
         <source>Space</source>
-        <target state="translated">Speicherplatz</target>
+        <target state="translated">Space</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySpaceDisplayString">
         <source>Space</source>
-        <target state="translated">Speicherplatz</target>
+        <target state="translated">Leerschritt</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySplitCell">
         <source>Alt+Ctrl+Shift+S</source>
-        <target state="translated">Alt+Strg+Umschalt+S</target>
+        <target state="translated">Alt+Ctrl+Shift+S</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySplitCellDisplayString">
@@ -3334,7 +3334,7 @@
       </trans-unit>
       <trans-unit id="KeySwitchViewingMode">
         <source>Ctrl+M</source>
-        <target state="translated">Strg+M</target>
+        <target state="translated">Ctrl+M</target>
         <note />
       </trans-unit>
       <trans-unit id="KeySwitchViewingModeDisplayString">
@@ -3344,7 +3344,7 @@
       </trans-unit>
       <trans-unit id="KeyTabBackward">
         <source>Shift+Tab</source>
-        <target state="translated">Umschalt+Tab</target>
+        <target state="translated">Shift+Tab</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyTabBackwardDisplayString">
@@ -3364,17 +3364,17 @@
       </trans-unit>
       <trans-unit id="KeyToggleBold">
         <source>Ctrl+B</source>
-        <target state="translated">STRG+B</target>
+        <target state="translated">Ctrl+Shift+F</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleBoldDisplayString">
         <source>Ctrl+B</source>
-        <target state="translated">STRG+B</target>
+        <target state="translated">Strg+Umschalt+F</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleBullets">
         <source>Ctrl+Shift+L</source>
-        <target state="translated">Strg+Umschalt+L</target>
+        <target state="translated">Ctrl+Shift+L</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleBulletsDisplayString">
@@ -3384,7 +3384,7 @@
       </trans-unit>
       <trans-unit id="KeyToggleInsert">
         <source>Insert</source>
-        <target state="translated">Einfg</target>
+        <target state="translated">Insert</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleInsertDisplayString">
@@ -3394,17 +3394,17 @@
       </trans-unit>
       <trans-unit id="KeyToggleItalic">
         <source>Ctrl+I</source>
-        <target state="translated">Strg+I</target>
+        <target state="translated">Ctrl+Shift+K</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleItalicDisplayString">
         <source>Ctrl+I</source>
-        <target state="translated">Strg+I</target>
+        <target state="translated">Strg+Umschalt+K</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleNumbering">
         <source>Ctrl+Shift+N</source>
-        <target state="translated">Strg+Umschalt+N</target>
+        <target state="translated">Ctrl+Shift+N</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleNumberingDisplayString">
@@ -3414,7 +3414,7 @@
       </trans-unit>
       <trans-unit id="KeyToggleSubscript">
         <source>Ctrl+OemPlus</source>
-        <target state="translated">Strg+OemPlus</target>
+        <target state="translated">Ctrl+OemPlus</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleSubscriptDisplayString">
@@ -3424,7 +3424,7 @@
       </trans-unit>
       <trans-unit id="KeyToggleSuperscript">
         <source>Ctrl+Shift+OemPlus</source>
-        <target state="translated">Strg+Umschalt+OemPlus</target>
+        <target state="translated">Ctrl+Shift+OemPlus</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleSuperscriptDisplayString">
@@ -3434,7 +3434,7 @@
       </trans-unit>
       <trans-unit id="KeyToggleUnderline">
         <source>Ctrl+U</source>
-        <target state="translated">Strg+U</target>
+        <target state="translated">Ctrl+U</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyToggleUnderlineDisplayString">
@@ -3444,7 +3444,7 @@
       </trans-unit>
       <trans-unit id="KeyUndo">
         <source>Ctrl+Z</source>
-        <target state="translated">Strg+Z</target>
+        <target state="translated">Ctrl+Z</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyUndoDisplayString">
@@ -3474,7 +3474,7 @@
       </trans-unit>
       <trans-unit id="ListBoxSelectAllKey">
         <source>Ctrl+A</source>
-        <target state="translated">Strg+A</target>
+        <target state="translated">Ctrl+A</target>
         <note />
       </trans-unit>
       <trans-unit id="ListBoxSelectAllKeyDisplayString">
@@ -3539,17 +3539,17 @@
       </trans-unit>
       <trans-unit id="MarkupExtensionDynamicOrBindingInCollection">
         <source>A '{0}' cannot be used within a '{1}' collection. A '{0}' can only be set on a DependencyProperty of a DependencyObject.</source>
-        <target state="translated">"{0}" kann nicht innerhalb einer {1}-Sammlung verwendet werden. "{0}" kann nur für eine DependencyProperty eines DependencyObject festgelegt werden.</target>
+        <target state="translated">"{0}" kann nicht innerhalb einer {1}-Sammlung verwendet werden. "{0}" kann nur für eine "DependencyProperty" eines "DependencyObject" festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupExtensionDynamicOrBindingOnClrProp">
         <source>A '{0}' cannot be set on the '{1}' property of type '{2}'. A '{0}' can only be set on a DependencyProperty of a DependencyObject.</source>
-        <target state="translated">"{0}" kann nicht für die Eigenschaft "{1}" vom Typ "{2}" festgelegt werden. "{0}" kann nur für eine DependencyProperty eines DependencyObject festgelegt werden.</target>
+        <target state="translated">"{0}" kann nicht für die Eigenschaft "{1}" vom Typ "{2}" festgelegt werden. "{0}" kann nur für eine "DependencyProperty" eines "DependencyObject" festgelegt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupExtensionNoContext">
         <source>Markup extension '{0}' requires '{1}' be implemented in the IServiceProvider for ProvideValue.</source>
-        <target state="translated">Die Markuperweiterung "{0}" erfordert die Implementierung von "{1}" in IServiceProvider für ProvideValue.</target>
+        <target state="translated">Die Markuperweiterung "{0}" erfordert die Implementierung von {1} in IServiceProvider für ProvideValue.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkupExtensionProperty">
@@ -3589,7 +3589,7 @@
       </trans-unit>
       <trans-unit id="MaxLengthExceedsBufferSize">
         <source>'{0}' maxLength value exceeds array character capacity with length '{1}' and startIndex '{2}'.</source>
-        <target state="translated">Der maxLength-Wert "{0}" überschreitet die Arrayzeichenkapazität mit der Länge {1} und dem startIndex "{2}".</target>
+        <target state="translated">Von dem maxLength-Wert "{0}" wird die Kapazität für Arrayzeichen mit der Länge "{1}" und "startIndex '{2}'" überschritten.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaximumNoteSizeExceeded">
@@ -3614,7 +3614,7 @@
       </trans-unit>
       <trans-unit id="MemberNotAllowedDuringTransaction">
         <source>'{0}' is not allowed during a transaction begun by '{1}'.</source>
-        <target state="translated">"{0}" ist während einer von "{1}" begonnenen Transaktion unzulässig.</target>
+        <target state="translated">"{0}" ist während einer von "{1}" gestarteten Transaktion nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="MemberNotAllowedForView">
@@ -3629,7 +3629,7 @@
       </trans-unit>
       <trans-unit id="MissingContentSource">
         <source>Cannot bind properties of ContentPresenter because there is no property named '{0}' on type '{1}'.</source>
-        <target state="translated">Die Eigenschaften von ContentPresenter können nicht gebunden werden, weil für den Typ "{1}" keine Eigenschaft mit dem Namen "{0}" vorhanden ist.</target>
+        <target state="translated">Die Eigenschaften von "ContentPresenter" können nicht gebunden werden, da für den Typ "{1}" keine Eigenschaft mit dem Namen "{0}" vorhanden ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingTagInNamespace">
@@ -3654,7 +3654,7 @@
       </trans-unit>
       <trans-unit id="ModifyingLogicalTreeViaStylesNotImplemented">
         <source>'{0}' is not a valid value for '{1}'; values derived from Visual or ContentElement are not supported.</source>
-        <target state="translated">"{0}" ist kein gültiger Wert für "{1}"; von Visual oder ContentElement abgeleitete Werte werden nicht unterstützt.</target>
+        <target state="translated">"{0}" ist kein gültiger Wert für "{1}"; von "Visual" oder "ContentElement" abgeleitete Werte werden nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneAttachedAnnotation">
@@ -3734,7 +3734,7 @@
       </trans-unit>
       <trans-unit id="MustImplementIUriContext">
         <source>RequestNavigateEventArgs.OriginalSource must implement '{1}'.</source>
-        <target state="translated">Von RequestNavigateEventArgs.OriginalSource muss "{1}" implementiert werden.</target>
+        <target state="translated">Von "RequestNavigateEventArgs.OriginalSource" muss "{1}" implementiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="MustNotTemplateUnassociatedControl">
@@ -3764,12 +3764,12 @@
       </trans-unit>
       <trans-unit id="NameScopeInvalidIdentifierName">
         <source>'{0}' name is not valid for identifier.</source>
-        <target state="translated">Der Name "{0}" ist für den Bezeichner nicht gültig.</target>
+        <target state="translated">Der Name "{0}" ist für den Bezeichner ungültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="NameScopeNameNotEmptyString">
         <source>Name cannot be an empty string.</source>
-        <target state="translated">Der Name kann keine leere Zeichenfolge sein.</target>
+        <target state="translated">Der Name darf keine leere Zeichenfolge sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="NameScopeNameNotFound">
@@ -3974,7 +3974,7 @@
       </trans-unit>
       <trans-unit id="ObjectDataProviderNonCLSExceptionInvoke">
         <source>Unknown exception while invoking method '{0}' on type '{1}' for ObjectDataProvider.</source>
-        <target state="translated">Unbekannte Ausnahme beim Abrufen der Methode "{0}" für den Typ "{1}" für ObjectDataProvider.</target>
+        <target state="translated">Unbekannte Ausnahme beim Abrufen der Methode "{0}" für den Typ "{1}" für "ObjectDataProvider".</target>
         <note />
       </trans-unit>
       <trans-unit id="ObjectDataProviderParameterCollectionIsNotInUse">
@@ -4084,7 +4084,7 @@
       </trans-unit>
       <trans-unit id="ParserAttachedPropInheritError">
         <source>'{0}' attached property is not defined on '{1}' or one of its base classes.</source>
-        <target state="translated">Die angefügte {0}-Eigenschaft ist für "{1}" oder für eine der zugehörigen Basisklassen nicht definiert.</target>
+        <target state="translated">Die angefügte {0}-Eigenschaft ist für "{1}" oder für eine der Basisklassen davon nicht definiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserAttributeArgsLow">
@@ -4109,12 +4109,12 @@
       </trans-unit>
       <trans-unit id="ParserBadChild">
         <source>'{0}' type element cannot be set on complex property '{1}'. They are not compatible types.</source>
-        <target state="translated">Das Element vom Typ "{0}" kann nicht für die komplexe Eigenschaft "{1}" festgelegt werden, weil es sich hierbei nicht um kompatible Typen handelt.</target>
+        <target state="translated">Das Element vom Typ "{0}" kann nicht für die komplexe Eigenschaft "{1}" festgelegt werden, da es sich hierbei nicht um kompatible Typen handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadConstructorParams">
         <source>Cannot find public constructor for '{0}' that takes '{1}' arguments.</source>
-        <target state="translated">Der öffentliche Konstruktor für "{0}", von dem {1}-Argumente angenommen werden, wurde nicht gefunden.</target>
+        <target state="translated">Der öffentliche Konstruktor für "{0}", von dem {1}-Argumente angenommen werden, kann nicht gefunden werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadEncoding">
@@ -4139,7 +4139,7 @@
       </trans-unit>
       <trans-unit id="ParserBadNullableType">
         <source>'{0}' property cannot be set to object of type '{2}' because it is of incompatible type Nullable&lt;{1}&gt;.</source>
-        <target state="translated">Die {0}-Eigenschaft kann nicht auf ein Objekt vom Typ "{2}" festgelegt werden, weil es sich um den nicht kompatiblen Typ "Nullable&lt;{1}&gt;" handelt.</target>
+        <target state="translated">Die {0}-Eigenschaft kann nicht auf ein Objekt vom Typ "{2}" festgelegt werden, da es sich um den nicht kompatiblen Typ "Nullable&lt;{1}&gt;" handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserBadString">
@@ -4184,7 +4184,7 @@
       </trans-unit>
       <trans-unit id="ParserCannotAddAnyChildren2">
         <source>Cannot add content of type '{1}' to an object of type '{0}'.</source>
-        <target state="translated">Einem Objekt vom Typ "{1}" kann kein Inhalt vom Typ "{0}" hinzugefügt werden.</target>
+        <target state="translated">Einem Objekt vom Typ "{0}" kann kein Inhalt vom Typ "{1}" hinzugefügt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCannotAddChild">
@@ -4224,7 +4224,7 @@
       </trans-unit>
       <trans-unit id="ParserCantCreateDelegate">
         <source>Cannot create event delegate '{0}' for handler method '{1}'. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="translated">Der Ereignisdelegat "{0}" für die Handlermethode "{1}" kann nicht erstellt werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
+        <target state="translated">Der Ereignisdelegat "{0}" für Handlermethode "{1}" kann nicht erstellt werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserCantCreateInstanceType">
@@ -4274,7 +4274,7 @@
       </trans-unit>
       <trans-unit id="ParserDefSharedOnlyInCompiled">
         <source>Shared attribute in namespace 'http://schemas.microsoft.com/winfx/2006/xaml' can be used only in compiled resource dictionaries.</source>
-        <target state="translated">Das freigegebene Attribut im Namespace 'http://schemas.microsoft.com/winfx/2006/xaml' kann nur in kompilierten Ressourcenwörterbüchern verwendet werden.</target>
+        <target state="translated">Das freigegebene Attribut im Namespace "http://schemas.microsoft.com/winfx/2006/xaml" kann nur in kompilierten Ressourcenwörterbüchern verwendet werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefTag">
@@ -4284,12 +4284,12 @@
       </trans-unit>
       <trans-unit id="ParserDefaultConverterElement">
         <source>The Element type '{0}' does not have an associated TypeConverter to parse the string '{1}'.</source>
-        <target state="translated">Der Elementtyp "{0}" verfügt nicht über einen zugehörigen TypeConverter, um die Zeichenfolge "{1}" zu analysieren.</target>
+        <target state="translated">Der Elementtyp "{0}" verfügt nicht über einen zugehörigen "TypeConverter", um die Zeichenfolge "{1}" zu analysieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDefaultConverterProperty">
         <source>The property '{1}' has type '{0}' and does not have an associated TypeConverter to parse the string '{2}'.</source>
-        <target state="translated">Die Eigenschaft "{1}" besitzt den Typ "{0}" und verfügt nicht über einen zugehörigen TypeConverter, um die Zeichenfolge "{2}" zu analysieren.</target>
+        <target state="translated">Die Eigenschaft "{1}" besitzt den Typ "{0}" und verfügt nicht über einen zugehörigen "TypeConverter", um die Zeichenfolge "{2}" zu analysieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserDeferContentAsync">
@@ -4319,7 +4319,7 @@
       </trans-unit>
       <trans-unit id="ParserDuplicateProperty2">
         <source>'{0}' and '{1}' properties refer to the same property. Duplicate property settings are not allowed.</source>
-        <target state="translated">Die Eigenschaften "{0}" und "{1}" verweisen auf die gleiche Eigenschaft. Doppelte Eigenschaftseinstellungen sind nicht zulässig.</target>
+        <target state="translated">Eigenschaften "{0}" und "{1}" verweisen auf die gleiche Eigenschaft. Doppelte Eigenschaftseinstellungen sind nicht zulässig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEmptyComplexProp">
@@ -4379,12 +4379,12 @@
       </trans-unit>
       <trans-unit id="ParserErrorParsingAttribType">
         <source>'{1}' string cannot be set on '{0}' property. Consider using TypeExtension for '{1}'.</source>
-        <target state="translated">Die Zeichenfolge "{1}" kann nicht für die {0}-Eigenschaft festgelegt werden. Verwenden Sie TypeExtension für "{1}".</target>
+        <target state="translated">Die Zeichenfolge "{1}" kann nicht für die {0}-Eigenschaft festgelegt werden. Verwenden Sie "TypeExtension" für "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserEventDelegateTypeNotAccessible">
         <source>Cannot access the delegate type '{0}' for the '{1}' event. '{0}' has incorrect access level or its assembly does not allow access.</source>
-        <target state="translated">Auf den Delegattyp "{0}" für das Ereignis {1}" kann nicht zugegriffen werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
+        <target state="translated">Auf den Delegattyp "{0}" für das Ereignis "{1}" kann nicht zugegriffen werden. "{0}" hat eine falsche Zugriffsebene, oder die zugehörige Assembly lässt den Zugriff nicht zu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserFailFindType">
@@ -4419,12 +4419,12 @@
       </trans-unit>
       <trans-unit id="ParserIEnumerableIAddChild">
         <source>'{0}' is a read-only IEnumerable property, so '{1}' must implement IAddChild.</source>
-        <target state="translated">Bei "{0}" handelt es sich um eine schreibgeschützte IEnumerable-Eigenschaft, weshalb IAddChild von "{1}" implementiert werden muss.</target>
+        <target state="translated">Bei "{0}" handelt es sich um eine schreibgeschützte IEnumerable-Eigenschaft, weshalb "IAddChild" von "{1}" implementiert werden muss.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidContentPropertyAttribute">
         <source>Invalid ContentPropertyAttribute on type '{0}', property '{1}' not found.</source>
-        <target state="translated">Ungültiges ContentPropertyAttribute für den Typ "{0}", die Eigenschaft "{1}" wurde nicht gefunden.</target>
+        <target state="translated">Ungültiges "ContentPropertyAttribute" für den Typ "{0}", die Eigenschaft "{1}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserInvalidIdentifierName">
@@ -4449,7 +4449,7 @@
       </trans-unit>
       <trans-unit id="ParserLineAndOffset">
         <source>Line '{0}' Position '{1}'.</source>
-        <target state="translated">Zeile {0}, Position {1}.</target>
+        <target state="translated">Zeile {0} Position {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMapPIMissingAssembly">
@@ -4484,12 +4484,12 @@
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionInvalidClosingBracketCharacers">
         <source>Encountered a closing BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' without a corresponding opening BracketCharacter.</source>
-        <target state="translated">Schließendes BracketCharacter-Objekt "{0}" in Zeilennummer {1} und an Zeilenposition {2} ohne entsprechendes öffnendes BracketCharacter-Objekt.</target>
+        <target state="translated">Schließendes BracketCharacter-Objekt "{0}" in Zeilennummer "{1}" und an Zeilenposition "{2}" ohne entsprechendes öffnendes BracketCharacter-Objekt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionMalformedBracketCharacers">
         <source>BracketCharacter '{0}' at Line Number '{1}' and Line Position '{2}' does not have a corresponding opening/closing BracketCharacter.</source>
-        <target state="translated">BracketCharacter "{0}" in Zeilennummer {1} und an Zeilenposition {2} verfügt nicht über ein entsprechendes öffnendes/schließendes BracketCharacter-Objekt.</target>
+        <target state="translated">BracketCharacter "{0}" in Zeilennummer "{1}" und an Zeilenposition "{2}" verfügt nicht über ein entsprechendes öffnendes/schließendes BracketCharacter-Objekt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMarkupExtensionNoEndCurlie">
@@ -4519,7 +4519,7 @@
       </trans-unit>
       <trans-unit id="ParserMetroUnknownAttribute">
         <source>Unrecognized '{0}' attribute in namespace '{1}'. Only Key attribute is valid in this namespace.</source>
-        <target state="translated">Unbekanntes {0}-Attribut im Namespace "{1}". In diesem Namespace ist nur ein Key-Attribut gültig.</target>
+        <target state="translated">Unbekanntes {0}-Attribut im Namespace "{1}". In diesem Namespace ist nur ein Key- Attribut gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserMultiBamls">
@@ -4554,7 +4554,7 @@
       </trans-unit>
       <trans-unit id="ParserNoDPOnOwner">
         <source>'{0}' property is not a valid DependencyProperty on the type '{1}'. Verify that the property has a DependencyProperty defined with a member field that ends with the 'Property' suffix.</source>
-        <target state="translated">Die Eigenschaft "{0}" ist keine gültige DependencyProperty für den Typ "{1}". Stellen Sie sicher, dass die Eigenschaft über eine DependencyProperty verfügt, die mit einem Memberfeld mit dem Suffix "Property" definiert ist.</target>
+        <target state="translated">Eigenschaft "{0}" ist keine gültige "DependencyProperty" für den Typ "{1}". Stellen Sie sicher, dass die Eigenschaft über eine "DependencyProperty" verfügt, die mit einem Memberfeld mit dem Suffix "Property" definiert ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoDefaultConstructor">
@@ -4579,7 +4579,7 @@
       </trans-unit>
       <trans-unit id="ParserNoDigitEnums">
         <source>'{1}' cannot be used as a value for '{0}'. Numbers are not valid enumeration values.</source>
-        <target state="translated">"{1}" kann nicht als Wert für "{0}" verwendet werden. Zahlen sind keine gültigen Enumerationswerte.</target>
+        <target state="translated">"{1}" kann nicht als Wert für "{0}" verwendet werden. Zahlen sind keine gültigen Auflistungswerte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNoElementCreate2">
@@ -4679,7 +4679,7 @@
       </trans-unit>
       <trans-unit id="ParserNotMarkupExtension">
         <source>'{0}' is not a valid markup extension expression. Cannot resolve '{1}' in namespace '{2}'. '{1}' must be subclass of MarkupExtension.</source>
-        <target state="translated">"{0}" ist kein gültiger Ausdruck für eine Markuperweiterung. "{1}" kann im Namespace "{2}" nicht aufgelöst werden. Bei "{1}" muss es sich um eine Unterklasse von MarkupExtension handeln.</target>
+        <target state="translated">"{0}" ist kein gültiger Ausdruck für eine Markuperweiterung. "{1}" kann im Namespace "{2}" nicht aufgelöst werden. Bei "{1}" muss es sich um eine Unterklasse von "MarkupExtension" handeln.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserNullPropertyCollection">
@@ -4689,7 +4689,7 @@
       </trans-unit>
       <trans-unit id="ParserNullReturned">
         <source>The '{0}' property with a string value of '{1}' was converted and a null value returned. TypeConverter might not be able to convert string.</source>
-        <target state="translated">Die {0}-Eigenschaft mit dem Zeichenfolgenwert "{1}" wurde konvertiert, und ein Nullwert wurde zurückgegeben. Die Zeichenfolge kann von TypeConverter möglicherweise nicht konvertiert werden.</target>
+        <target state="translated">Die {0}-Eigenschaft mit dem Zeichenfolgenwert "{1}" wurde konvertiert, und ein Nullwert wurde zurückgegeben. Die Zeichenfolge kann von "TypeConverter" möglicherweise nicht konvertiert werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParserOwnerEventMustBePublic">
@@ -4874,7 +4874,7 @@
       </trans-unit>
       <trans-unit id="PathParametersIndexOutOfRange">
         <source>Index {0} is out of range of the PathParameters list, which has length {1}.</source>
-        <target state="translated">Der Index "{0}" befindet sich außerhalb des gültigen Bereichs der PathParameters-Liste mit der Länge {1}.</target>
+        <target state="translated">Der Index "{0}" befindet sich außerhalb des gültigen Bereichs der PathParameters-Liste mit der Länge"{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="PathSyntax">
@@ -4934,7 +4934,7 @@
       </trans-unit>
       <trans-unit id="PrintJobDescription">
         <source>{0} - {1}</source>
-        <target state="translated">{0}: {1}</target>
+        <target state="translated">{0} - {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ProgressBarReadOnly">
@@ -5039,7 +5039,7 @@
       </trans-unit>
       <trans-unit id="ReadNotSupported">
         <source>Stream does not support reading.</source>
-        <target state="translated">Der Datenstrom unterstützt keine Lesevorgänge.</target>
+        <target state="translated">Vom Datenstrom werden Lesevorgänge nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReadOnlyPropertyNotAllowed">
@@ -5089,7 +5089,7 @@
       </trans-unit>
       <trans-unit id="RemoveRequiresOffsetZero">
         <source>GeneratorPosition '{0},{1}' passed to Remove does not have Offset equal to 0.</source>
-        <target state="translated">Die an "Remove" weitergegebene "GeneratorPosition '{0},{1}'" besitzt kein Offset mit dem Wert 0 (Null).</target>
+        <target state="translated">Die an "Remove" weitergegebene "GeneratorPosition '{0},{1}'" besitzt kein "Offset" mit dem Wert Null.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRequiresPositiveCount">
@@ -5269,7 +5269,7 @@
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="translated">Oben</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">
@@ -5454,7 +5454,7 @@
       </trans-unit>
       <trans-unit id="StartIndexExceedsBufferSize">
         <source>startIndex '{0}' exceeds length '{1}' of destination array textBuffer.</source>
-        <target state="translated">startIndex "{0}" übersteigt die Länge {1} von textBuffer des Zielarrays.</target>
+        <target state="translated">"startIndex" "{0}" übersteigt die Länge "{1}" von "textBuffer" des Zielarrays.</target>
         <note />
       </trans-unit>
       <trans-unit id="StartNodeMustBeDocumentPageViewOrFixedPage">
@@ -5474,7 +5474,7 @@
       </trans-unit>
       <trans-unit id="Storyboard_AnimationMismatch">
         <source>'{0}' animation object cannot be used to animate property '{1}' because it is of incompatible type '{2}'.</source>
-        <target state="translated">Das Animationsobjekt "{0}" kann nicht zum Animieren der Eigenschaft "{1}" verwendet werden, da es den nicht kompatiblen Typ "{2}" aufweist.</target>
+        <target state="translated">Das Animationsobjekt "{0}" kann nicht zum Animieren der Eigenschaft "{1}" verwendet werden, da es sich um den nicht kompatiblen Typ "{2}" handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="Storyboard_BeginStoryboardNameNotFound">
@@ -5514,7 +5514,7 @@
       </trans-unit>
       <trans-unit id="Storyboard_NameNotFound">
         <source>'{0}' name cannot be found in the name scope of '{1}'.</source>
-        <target state="translated">Der Name "{0}" wurde im Namensbereich von "{1}" nicht gefunden.</target>
+        <target state="translated">Der Name "{0}" kann im Namensbereich von "{1}" nicht gefunden werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="Storyboard_NeverApplied">
@@ -5549,7 +5549,7 @@
       </trans-unit>
       <trans-unit id="Storyboard_PropertyPathMustPointToDependencyObject">
         <source>'{0}' property does not point to a DependencyObject in path '{1}'.</source>
-        <target state="translated">Von der {0}-Eigenschaft wird nicht auf ein DependencyObject im Pfad "{1}" verwiesen.</target>
+        <target state="translated">Von der {0}-Eigenschaft wird nicht auf "DependencyObject" im Pfad "{1}" verwiesen.</target>
         <note />
       </trans-unit>
       <trans-unit id="Storyboard_PropertyPathMustPointToDependencyProperty">
@@ -5569,7 +5569,7 @@
       </trans-unit>
       <trans-unit id="Storyboard_PropertyPathSealedCheckFailed">
         <source>'{0}' property value in the path '{1}' is on an immutable instance of '{2}'.</source>
-        <target state="translated">Der Eigenschaftswert "{0}" im Pfad "{1}" befindet sich in einer unveränderlichen Instanz von "{2}".</target>
+        <target state="translated">Eigenschaftswert "{0}" in Pfad "{1}" befindet sich in einer unveränderlichen Instanz von "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="Storyboard_PropertyPathUnresolved">
@@ -5679,7 +5679,7 @@
       </trans-unit>
       <trans-unit id="StyleImpliedAndComplexChildren">
         <source>Cannot use both '{0}' tags and Style.'{1}' property tags for a single Style. Use one or the other.</source>
-        <target state="translated">Für einen einzelnen Style können nicht gleichzeitig {0}-Tags und Style.'{1}'-Eigenschaftstags verwendet werden. Verwenden Sie nicht beide gleichzeitig.</target>
+        <target state="translated">Für einen einzelnen "Style" können nicht gleichzeitig {0}-Tags und Style."{1}"-Eigenschaftstags verwendet werden. Verwenden Sie nicht beide gleichzeitig.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleInvalidElementTag">
@@ -5724,7 +5724,7 @@
       </trans-unit>
       <trans-unit id="StyleNoTarget">
         <source>Cannot resolve the Style {0} '{1}'. Verify that the owning type is the Style's TargetType, or use Class.Property syntax to specify the {0}.</source>
-        <target state="translated">Style {0} "{1}" kann nicht aufgelöst werden. Stellen Sie sicher, dass der besitzende Typ "TargetType" von "Style" ist, oder verwenden Sie die Class.Property-Syntax, um "{0}" anzugeben.</target>
+        <target state="translated">Style {0} "{1}" kann nicht aufgelöst werden. Stellen Sie sicher, dass der besitzende Typ "TargetType" von "Style" ist, oder verwenden Sie die Class.Property-Syntax, um {0} anzugeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleNoTemplateBindInSetters">
@@ -5774,7 +5774,7 @@
       </trans-unit>
       <trans-unit id="StyleTargetTypeMismatchWithElement">
         <source>'{0}' TargetType does not match type of element '{1}'.</source>
-        <target state="translated">TargetType "{0}" entspricht nicht dem Typ des Elements "{1}".</target>
+        <target state="translated">"TargetType '{0}'" entspricht nicht dem Typ des Elements "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="StyleTextNotSupported">
@@ -5804,7 +5804,7 @@
       </trans-unit>
       <trans-unit id="SwitchViewingMode">
         <source>_Switch ViewingMode</source>
-        <target state="translated">ViewingMode wech_seln</target>
+        <target state="translated">_Switch ViewingMode</target>
         <note />
       </trans-unit>
       <trans-unit id="SystemResourceForTypeIsNotStyle">
@@ -5899,7 +5899,7 @@
       </trans-unit>
       <trans-unit id="TemplateCircularReferenceFound">
         <source>Infinite loop in references found while processing the Template for an element named '{0}' of type '{1}'.</source>
-        <target state="translated">Beim Verarbeiten von Template für das Element "{0}" vom Typ "{1}" wurde in den Verweisen eine Endlosschleife gefunden.</target>
+        <target state="translated">Beim Verarbeiten von "Template" für das Element "{0}" vom Typ "{1}" wurde in den Verweisen eine Endlosschleife gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateContentSetTwice">
@@ -5979,7 +5979,7 @@
       </trans-unit>
       <trans-unit id="TemplateTargetTypeMismatch">
         <source>'{0}' ControlTemplate TargetType does not match templated type '{1}'.</source>
-        <target state="translated">TargetType "{0}" für ControlTemplate stimmt nicht mit dem als Vorlage verwendeten Typ "{1}" überein.</target>
+        <target state="translated">"TargetType '{0}'" für "ControlTemplate" stimmt nicht mit dem als Vorlage verwendeten Typ "{1}" überein.</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateTextNotSupported">
@@ -6084,7 +6084,7 @@
       </trans-unit>
       <trans-unit id="TextEditorCanNotRegisterCommandHandler">
         <source>'{0}' class editing commands cannot be registered because they are registered on its derived class '{1}'.</source>
-        <target state="translated">Die Bearbeitungsbefehle der Klasse "{0}" können nicht registriert werden, weil sie für deren abgeleitete Klasse "{1}" registriert sind.</target>
+        <target state="translated">Die Bearbeitungsbefehle der Klasse "{0}" können nicht registriert werden, da sie für deren abgeleitete Klasse "{1}" registriert sind.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextEditorCopyPaste_EntryPartIsMissingInXamlPackage">
@@ -6109,7 +6109,7 @@
       </trans-unit>
       <trans-unit id="TextElementCollection_CannotCopyToArrayNotSufficientMemory">
         <source>Not enough space to copy {0} elements to index {1} of array with length {2}.</source>
-        <target state="translated">Es ist nicht genügend Speicher vorhanden, um {0} Elemente in Index "{1}" eines Arrays mit der Länge {2} zu kopieren.</target>
+        <target state="translated">Es ist nicht genügend Speicher vorhanden, um {0} Elemente in Index "{1}" eines Arrays mit der Länge "{2}" zu kopieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextElementCollection_IndexOutOfRange">
@@ -6149,7 +6149,7 @@
       </trans-unit>
       <trans-unit id="TextPanelIllegalParaTypeForIAddChild">
         <source>'{0}' parameter of unexpected type '{1}'. Expected type is UIElement or FrameworkContentElement.</source>
-        <target state="translated">Der Parameter "{0}" weist den unerwarteten Typ "{1}" auf. Erwartet wurde der Typ "UIElement" oder "FrameworkContentElement".</target>
+        <target state="translated">Bei dem Parameter "{0}" handelt es sich um den unerwarteten Typ "{1}". Erwartet wurde der Typ "UIElement" oder "FrameworkContentElement".</target>
         <note />
       </trans-unit>
       <trans-unit id="TextPointer_CannotInsertTextElementBecauseItBelongsToAnotherTree">
@@ -6179,7 +6179,7 @@
       </trans-unit>
       <trans-unit id="TextRangeEdit_InvalidStructuralPropertyApply">
         <source>Cannot apply '{0}' property across the borders of TextElements of type '{1}'.</source>
-        <target state="translated">Die Eigenschaft "{0}" kann nicht über die Grenzen von TextElements vom Typ "{1}" hinweg angewendet werden.</target>
+        <target state="translated">Eigenschaft "{0}" kann nicht über die Grenzen von "TextElements" vom Typ "{1}" hinweg angewendet werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextRangeProvider_EmptyStringParameter">
@@ -6229,7 +6229,7 @@
       </trans-unit>
       <trans-unit id="TextSchema_ChildTypeIsInvalid">
         <source>'{1}' type element is not valid at this position as a child of type '{0}'.</source>
-        <target state="translated">Das Element vom Typ "{1}" ist als untergeordnetes Element des Typs "{0}" an dieser Position nicht gültig.</target>
+        <target state="translated">Das Element vom Typ "{1}" ist als untergeordnetes Element vom Typ "{0}" an dieser Position nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextSchema_IllegalElement">
@@ -6259,12 +6259,12 @@
       </trans-unit>
       <trans-unit id="TextSchema_ThisBlockUIContainerHasAChildUIElementAlready">
         <source>'{0}' already has a child '{1}'. '{2}' element needs its own BlockUIContainer parent.</source>
-        <target state="translated">"{0}" besitzt bereits ein untergeordnetes {1}-Objekt. Für das Element "{2}" ist ein eigener übergeordneter BlockUIContainer erforderlich.</target>
+        <target state="translated">"{0}" besitzt bereits ein untergeordnetes {1}-Objekt. Für das Element "{2}" ist ein eigener übergeordneter "BlockUIContainer" erforderlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextSchema_ThisInlineUIContainerHasAChildUIElementAlready">
         <source>'{0}' already has a child '{1}'. '{2}' element needs its own InlineUIContainer parent.</source>
-        <target state="translated">"{0}" besitzt bereits ein untergeordnetes {1}-Objekt. Für das Element "{2}" ist ein eigener übergeordneter InlineUIContainer erforderlich.</target>
+        <target state="translated">"{0}" besitzt bereits ein untergeordnetes {1}-Objekt. Für das Element "{2}" ist ein eigener übergeordneter "InlineUIContainer" erforderlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextSchema_UIElementNotAllowedInThisPosition">
@@ -6279,7 +6279,7 @@
       </trans-unit>
       <trans-unit id="TextStore_BadIMECharOffset">
         <source>Character offset {0} is not valid in document with {1} characters.</source>
-        <target state="translated">Das Zeichenoffset {0} ist im Dokument mit {1} Zeichen nicht gültig.</target>
+        <target state="translated">Zeichenoffset {0} ist im Dokument mit {1}-Zeichen nicht gültig.</target>
         <note />
       </trans-unit>
       <trans-unit id="TextStore_BadLockFlags">
@@ -6364,57 +6364,57 @@
       </trans-unit>
       <trans-unit id="ToStringFormatString_GridView">
         <source>{0} Columns.Count:{1}</source>
-        <target state="translated">{0}: Columns.Count:{1}</target>
+        <target state="translated">{0} Columns.Count:{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_GridViewColumn">
         <source>{0} Header:{1}</source>
-        <target state="translated">{0}: Header:{1}</target>
+        <target state="translated">{0} Header:{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_GridViewRowPresenter">
         <source>{0} Content:{1} Columns.Count:{2}</source>
-        <target state="translated">{0}: Inhalt:{1}, Columns.Count:{2}</target>
+        <target state="translated">{0} Content:{1} Columns.Count:{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_GridViewRowPresenterBase">
         <source>{0} Columns.Count:{1}</source>
-        <target state="translated">{0}: Columns.Count:{1}</target>
+        <target state="translated">{0} Columns.Count:{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_HeaderedContentControl">
         <source>{0} Header:{1} Content:{2}</source>
-        <target state="translated">{0}: Header:{1}, Inhalt:{2}</target>
+        <target state="translated">{0} Header:{1} Content:{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_HeaderedItemsControl">
         <source>{0} Header:{1} Items.Count:{2}</source>
-        <target state="translated">{0}: Header:{1}, Items.Count:{2}</target>
+        <target state="translated">{0} Header:{1} Items.Count:{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_ItemsControl">
         <source>{0} Items.Count:{1}</source>
-        <target state="translated">{0}: Items.Count:{1}</target>
+        <target state="translated">{0} Items.Count:{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_RangeBase">
         <source>{0} Minimum:{1} Maximum:{2} Value:{3}</source>
-        <target state="translated">{0}: Minimum:{1}, Maximum:{2}, Wert:{3}</target>
+        <target state="translated">{0} Minimum:{1} Maximum:{2} Value:{3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToStringFormatString_ToggleButton">
         <source>{0} Content:{1} IsChecked:{2}</source>
-        <target state="translated">{0}: Inhalt:{1}, IsChecked:{2}</target>
+        <target state="translated">{0} Content:{1} IsChecked:{2}</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperEmptyToken">
         <source>Empty token encountered at position {0} while parsing '{1}'.</source>
-        <target state="translated">Beim Analysieren von "{1}" wurde ein leeres Token an Position {0} gefunden.</target>
+        <target state="translated">Beim Analysieren von "{1}" wurde ein leeres Token an der Position "{0}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperExtraDataEncountered">
         <source>Extra data encountered at position {0} while parsing '{1}'.</source>
-        <target state="translated">Beim Analysieren von "{1}" wurden zusätzliche Daten an Position {0} gefunden.</target>
+        <target state="translated">Beim Analysieren von "{1}" wurden zusätzliche Daten an der Position "{0}" gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="TokenizerHelperMissingEndQuote">
@@ -6619,17 +6619,17 @@
       </trans-unit>
       <trans-unit id="UnexpectedParameterType">
         <source>Parameter is unexpected type '{0}'. Expected type is '{1}'.</source>
-        <target state="translated">Der Parameter weist den nicht erwarteten Typ "{0}" auf. Erwartet wurde der Typ "{1}".</target>
+        <target state="translated">Bei dem Parameter handelt es sich um den nicht erwarteten Typ "{0}". Erwartet wurde der Typ "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedProperty">
         <source>Expected {0} property, got {1}.</source>
-        <target state="translated">Die {0}-Eigenschaft wurde erwartet, "{1}" wurde gefunden.</target>
+        <target state="translated">Die {0}-Eigenschaft wurde erwartet, {1} wurde gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedType">
         <source>Expected {0}, got {1}.</source>
-        <target state="translated">"{0}" wurde erwartet, "{1}" wurde gefunden.</target>
+        <target state="translated">{0} wurde erwartet, {1} wurde gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="UnexpectedValueTypeForCondition">
@@ -6644,12 +6644,12 @@
       </trans-unit>
       <trans-unit id="UnexpectedXmlNodeInXmlFixedPageInfoConstructor">
         <source>\"{{{0}}}{1}\" element found. Expected fixed page element ({{{2}}}{3}).</source>
-        <target state="translated">Das Element \"{{{0}}}{1}\" wurde gefunden. Erwartet wurde ein fixiertes Seitenelement ({{{2}}}{3}).</target>
+        <target state="needs-review-translation">Es wurde das Element "{{{0}}}{1}" gefunden. Erwartet wurde ein fixiertes Seitenelement ("{{{2}}}{3}").</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownBamlRecord">
         <source>Found unknown BAML record {0}.</source>
-        <target state="translated">Ein unbekannter BAML-Datensatz "{0}" wurde gefunden.</target>
+        <target state="needs-review-translation">"Ein unbekannter BAML-Datensatz "{0}" wurde gefunden".</target>
         <note />
       </trans-unit>
       <trans-unit id="UnknownContainerFormat">
@@ -6704,12 +6704,12 @@
       </trans-unit>
       <trans-unit id="Untitled">
         <source>Untitled</source>
-        <target state="translated">Ohne Titel</target>
+        <target state="translated">Unbenannt</target>
         <note />
       </trans-unit>
       <trans-unit id="UntitledPrintJobDescription">
         <source>Untitled</source>
-        <target state="translated">Ohne Titel</target>
+        <target state="translated">Unbenannt</target>
         <note />
       </trans-unit>
       <trans-unit id="UriNotMatchWithRootType">
@@ -6719,12 +6719,12 @@
       </trans-unit>
       <trans-unit id="ValidationRule_UnexpectedValue">
         <source>Validation rule '{0}' received unexpected value '{1}'.  (This could be caused by assigning the wrong ValidationStep to the rule.)</source>
-        <target state="translated">Von der Validierungsregel "{0}" wurde der unerwartete Wert "{1}" empfangen. (Möglicherweise wurde der Regel ein falscher ValidationStep zugewiesen.)</target>
+        <target state="translated">Von der Validierungsregel "{0}" wurde der unerwartete Wert "{1}" empfangen. (Möglicherweise wurde der Regel ein falsches ValidationStep-Element zugewiesen.)</target>
         <note />
       </trans-unit>
       <trans-unit id="ValidationRule_UnknownStep">
         <source>Unrecognized ValidationStep '{0}' obtained from '{1}'.</source>
-        <target state="translated">Von "{1}" wurde der unbekannte ValidationStep "{0}" empfangen.</target>
+        <target state="translated">Von "{1}" wurde das unbekannte ValidationStep-Element "{0}" empfangen.</target>
         <note />
       </trans-unit>
       <trans-unit id="Validation_ConversionFailed">
@@ -6764,7 +6764,7 @@
       </trans-unit>
       <trans-unit id="VisualTreeRootIsFrameworkElement">
         <source>'{0}' Style TargetType is a FrameworkElement, but the VisualTree root element '{1}' is a FrameworkContentElement. The root of the VisualTree must be a FrameworkElement when the TargetType is FrameworkElement.</source>
-        <target state="translated">Bei TargetType "{0}" von Style handelt es sich um ein FrameworkElement, das Stammelement "{1}" von VisualTree ist jedoch ein FrameworkContentElement. Beim Stamm von VisualTree muss es sich um ein FrameworkElement handeln, wenn TargetType ein FrameworkElement ist.</target>
+        <target state="translated">Bei "TargetType '{0}'" von "Style" handelt es sich um ein "FrameworkElement", das Stammelement "{1}" von "VisualTree" ist jedoch ein "FrameworkContentElement". Beim Stamm von "VisualTree" muss es sich um ein "FrameworkElement" handeln, wenn "TargetType" ein "FrameworkElement" ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="VisualTriggerSettersIncludeUnsupportedSetterType">
@@ -6814,7 +6814,7 @@
       </trans-unit>
       <trans-unit id="WriteNotSupported">
         <source>Stream does not support writing.</source>
-        <target state="translated">Der Datenstrom unterstützt keine Schreibvorgänge.</target>
+        <target state="translated">Vom Datenstrom werden keine Schreibvorgänge unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="WrongNavigateRootElement">


### PR DESCRIPTION
A previous loc check-in translated locked strings, only in DE.   I'm reviewing other loc updates to verify this didn't happen elsewhere.