### PR TITLE
Revert "Ensure the identity name is the same for C# and VB templates(#946)" 

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A project for creating a .NET Core WPF Application",
   "groupIdentity": "Microsoft.Common.WPF",
   "precedence": "3000",
-  "identity": "Microsoft.Common.WPF",
+  "identity": "Microsoft.Common.WPF.VisualBasic.3.0",
   "shortName": "wpf",
   "tags": {
     "language": "VB",


### PR DESCRIPTION
This reverts Revert "Ensure the identity name is the same for C# and VB templates(#946)"; commit cf0bed3f96531e505ee0edc2fad6774deb2804bc

Fixes #987
This could regress [AB#902637](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/902637), FYI @jmarolf 

/cc @peterhuene, @livarcocc 