### PR TITLE
Ensure the identity name is the same for C# and VB templates

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a .NET Core WPF Application",
   "groupIdentity": "Microsoft.Common.WPF",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.VisualBasic.3.0",
+  "identity": "Microsoft.Common.WPF",
   "shortName": "wpf",
   "tags": {
     "language": "VB",


### PR DESCRIPTION
Having mismatched identities means that shim templates cannot be re-used across languages in VS