### PR TITLE
Fix a incorrect spelled word.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -11,7 +11,7 @@
 //              to compile it.
 //              
 //              The new project file will replace all the Reference Items with the 
-//              resolved ReferenctPath, add all the generated code file into Compile 
+//              resolved ReferencePath, add all the generated code file into Compile 
 //              Item list.
 //
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Actually, the correct word is `ReferencePath`.

```xml
<ReferencePath Include="xxx" />
```