### PR TITLE
Add PackageReference to account for XamlAccessLevel move

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -121,6 +121,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\ref\System.Xaml-ref.csproj">

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
@@ -50,5 +50,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Related to issue #1183 

`XamlAccessLevel` was moved to System.Windows.Extensions.dll as part of the following PR: https://github.com/dotnet/corefx/pull/38908
Updating System.Xaml.csproj to have this package reference so that when dependencies are updated, the type can be found in its new location