### PR TITLE
Add FlagsToEnable property to JumpTask to allow JumpList to set the SHELL_LINK_DATA_FLAGS enumeration on the shell link

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ComGuids.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ComGuids.cs
@@ -33,6 +33,8 @@ namespace MS.Internal.AppModel
         public const string ShellFolder = "000214E6-0000-0000-C000-000000000046";
         /// <summary>IID_IShellLink</summary>
         public const string ShellLink = "000214F9-0000-0000-C000-000000000046";
+        /// <summary>IID_IShellLinkDataList</summary>
+        public const string ShellLinkDataList = "45E2B4AE-B1C3-11D0-B92F-00A0C90312E1";
         /// <summary>IID_IShellItem</summary>
         public const string ShellItem = "43826d1e-e718-42ee-bc55-a1e261c37bfe";
         /// <summary>IID_IShellItem2</summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ShellProvider.cs
@@ -434,6 +434,30 @@ namespace MS.Internal.AppModel
     [SecurityCritical(SecurityCriticalScope.Everything), SuppressUnmanagedCodeSecurity]
     [
         ComImport,
+        InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown),
+        Guid(IID.ShellLinkDataList),
+    ]
+    internal interface IShellLinkDataListW
+    {
+        [PreserveSig]
+        Int32 AddDataBlock(IntPtr pDataBlock);
+
+        [PreserveSig]
+        Int32 CopyDataBlock(UInt32 dwSig, out IntPtr ppDataBlock);
+
+        [PreserveSig]
+        Int32 RemoveDataBlock(UInt32 dwSig);
+
+        void GetFlags(out uint pdwFlags);
+        void SetFlags(uint dwFlags);
+    }
+
+    /// <SecurityNote>
+    /// Critical: Suppresses unmanaged code security.
+    /// </SecurityNote>
+    [SecurityCritical(SecurityCriticalScope.Everything), SuppressUnmanagedCodeSecurity]
+    [
+        ComImport,
         InterfaceType(ComInterfaceType.InterfaceIsIUnknown),
         Guid(IID.FileDialogEvents),
     ]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -1085,7 +1085,7 @@ namespace System.Windows.Shell
 				if (jumpTask.FlagsToEnable != null)
 				{
 					var shellLinkDataList = (ShellLinkDataList)link;
-					shellLinkDataList.GetFlags(out uint flags);
+					shellLinkDataList.GetFlags(out UInt32 flags);
 					foreach (var flagToEnable in jumpTask.FlagsToEnable)
 					{
 						flags |= flagToEnable;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpList.cs
@@ -1082,6 +1082,17 @@ namespace System.Windows.Shell
                     link.SetDescription(jumpTask.Description);
                 }
 
+				if (jumpTask.FlagsToEnable != null)
+				{
+					var shellLinkDataList = (ShellLinkDataList)link;
+					shellLinkDataList.GetFlags(out uint flags);
+					foreach (var flagToEnable in jumpTask.FlagsToEnable)
+					{
+						flags |= flagToEnable;
+					}
+					shellLinkDataList.SetFlags(flags);
+				}
+
                 IPropertyStore propStore = (IPropertyStore)link;
                 var pv = new PROPVARIANT();
                 try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/JumpTask.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-﻿
+using System.Collections;
 
 namespace System.Windows.Shell
 {
@@ -24,5 +24,11 @@ namespace System.Windows.Shell
         public string IconResourcePath { get; set; }
 
         public int IconResourceIndex { get; set; }
+
+        /// <summary>
+        /// Shell link data flags to enable. For more details see the SHELL_LINK_DATA_FLAGS documentation
+        /// https://docs.microsoft.com/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags 
+        /// </summary>
+        public IEnumerable<UInt32> FlagsToEnable { get; set; }
     }
 }


### PR DESCRIPTION
Closes #950

Add FlagsToEnable property to JumpTask to allow JumpList to set the [SHELL_LINK_DATA_FLAGS](https://docs.microsoft.com/en-us/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags) enumeration on the shell link. This enables various scenarios such as e.g. being able to request elevation of a JumpTask or allowing the link to point to another shell. Because there are so many scenarios, I decided to expose this low level enumeration. Do we need to create an enum wrapper for possible [SHELL_LINK_DATA_FLAGS](https://docs.microsoft.com/en-us/windows/desktop/api/shlobj_core/ne-shlobj_core-shell_link_data_flags) values or shall we leave it up to people? This has the complexity that some enumerations were only introduced in newer versions of Windows (e.g. Win8) or can we disregard this since support for Windows 7 runs out in 6 months anyway?

Context: This is so that PowerShell does not have to maintain hundreds of lines of COM code just for the `Run As Administrator` jump task and also receive the more sophisticated handling by WPF as it has shown that PowerShell's custom code can sometimes cause fatal CLR errors.