### PR TITLE
Crash in DataGridItemAutomationPeer

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
@@ -211,7 +211,7 @@ namespace System.Windows.Automation.Peers
                             // Ignore such children.
                             if (item == DependencyProperty.UnsetValue)
                             {
-                                item = null;
+                                continue;
                             }
 
                             // try to reuse old peer if it exists either in Current AT or in WeakRefStorage of Peers being sent to Client

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Automation.Peers
                         // Ignore such children. 
                         if (dataItem == DependencyProperty.UnsetValue)
                         {
-                            dataItem = null;
+                            continue;
                         }
                     }
                     else


### PR DESCRIPTION
VS 2017 and 2019 crash when
a. Automation is enabled (e.g. Narrator or Inspect are running)
b. User clicks on the Text Editor\C#\Code Style\Naming page in Tools\Options
(also other similar pages)

This is a regression in 4.8.  The bad pages contain a DataGrid whose cells contain a ComboBox, and whose virtualizing mode is Recycling

Fixes #860 