### PR TITLE
Update build to use Preview 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview5-011568",
+    "dotnet": "3.0.100-preview6-012264",
     "runtimes": {
       "dotnet": [
         "2.1.7",


### PR DESCRIPTION
This moves the dotnet version used from `3.0.100-preview5-011568` to the now released `3.0.100-preview6-012264`