### PR TITLE
yml improvements and helix decoupling to separate pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ trigger:
     # - arcade
   paths:
     exclude:
-    -Documentation/*
+    - Documentation/*
 
 pr:
   autoCancel: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ variables:
   _PublishUsingPipelines: true
   _DotNetArtifactsCategory: WINDOWSDESKTOP
 
+# This is set in the pipeline directly 
+# When set to false, CI tests will not be enabled in builds. 
+#
+# _ContinuousIntegrationTestsEnabled: true
+
 # Setting batch to true, triggers one build at a time.
 # if there is a push while a build in progress, it will wait,
 # until the running build finishes, and produce a build with all the changes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
 # This is set in the pipeline directly 
 # When set to false, CI tests will not be enabled in builds. 
 #
-# _ContinuousIntegrationTestsEnabled: true
+# _ContinuousIntegrationTestsEnabled: false
 
 # Setting batch to true, triggers one build at a time.
 # if there is a push while a build in progress, it will wait,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,16 +14,31 @@ variables:
   _PublishUsingPipelines: true
   _DotNetArtifactsCategory: WINDOWSDESKTOP
 
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+#
 # only trigger ci builds for the master and release branches
 trigger:
-- master
-- release/3.0
-- arcade
+  batch: true 
+  branches:
+    include: 
+    - master
+    - release/3.0
+    # - arcade
+  paths:
+    exclude:
+    -Documentation/*
 
-# To be added in the future when VSTS supports this feature
-# only trigger pull request builds for the master branch
-# pr:
-# - master
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - master
+    - release/3.0
+  paths:
+    exclude:
+    - Documentation/*
 
 # Call the pipeline.yml template, which does the real work
 jobs:

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -157,4 +157,4 @@ jobs:
           HelixAccessToken: $(_HelixToken)              # only defined for internal CI
           Creator: $(_HelixCreator)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true')) # on helix machine (with real signing) when running on the public build pipeline
+        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), ne(variables['_ContinuousIntegrationTestsEnabled'], 'false')) # on helix machine (with real signing) when running on the public build pipeline

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -171,4 +171,4 @@ jobs:
         #
         #   (_HelixPipeline && _PublicBuildPipeline && _ContinuousIntegrationTestsEnabled && _BuildConfig == Release)
         #
-        condition: and(succeeded(), eq(variables[_HelixPipeline], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))
+        condition: and(succeeded(), eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -50,6 +50,8 @@ jobs:
           value: x86
         - name: _PlatformArgs
           value: /p:Platform=$(_Platform)
+        - name: _PublicBuildPipeline  # We will run Helix tests when building in the open, but do not repeat when building and publishing again using the internal build-pipeline
+          value: true
         - name: _TestHelixAgentPool
           value: 'Windows.10.Amd64.ClientRS5.Open' # Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'; See https://github.com/dotnet/wpf/issues/952
         - name: _HelixStagingDir
@@ -60,8 +62,7 @@ jobs:
           value: ''
         - name: _HelixCreator
           value: ${{ parameters.repoName }}
-        - name: _HelixPublicBuildPipeline  # Run Helix tests when building in the open, do not repeat when building and publishign again using the internal build-pipeline
-          value: true
+
 
         # Override some values if we're building internally
         - ${{ if eq(parameters.runAsPublic, 'false') }}:
@@ -93,6 +94,8 @@ jobs:
               /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           - name: _OfficialBuildIdArgs
             value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _PublicBuildPipeline
+            value: false
           - name: _HelixSource
             value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
           - name: _HelixToken
@@ -101,8 +104,7 @@ jobs:
             value: '' #if _HelixToken is set, Creator must be empty
           - name: _TestHelixAgentPool
             value: 'Windows.10.Amd64.ClientRS5' # Preferred: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
-          - name: _HelixPublicBuildPipeline
-            value: false
+
       strategy:
         matrix:
           Build_Debug_x86:
@@ -141,7 +143,11 @@ jobs:
           $(_PlatformArgs)
         displayName: Windows Build / Publish
         # This condition should be kept in sync with the condition for 'Run DRTs' step 
-        condition: or(ne(variables['_ContinuousIntegrationTestsOnlyPipeline'], 'true'), and(eq(variables['_ContinuousIntegrationTestsOnlyPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')))
+        #   When building on a regular pipeline (!_HelixPipeline), build as usual 
+        #   When building on a Helix pipeline, only build Release configs
+        #   (!_HelixPipeline) ||
+        #   (_HelixPipeline && _PublicBuildPipeline && _ContinuousIntegrationTestsEnabled && _BuildConfig == Release)
+        condition: or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')))
 
       # Run DRTs
       - powershell: eng\common\cibuild.cmd
@@ -159,5 +165,10 @@ jobs:
           HelixAccessToken: $(_HelixToken)              # only defined for internal CI
           Creator: $(_HelixCreator)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        # This condition should be kept in sync with the condition for cibuild.cmd step
-        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')) # on helix machine (with real signing) when running on the public build pipeline
+        # This condition should be kept in sync with the condition for cibuild.cmd step with displayName: "Windows Build / Publish"
+        # Only run ...
+        # ...When building on a Helix pipeline, only build Release configs
+        #
+        #   (_HelixPipeline && _PublicBuildPipeline && _ContinuousIntegrationTestsEnabled && _BuildConfig == Release)
+        #
+        condition: and(succeeded(), eq(variables[_HelixPipeline], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -140,6 +140,8 @@ jobs:
           $(_OfficialBuildIdArgs)
           $(_PlatformArgs)
         displayName: Windows Build / Publish
+        # This condition should be kept in sync with the condition for 'Run DRTs' step 
+        condition: or(ne(variables['_ContinuousIntegrationTestsOnlyPipeline'], 'true'), and(eq(variables['_ContinuousIntegrationTestsOnlyPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')))
 
       # Run DRTs
       - powershell: eng\common\cibuild.cmd
@@ -157,4 +159,5 @@ jobs:
           HelixAccessToken: $(_HelixToken)              # only defined for internal CI
           Creator: $(_HelixCreator)
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), ne(variables['_ContinuousIntegrationTestsEnabled'], 'false')) # on helix machine (with real signing) when running on the public build pipeline
+        # This condition should be kept in sync with the condition for cibuild.cmd step
+        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), eq(variables['_HelixPublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')) # on helix machine (with real signing) when running on the public build pipeline


### PR DESCRIPTION
YAML improvements - various. 

Fixes #1121 

Intended to prevent build backlogs due to slow and overlapping builds that were observed to bottleneck PR'son 6/24. 

- Introduces a new AzDo build _public_ pipeline - `dotnet-wpf-citests`
  - This is a test-signed pipeline
  - CI builds are disabled on this pipeline. Only PR builds are allowed [This is an AzDo pipeline setting]
    - ![image](https://user-images.githubusercontent.com/20246435/60376226-490ffb00-99c2-11e9-82c5-60d40cde73fc.png)
  - Will create and test _Release_ builds only on _Helix_
  - Helix test-runs can be disabled by disabling the pipeline on AzDo
    - ![image](https://user-images.githubusercontent.com/20246435/60376206-1d8d1080-99c2-11e9-8731-cfd28ca3344c.png)
  - Main AzDo pipeline `dotnet-wpf CI` will no longer run any tests (in _Helix_ or on build machines locally). 
    - It will only validate that the build succeeds. 
    - We will open a new issue to re-add the capability to run tests locally on build-machines (could be something we want to turn on selectively). 
- CI builds will be [batched](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema)
  -  PR builds will remain un-batched as before
- `Documentation/*` updates will not trigger builds. 


/cc @dotnet/wpf-developers 


