### PR TITLE
Preventing focus steal if parent window/application is not active

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2498,7 +2498,10 @@ namespace System.Windows.Controls
             // but if we fail to focus we should still select.
             // (This is to help enable focusless menus).
             // Check IsKeyboardFocusWithin to allow rich content within the menuitem.
-            if (!IsKeyboardFocusWithin)
+            if (!IsKeyboardFocusWithin
+                // but only aquire focus the window we are inside is currently active
+                // otherwise we would potentially steal focus from other applications.
+                && Window.GetWindow(this)?.IsActive == true)
             {
                 Focus();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2501,7 +2501,7 @@ namespace System.Windows.Controls
             if (!IsKeyboardFocusWithin
                 // But only acquire focus if the window we are inside of is currently active or there is no window.
                 // Otherwise we would potentially steal focus from other applications.
-                && Window.GetWindow(this)?.IsActive ?? true)
+                && (Window.GetWindow(this)?.IsActive ?? true))
             {
                 Focus();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2499,7 +2499,7 @@ namespace System.Windows.Controls
             // (This is to help enable focusless menus).
             // Check IsKeyboardFocusWithin to allow rich content within the menuitem.
             if (!IsKeyboardFocusWithin
-                // But only aquire focus if the window we are inside of is currently active or there is no window.
+                // But only acquire focus if the window we are inside of is currently active or there is no window.
                 // Otherwise we would potentially steal focus from other applications.
                 && Window.GetWindow(this)?.IsActive ?? true)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2501,7 +2501,7 @@ namespace System.Windows.Controls
             if (!IsKeyboardFocusWithin
                 // but only aquire focus the window we are inside is currently active
                 // otherwise we would potentially steal focus from other applications.
-                && Window.GetWindow(this)?.IsActive == true)
+                && Window.GetWindow(this)?.IsActive ?? true)
             {
                 Focus();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -2499,8 +2499,8 @@ namespace System.Windows.Controls
             // (This is to help enable focusless menus).
             // Check IsKeyboardFocusWithin to allow rich content within the menuitem.
             if (!IsKeyboardFocusWithin
-                // but only aquire focus the window we are inside is currently active
-                // otherwise we would potentially steal focus from other applications.
+                // But only aquire focus if the window we are inside of is currently active or there is no window.
+                // Otherwise we would potentially steal focus from other applications.
                 && Window.GetWindow(this)?.IsActive ?? true)
             {
                 Focus();


### PR DESCRIPTION
This fixes #1168