### PR TITLE
Fix globbing in ResolveRefApiCompatItems

### DIFF
--- a/eng/WpfArcadeSdk/tools/ApiCompat.targets
+++ b/eng/WpfArcadeSdk/tools/ApiCompat.targets
@@ -58,6 +58,8 @@
                                       Condition="'$(WpfRuntimeIdentifier)'=='win-x64'"/>
       <ResolvedImplementationAssembly Include="$(BaseOutputPath)..\$(AssemblyName)-ref\$(Configuration)\**\$(AssemblyName).dll"
                                       Condition="'$(WpfRuntimeIdentifier)'=='win-x86'"/>
+
+      <Error Condition="@(ResolvedImplementationAssembly->Count()) &gt; 1" Text="More than one reference assembly was added to ResolvedImplementationAssembly!" />
     </ItemGroup>
   </Target>
 

--- a/eng/WpfArcadeSdk/tools/ApiCompat.targets
+++ b/eng/WpfArcadeSdk/tools/ApiCompat.targets
@@ -54,7 +54,10 @@
     <ItemGroup>
       <ResolvedMatchingContract Include="$(OutputPath)$(AssemblyName).dll" />
       <!-- Work backwards to find the output for a hand-crafted ref assembly. -->
-      <ResolvedImplementationAssembly Include="$(BaseOutputPath)..\$(AssemblyName)-ref\**\$(AssemblyName).dll" />
+      <ResolvedImplementationAssembly Include="$(BaseOutputPath)..\$(AssemblyName)-ref\$(Platform)\$(Configuration)\**\$(AssemblyName).dll" 
+                                      Condition="'$(WpfRuntimeIdentifier)'=='win-x64'"/>
+      <ResolvedImplementationAssembly Include="$(BaseOutputPath)..\$(AssemblyName)-ref\$(Configuration)\**\$(AssemblyName).dll"
+                                      Condition="'$(WpfRuntimeIdentifier)'=='win-x86'"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #1023 

Makes the globbing in ResolveRefApiCompatItems more specific so that it always picks exactly one reference assembly.