### PR TITLE
corrected line breaks within the file dialog resource strings.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/ExceptionStringTable.txt
@@ -1672,10 +1672,10 @@ FlowDocumentReader_MultipleViewProvider_ScrollViewName=Scroll
 
 ; File and Save Dialog error messages
 FileDialogBufferTooSmall=Too many files selected. Select fewer files and try again.
-FileDialogCreatePrompt='{0}' does not exist.\r\nDo you want to create it?
-FileDialogFileNotFound='{0}' does not exist.\r\nVerify that the file name is correct.
+FileDialogCreatePrompt='{0}' does not exist.\nDo you want to create it?
+FileDialogFileNotFound='{0}' does not exist.\nVerify that the file name is correct.
 FileDialogInvalidFileName='{0}' is not a valid file name.
-FileDialogOverwritePrompt='{0}' already exists.\r\nDo you want to replace it?
+FileDialogOverwritePrompt='{0}' already exists.\nDo you want to replace it?
 
 ; Navigation Window
 NavWindowMenuCurrentPage=Current Page

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -1027,10 +1027,10 @@
     <value>Too many files selected. Select fewer files and try again.</value>
   </data>
   <data name="FileDialogCreatePrompt" xml:space="preserve">
-    <value>'{0}' does not exist.\r\nDo you want to create it?</value>
+    <value>'{0}' does not exist.\nDo you want to create it?</value>
   </data>
   <data name="FileDialogFileNotFound" xml:space="preserve">
-    <value>'{0}' does not exist.\r\nVerify that the file name is correct.</value>
+    <value>'{0}' does not exist.\nVerify that the file name is correct.</value>
   </data>
   <data name="FileDialogInvalidFileName" xml:space="preserve">
     <value>'{0}' is not a valid file name.</value>
@@ -1042,7 +1042,7 @@
     <value>Filter index is not valid.</value>
   </data>
   <data name="FileDialogOverwritePrompt" xml:space="preserve">
-    <value>'{0}' already exists.\r\nDo you want to replace it?</value>
+    <value>'{0}' already exists.\nDo you want to replace it?</value>
   </data>
   <data name="FileDialogSubClassFailure" xml:space="preserve">
     <value>Cannot subclass a file dialog because sufficient memory is not available.</value>
@@ -1609,31 +1609,31 @@
     <value>Alt+Backspace</value>
   </data>
   <data name="KeyApplyBackground" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyBackgroundDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyDoubleSpaceDisplayString" xml:space="preserve">
     <value>Ctrl+2</value>
   </data>
   <data name="KeyApplyFontFamily" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyFontFamilyDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyFontSize" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyFontSizeDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyForeground" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyForegroundDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyApplyOneAndAHalfSpaceDisplayString" xml:space="preserve">
     <value>Ctrl+5</value>
@@ -1654,10 +1654,10 @@
     <value>Ctrl+Shift+C</value>
   </data>
   <data name="KeyCorrectionList" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyCorrectionListDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyCtrlInsertDisplayString" xml:space="preserve">
     <value>Ctrl+Insert</value>
@@ -1684,10 +1684,10 @@
     <value>Ctrl+Backspace</value>
   </data>
   <data name="KeyDeleteRows" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyDeleteRowsDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyEnterLineBreakDisplayString" xml:space="preserve">
     <value>Shift+Enter</value>
@@ -1879,10 +1879,10 @@
     <value>Ctrl+Shift+N</value>
   </data>
   <data name="KeyToggleSpellCheck" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyToggleSpellCheckDisplayString" xml:space="preserve">
-    <value/>
+    <value />
   </data>
   <data name="KeyToggleSubscriptDisplayString" xml:space="preserve">
     <value>Ctrl+OemPlus</value>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">Prvek {0} neexistuje.\r\nChcete ho vytvořit?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">Prvek {0} neexistuje.\nChcete ho vytvořit?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">Prvek {0} neexistuje.\r\nOvěřte, zda je správný název souboru.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">Prvek {0} neexistuje.\nOvěřte, zda je správný název souboru.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">Prvek {0} již existuje.\r\nChcete ho nahradit?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">Prvek {0} již existuje.\nChcete ho nahradit?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -1613,12 +1613,12 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
         <target state="needs-review-translation">'{0}' ist nicht vorhanden.]D;]A;Möchten Sie das Element erstellen?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
         <target state="needs-review-translation">'{0}' ist nicht vorhanden.]D;]A;Überprüfen Sie den Dateinamen.</target>
         <note />
       </trans-unit>
@@ -1638,7 +1638,7 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
         <target state="needs-review-translation">'{0}' ist bereits vorhanden.]D;]A;Möchten Sie das Element ersetzen?</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" no existe.\r\n¿Desea crearlo?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">"{0}" no existe.\n¿Desea crearlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" no existe.\r\nCompruebe que el nombre de archivo sea correcto.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">"{0}" no existe.\nCompruebe que el nombre de archivo sea correcto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="new">'{0}' already exists.\r\nDo you want to replace it?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="new">'{0}' already exists.\nDo you want to replace it?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' n'existe pas.\r\nVoulez-vous le créer ?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' n'existe pas.\nVoulez-vous le créer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' n'existe pas.\r\nVérifiez que le nom de fichier est correct.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' n'existe pas.\nVérifiez que le nom de fichier est correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' existe déjà.\r\nVoulez-vous le remplacer ?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' existe déjà.\nVoulez-vous le remplacer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' non esiste.\r\nCrearlo?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' non esiste.\nCrearlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' non esiste.\r\nVerificare che il nome file sia corretto.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' non esiste.\nVerificare che il nome file sia corretto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' già esistente.\r\nSostituirlo?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' già esistente.\nSostituirlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' が存在しません。\r\n作成しますか?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' が存在しません。\n作成しますか?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' は存在しません。\r\nファイル名が正しいことをご確認ください。</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' は存在しません。\nファイル名が正しいことをご確認ください。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' は既に存在します。\r\n置き換えますか?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' は既に存在します。\n置き換えますか?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}'이(가) 없습니다.\r\n만드시겠습니까?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}'이(가) 없습니다.\n만드시겠습니까?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}'이(가) 없습니다.\r\n파일 이름이 올바른지 확인하세요.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}'이(가) 없습니다.\n파일 이름이 올바른지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">’{0}'이(가) 이미 있습니다.\r\n바꾸시겠습니까?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">’{0}'이(가) 이미 있습니다.\n바꾸시겠습니까?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">Element „{0}” nie istnieje.\r\nCzy chcesz go utworzyć?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">Element „{0}” nie istnieje.\nCzy chcesz go utworzyć?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">Element „{0}” nie istnieje.\r\nSprawdź, czy nazwa pliku jest prawidłowa.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">Element „{0}” nie istnieje.\nSprawdź, czy nazwa pliku jest prawidłowa.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">Element „{0}” już istnieje.\r\nCzy chcesz go zastąpić?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">Element „{0}” już istnieje.\nCzy chcesz go zastąpić?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' não existe.\r\nDeseja criá-lo?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' não existe.\nDeseja criá-lo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' não existe.\r\nVerifique se o nome de arquivo está correto.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' não existe.\nVerifique se o nome de arquivo está correto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' já existe.\r\nDeseja substituí-lo?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' já existe.\nDeseja substituí-lo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" не существует.\r\nВы хотите создать его?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">"{0}" не существует.\nВы хотите создать его?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" не существует.\r\nПроверьте имя файла.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">"{0}" не существует.\nПроверьте имя файла.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">"{0}" уже существует.\r\nВы хотите заменить его?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">"{0}" уже существует.\nВы хотите заменить его?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' yok.\r\nOluşturmak istiyor musunuz?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' yok.\nOluşturmak istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' yok.\r\nDosya adının doğru olduğunu kontrol edin.</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' yok.\nDosya adının doğru olduğunu kontrol edin.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' zaten var.\r\nDeğiştirmek istiyor musunuz?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' zaten var.\nDeğiştirmek istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">“{0}”不存在。\r\n是否创建?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">“{0}”不存在。\n是否创建?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">“{0}”不存在。\r\n请验证文件名是否正确。</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">“{0}”不存在。\n请验证文件名是否正确。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">“{0}”已存在。\r\n是否替换它?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">“{0}”已存在。\n是否替换它?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -1613,13 +1613,13 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' 不存在。\r\n要建立嗎?</target>
+        <source>'{0}' does not exist.\nDo you want to create it?</source>
+        <target state="translated">'{0}' 不存在。\n要建立嗎?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' 不存在。\r\n請確認檔案名稱正確。</target>
+        <source>'{0}' does not exist.\nVerify that the file name is correct.</source>
+        <target state="translated">'{0}' 不存在。\n請確認檔案名稱正確。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1638,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' 已存在。\r\n要取代掉嗎?</target>
+        <source>'{0}' already exists.\nDo you want to replace it?</source>
+        <target state="translated">'{0}' 已存在。\n要取代掉嗎?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">


### PR DESCRIPTION
Fixes #977 

I noticed in all of the other resource strings only \n is used not \r\n. Updated all of the file dialog resources to use \n instead of the \r\n.