### PR TITLE
Restore PackageReferences in temporary assembly projects to import build extensions

### DIFF
--- a/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationBuildTasks-Net48.baseline.txt
+++ b/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationBuildTasks-Net48.baseline.txt
@@ -1,3 +1,13 @@
 Compat issues with assembly PresentationBuildTasks:
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.CompileTypeName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.CompileTypeName.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.GeneratedCodeFiles.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.GeneratedCodeFiles.set(Microsoft.Build.Framework.ITaskItem[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.MSBuildBinPath.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.MSBuildBinPath.set(System.String)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.ReferencePath.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.ReferencePath.set(Microsoft.Build.Framework.ITaskItem[])' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.ReferencePathTypeName.get()' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly.ReferencePathTypeName.set(System.String)' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'Microsoft.Build.Tasks.Windows.GetWinFXPath' does not exist in the implementation but it does exist in the contract.
-Total Issues: 1
+Total Issues: 11

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -20,6 +20,8 @@
   <UsingTask TaskName="Microsoft.Build.Tasks.Windows.FileClassifier" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass2" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.CreateTemporaryTargetAssemblyProject" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.RunProjectBuildTarget" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
   <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
 
 
@@ -380,6 +382,8 @@
   <PropertyGroup>
 
        <MarkupCompilePass2ForMainAssemblyDependsOn>
+                     CreateTemporaryTargetAssemblyProject;
+                     RestoreTemporaryTargetAssemblyProject;
                      GenerateTemporaryTargetAssembly;
                      MarkupCompilePass2;
                      AfterMarkupCompilePass2;
@@ -400,6 +404,57 @@
 
   </Target>
 
+  <!--
+
+                ==========================================
+                  CreateTemporaryTargetAssemblyProject
+                ==========================================
+
+                Name : CreateTemporaryTargetAssemblyProject
+
+  -->
+
+   <Target Name="CreateTemporaryTargetAssemblyProject"
+               Condition="'$(_RequireMCPass2ForMainAssembly)' == 'true' " >
+
+       <CreateTemporaryTargetAssemblyProject 
+                CurrentProject="$(MSBuildProjectFullPath)"
+                GeneratedCodeFiles="@(_GeneratedCodeFiles)"
+                CompileTypeName="Compile"
+                ReferencePath="@(ReferencePath)"
+                ReferencePathTypeName="ReferencePath" >
+           <Output TaskParameter="TemporaryTargetAssemblyProjectName" PropertyName="_TemporaryTargetAssemblyProjectName"/>
+       </CreateTemporaryTargetAssemblyProject>
+
+      <Message Text="GenerateTemporaryTargetAssembyProject project is $(_TemporaryTargetAssemblyProjectName)" />
+
+  </Target>
+
+  <!--
+
+                ==========================================
+                   RestoreTemporaryTargetAssemblyProject
+                ==========================================
+
+                Name : RestoreTemporaryTargetAssemblyProject
+
+  -->
+
+   <Target Name="RestoreTemporaryTargetAssemblyProject"
+               Condition="'$(_RequireMCPass2ForMainAssembly)' == 'true' " >
+
+      <Message Text="RestoreTemporaryTargetAssemblyProject project is $(_TemporaryTargetAssemblyProjectName)" Condition="'$(MSBuildTargetsVerbose)' == 'true'" />
+
+      <RunProjectBuildTarget 
+          ProjectName="$(_TemporaryTargetAssemblyProjectName)"
+          BuildTarget="Restore"
+          />
+
+       <CreateItem Include="$(IntermediateOutputPath)$(TargetFileName)" >
+               <Output TaskParameter="Include" ItemName="AssemblyForLocalTypeReference" />
+       </CreateItem>
+
+  </Target>
 
   <!--
 
@@ -418,13 +473,9 @@
 
        <GenerateTemporaryTargetAssembly
                 CurrentProject="$(MSBuildProjectFullPath)"
-                MSBuildBinPath="$(MSBuildBinPath)"
-                ReferencePathTypeName="ReferencePath"
-                CompileTypeName="Compile"
-                GeneratedCodeFiles="@(_GeneratedCodeFiles)"
-                ReferencePath="@(ReferencePath)"
                 IntermediateOutputPath="$(IntermediateOutputPath)"
                 AssemblyName="$(AssemblyName)"
+                TemporaryTargetAssemblyProjectName="$(_TemporaryTargetAssemblyProjectName)"
                 CompileTargetName="$(_CompileTargetNameForLocalType)"
                 GenerateTemporaryTargetAssemblyDebuggingInformation="$(GenerateTemporaryTargetAssemblyDebuggingInformation)"
                  >

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/CreateTemporaryTargetAssemblyProject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/CreateTemporaryTargetAssemblyProject.cs
@@ -73,8 +73,6 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
-            System.Diagnostics.Debugger.Launch();
-
             bool retValue = true;
 
             // Verification

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/CreateTemporaryTargetAssemblyProject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/CreateTemporaryTargetAssemblyProject.cs
@@ -1,0 +1,391 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections;
+
+using System.Globalization;
+using System.Diagnostics;
+using System.Reflection;
+using System.Resources;
+using System.Xml;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using MS.Utility;
+using MS.Internal.Tasks;
+
+// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
+// We first need to disable warnings about unknown message numbers and unknown pragmas.
+#pragma warning disable 1634, 1691
+
+namespace Microsoft.Build.Tasks.Windows
+{
+    #region CreateTemporaryTargetAssemblyProject Task class
+
+    /// <summary>
+    ///   This task is used to generate a temporary target assembly project. 
+    /// 
+    ///   The generated project file is based on current project file, with below
+    ///   modification:
+    /// 
+    ///       A:  Add the generated code files (.g.cs) to Compile Item list.
+    ///       B:  Replace Reference Item list with ReferencePath item list.
+    ///           So that it doesn't need to rerun time-consuming task 
+    ///           ResolveAssemblyReference (RAR) again.
+    /// 
+    /// </summary>
+    public sealed class CreateTemporaryTargetAssemblyProject : Task
+    {
+        //------------------------------------------------------
+        //
+        //  Constructors
+        //
+        //------------------------------------------------------
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor 
+        /// </summary>
+        public CreateTemporaryTargetAssemblyProject()
+            : base(SR.SharedResourceManager)
+        {
+        }   
+        
+        #endregion Constructors
+
+        //------------------------------------------------------
+        //
+        //  Public Methods
+        //
+        //------------------------------------------------------
+
+        #region Public Methods
+
+        /// <summary>
+        /// ITask Execute method
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>Catching all exceptions in this method is appropriate - it will allow the build process to resume if possible after logging errors</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        public override bool Execute()
+        {
+            System.Diagnostics.Debugger.Launch();
+
+            bool retValue = true;
+
+            // Verification
+            try
+            {
+                // Create a random file name
+                // This can fix the problem of project cache in VS.NET environment.
+                //
+                // GetRandomFileName( ) could return any possible file name and extension
+                // Since this temporary file will be used to represent an MSBUILD project file, 
+                // we will use the same extension as that of the current project file
+                //
+                string currentProjectName = Path.GetFileNameWithoutExtension(CurrentProject);
+                string currentProjectExtension = Path.GetExtension(CurrentProject);
+
+                string randomFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
+                string tempProjPrefix = string.Join("_", currentProjectName, randomFileName, WPFTMP);
+                TemporaryTargetAssemblyProjectName = tempProjPrefix  + currentProjectExtension;
+
+                XmlDocument xmlProjectDoc = null;
+
+                xmlProjectDoc = new XmlDocument( );
+                xmlProjectDoc.Load(CurrentProject);
+
+                // remove all the WinFX specific item lists
+                // ApplicationDefinition, Page, MarkupResource and Resource
+                RemoveItemsByName(xmlProjectDoc, APPDEFNAME);
+                RemoveItemsByName(xmlProjectDoc, PAGENAME);
+                RemoveItemsByName(xmlProjectDoc, MARKUPRESOURCENAME);
+                RemoveItemsByName(xmlProjectDoc, RESOURCENAME);
+
+                // Replace the Reference Item list with ReferencePath
+                RemoveItemsByName(xmlProjectDoc, REFERENCETYPENAME);
+                AddNewItems(xmlProjectDoc, ReferencePathTypeName, ReferencePath);
+
+                // Add GeneratedCodeFiles to Compile item list.
+                AddNewItems(xmlProjectDoc, CompileTypeName, GeneratedCodeFiles);
+
+                // Save the xmlDocument content into the temporary project file.
+                xmlProjectDoc.Save(TemporaryTargetAssemblyProjectName);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e);
+                retValue = false;
+            }
+
+            return retValue;
+        }
+
+        #endregion Public Methods
+        
+        //------------------------------------------------------
+        //
+        //  Public Properties
+        //
+        //------------------------------------------------------
+
+        #region Public Properties
+
+        /// <summary>
+        /// CurrentProject 
+        ///    The full path of current project file.
+        /// </summary>
+        [Required]
+        public string  CurrentProject
+        { get; set; }
+
+        /// <summary>
+        /// GeneratedCodeFiles
+        ///    A list of generated code files, it could be empty.
+        ///    The list will be added to the Compile item list in new generated project file.
+        /// </summary>
+        public ITaskItem[] GeneratedCodeFiles
+        { get; set; }
+
+        /// <summary>
+        /// CompileTypeName
+        ///   The appropriate item name which can be accepted by managed compiler task.
+        ///   It is "Compile" for now.
+        ///   
+        ///   Adding this property is to make the type name configurable, if it is changed, 
+        ///   No code is required to change in this task, but set a new type name in project file.
+        /// </summary>
+        [Required]
+        public string CompileTypeName
+        { get; set; }
+
+        /// <summary>
+        /// ReferencePath
+        ///    A list of resolved reference assemblies.
+        ///    The list will replace the original Reference item list in generated project file.
+        /// </summary>
+        public ITaskItem[] ReferencePath
+        { get; set; }
+
+        /// <summary>
+        /// ReferencePathTypeName
+        ///   The appropriate item name which is used to keep the Reference list in managed compiler task.
+        ///   It is "ReferencePath" for now.
+        ///   
+        ///   Adding this property is to make the type name configurable, if it is changed, 
+        ///   No code is required to change in this task, but set a new type name in project file.
+        /// </summary>
+        [Required]
+        public string ReferencePathTypeName
+        { get; set; }
+
+        [Output]
+        public string TemporaryTargetAssemblyProjectName 
+        { get; set; }
+
+        #endregion Public Properties
+  
+        //------------------------------------------------------
+        //
+        //  Private Methods
+        //
+        //------------------------------------------------------
+
+        #region Private Methods
+
+        //
+        // Remove specific items from project file. Every item should be under an ItemGroup.
+        //
+        private void RemoveItemsByName(XmlDocument xmlProjectDoc, string sItemName)
+        {
+            if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName))
+            {
+                // When the parameters are not valid, simply return it, instead of throwing exceptions.
+                return;
+            }
+
+            //
+            // The project file format is always like below:
+            //
+            //  <Project  xmlns="...">
+            //     <ProjectGroup>
+            //         ......
+            //     </ProjectGroup>
+            //
+            //     ...
+            //     <ItemGroup>
+            //         <ItemNameHere ..../>
+            //         ....
+            //     </ItemGroup>
+            //
+            //     ....
+            //     <Import ... />
+            //     ...
+            //     <Target Name="xxx" ..../>
+            //     
+            //      ...
+            //
+            //  </Project>
+            //
+            //
+            // The order of children nodes under Project Root element is random
+            //
+
+            XmlNode root = xmlProjectDoc.DocumentElement;
+
+            if (root.HasChildNodes == false)
+            {
+                // If there is no child element in this project file, just return immediatelly.
+                return;
+            }
+
+            for (int i = 0; i < root.ChildNodes.Count; i++)
+            {
+                XmlElement nodeGroup = root.ChildNodes[i] as XmlElement;
+
+                if (nodeGroup != null && String.Compare(nodeGroup.Name, ITEMGROUP_NAME, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    //
+                    // This is ItemGroup element.
+                    //
+                    if (nodeGroup.HasChildNodes)
+                    {
+                        ArrayList itemToRemove = new ArrayList();
+
+                        for (int j = 0; j < nodeGroup.ChildNodes.Count; j++)
+                        {
+                            XmlElement nodeItem = nodeGroup.ChildNodes[j] as XmlElement;
+
+                            if (nodeItem != null && String.Compare(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase) == 0)
+                            {
+                                // This is the item that need to remove.
+                                // Add it into the temporary array list.
+                                // Don't delete it here, since it would affect the ChildNodes of parent element.
+                                //
+                                itemToRemove.Add(nodeItem);
+                            }
+                        }
+
+                        //
+                        // Now it is the right time to delete the elements.
+                        //
+                        if (itemToRemove.Count > 0)
+                        {
+                            foreach (object node in itemToRemove)
+                            {
+                                XmlElement item = node as XmlElement;
+
+                                //
+                                // Remove this item from its parent node.
+                                // the parent node should be nodeGroup.
+                                //
+                                if (item != null)
+                                {
+                                    nodeGroup.RemoveChild(item);
+                                }
+                            }
+                        }
+                    }
+
+                    //
+                    // Removed all the items with given name from this item group.
+                    //
+                    // Continue the loop for the next ItemGroup.
+                }
+
+            }   // end of "for i" statement.
+
+        }
+
+        //
+        // Add a list of files into an Item in the project file, the ItemName is specified by sItemName.
+        //
+        private void AddNewItems(XmlDocument xmlProjectDoc, string sItemName, ITaskItem[] pItemList)
+        {
+            if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName) || pItemList == null)
+            {
+                // When the parameters are not valid, simply return it, instead of throwing exceptions.
+                return;
+            }
+
+            XmlNode root = xmlProjectDoc.DocumentElement;
+
+            // Create a new ItemGroup element
+            XmlNode nodeItemGroup = xmlProjectDoc.CreateElement(ITEMGROUP_NAME, root.NamespaceURI);
+
+            // Append this new ItemGroup item into the list of children of the document root.
+            root.AppendChild(nodeItemGroup);
+
+            XmlElement embedItem = null;
+
+            for (int i = 0; i < pItemList.Length; i++)
+            {
+                // Create an element for the given sItemName
+                XmlElement nodeItem = xmlProjectDoc.CreateElement(sItemName, root.NamespaceURI);
+
+                // Create an Attribute "Include"
+                XmlAttribute attrInclude = xmlProjectDoc.CreateAttribute(INCLUDE_ATTR_NAME);
+
+                ITaskItem pItem = pItemList[i];
+
+                // Set the value for Include attribute.
+                attrInclude.Value = pItem.ItemSpec;
+
+                // Add the attribute to current item node.
+                nodeItem.SetAttributeNode(attrInclude);
+
+                if (TRUE == pItem.GetMetadata(EMBEDINTEROPTYPES))
+                {
+                    embedItem = xmlProjectDoc.CreateElement(EMBEDINTEROPTYPES, root.NamespaceURI);
+                    embedItem.InnerText = TRUE;
+                    nodeItem.AppendChild(embedItem);
+                }
+
+                string aliases = pItem.GetMetadata(ALIASES);
+                if (!String.IsNullOrEmpty(aliases))
+                {
+                    embedItem = xmlProjectDoc.CreateElement(ALIASES, root.NamespaceURI);
+                    embedItem.InnerText = aliases;
+                    nodeItem.AppendChild(embedItem);
+                }
+
+                // Add current item node into the children list of ItemGroup
+                nodeItemGroup.AppendChild(nodeItem);
+            }
+        }
+
+        #endregion Private Methods
+
+
+        //------------------------------------------------------
+        //
+        //  Private Fields
+        //
+        //------------------------------------------------------
+
+        #region Private Fields
+
+        private const string ALIASES = "Aliases";
+        private const string REFERENCETYPENAME = "Reference";
+        private const string EMBEDINTEROPTYPES = "EmbedInteropTypes";
+        private const string APPDEFNAME = "ApplicationDefinition";
+        private const string PAGENAME = "Page";
+        private const string MARKUPRESOURCENAME = "MarkupResource";
+        private const string RESOURCENAME = "Resource";
+
+        private const string ITEMGROUP_NAME = "ItemGroup";
+        private const string INCLUDE_ATTR_NAME = "Include";
+
+        private const string TRUE = "True";
+        private const string WPFTMP = "wpftmp";
+
+        #endregion Private Fields
+
+    }
+    
+    #endregion CreateTemporaryTargetAssemblyProject Task class
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -89,8 +89,6 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
-            System.Diagnostics.Debugger.Launch();
-
             bool retValue = true;
 
             // Verification

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -89,83 +89,34 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
+            System.Diagnostics.Debugger.Launch();
+
             bool retValue = true;
 
             // Verification
             try
             {
-                XmlDocument xmlProjectDoc = null;
-
-                xmlProjectDoc = new XmlDocument( );
-                xmlProjectDoc.Load(CurrentProject);
-
-                //
-                // remove all the WinFX specific item lists
-                // ApplicationDefinition, Page, MarkupResource and Resource
-                //
-
-                RemoveItemsByName(xmlProjectDoc, APPDEFNAME);
-                RemoveItemsByName(xmlProjectDoc, PAGENAME);
-                RemoveItemsByName(xmlProjectDoc, MARKUPRESOURCENAME);
-                RemoveItemsByName(xmlProjectDoc, RESOURCENAME);
-
-                // Replace the Reference Item list with ReferencePath
-
-                RemoveItemsByName(xmlProjectDoc, REFERENCETYPENAME);
-                AddNewItems(xmlProjectDoc, ReferencePathTypeName, ReferencePath);
-
-                // Add GeneratedCodeFiles to Compile item list.
-                AddNewItems(xmlProjectDoc, CompileTypeName, GeneratedCodeFiles);
-
-                string currentProjectName = Path.GetFileNameWithoutExtension(CurrentProject);
-                string currentProjectExtension = Path.GetExtension(CurrentProject);
-
-                // Create a random file name
-                // This can fix the problem of project cache in VS.NET environment.
-                //
-                // GetRandomFileName( ) could return any possible file name and extension
-                // Since this temporary file will be used to represent an MSBUILD project file, 
-                // we will use the same extension as that of the current project file
-                //
-                string randomFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
-
-                // Don't call Path.ChangeExtension to append currentProjectExtension. It will do 
-                // odd things with project names that already contains a period (like System.Windows.
-                // Contols.Ribbon.csproj). Instead, just append the extension - after all, we already know
-                // for a fact that this name (i.e., tempProj) lacks a file extension.
-                string tempProjPrefix = string.Join("_", currentProjectName, randomFileName, WPFTMP);
-                string tempProj = tempProjPrefix  + currentProjectExtension;
-
-
-                // Save the xmlDocument content into the temporary project file.
-                xmlProjectDoc.Save(tempProj);
-
-                //
-                // Invoke MSBUILD engine to build this temporary project file.
-                //
-
-                Hashtable globalProperties = new Hashtable(3);
-
                 // Add AssemblyName, IntermediateOutputPath and _TargetAssemblyProjectName to the global property list
                 // Note that _TargetAssemblyProjectName is not defined as a property with Output attribute - that doesn't do us much 
                 // good here. We need _TargetAssemblyProjectName to be a well-known property in the new (temporary) project
                 // file, and having it be available in the current MSBUILD process is not useful.
-                globalProperties[intermediateOutputPathPropertyName] = IntermediateOutputPath;
+                Hashtable globalProperties = new Hashtable(3);
+                globalProperties[nameof(IntermediateOutputPath)] = IntermediateOutputPath;
+                globalProperties[nameof(AssemblyName)] = AssemblyName;
+                globalProperties[targetAssemblyProjectNamePropertyName] = Path.GetFileNameWithoutExtension(CurrentProject);
 
-                globalProperties[assemblyNamePropertyName] = AssemblyName;
-                globalProperties[targetAssemblyProjectNamePropertyName] = currentProjectName;
-
-                retValue = BuildEngine.BuildProjectFile(tempProj, new string[] { CompileTargetName }, globalProperties, null);
+                // Compile the project
+                retValue = BuildEngine.BuildProjectFile(TemporaryTargetAssemblyProjectName, new string[] { CompileTargetName }, globalProperties, null);
 
                 // Delete the temporary project file and generated files unless diagnostic mode has been requested
                 if (!GenerateTemporaryTargetAssemblyDebuggingInformation)
                 {
                     try
                     {
-                        File.Delete(tempProj);
+                        File.Delete(TemporaryTargetAssemblyProjectName);
 
                         DirectoryInfo intermediateOutputPath = new DirectoryInfo(IntermediateOutputPath);
-                        foreach (FileInfo temporaryProjectFile in intermediateOutputPath.EnumerateFiles(string.Concat(tempProjPrefix, "*")))
+                        foreach (FileInfo temporaryProjectFile in intermediateOutputPath.EnumerateFiles(string.Concat(Path.GetFileNameWithoutExtension(TemporaryTargetAssemblyProjectName), "*")))
                         {
                             temporaryProjectFile.Delete();
                         }
@@ -202,75 +153,7 @@ namespace Microsoft.Build.Tasks.Windows
         /// </summary>
         [Required]
         public string  CurrentProject
-        {
-            get { return _currentProject; }
-            set { _currentProject = value; }
-        }
-
-        /// <summary>
-        /// MSBuild Binary Path.
-        ///   This is required for Project to work correctly.
-        /// </summary>
-        [Required]
-        public string MSBuildBinPath
-        {
-            get { return _msbuildBinPath; }
-            set { _msbuildBinPath = value; }
-        }
-        
-        /// <summary>
-        /// GeneratedCodeFiles
-        ///    A list of generated code files, it could be empty.
-        ///    The list will be added to the Compile item list in new generated project file.
-        /// </summary>
-        public ITaskItem[] GeneratedCodeFiles
-        {
-            get { return _generatedCodeFiles; }
-            set { _generatedCodeFiles = value; }
-        }
-
-        /// <summary>
-        /// CompileTypeName
-        ///   The appropriate item name which can be accepted by managed compiler task.
-        ///   It is "Compile" for now.
-        ///   
-        ///   Adding this property is to make the type name configurable, if it is changed, 
-        ///   No code is required to change in this task, but set a new type name in project file.
-        /// </summary>
-        [Required]
-        public string CompileTypeName
-        {
-            get { return _compileTypeName; }
-            set { _compileTypeName = value; }
-        }
-
-
-        /// <summary>
-        /// ReferencePath
-        ///    A list of resolved reference assemblies.
-        ///    The list will replace the original Reference item list in generated project file.
-        /// </summary>
-        public ITaskItem[] ReferencePath
-        {
-            get { return _referencePath; }
-            set { _referencePath = value; }
-        }
-
-        /// <summary>
-        /// ReferencePathTypeName
-        ///   The appropriate item name which is used to keep the Reference list in managed compiler task.
-        ///   It is "ReferencePath" for now.
-        ///   
-        ///   Adding this property is to make the type name configurable, if it is changed, 
-        ///   No code is required to change in this task, but set a new type name in project file.
-        /// </summary>
-        [Required]
-        public string ReferencePathTypeName
-        {
-            get { return _referencePathTypeName; }
-            set { _referencePathTypeName = value; }
-        }
-
+        { get; set; }
 
         /// <summary>
         /// IntermediateOutputPath
@@ -282,10 +165,7 @@ namespace Microsoft.Build.Tasks.Windows
         /// </summary>
         [Required]
         public string IntermediateOutputPath
-        {
-            get { return _intermediateOutputPath; }
-            set { _intermediateOutputPath = value; }
-        }
+        { get; set; }
 
         /// <summary>
         /// AssemblyName
@@ -297,10 +177,7 @@ namespace Microsoft.Build.Tasks.Windows
         /// </summary>
         [Required]
         public string AssemblyName
-        {
-            get { return _assemblyName; }
-            set { _assemblyName = value; }
-        }
+        { get; set; }
 
         /// <summary>
         /// CompileTargetName
@@ -311,10 +188,14 @@ namespace Microsoft.Build.Tasks.Windows
         /// </summary>
         [Required]
         public string CompileTargetName
-        {
-            get { return _compileTargetName; }
-            set { _compileTargetName = value; }
-        }
+        { get; set; }
+
+        public bool Restore
+        { get; set; }
+
+        [Required]
+        public string TemporaryTargetAssemblyProjectName 
+        { get; set; }
 
         /// <summary>
         /// Optional <see cref="Boolean"/> task parameter
@@ -328,185 +209,10 @@ namespace Microsoft.Build.Tasks.Windows
         /// This is a diagnostic parameter, and it defaults to <code>false</code>.
         /// </summary>
         public bool GenerateTemporaryTargetAssemblyDebuggingInformation 
-        { 
-            get { return _generateTemporaryTargetAssemblyDebuggingInformation; }
-            set { _generateTemporaryTargetAssemblyDebuggingInformation = value; } 
-        }
+        { get; set; } = false;
 
         #endregion Public Properties
   
-        //------------------------------------------------------
-        //
-        //  Private Methods
-        //
-        //------------------------------------------------------
-
-        #region Private Methods
-
-        //
-        // Remove specific items from project file. Every item should be under an ItemGroup.
-        //
-        private void RemoveItemsByName(XmlDocument xmlProjectDoc, string sItemName)
-        {
-            if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName))
-            {
-                // When the parameters are not valid, simply return it, instead of throwing exceptions.
-                return;
-            }
-
-            //
-            // The project file format is always like below:
-            //
-            //  <Project  xmlns="...">
-            //     <ProjectGroup>
-            //         ......
-            //     </ProjectGroup>
-            //
-            //     ...
-            //     <ItemGroup>
-            //         <ItemNameHere ..../>
-            //         ....
-            //     </ItemGroup>
-            //
-            //     ....
-            //     <Import ... />
-            //     ...
-            //     <Target Name="xxx" ..../>
-            //     
-            //      ...
-            //
-            //  </Project>
-            //
-            //
-            // The order of children nodes under Project Root element is random
-            //
-
-            XmlNode root = xmlProjectDoc.DocumentElement;
-
-            if (root.HasChildNodes == false)
-            {
-                // If there is no child element in this project file, just return immediatelly.
-                return;
-            }
-
-            for (int i = 0; i < root.ChildNodes.Count; i++)
-            {
-                XmlElement nodeGroup = root.ChildNodes[i] as XmlElement;
-
-                if (nodeGroup != null && String.Compare(nodeGroup.Name, ITEMGROUP_NAME, StringComparison.OrdinalIgnoreCase) == 0)
-                {
-                    //
-                    // This is ItemGroup element.
-                    //
-                    if (nodeGroup.HasChildNodes)
-                    {
-                        ArrayList itemToRemove = new ArrayList();
-
-                        for (int j = 0; j < nodeGroup.ChildNodes.Count; j++)
-                        {
-                            XmlElement nodeItem = nodeGroup.ChildNodes[j] as XmlElement;
-
-                            if (nodeItem != null && String.Compare(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase) == 0)
-                            {
-                                // This is the item that need to remove.
-                                // Add it into the temporary array list.
-                                // Don't delete it here, since it would affect the ChildNodes of parent element.
-                                //
-                                itemToRemove.Add(nodeItem);
-                            }
-                        }
-
-                        //
-                        // Now it is the right time to delete the elements.
-                        //
-                        if (itemToRemove.Count > 0)
-                        {
-                            foreach (object node in itemToRemove)
-                            {
-                                XmlElement item = node as XmlElement;
-
-                                //
-                                // Remove this item from its parent node.
-                                // the parent node should be nodeGroup.
-                                //
-                                if (item != null)
-                                {
-                                    nodeGroup.RemoveChild(item);
-                                }
-                            }
-                        }
-                    }
-
-                    //
-                    // Removed all the items with given name from this item group.
-                    //
-                    // Continue the loop for the next ItemGroup.
-                }
-
-            }   // end of "for i" statement.
-
-        }
-
-        //
-        // Add a list of files into an Item in the project file, the ItemName is specified by sItemName.
-        //
-        private void AddNewItems(XmlDocument xmlProjectDoc, string sItemName, ITaskItem[] pItemList)
-        {
-            if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName) || pItemList == null)
-            {
-                // When the parameters are not valid, simply return it, instead of throwing exceptions.
-                return;
-            }
-
-            XmlNode root = xmlProjectDoc.DocumentElement;
-
-            // Create a new ItemGroup element
-            XmlNode nodeItemGroup = xmlProjectDoc.CreateElement(ITEMGROUP_NAME, root.NamespaceURI);
-
-            // Append this new ItemGroup item into the list of children of the document root.
-            root.AppendChild(nodeItemGroup);
-
-            XmlElement embedItem = null;
-
-            for (int i = 0; i < pItemList.Length; i++)
-            {
-                // Create an element for the given sItemName
-                XmlElement nodeItem = xmlProjectDoc.CreateElement(sItemName, root.NamespaceURI);
-
-                // Create an Attribute "Include"
-                XmlAttribute attrInclude = xmlProjectDoc.CreateAttribute(INCLUDE_ATTR_NAME);
-
-                ITaskItem pItem = pItemList[i];
-
-                // Set the value for Include attribute.
-                attrInclude.Value = pItem.ItemSpec;
-
-                // Add the attribute to current item node.
-                nodeItem.SetAttributeNode(attrInclude);
-
-                if (TRUE == pItem.GetMetadata(EMBEDINTEROPTYPES))
-                {
-                    embedItem = xmlProjectDoc.CreateElement(EMBEDINTEROPTYPES, root.NamespaceURI);
-                    embedItem.InnerText = TRUE;
-                    nodeItem.AppendChild(embedItem);
-                }
-
-                string aliases = pItem.GetMetadata(ALIASES);
-                if (!String.IsNullOrEmpty(aliases))
-                {
-                    embedItem = xmlProjectDoc.CreateElement(ALIASES, root.NamespaceURI);
-                    embedItem.InnerText = aliases;
-                    nodeItem.AppendChild(embedItem);
-                }
-
-                // Add current item node into the children list of ItemGroup
-                nodeItemGroup.AppendChild(nodeItem);
-            }
-        }
-
-        #endregion Private Methods
-
-
         //------------------------------------------------------
         //
         //  Private Fields
@@ -515,42 +221,11 @@ namespace Microsoft.Build.Tasks.Windows
 
         #region Private Fields
 
-        private string _currentProject = String.Empty;
-
-        private ITaskItem[] _generatedCodeFiles;
-        private ITaskItem[] _referencePath;
-
-        private string _referencePathTypeName;
-        private string _compileTypeName;
-
-        private string _msbuildBinPath;
-
-        private string  _intermediateOutputPath;
-        private string  _assemblyName;
-        private string  _compileTargetName;
-        private bool _generateTemporaryTargetAssemblyDebuggingInformation = false;
-
-        private const string intermediateOutputPathPropertyName = "IntermediateOutputPath";
-        private const string assemblyNamePropertyName = "AssemblyName";
         private const string targetAssemblyProjectNamePropertyName = "_TargetAssemblyProjectName";
-
-        private const string ALIASES = "Aliases";
-        private const string REFERENCETYPENAME = "Reference";
-        private const string EMBEDINTEROPTYPES = "EmbedInteropTypes";
-        private const string APPDEFNAME = "ApplicationDefinition";
-        private const string PAGENAME = "Page";
-        private const string MARKUPRESOURCENAME = "MarkupResource";
-        private const string RESOURCENAME = "Resource";
-
-        private const string ITEMGROUP_NAME = "ItemGroup";
-        private const string INCLUDE_ATTR_NAME = "Include";
-
-        private const string TRUE = "True";
-        private const string WPFTMP = "wpftmp";
 
         #endregion Private Fields
 
     }
     
-    #endregion GenerateProjectForLocalTypeReference Task class
+    #endregion GenerateTemporaryTargetAssembly Task class
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/RunProjectBuildTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/RunProjectBuildTarget.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections;
+
+using System.Globalization;
+using System.Diagnostics;
+using System.Reflection;
+using System.Resources;
+using System.Xml;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using MS.Utility;
+using MS.Internal.Tasks;
+
+// Since we disable PreSharp warnings in this file, PreSharp warning is unknown to C# compiler.
+// We first need to disable warnings about unknown message numbers and unknown pragmas.
+#pragma warning disable 1634, 1691
+
+namespace Microsoft.Build.Tasks.Windows
+{
+    #region RunProjectBuildTarget Task class
+
+    /// <summary>
+    /// </summary>
+    public sealed class RunProjectBuildTarget : Task
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Constructor 
+        /// </summary>
+        public RunProjectBuildTarget()
+            : base(SR.SharedResourceManager)
+        {
+        }   
+        
+        #endregion Constructors
+
+        #region Public Methods
+
+        /// <summary>
+        /// ITask Execute method
+        /// </summary>
+        /// <returns></returns>
+        /// <remarks>Catching all exceptions in this method is appropriate - it will allow the build process to resume if possible after logging errors</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        public override bool Execute()
+        {
+            System.Diagnostics.Debugger.Launch();
+
+            bool retValue = true;
+
+            // Verification
+            try
+            {
+                // Run project build target
+                retValue = BuildEngine.BuildProjectFile(ProjectName, new string[] { BuildTarget }, null, null);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e);
+                retValue = false;
+            }
+
+            return retValue;
+        }
+
+        #endregion Public Methods
+        
+        #region Public Properties
+
+        [Required]
+        public string ProjectName 
+        { get; set; }
+
+        [Required]
+        public string BuildTarget 
+        { get; set; }
+
+        #endregion Public Properties
+    }
+    
+    #endregion RunProjectBuildTarget Task class
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/RunProjectBuildTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/RunProjectBuildTarget.cs
@@ -52,8 +52,6 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
-            System.Diagnostics.Debugger.Launch();
-
             bool retValue = true;
 
             // Verification

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -296,6 +296,8 @@
     <Compile Include="Microsoft\Build\Tasks\Windows\UpdateManifestForBrowserApplication.cs" />
     <Compile Include="Microsoft\Build\Tasks\Windows\ResourcesGenerator.cs" />
     <Compile Include="Microsoft\Build\Tasks\Windows\GenerateTemporaryTargetAssembly.cs" />
+    <Compile Include="Microsoft\Build\Tasks\Windows\CreateTemporaryTargetAssemblyProject.cs" />
+    <Compile Include="Microsoft\Build\Tasks\Windows\RunProjectBuildTarget.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
**The temporary project is not getting props and targets files (build extension files) from PackageReferences defined in their parent project.**  This is causing failures in referenced packages that rely on build extensions (e.g., Google Protocol Buffers) to perform pre-compile tasks, such as code generation.  

Several options were considered, including consuming the generated props and targets that include the PackageReferences props/targets from the outer parent project, as the parent project `Restore` has already run and includes identical PackageReferences. However, we opted to run `Restore` directly on the temporary project instead, which allowed a fix without changes to external build files (other than a minor change to the Arcade SDK).  There are now two `Restore` operations: one for the parent project and one for the temporary project.  Note that `Restore` will not re-download packages but will generate the assets file, targets file, and props file.  These files include imports for build extensions in the PackageReferences.

These tasks could easily be condensed in to a single parameterized task, but breaking the steps in to three made a logs easier to read and improved debugging.  There are now three tasks: 

1. `CreateTemporaryTargetAssemblyProject`
2. `RestoreTemporaryTargetAssemblyProject` (which calls `RunProjectBuildTarget` with `Restore`)
3. `GenerateTemporaryTargetAssembly`

The first task creates a temporary project with random component in the name from the outer parent project.  `RestoreTemporaryTargetAssemblyProject` consumes the temporary project and runs `Restore`, generating assets, .props, and .targets files that include imports to any build extensions inside PackageReferences.  These files are then consumed in `GenerateTemporaryTargetAssembly` as part of the
normal build process for the temporary project.

Note that there is an Arcade SDK targets file change that needs to be coordinated with this change.  Workaround.props needs to be modified to remove a temporary workaround for the lack of PackageReference support to prevent duplicate import errors.  https://github.com/dotnet/arcade/pull/3127

(APICompat was re-baselined to account for the public API surface changes in PresentationBuildTasks.)