### PR TITLE
Don't generate ref assemblies for WPF extension assemblies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemCore/PresentationFramework-SystemCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemCore/PresentationFramework-SystemCore.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemCoreExtension.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/PresentationFramework-SystemData.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemData/PresentationFramework-SystemData.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemDataExtension.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemDrawing/PresentationFramework-SystemDrawing.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemDrawing/PresentationFramework-SystemDrawing.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemDrawingExtension.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/PresentationFramework-SystemXml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXml/PresentationFramework-SystemXml.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemXmlExtension.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXmlLinq/PresentationFramework-SystemXmlLinq.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/Extensions/PresentationFramework-SystemXmlLinq/PresentationFramework-SystemXmlLinq.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateDependencyFile>false</GenerateDependencyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SystemXmlLinqExtension.cs" />


### PR DESCRIPTION
Fixes #801. 