### PR TITLE
Support `Microsoft.NetCore.App.Wpf` and `Microsoft.NetCore.App.WinForms` profiles in `Microsoft.NET.Sdk.WidnowsDesktop` 

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -1,5 +1,4 @@
 <Project>
-
   <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true'">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
@@ -23,8 +22,16 @@
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' == 'true' And '$(UseWindowsForms)' == 'true'">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' == 'true' And '$(UseWindowsForms)' != 'true'">
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' != 'true' And '$(UseWindowsForms)' == 'true'">
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(UseWPF)' == 'true' ">


### PR DESCRIPTION
Fixes #866 

Related: [WindowsDesktop reference assembly split](https://github.com/dotnet/cli/issues/10536)

| UseWPF  | UseWindowsForms  | FrameworkReference |
| --- | --- | --- |
| False | False  | *Error* (Will be addressed in #867)  |
| True  | False   | `Microsoft.WindowsDesktop.App.WPF` |
| False | True   | `Microsoft.WindowsDesktop.App.WindowsForms`   |
| True | True    | `Microsoft.WindowsDesktop.App` | 






