### PR TITLE
Add warnings to Microsoft.NET.Sdk.WindowsDesktop to improve UseWpf/UseWinforms and multi-targeting experience

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview6-012264",
+    "dotnet": "3.0.100-preview7-012512",
     "runtimes": {
       "dotnet": [
         "2.1.7",

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -23,7 +23,8 @@
     <_WindowsDesktopSdkTargetFrameworkVersionFloor>3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And 
+                         ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
@@ -54,17 +55,22 @@
           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And '$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true" />
-  </ItemGroup>
+  
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And
+                      ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And
+                      ('$(_TargetFrameworkVersionWithoutV)' != '') And
+                      ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" IsImplicitlyDefined="true" />
-  </ItemGroup>
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true"
+                        Condition="('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true')"/>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true" />
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" IsImplicitlyDefined="true"
+                        Condition="('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' != 'true')"/>
+
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true"
+                        Condition="('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true')"/>
   </ItemGroup>
+  
 
   <!--
     Traditionally, Visual Studio has supplied these references for .NET Framework based
@@ -89,7 +95,8 @@
      Note:
        These are WPF specific version lower-bounds. Do not use $(_WindowsDesktopSdkTargetFrameworkVersionFloor) in place of '3.0' below.
   -->
-  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 
+                        ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <_WpfCommonNetFxReference Include="WindowsBase" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationCore" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationFramework" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
@@ -105,15 +112,16 @@
     <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.5'" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWPF)' == 'true') ">
-    <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWindowsForms)' == 'true') ">
-    <_SDKImplicitReference Include="System.Windows.Forms"/>
-  </ItemGroup>
-
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') ">
-    <_SDKImplicitReference Include="WindowsFormsIntegration"/>
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And 
+                        ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+    
+    <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)"
+                       Condition="'$(UseWPF)' == 'true'"/>
+    
+    <_SDKImplicitReference Include="System.Windows.Forms"
+                        Condition="('$(UseWindowsForms)' == 'true') " />
+    
+    <_SDKImplicitReference Include="WindowsFormsIntegration"
+                       Condition=" ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') "/>
   </ItemGroup>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -91,15 +91,21 @@
     .NET 4.5+:  PresentationCore, PresentationFramework, WindowsBase, System.Xaml, 
                 UIAutomationClient, UIAutomationClientSideProviders, UIAutomationProvider, UIAutomationTypes
                 System.Windows.Controls.Ribbon
-                
-     Note:
-       These are WPF specific version lower-bounds. Do not use $(_WindowsDesktopSdkTargetFrameworkVersionFloor) in place of '3.0' below.
+
   -->
   <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 
                         ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    <_WpfCommonNetFxReference Include="WindowsBase" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
-    <_WpfCommonNetFxReference Include="PresentationCore" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
-    <_WpfCommonNetFxReference Include="PresentationFramework" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
+
+    <!--
+      The following 3 _WpfCommonNetFxReference items normally require Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'", since
+      they are supported on .NET Framework 3.0 and above. 
+      
+      This condition is implicitly satisfied by '$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' 
+      in the outer ItemGroup
+    -->
+    <_WpfCommonNetFxReference Include="WindowsBase" /> 
+    <_WpfCommonNetFxReference Include="PresentationCore" />
+    <_WpfCommonNetFxReference Include="PresentationFramework" />
 
     <_WpfCommonNetFxReference Include="System.Xaml" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -3,7 +3,27 @@
     <_MicrosoftNetSdkWindowsDesktop>true</_MicrosoftNetSdkWindowsDesktop>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+  <PropertyGroup>
+    <!-- 
+    WindowsDesktop SDK supports WPF and WinForms on 
+      - .NET Core 3.0 and greater
+      - .NET Framework 3.0 and greater
+   
+    Note that on .NET Framework versions < 4.0, additional workarounds may be required to build applications 
+    using the SDK style projects. For e.g., see https://github.com/microsoft/msbuild/issues/1333
+    
+    Irrespective of whether '$(TargetFrameworkIdentifier)' is '.NETCoreApp' or '.NETFramework', 
+    the minimum value of $(_TargetFrameworkVersionWithoutV) we will be testing for is '3.0'
+    
+    Note:
+      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of 
+      the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
+      is safe to use here. 
+  -->
+    <_WindowsDesktopSdkTargetFrameworkVersionFloor>3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
@@ -34,15 +54,15 @@
           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And '$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true" />
   </ItemGroup>
 
@@ -66,12 +86,10 @@
                 UIAutomationClient, UIAutomationClientSideProviders, UIAutomationProvider, UIAutomationTypes
                 System.Windows.Controls.Ribbon
                 
-    Note:
-      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of 
-      the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
-      is safe to use here. 
+     Note:
+       These are WPF specific version lower-bounds. Do not use $(_WindowsDesktopSdkTargetFrameworkVersionFloor) in place of '3.0' below.
   -->
-  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <_WpfCommonNetFxReference Include="WindowsBase" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationCore" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationFramework" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
@@ -87,15 +105,15 @@
     <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.5'" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWPF)' == 'true') ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWPF)' == 'true') ">
     <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWindowsForms)' == 'true') ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWindowsForms)' == 'true') ">
     <_SDKImplicitReference Include="System.Windows.Forms"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)') And ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') ">
     <_SDKImplicitReference Include="WindowsFormsIntegration"/>
   </ItemGroup>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <_MicrosoftNetSdkWindowsDesktop>true</_MicrosoftNetSdkWindowsDesktop>
   </PropertyGroup>
-  
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true'">
+
+  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true' And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
@@ -13,28 +13,36 @@
       <Generator>MSBuild:Compile</Generator>
     </ApplicationDefinition>
 
-    <None Remove="@(ApplicationDefinition)"
-          Condition="'$(EnableDefaultApplicationDefinition)' != 'false'" />
-
     <Page Include="**/*.xaml"
           Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(ApplicationDefinition)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" >
       <Generator>MSBuild:Compile</Generator>
     </Page>
 
-    <None Remove="@(Page)"
-          Condition="'$(EnableDefaultPageItems)' != 'false'" />
+
+    <!-- 
+      See https://github.com/dotnet/wpf/issues/685
+      Visual Studio would prefer that we remove **/*.xaml instead of 
+      being more precise.
+
+      <None Remove="@(Page)"
+              Condition="'$(EnableDefaultPageItems)' != 'false'" />
+      <None Remove="@(ApplicationDefinition)"
+            Condition="'$(EnableDefaultApplicationDefinition)' != 'false'" />
+    -->
+    <None Remove="**/*.xaml"
+          Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And '$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' == 'true' And '$(UseWindowsForms)' == 'true'">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' == 'true' And '$(UseWindowsForms)' != 'true'">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWPF)' != 'true' And '$(UseWindowsForms)' == 'true'">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true') And ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true" />
   </ItemGroup>
 
@@ -63,7 +71,7 @@
       the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
       is safe to use here. 
   -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(_TargetFrameworkVersionWithoutV)' != ''">
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     <_WpfCommonNetFxReference Include="WindowsBase" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationCore" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
     <_WpfCommonNetFxReference Include="PresentationFramework" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'" />
@@ -79,15 +87,15 @@
     <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.5'" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(UseWPF)' == 'true' ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWPF)' == 'true') ">
     <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(UseWindowsForms)' == 'true' ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWindowsForms)' == 'true') ">
     <_SDKImplicitReference Include="System.Windows.Forms"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(UseWindowsForms)' == 'true' And '$(UseWPF)' == 'true' ">
+  <ItemGroup Condition=" ('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0') And ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') ">
     <_SDKImplicitReference Include="WindowsFormsIntegration"/>
   </ItemGroup>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -1,20 +1,8 @@
 <Project>
-
-   <!-- 
-    For now, UseLegacyPresentationBuildTasks=true can be used to use the in-box framework 
-    PresentationBuildTasks and targets when running in full framework MSBuild. This is
-    just an escape hatch while the new PresentationBuildTasks bake. 
-    
-    When we remove this,we can remove the correpsonding corresponding mscorlib swap targets in
-    Microsoft.DesktopUI.App.targets, and the production of ref-mscorlib shims 
-  -->
- <Import Project="$(MSBuildToolsPath)\Microsoft.WinFX.targets" 
-         Condition ="'$(MSBuildRuntimeType)' != 'Core' and '$(UseLegacyPresentationBuildTasks)' == 'true'"/>
-
- <Import Project="Microsoft.WinFX.targets" 
-         Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(UseLegacyPresentationBuildTasks)' != 'true'" />
-
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' And '$(UseWPF)' == 'true'">
+  <Import Project="Microsoft.WinFX.targets" />
+  
+  <!-- $(TargetFrameworkIdentifier) can be '.NETCoreApp' or '.NETFramework' -->
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
     
     <!-- In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content, or None items, then remove them from the Page items. -->
@@ -25,9 +13,10 @@
   <!-- Generate error if there are duplicate page items.  The task comes from the .NET SDK, and this target follows
        the pattern in the CheckForDuplicateItems task, where the .NET SDK checks for duplicate items for the item
        types it knows about. -->
-  <Target Name="CheckForDuplicatePageItems" BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile"
+  <Target Name="CheckForDuplicatePageItems" 
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile"
           DependsOnTargets="CheckForDuplicateItems"
-          Condition="'$(UseWPF)' == 'true'">
+          Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
 
     <CheckForDuplicateItems
       Items="@(Page)"
@@ -47,4 +36,27 @@
 
   </Target>
 
+  <!-- 
+    This warning can be suppressed by setting $(MSBuildWarningsAsMessages) property, like this:
+    <PropertyGroup>
+      <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1106</MSBuildWarningsAsMessages>
+    </PropertyGroup>
+  --> 
+  <Target Name="_WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+          Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'">
+    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" />
+  </Target>
+
+    <!-- 
+    This warning can be suppressed by setting $(MSBuildWarningsAsMessages) property, like this:
+    <PropertyGroup>
+      <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1105</MSBuildWarningsAsMessages>
+    </PropertyGroup>
+  --> 
+  <Target Name="_WindowsDesktopFrameworkRequiresVersion30"
+        BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
+    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
+  </Target>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -1,7 +1,8 @@
 <Project>
   <Import Project="Microsoft.WinFX.targets" />
 
-  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 
+                         ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     
     <!-- In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content, or None items, then remove them from the Page items. -->
@@ -43,7 +44,7 @@
   --> 
   <Target Name="_WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-          Condition="'$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+          Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" 
                    Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'"/>
   </Target>
@@ -56,7 +57,8 @@
   --> 
   <Target Name="_WindowsDesktopFrameworkRequiresVersion30"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+        Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And 
+                  ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -1,8 +1,7 @@
 <Project>
   <Import Project="Microsoft.WinFX.targets" />
-  
-  <!-- $(TargetFrameworkIdentifier) can be '.NETCoreApp' or '.NETFramework' -->
-  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     
     <!-- In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content, or None items, then remove them from the Page items. -->
@@ -16,7 +15,7 @@
   <Target Name="CheckForDuplicatePageItems" 
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile"
           DependsOnTargets="CheckForDuplicateItems"
-          Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '3.0')">
+          Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
     <CheckForDuplicateItems
       Items="@(Page)"
@@ -44,8 +43,9 @@
   --> 
   <Target Name="_WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-          Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'">
-    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" />
+          Condition="'$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" 
+                   Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'"/>
   </Target>
 
     <!-- 
@@ -56,7 +56,7 @@
   --> 
   <Target Name="_WindowsDesktopFrameworkRequiresVersion30"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
+        Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes the following:

- Fixes #685: Remove **/*.xaml from None
- Fixes #327: Cannot multi-target netcoreap < 3.0 and use WindowsDesktop SDK unconditionally.
- Fixes #746: [Epic] Support WPF and WinForms specific FrameworkReferences a Profiles
  - Fixes #867: Show error when neither UseWpf nor UseWindowsForms is set to true

Also cleans up the way in which we import Microsoft.WinFX.targets - UseLegacyPresentationBuildTasks has been broken for some time now and unusable.