### PR TITLE
fix helix target queues

### DIFF
--- a/eng/helixpublish.proj
+++ b/eng/helixpublish.proj
@@ -26,9 +26,6 @@
 
     <!-- Semi-colon delimited list of commands that are executed before every test.-->
     <HelixPreCommands>$(HelixPreCommands);</HelixPreCommands>
-
-    <!-- These are the list of Windows versions that we run tests on-->
-    <HelixTargetQueues>Windows.10.Amd64.Open;Windows.7.Amd64.Open;Windows.10.Amd64.ServerRS5.Open</HelixTargetQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         - name: _PlatformArgs
           value: /p:Platform=$(_Platform)
         - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.Open'
+          value: 'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open'
         - name: _HelixStagingDir
           value: $(BUILD.STAGINGDIRECTORY)\helix\functests
         - name: _HelixSource
@@ -96,6 +96,8 @@ jobs:
             value: '$(HelixApiAccessToken)' # from DotNet-HelixApi-Access group
           - name: _HelixCreator
             value: '' #if _HelixToken is set, Creator must be empty
+          - name: _TestHelixAgentPool
+          value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ServerRS5'
       strategy:
         matrix:
           Build_Debug_x86:

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -97,7 +97,7 @@ jobs:
           - name: _HelixCreator
             value: '' #if _HelixToken is set, Creator must be empty
           - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ServerRS5'
+            value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ServerRS5'
       strategy:
         matrix:
           Build_Debug_x86:


### PR DESCRIPTION
fixing helix queues. we can't have a queue that ends with ".Open" for internal builds.

Fixes #889