### PR TITLE
Define _WindowsDesktopSdkTargetFrameworkVersionFloor before  Microsoft.NET.Sdk.WindowsDesktop.targets is imported

### DIFF
--- a/eng/WpfArcadeSdk/tools/Pbt.props
+++ b/eng/WpfArcadeSdk/tools/Pbt.props
@@ -13,6 +13,14 @@
   </PropertyGroup>
 
   <!-- 
+    Local markup compilation uses $(InternalMarkupCompilation) instead of $(UseWpf). Suppress the 
+    corresponding SDK warning. 
+  -->
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1106</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
+  <!-- 
     We will use Microsoft.NET.Sdk.WindowsDesktop targets directly when local PresentationBuildTasks is not available
     We do not need to import Microsoft.NET.Sdk.WindowsDesktop.props from the Sdk - this only provides us with 
     WPF references and Page, ApplicationDefinition globbing functionality - neither of which is used by our projects. 

--- a/eng/WpfArcadeSdk/tools/Pbt.targets
+++ b/eng/WpfArcadeSdk/tools/Pbt.targets
@@ -90,7 +90,14 @@
   -->
   <Import Project="$(WpfSourceDir)PresentationBuildTasks\Microsoft.WinFX.targets" 
           Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)') "/>
-  
+
+  <!-- 
+    _WindowsDesktopSdkTargetFrameworkVersionFloor is defined in Microsoft.NET.WindowDesktop.props. 
+    This needs to be defined before Microsoft.NET.Sdk.WindowsDesktop.targets is imported. 
+  -->
+  <PropertyGroup Condition="'$(InternalMarkupCompilation)'=='true' And !Exists('$(LocalMicrosoftWinFXTargets)') ">
+    <_WindowsDesktopSdkTargetFrameworkVersionFloor Condition="'$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' == ''">3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
+  </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
           Project="../targets/Microsoft.NET.Sdk.WindowsDesktop.targets"
           Condition="'$(InternalMarkupCompilation)'=='true' And !Exists('$(LocalMicrosoftWinFXTargets)') "/>


### PR DESCRIPTION
Define `_WindowsDesktopSdkTargetFrameworkVersionFloor` before `Microsoft.NET.Sdk.WindowsDesktop.targets` is imported

This is needed since we changed the way props are defined in #1027 