### PR TITLE
Update how timeout is defined in yml files.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,5 +36,4 @@ jobs:
         queue: buildpool.windows.10.amd64.vs2019.pre
       # runAsPublic is used in expressions, which can't read from user-defined variables
       runAsPublic: false
-    timeoutInMinutes: 120 # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
 

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -26,6 +26,7 @@ jobs:
 
     jobs:
     - job: Windows_NT
+      timeoutInMinutes: 120  # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
       pool: ${{ parameters.agentPool }}
       variables:
         # needed for signing


### PR DESCRIPTION
Update how timeout is defined in yml files.

We just noticed that our 120 min timeout is not working correctly, causing backlogs in build and preventing work from progressing. Trying to define this a different way. 