### PR TITLE
Fix crash when copying from RichTextBox

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(WpfSharedDir)\MS\Internal\SecurityHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SafeSecurityHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SafeSecurityHelperAvalon.cs" />
+    <Compile Include="$(WpfSharedDir)\MS\Internal\Text\InternalEncoding.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\WindowsRuntime\ReflectionHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\Xaml\Context\XamlContextStack.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\Xaml\Context\XamlFrame.cs" />
@@ -1418,6 +1419,7 @@
     <NetCoreReference Include="System.Security.Cryptography.Primitives" />
     <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
+    <NetCoreReference Include="System.Text.Encoding.CodePages" />
     <NetCoreReference Include="System.Xml" />
     <NetCoreReference Include="System.Xml.XPath" />
     <NetCoreReference Include="System.Xml.Document" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridClipboardHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridClipboardHelper.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows;
+using MS.Internal.Text;
 
 namespace System.Windows.Controls
 {
@@ -84,7 +85,7 @@ namespace System.Windows.Controls
             // There are characters in Asian languages which require more than 2 bytes for encoding into UTF-8
             // Marshal.SystemDefaultCharSize is 2 and would not be appropriate in all cases. We have to explicitly calculate the number of bytes.  
             byte[] sourceBytes = Encoding.Unicode.GetBytes(content.ToString());
-            byte[] destinationBytes = Encoding.Convert(Encoding.Unicode, Encoding.UTF8, sourceBytes);
+            byte[] destinationBytes = InternalEncoding.Convert(Encoding.Unicode, Encoding.UTF8, sourceBytes);
 
             int bytecountEndOfFragment = bytecountPrefixContext + destinationBytes.Length;
             int bytecountEndOfHtml = bytecountEndOfFragment + bytecountSuffixContext;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlLexer.cs
@@ -10,7 +10,8 @@ using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using System.IO; // Stream            
+using System.IO; // Stream   
+using MS.Internal.Text;
 
 namespace System.Windows.Documents
 {
@@ -35,7 +36,7 @@ namespace System.Windows.Documents
             _rtfBytes = rtfBytes;
 
             _currentCodePage = CultureInfo.CurrentCulture.TextInfo.ANSICodePage;
-            _currentEncoding = Encoding.GetEncoding(_currentCodePage);
+            _currentEncoding = InternalEncoding.GetEncoding(_currentCodePage);
         }
 
         #endregion Constructors
@@ -300,7 +301,7 @@ namespace System.Windows.Documents
                 if (_currentCodePage != value)
                 {
                     _currentCodePage = value;
-                    _currentEncoding = Encoding.GetEncoding(_currentCodePage);
+                    _currentEncoding = InternalEncoding.GetEncoding(_currentCodePage);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -7820,7 +7820,7 @@ namespace System.Windows.Documents
         /// </summary>
         internal RtfToXamlReader(string rtfString)
         {
-            _rtfBytes = InternalEncoding.Default.GetBytes(rtfString);
+            _rtfBytes = Encoding.Default.GetBytes(rtfString);
             _bForceParagraph = false;
 
             Initialize();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Windows.Media; // Color
 using Microsoft.Win32; // Registry for font substitutes
 using MS.Internal; // Invariant
+using MS.Internal.Text;
 
 
 namespace System.Windows.Documents
@@ -3444,7 +3445,7 @@ namespace System.Windows.Documents
 
                 for (int i = 0; i < CodePageList.Length; i++)
                 {
-                    Encoding e = Encoding.GetEncoding(CodePageList[i]);
+                    Encoding e = InternalEncoding.GetEncoding(CodePageList[i]);
 
                     int cb = e.GetBytes(Name, 0, Name.Length, rgBytes, 0);
                     int cch = e.GetChars(rgBytes, 0, cb, rgChars, 0);
@@ -7819,7 +7820,7 @@ namespace System.Windows.Documents
         /// </summary>
         internal RtfToXamlReader(string rtfString)
         {
-            _rtfBytes = Encoding.Default.GetBytes(rtfString);
+            _rtfBytes = InternalEncoding.Default.GetBytes(rtfString);
             _bForceParagraph = false;
 
             Initialize();
@@ -8844,7 +8845,7 @@ namespace System.Windows.Documents
                     if (nChar < 0xFFFF)
                     {
                         // NB: How to interpret this numeric value as Shift-JIS?
-                        Encoding ec = Encoding.GetEncoding(932);
+                        Encoding ec = InternalEncoding.GetEncoding(932);
                         int nChars = nChar > 256 ? 2 : 1;
                         byte[] ba = new byte[2];
                         if (nChars == 1)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -13,6 +13,7 @@ using System.Windows.Media; // Color
 using System.Globalization;
 using System.IO;
 using MS.Internal.Globalization;
+using MS.Internal.Text;
 
 #if WindowsMetaFile // GetWinMetaFileBits
 using System.Runtime.InteropServices;
@@ -2206,7 +2207,7 @@ namespace System.Windows.Documents
             }
 
             // Return the image hex data string that is the default image data type on Rtf
-            return Encoding.GetEncoding(XamlRtfConverter.RtfCodePage).GetString(imageHexBytes);
+            return InternalEncoding.GetEncoding(XamlRtfConverter.RtfCodePage).GetString(imageHexBytes);
         }
 #endif // WindowsMetaFile
 
@@ -2227,7 +2228,7 @@ namespace System.Windows.Documents
             }
 
             // Return the image hex data string that is the default image data type on Rtf
-            return Encoding.GetEncoding(XamlRtfConverter.RtfCodePage).GetString(imageHexBytes);
+            return InternalEncoding.GetEncoding(XamlRtfConverter.RtfCodePage).GetString(imageHexBytes);
         }
 
         // Get the image type from image source name
@@ -4023,7 +4024,7 @@ namespace System.Windows.Documents
             {
                 if (e == null)
                 {
-                    e = Encoding.GetEncoding(cp);
+                    e = InternalEncoding.GetEncoding(cp);
                 }
                 int cb = e.GetBytes(new char[] { c }, 0, 1, rgAnsi, 0);
                 int cch = e.GetChars(rgAnsi, 0, cb, rgChar, 0);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
@@ -22,5 +22,10 @@ namespace MS.Internal.Text
         {
             return Encoding.GetEncoding(codepage);
         }
+
+        internal static byte[] Convert(System.Text.Encoding srcEncoding, System.Text.Encoding dstEncoding, byte[] bytes)
+        {
+            return Encoding.Convert(srcEncoding, dstEncoding, bytes);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
@@ -6,8 +6,10 @@ using System.Text;
 
 namespace MS.Internal.Text
 {
-    // We use encodings that are not provided by default in core.
-    // This class makes sure that we register extra providers that are required before use.
+    /// <summary>
+    /// We use encodings that are not provided by default in core.
+    /// This class makes sure that we register extra providers that are required before use.
+    /// </summary>
     internal static class InternalEncoding
     {
 
@@ -20,14 +22,5 @@ namespace MS.Internal.Text
         {
             return Encoding.GetEncoding(codepage);
         }
-
-        internal static Encoding Default
-        {
-            get
-            {
-                return Encoding.Default;
-            }
-        }
-
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
@@ -29,5 +29,5 @@ namespace MS.Internal.Text
             }
         }
 
-    };
+    }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Text/InternalEncoding.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace MS.Internal.Text
+{
+    // We use encodings that are not provided by default in core.
+    // This class makes sure that we register extra providers that are required before use.
+    internal static class InternalEncoding
+    {
+
+        static InternalEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
+        internal static Encoding GetEncoding(int codepage)
+        {
+            return Encoding.GetEncoding(codepage);
+        }
+
+        internal static Encoding Default
+        {
+            get
+            {
+                return Encoding.Default;
+            }
+        }
+
+    };
+}


### PR DESCRIPTION
Fixes issue #664, #579 

The cause of the crash was that we were missing an encoding (Windows-1252) that is not available by default in core. In order to obtain it, we need to register an encoding provider. I added an internal encoding class to make sure we have this encoding provider registered.
I wrapped the uses of the static Encoding class that pass in parameters such as code page id or some `Encoding` parameters (as opposed to the places where we are just accessing properties)