### PR TITLE
Reuse MSBuild's ContinueOnError property

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -25,7 +25,7 @@
       DefaultItemsOfThisTypeEnabled="$(EnableDefaultPageItems)"
       PropertyNameToDisableDefaultItems="EnableDefaultPageItems"
       MoreInformationLink="$(DefaultItemsMoreInformationLink)"
-      ContinueOnError="$(CheckForDuplicateItemsContinueOnError)">
+      ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedPageItems" />
     </CheckForDuplicateItems>
 


### PR DESCRIPTION
I'm looking to make the same change in https://github.com/dotnet/sdk/pull/3399 and am blocked by the fact that `Microsoft.NET.Sdk.WindowsDesktop.targets` still uses the property defined there.

This property is defaulted to `false` by MSBuild in https://github.com/microsoft/msbuild/blob/0cd0e92a7243088977d31b56626b56d6116de016/src/Tasks/Microsoft.Common.CurrentVersion.targets#L608

In a design time build it will have a value of `ContinueOnError`.

This is the same behaviour as for `CheckForDuplicateItemsContinueOnError`, just without the redundant duplicate property.

//cc: @nguerrera @davkean 