### PR TITLE
Bindings to System.Dynamic types fail to resolve

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AssemblyHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AssemblyHelper.cs
@@ -42,7 +42,7 @@ namespace MS.Internal
         System_Xml_Linq,
         System_Private_Xml_Linq,
         System_Data,
-        System_Core,
+        System_Linq_Expressions,
     }
 
     [FriendAccessAllowed]
@@ -180,8 +180,13 @@ namespace MS.Internal
         // load the extension class for System.Core
         internal static SystemCoreExtensionMethods ExtensionsForSystemCore(bool force=false)
         {
+            // System.Core is always loaded by default on .NET Framework. On .NET Core, 
+            // System.Core is a facade assembly never loaded by the CLR, and System.Core types 
+            // have been forwarded to System.Runtime (always loaded by default) and 
+            // System.Linq.Expressions.  Only load the extension assembly if System.Linq.Expressions 
+            // has already been loaded (e.g., a System.Dynamic type has been created).  
             if (_systemCoreExtensionMethods == null &&
-                (force || IsLoaded(UncommonAssembly.System_Core)))
+                (force || IsLoaded(UncommonAssembly.System_Linq_Expressions)))
             {
                 _systemCoreExtensionMethods = (SystemCoreExtensionMethods)LoadExtensionFor("SystemCore");
             }


### PR DESCRIPTION
`MS.Internal.SystemCoreHelper.IsIDynamicMetaObjectProvider` was returning false for `System.Dynamic.ExpandoObject` causing the PropertyPath resolution to fail. 

On .NET Core, System.Core is now a facade assembly that will never be loaded by the CLR.  **All System.Core types are now forwarded to other assemblies.**  This change updates the required assemblies to those containing the forwarded types (System.Runtime, loaded by default, and System.Linq.Expressions).  AssemblyHelper.cs will now check for System.Linq.Expressions instead of System.Core before loading the extension assembly. 

 Fixes #695.  A larger architectural fix for the extension assemblies may happen after RTM.  