### PR TITLE
Change _TestHelixAgentPool from 19H1 to RS5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,3 +36,5 @@ jobs:
         queue: buildpool.windows.10.amd64.vs2019.pre
       # runAsPublic is used in expressions, which can't read from user-defined variables
       runAsPublic: false
+    timeoutInMinutes: 120 # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
+

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         - name: _PlatformArgs
           value: /p:Platform=$(_Platform)
         - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.Client19H1.Open'
+          value: 'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'
         - name: _HelixStagingDir
           value: $(BUILD.STAGINGDIRECTORY)\helix\functests
         - name: _HelixSource
@@ -97,7 +97,7 @@ jobs:
           - name: _HelixCreator
             value: '' #if _HelixToken is set, Creator must be empty
           - name: _TestHelixAgentPool
-            value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.Client19H1'
+            value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
       strategy:
         matrix:
           Build_Debug_x86:

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         - name: _PlatformArgs
           value: /p:Platform=$(_Platform)
         - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.ClientRS5.Open' # Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'
+          value: 'Windows.10.Amd64.ClientRS5.Open' # Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'; See https://github.com/dotnet/wpf/issues/952
         - name: _HelixStagingDir
           value: $(BUILD.STAGINGDIRECTORY)\helix\functests
         - name: _HelixSource

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -50,7 +50,7 @@ jobs:
         - name: _PlatformArgs
           value: /p:Platform=$(_Platform)
         - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'
+          value: 'Windows.10.Amd64.ClientRS5.Open' # Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'
         - name: _HelixStagingDir
           value: $(BUILD.STAGINGDIRECTORY)\helix\functests
         - name: _HelixSource
@@ -59,6 +59,8 @@ jobs:
           value: ''
         - name: _HelixCreator
           value: ${{ parameters.repoName }}
+        - name: _HelixPublicBuildPipeline  # Run Helix tests when building in the open, do not repeat when building and publishign again using the internal build-pipeline
+          value: true
 
         # Override some values if we're building internally
         - ${{ if eq(parameters.runAsPublic, 'false') }}:
@@ -97,7 +99,9 @@ jobs:
           - name: _HelixCreator
             value: '' #if _HelixToken is set, Creator must be empty
           - name: _TestHelixAgentPool
-            value: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
+            value: 'Windows.10.Amd64.ClientRS5' # Preferred: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
+          - name: _HelixPublicBuildPipeline
+            value: false
       strategy:
         matrix:
           Build_Debug_x86:
@@ -152,4 +156,4 @@ jobs:
           HelixAccessToken: $(_HelixToken)              # only defined for internal CI
           Creator: $(_HelixCreator)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release')) # on helix machine (with real signing)
+        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true')) # on helix machine (with real signing) when running on the public build pipeline


### PR DESCRIPTION
Changing `_TestHelixAgentPool` from 19H1 to RS5 seems to bring down execution time in Helix to approx 15 mins. 

https://dev.azure.com/dnceng/public/_build/results?buildId=226613&view=logs 

Looks like the 19H1 pool may have been the reason our builds have been suffering from chronic timeouts, much like the ServerRS5 pool prior to that. 

Fixes #952 