### PR TITLE
Added missing null check to uri in MediaPlayerState

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
@@ -877,7 +877,7 @@ namespace System.Windows.Media
                 {
                     // target is HTTPS. Then, elevate ONLY if we are NOT coming from HTTPS (=XDomain HTTPS app to HTTPS media disallowed)
                     Uri appDeploymentUri = SecurityHelper.ExtractUriForClickOnceDeployedApp();
-                    if (!SecurityHelper.AreStringTypesEqual(appDeploymentUri.Scheme, Uri.UriSchemeHttps))
+                    if (appDeploymentUri != null && !SecurityHelper.AreStringTypesEqual(appDeploymentUri.Scheme, Uri.UriSchemeHttps))
                     {
                         new WebPermission(NetworkAccess.Connect, BindUriHelper.UriToString(uriToOpen)).Assert();
                         elevated = true;


### PR DESCRIPTION
Adds null check for when playing streams from https (would throw NullReferenceException otherwise). 
Fixes #722

This check matches what is already in place here:
https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs#L302