### PR TITLE
Fix for Relative Uri's in Flowdocument being broken

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
@@ -615,8 +615,6 @@ namespace System.Windows.Documents
             Debug.Assert(dpo != null, "GetLinkUri shouldn't be called for non-DependencyObjects.");
 
             if (inputUri != null)
-            // We want to allow navigation to pack:// Uris as we may get these from automation, but we 
-            // wouldn't support this if an actual Uri were given as a pack:// Uri
             {
                 //
                 // First remove the fragment, this is to prevent escape in file URI case, for example,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedPage.cs
@@ -614,8 +614,7 @@ namespace System.Windows.Documents
             DependencyObject dpo = element as DependencyObject;
             Debug.Assert(dpo != null, "GetLinkUri shouldn't be called for non-DependencyObjects.");
 
-            if (inputUri != null &&
-                (inputUri.Scheme == PackUriHelper.UriSchemePack && !String.IsNullOrEmpty(inputUri.Fragment)))
+            if (inputUri != null)
             // We want to allow navigation to pack:// Uris as we may get these from automation, but we 
             // wouldn't support this if an actual Uri were given as a pack:// Uri
             {


### PR DESCRIPTION
Issue #1141 

This test was failing because we were trying to read the scheme of a relative URI (which was throwing an exception). Removed this statement as the check should have been removed as part of the changes that were made here: https://github.com/dotnet/wpf/pull/969/files#diff-d6cd62f214719773a7a26ab93a0235b8

Ran a full DRT test pass on this change for verification.