### PR TITLE
Delay first execution of ICommand.CanExecute(object parameter) until …

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Commands/CommandHelpers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Commands/CommandHelpers.cs
@@ -118,6 +118,14 @@ namespace MS.Internal.Commands
 
         internal static bool CanExecuteCommandSource(ICommandSource commandSource)
         {
+            if (commandSource is FrameworkElement fe)
+            {
+                if (!fe.IsInitialized)
+                {
+                    return false;
+                }
+            }
+
             ICommand command = commandSource.Command;
             if (command != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -1282,6 +1282,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override void OnInitialized(EventArgs e)
         {
+            UpdateCanExecute();
             base.OnInitialized(e);
             UpdateRole();
 #if OLD_AUTOMATION

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ButtonBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ButtonBase.cs
@@ -329,6 +329,12 @@ namespace System.Windows.Controls.Primitives
             }
         }
 
+        protected override void OnInitialized(EventArgs e)
+        {
+            UpdateCanExecute();
+            base.OnInitialized(e);
+        }
+
         /// <summary>
         ///     Fetches the value of the IsEnabled property
         /// </summary>


### PR DESCRIPTION
…after initialization. Issue #316

Revert changes to Hyperlink.cs