### PR TITLE
Cleanup System.Security.Permissions using directives and more comments

### DIFF
--- a/eng/WpfArcadeSdk/tools/TestProjects.targets
+++ b/eng/WpfArcadeSdk/tools/TestProjects.targets
@@ -30,7 +30,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" CopyLocal="true"  />
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogPackageVersion)" CopyLocal="true" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" CopyLocal="true" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" CopyLocal="true" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" CopyLocal="true" />
 
     <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlPackageVersion)" CopyLocal="true" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -219,8 +219,6 @@ namespace System.Windows.Automation.Peers
     {
         /// <summary>
         /// This is the only public constructor on this class.
-        /// It requires "Full Trust" level of security permissions to be executed, since this
-        /// class is wrappign an HWND direct access to which is a critical asset.
         /// </summary>
         public HostedWindowWrapper(IntPtr hwnd)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/ContentElement.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/UIElement3D.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/ApplicationCommands.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/ApplicationCommands.cs
@@ -20,7 +20,6 @@ using System.Windows.Input;
 using System.Collections;
 using System.ComponentModel;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using MS.Internal; // CommandHelper

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
@@ -284,9 +284,6 @@ namespace System.Windows.Input
         ///     Will be set by Rights Management code.
         /// </summary>
         /// <value></value>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         internal bool IsBlockedByRM
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
@@ -40,9 +40,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Return the input manager associated with the current context.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static InputManager Current
         {
             get
@@ -180,10 +177,6 @@ namespace System.Windows.Input
             _inputTimer.Interval = TimeSpan.FromMilliseconds(125);
         }
 
-        /// <summary></summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public event PreProcessInputEventHandler PreProcessInput
         {
             add
@@ -196,11 +189,6 @@ namespace System.Windows.Input
             }
         }
 
-
-        /// <summary></summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public event NotifyInputEventHandler PreNotifyInput
         {
             add
@@ -212,10 +200,6 @@ namespace System.Windows.Input
                 _preNotifyInput -= value;
             }
 }
-        /// <summary></summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public event NotifyInputEventHandler PostNotifyInput
         {
             add
@@ -228,10 +212,6 @@ namespace System.Windows.Input
 }
         }
 
-        /// <summary></summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public event ProcessInputEventHandler PostProcessInput
         {
             add
@@ -300,9 +280,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Returns a collection of input providers registered with the input manager.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public ICollection InputProviders
         {
             get
@@ -568,7 +545,6 @@ namespace System.Windows.Input
         ///     The specified input is processed by all of the filters and
         ///     monitors, and is finally dispatched to the appropriate
         ///     element as an input event.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         /// <returns>
         ///     Whether or not any event generated as a consequence of this

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputMethod.cs
@@ -642,10 +642,7 @@ namespace System.Windows.Input
 
         /// <summary> 
         /// Access the current microphone on/off status.
-        /// </summary> 
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
+        /// </summary>
         public InputMethodState MicrophoneState
         {
             get
@@ -716,9 +713,6 @@ namespace System.Windows.Input
         /// <summary> 
         /// Access the current speech mode
         /// </summary> 
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public SpeechMode SpeechMode
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyEventArgs.cs
@@ -51,9 +51,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     The input source that provided this input.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public PresentationSource InputSource
         {
             get 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -88,10 +88,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Returns the PresentationSource that is reporting input for this device.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
-
         public override PresentationSource ActiveSource
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/NotifyInputEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/NotifyInputEventArgs.cs
@@ -40,9 +40,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     The input manager processing the input event.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public InputManager InputManager 
         {
             get 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/ProcessInputEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/ProcessInputEventArgs.cs
@@ -50,9 +50,6 @@ namespace System.Windows.Input
         /// <returns>
         ///     The staging area input item that wraps the specified input.
         /// </returns>
-        ///<remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        ///</remarks> 
         public StagingAreaInputItem PushInput(InputEventArgs input, 
                                               StagingAreaInputItem promote) // Note: this should be a bool, and always use the InputItem available on these args.
         {
@@ -73,10 +70,7 @@ namespace System.Windows.Input
         /// </param>
         /// <returns>
         ///     The specified staging area input item.
-        /// </returns>
-        ///<remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        ///</remarks>        
+        /// </returns>      
         public StagingAreaInputItem PushInput(StagingAreaInputItem input)
         {
             if(!_allowAccessToStagingArea)
@@ -93,10 +87,7 @@ namespace System.Windows.Input
         /// <returns>
         ///     The input event that was on the top of the staging area.
         ///     This can be null, if the staging area was empty.
-        /// </returns>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>        
+        /// </returns>    
         public StagingAreaInputItem PopInput()
         {
             
@@ -115,9 +106,6 @@ namespace System.Windows.Input
         ///     The input event that is on the top of the staging area.
         ///     This can be null, if the staging area is empty.
         /// </returns>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public StagingAreaInputItem PeekInput()
         {
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/StagingAreaInputItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/StagingAreaInputItem.cs
@@ -50,9 +50,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Returns the input event.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public InputEventArgs Input
         {
             get {return _input;}
@@ -83,9 +80,6 @@ namespace System.Windows.Input
         /// <param name="value">
         ///     The data to set for this key.  This can be null.
         /// </param>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public void SetData(object key, object value)
         {
             _dictionary[key] = value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextComposition.cs
@@ -142,9 +142,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Finalize the composition.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual void Complete()
         {
 //             VerifyAccess();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TextCompositionManager.cs
@@ -285,9 +285,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Start the composition.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static bool StartComposition(TextComposition composition)
         {
             return UnsafeStartComposition(composition);
@@ -296,9 +293,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Update the composition.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static bool UpdateComposition(TextComposition composition)
         {
             return UnsafeUpdateComposition(composition);
@@ -307,9 +301,6 @@ namespace System.Windows.Input
         /// <summary>
         ///     Complete the composition.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static bool CompleteComposition(TextComposition composition)
         {
             return UnsafeCompleteComposition(composition);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2631,9 +2631,6 @@ namespace System.Windows.Interop
             /// <summary>
             ///     Handles the messages for the notification window
             /// </summary>
-            /// <SecurityNode>
-            ///     Critical: Elevates permissions via unsafe native methods
-            /// </SecurityNode>
             private IntPtr NotificationFilterMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
             {
                 IntPtr retInt = IntPtr.Zero;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Animatable.cs
@@ -22,7 +22,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Threading;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ColorIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/DoubleIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/MatrixIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/MatrixIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ParallelTimeline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/ParallelTimeline.cs
@@ -33,7 +33,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Point3DIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/PointIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/QuaternionIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/RectIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/SizeIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Timeline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Timeline.cs
@@ -33,7 +33,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
@@ -33,7 +33,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineGroup.cs
@@ -33,7 +33,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DIndependentAnimationStorage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/Vector3DIndependentAnimationStorage.cs
@@ -22,7 +22,6 @@ using System.Windows.Media;
 using System.Windows.Media.Composition;
 using System.Windows.Media.Media3D;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media.Animation
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/BrushValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/CacheModeValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/DoubleCollectionValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/GeometryValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/Int32CollectionValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PathFigureCollectionValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/PointCollectionValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/TransformValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Converters/Generated/VectorCollectionValueSerializer.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BevelBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BevelBitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectGroup.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectInput.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectInput.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurBitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BlurEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR = MS.Internal.PresentationCore.SR;
 using SRID = MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowBitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/DropShadowEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/Effect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/Effect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/EmbossBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/EmbossBitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ImplicitInputBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ImplicitInputBrush.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/OuterGlowBitmapEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/OuterGlowBitmapEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/PixelShader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/PixelShader.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ShaderEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/ShaderEffect.cs
@@ -32,7 +32,6 @@ using System.Windows.Media.Composition;
 using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ArcSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ArcSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BezierSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCache.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCacheBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BitmapCacheBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Brush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BrushConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/BrushConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheMode.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CacheModeConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CombinedGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/CombinedGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DashStyle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DashStyle.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollectionConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Drawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Drawing.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContext.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContextDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContextDrawingContextWalker.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingContextWalker.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingGroup.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingImage.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/EllipseGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformGroup.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Geometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryDrawing.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryGroup.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GlyphRunDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GlyphRunDrawing.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStop.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GuidelineSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GuidelineSet.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageSource.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32Collection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32Collection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32CollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32CollectionConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MatrixTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MatrixTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MediaTimeline.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MediaTimeline.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigure.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigure.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollectionConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Pen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Pen.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollectionConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegmentFigureLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyBezierSegmentFigureLogic.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Security.Permissions;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Media.Animation;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegmentFigureLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyLineSegmentFigureLogic.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Security.Permissions;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Media.Animation;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegmentFigureLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PolyQuadraticBezierSegmentFigureLogic.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Security.Permissions;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Media.Animation;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/QuadraticBezierSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/QuadraticBezierSegment.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RadialGradientBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RadialGradientBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RectangleGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderData.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderDataDrawingContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderDataDrawingContext.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Security;
-using System.Security.Permissions;
 
 namespace System.Windows.Media
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RotateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RotateTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ScaleTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ScaleTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SkewTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SkewTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SolidColorBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/SolidColorBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/StreamGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/StreamGeometry.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffect.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TileBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TileBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Transform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformGroup.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TranslateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TranslateTransform.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollection.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollectionConverter.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VideoDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VideoDrawing.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VisualBrush.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VisualBrush.cs
@@ -34,7 +34,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Markup;
 using System.Windows.Media.Converters;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 // These types are aliased to match the unamanaged names used in interop

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapCodecInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapCodecInfo.cs
@@ -58,9 +58,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Container format
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual Guid ContainerFormat
         {
             get
@@ -82,9 +79,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Author
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string Author
         {
             get
@@ -128,9 +122,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Version
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual System.Version Version
         {
             get
@@ -174,9 +165,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Spec Version
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual Version SpecificationVersion
         {
             get
@@ -220,9 +208,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Friendly Name
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string FriendlyName
         {
             get
@@ -266,9 +251,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Device Manufacturer
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string DeviceManufacturer
         {
             get
@@ -312,9 +294,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Device Models
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string DeviceModels
         {
             get
@@ -358,9 +337,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Mime types
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string MimeTypes
         {
             get
@@ -404,9 +380,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// File extensions
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual string FileExtensions
         {
             get
@@ -450,9 +423,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Does Support Animation
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual bool SupportsAnimation
         {
             get
@@ -474,9 +444,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Does Support Lossless
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual bool SupportsLossless
         {
             get
@@ -498,9 +465,6 @@ namespace System.Windows.Media.Imaging
         /// <summary>
         /// Does Support Multiple Frames
         /// </summary>
-        /// <remarks>
-        ///     Callers must have RegistryPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public virtual bool SupportsMultipleFrames
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/LateBoundBitmapDecoder.cs
@@ -154,9 +154,6 @@ namespace System.Windows.Media.Imaging
         /// The info that identifies this codec.
         /// If the LateBoundDecoder is still downloading, the returned CodecInfo is null.
         /// </summary>
-        /// <Remarks>
-        ///     The getter demands RegistryPermission(PermissionState.Unrestricted)
-        /// </Remarks>
         public override BitmapCodecInfo CodecInfo
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Matrix3DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DCollectionValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point3DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Point4DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/QuaternionValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Rect3DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Size3DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DCollectionValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Converters/Generated/Vector3DValueSerializer.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AffineTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AffineTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AmbientLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AmbientLight.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AxisAngleRotation3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/AxisAngleRotation3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Camera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Camera.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DiffuseMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DiffuseMaterial.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DirectionalLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/DirectionalLight.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/EmissiveMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/EmissiveMaterial.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DGroup.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Geometry3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Geometry3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeometryModel3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeometryModel3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Light.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Light.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Material.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Material.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialGroup.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Matrix3DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixCamera.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MatrixTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MeshGeometry3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MeshGeometry3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DGroup.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/OrthographicCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/OrthographicCamera.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PerspectiveCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PerspectiveCamera.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollectionConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point4DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLight.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLightBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/PointLightBase.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ProjectionCamera.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ProjectionCamera.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Quaternion.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionRotation3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/QuaternionRotation3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rect3DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/RotateTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/RotateTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rotation3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Rotation3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ScaleTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/ScaleTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Size3DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpecularMaterial.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpecularMaterial.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpotLight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/SpotLight.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DGroup.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/TranslateTransform3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/TranslateTransform3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3D.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollection.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollectionConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DConverter.cs
@@ -29,7 +29,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;
 using System.Security;
-using System.Security.Permissions;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using System.Windows.Media.Imaging;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Visual3D.cs
@@ -22,7 +22,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Threading;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Composition;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -88,9 +88,6 @@ namespace Microsoft.Win32
         ///  implementation of Reset() if they choose to
         ///  override this function.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public override void Reset()
         {
 
@@ -136,9 +133,6 @@ namespace Microsoft.Win32
         ///  dialog box automatically adds an extension to a
         ///  file name if the user omits the extension.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public bool AddExtension
         {
             get
@@ -164,9 +158,6 @@ namespace Microsoft.Win32
         ///  the dialog box displays a warning if the 
         ///  user specifies a file name that does not exist.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public virtual bool CheckFileExists
         {
             get
@@ -186,9 +177,6 @@ namespace Microsoft.Win32
         ///  used and the user types an invalid path and file name in the File Name entry field, 
         ///  a warning is displayed in a message box.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public bool CheckPathExists
         {
             get
@@ -245,9 +233,6 @@ namespace Microsoft.Win32
         ///  of the file referenced by the shortcut or whether it returns the location 
         ///  of the shortcut (.lnk).
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public bool DereferenceLinks
         {
             get
@@ -327,9 +312,6 @@ namespace Microsoft.Win32
         ///  Gets or sets a string containing the full path of the file selected in 
         ///  the file dialog box.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public string FileName
         {
             get
@@ -360,9 +342,6 @@ namespace Microsoft.Win32
         /// <summary>
         ///     Gets the file names of all selected files in the dialog box.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public string[] FileNames
         {
             get
@@ -466,9 +445,6 @@ namespace Microsoft.Win32
         /// <summary>
         ///  Gets or sets the initial directory displayed by the file dialog box.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public string InitialDirectory
         {
             get
@@ -490,9 +466,6 @@ namespace Microsoft.Win32
         ///  This property is only valid for SaveFileDialog;  it has no effect
         ///  when set on an OpenFileDialog.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public bool RestoreDirectory
         {
             get
@@ -511,9 +484,6 @@ namespace Microsoft.Win32
         ///       If this property is null, a localized default from the operating
         ///       system itself will be used (typically something like "Save As" or "Open")
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public string Title
         {
             get
@@ -536,9 +506,6 @@ namespace Microsoft.Win32
         ///  Gets or sets a value indicating whether the dialog box accepts only valid
         ///  Win32 file names.
         /// </summary>
-        /// <Remarks>
-        ///     Callers must have FileIOPermission(PermissionState.Unrestricted) to call this API.
-        /// </Remarks>
         public bool ValidateNames
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FrameworkTextComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FrameworkTextComposition.cs
@@ -60,9 +60,6 @@ namespace System.Windows.Documents
         ///     We finalize Cicero's composition and TextStore will automatically
         ///     generate the proper TextComposition events.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public override void Complete()
         {
             _pendingComplete = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NLGSpellerInterop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/NLGSpellerInterop.cs
@@ -314,9 +314,6 @@ namespace System.Windows.Documents
         /// which we created and filled with data from pack Uri locations specified by user.
         /// These 'trusted' files are placed under <paramref name="trustedFolder"/>.
         ///
-        /// Explicitely specified file locations we will passed to ILexicon APIs without asserting
-        /// Security permissions, so it would pass in FullTrust and fail in PartialTrust.
-        ///
         /// Files specified in <paramref name="trustedFolder"/> are wrapped in FileIOPermission.Assert(),
         /// providing read access to trusted files under <paramref name="trustedFolder"/>, i.e. additionally
         /// we're making sure that specified trusted locations are under the trusted Folder.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerInteropBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerInteropBase.cs
@@ -175,9 +175,6 @@ namespace System.Windows.Documents
         /// which we created and filled with data from pack Uri locations specified by user.
         /// These 'trusted' files are placed under <paramref name="trustedFolder"/>.
         ///
-        /// Explicitly specified file locations will be passed to COM APIs without asserting
-        /// Security permissions, so it would pass in FullTrust and fail in PartialTrust.
-        ///
         /// Files specified in <paramref name="trustedFolder"/> are wrapped in FileIOPermission.Assert(),
         /// providing read access to trusted files under <paramref name="trustedFolder"/>, i.e. additionally
         /// we're making sure that specified trusted locations are under the trusted Folder.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Controls;
 using System.Windows.Diagnostics;
 using System.Windows.Media;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Security;
-using System.Security.Permissions;
 using System.Windows.Controls;
 using System.Windows.Diagnostics;
 using System.Windows.Media;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Ink/KnownIds.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Ink/KnownIds.cs
@@ -296,7 +296,6 @@ namespace System.Windows.Ink
         internal static string ConvertToString (Guid id)
         {
 
-            // Assert Reflection permissions shouldn't be required since we are only accessing public members
             if (null == PublicMemberInfo)
             {
                 PublicMemberInfo = typeof(KnownIds).FindMembers(System.Reflection.MemberTypes.Field,

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
@@ -71,11 +71,6 @@ namespace System.Windows.Automation
         /// <param name="el2">element to compare</param>
         /// <returns>true if el1 and el2 refer to the same underlying UI</returns>
         /// <remarks>Both el1 and el1 must be non-null</remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static bool Compare(AutomationElement el1, AutomationElement el2)
         {
             return Misc.Compare(el1, el2);
@@ -89,11 +84,6 @@ namespace System.Windows.Automation
         /// <returns>true if runtimeId1 and runtimeId2 refer to the same underlying UI</returns>
         /// <remarks>Both runtimeId1 and runtimeId2 must be non-null. Can be
         /// used to compare RuntimeIds from elements.</remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static bool Compare(int[] runtimeId1, int[] runtimeId2)
         {
             return Misc.Compare(runtimeId1, runtimeId2);
@@ -138,11 +128,6 @@ namespace System.Windows.Automation
         /// <param name="element">Element on which to listen for control pattern or custom events.</param>
         /// <param name="scope">Specifies whether to listen to property changes events on the specified element, and/or its ancestors and children.</param>
         /// <param name="eventHandler">Delegate to call when the specified event occurs.</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void AddAutomationEventHandler(
             AutomationEvent eventId,
             AutomationElement element,
@@ -215,11 +200,6 @@ namespace System.Windows.Automation
         /// <param name="eventId">a UIAccess or custom event identifier.</param>
         /// <param name="element">Element to remove listener for</param>
         /// <param name="eventHandler">The handler object that was passed to AddEventListener</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void RemoveAutomationEventHandler(
             AutomationEvent eventId,
             AutomationElement element,
@@ -243,11 +223,6 @@ namespace System.Windows.Automation
         /// <param name="scope">Specifies whether to listen to property changes events on the specified element, and/or its ancestors and children.</param>
         /// <param name="eventHandler">Callback object to call when a specified property change occurs.</param>
         /// <param name="properties">Params array of properties to listen for changes in.</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void AddAutomationPropertyChangedEventHandler(
             AutomationElement element,            // reference element for listening to the event
             TreeScope scope,                   // scope to listen to
@@ -281,11 +256,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="element">Element to remove listener for</param>
         /// <param name="eventHandler">The handler object that was passed to AutomationPropertyChangedEventHandler</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void RemoveAutomationPropertyChangedEventHandler(
             AutomationElement element,            // reference element being listened to
             AutomationPropertyChangedEventHandler eventHandler     // callback object (used as cookie here)
@@ -304,11 +274,6 @@ namespace System.Windows.Automation
         /// <param name="element">Element on which to listen for structure change events.</param>
         /// <param name="scope">Specifies whether to listen to property changes events on the specified element, and/or its ancestors and children.</param>
         /// <param name="eventHandler">Delegate to call when a structure change event occurs.</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void AddStructureChangedEventHandler(AutomationElement element, TreeScope scope, StructureChangedEventHandler eventHandler)
         {
             Misc.ValidateArgumentNonNull(element, "element");
@@ -325,11 +290,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="element">Element to remove listener for</param>
         /// <param name="eventHandler">The handler object that was passed to AddStructureChangedListener</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void RemoveStructureChangedEventHandler(AutomationElement element, StructureChangedEventHandler eventHandler)
         {
             Misc.ValidateArgumentNonNull(element, "element");
@@ -343,11 +303,6 @@ namespace System.Windows.Automation
         /// Called by a client to add a listener for focus changed events.
         /// </summary>
         /// <param name="eventHandler">Delegate to call when a focus change event occurs.</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void AddAutomationFocusChangedEventHandler(
             AutomationFocusChangedEventHandler eventHandler
             )
@@ -366,11 +321,6 @@ namespace System.Windows.Automation
         /// Called by a client to remove a listener for focus changed events.
         /// </summary>
         /// <param name="eventHandler">The handler object that was passed to AddAutomationFocusChangedListener</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void RemoveAutomationFocusChangedEventHandler(
             AutomationFocusChangedEventHandler eventHandler
             )
@@ -384,11 +334,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Called by a client to remove all listeners that the client has added.
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static void RemoveAllEventHandlers()
         {
             // Remove the client-side listener for for this event

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -370,11 +370,6 @@ namespace System.Windows.Automation
         /// These identifies are only guaranteed to be unique on a given desktop.
         /// Identifiers may be recycled over time.
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public int[] GetRuntimeId()
         {
             if (_runtimeId != null)
@@ -408,11 +403,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="pt">point in screen coordinates</param>
         /// <returns>element at specified point</returns>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static AutomationElement FromPoint(Point pt)
         {
             return DrillForPointOrFocus(true, pt, CacheRequest.CurrentUiaCacheRequest);
@@ -423,11 +413,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="hwnd">Handle of window to get element for</param>
         /// <returns>element representing root node of specified window</returns>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static AutomationElement FromHandle(IntPtr hwnd)
         {
             Misc.ValidateArgument(hwnd != IntPtr.Zero, SRID.HwndMustBeNonNULL);
@@ -481,11 +466,6 @@ namespace System.Windows.Automation
         /// a cross-process performance hit. To access values in this AutomationElement's
         /// cache, use GetCachedPropertyValue instead.
         /// </remarks>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCurrentPropertyValue(AutomationProperty property)
         {
             return GetCurrentPropertyValue(property, false);
@@ -504,11 +484,6 @@ namespace System.Windows.Automation
         /// a cross-process performance hit. To access values in this AutomationElement's
         /// cache, use GetCachedPropertyValue instead.
         /// </remarks>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCurrentPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
             Misc.ValidateArgumentNonNull(property, "property");
@@ -564,11 +539,6 @@ namespace System.Windows.Automation
         /// a cross-process performance hit. To access patterns in this AutomationElement's
         /// cache, use GetCachedPattern instead.
         /// </remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCurrentPattern(AutomationPattern pattern)
         {
             object retObject;
@@ -596,11 +566,6 @@ namespace System.Windows.Automation
         /// a cross-process performance hit. To access patterns in this AutomationElement's
         /// cache, use GetCachedPattern instead.
         /// </remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public bool TryGetCurrentPattern(AutomationPattern pattern, out object patternObject)
         {
             patternObject = null;
@@ -645,11 +610,6 @@ namespace System.Windows.Automation
         /// support the AutomationElement.NameProperty, calling GetCachedPropertyValue
         /// for that property will return an empty string.
         /// </remarks>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCachedPropertyValue(AutomationProperty property)
         {
             return GetCachedPropertyValue(property, false);
@@ -674,11 +634,6 @@ namespace System.Windows.Automation
         /// When ignoreDefaultValue is true, the value AutomationElement.NotSupported will
         /// be returned instead.
         /// </remarks>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCachedPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
             Misc.ValidateArgumentNonNull(property, "property");
@@ -707,11 +662,6 @@ namespace System.Windows.Automation
         /// 
         /// This API gets the pattern from the cache. 
         /// </remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public object GetCachedPattern(AutomationPattern pattern)
         {
             object patternObject;
@@ -731,11 +681,6 @@ namespace System.Windows.Automation
         /// <remarks>
         /// This API gets the pattern from the cache. 
         /// </remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public bool TryGetCachedPattern(AutomationPattern pattern, out object patternObject)
         {
             patternObject = null;
@@ -843,11 +788,6 @@ namespace System.Windows.Automation
         /// currently support or which have null or empty values. Use GetPropertyValue to determine
         /// whether a property is currently supported and to determine what its current value is.
         /// </remarks>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public AutomationProperty [ ] GetSupportedProperties()
         {
             CheckElement();
@@ -878,11 +818,6 @@ namespace System.Windows.Automation
         /// Get the interfaces that this object supports
         /// </summary>
         /// <returns>An array of AutomationPatterns that represent the supported interfaces</returns>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public AutomationPattern [ ] GetSupportedPatterns()
         {
             CheckElement();
@@ -903,11 +838,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Request to set focus to this element
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetFocus()
         {
             CheckElement();
@@ -929,11 +859,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="pt">A point that can be used ba a client to click on this LogicalElement</param>
         /// <returns>true if there is point that is clickable</returns>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public bool TryGetClickablePoint( out Point pt )
         {
             // initialize point here so if we return false its initialized
@@ -983,11 +908,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <returns>A point that can be used by a client to click on this LogicalElement</returns>
         /// <exception cref="NoClickablePointException">If there is not clickable point for this element</exception>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public Point GetClickablePoint()
         {
             Point pt;
@@ -1011,11 +931,6 @@ namespace System.Windows.Automation
         /// Get root element for current desktop
         /// </summary>
         /// <returns>root element for current desktop</returns>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static AutomationElement RootElement
         {
             get
@@ -1035,11 +950,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Return the currently focused element
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public static AutomationElement FocusedElement
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/DockPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/DockPattern.cs
@@ -65,11 +65,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Moves the window to be docked at the requested location.
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetDockPosition( DockPosition dockPosition )
         {
             UiaCoreApi.DockPattern_SetDockPosition(_hPattern, dockPosition);
@@ -200,11 +195,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>Returns whether the DockPosition is Top, Left, Bottom, Right, Fill, or None.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public DockPosition DockPosition
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ExpandCollapsePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ExpandCollapsePattern.cs
@@ -63,11 +63,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Blocking method that returns after the element has been expanded
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Expand()
         {
             UiaCoreApi.ExpandCollapsePattern_Expand(_hPattern);
@@ -76,11 +71,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Blocking method that returns after the element has been collapsed
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Collapse()
         {
             UiaCoreApi.ExpandCollapsePattern_Collapse(_hPattern);
@@ -220,11 +210,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             ///<summary>indicates an element's current Collapsed or Expanded state</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public ExpandCollapseState ExpandCollapseState
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/GridItemPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/GridItemPattern.cs
@@ -213,11 +213,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// the row number of the element.  This is zero based.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int Row
             {
                 get
@@ -229,11 +224,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// the column number of the element.  This is zero based.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int Column
             {
                 get
@@ -246,11 +236,6 @@ namespace System.Windows.Automation
             /// count of how many rows the element spans
             /// -- non merged cells should always return 1
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int RowSpan
             {
                 get
@@ -263,11 +248,6 @@ namespace System.Windows.Automation
             /// count of how many columns the element spans
             /// -- non merged cells should always return 1
             ///</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int ColumnSpan
             {
                 get
@@ -279,11 +259,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// The logical element that supports the GripPattern for this Item
             ///</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement ContainingGrid
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/GridPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/GridPattern.cs
@@ -68,11 +68,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="row">Row of item to get</param>
         /// <param name="column">Column of item to get</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public AutomationElement GetItem(int row, int column) 
         {
             SafeNodeHandle hNode = UiaCoreApi.GridPattern_GetItem(_hPattern, row, column);
@@ -214,11 +209,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// number of rows in the grid
             /// </summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int RowCount
             {
                 get
@@ -230,11 +220,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// number of columns in the grid
             /// </summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int ColumnCount
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/InvokePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/InvokePattern.cs
@@ -74,11 +74,6 @@ namespace System.Windows.Automation
         /// There is no way to determine what happened, when it happend, or whether
         /// anything happened at all.
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Invoke()
         {
             UiaCoreApi.InvokePattern_Invoke(_hPattern);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/MultipleViewPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/MultipleViewPattern.cs
@@ -71,11 +71,6 @@ namespace System.Windows.Automation
         /// be the same across instances.
         /// </param>
         /// <returns>Return a localized, human readable string in the application's current UI language.</returns>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public string GetViewName( int viewId )
         {
             return UiaCoreApi.MultipleViewPattern_GetViewName(_hPattern, viewId);
@@ -84,11 +79,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Change the current view using an ID returned from GetSupportedViews()        
         /// </summary>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetCurrentView( int viewId )
         {
             UiaCoreApi.MultipleViewPattern_SetCurrentView(_hPattern, viewId);
@@ -226,11 +216,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>The view ID corresponding to the control's current state. This ID is control-specific</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int CurrentView
             {
                 get
@@ -240,11 +225,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Returns an array of ints representing the full set of views available in this control.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int [] GetSupportedViews()
             {
                 return (int [])_el.GetPatternPropertyValue(SupportedViewsProperty, _useCache);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/RangeValuePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/RangeValuePattern.cs
@@ -85,11 +85,6 @@ namespace System.Windows.Automation
         /// Request to set the value that this UI element is representing
         /// </summary>
         /// <param name="value">Value to set the UI to, as a double</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetValue(double value)
         {
             // Test the Enabled state prior to the more general Read-Only state.            
@@ -241,11 +236,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             ///<summary>Value of a value control</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double Value
             {
                 get
@@ -276,11 +266,6 @@ namespace System.Windows.Automation
 
             ///<summary>Indicates that the value can only be read, not modified.
             ///returns True if the control is read-only</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsReadOnly
             {
                 get
@@ -290,11 +275,6 @@ namespace System.Windows.Automation
             }
 
             ///<summary>maximum value </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double Maximum
             {
                 get
@@ -324,11 +304,6 @@ namespace System.Windows.Automation
             }
 
             ///<summary>minimum value</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double Minimum
             {
                 get
@@ -362,11 +337,6 @@ namespace System.Windows.Automation
             /// Gets a value to be added to or subtracted from the Value property 
             /// when the element is moved a large distance.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double LargeChange
             {
                 get
@@ -399,11 +369,6 @@ namespace System.Windows.Automation
             /// Gets a value to be added to or subtracted from the Value property 
             /// when the element is moved a small distance.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double SmallChange
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ScrollPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ScrollPattern.cs
@@ -87,11 +87,6 @@ namespace System.Windows.Automation
         /// vertically provides simple panning support.</summary>
         /// <param name="horizontalPercent">Amount to scroll by horizontally</param>
         /// <param name="verticalPercent">Amount to scroll by vertically </param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetScrollPercent( double horizontalPercent, double verticalPercent )
         {
             UiaCoreApi.ScrollPattern_SetScrollPercent(_hPattern, horizontalPercent, verticalPercent);
@@ -105,11 +100,6 @@ namespace System.Windows.Automation
         ///
         /// <param name="horizontalAmount">amount to scroll by horizontally</param>
         /// <param name="verticalAmount">amount to scroll by vertically </param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Scroll( ScrollAmount horizontalAmount, ScrollAmount verticalAmount )
         {
             UiaCoreApi.ScrollPattern_Scroll(_hPattern, horizontalAmount, verticalAmount);
@@ -119,11 +109,6 @@ namespace System.Windows.Automation
         /// Request to scroll horizontally by the specified amount
         /// </summary>
         /// <param name="amount">Amount to scroll by</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void ScrollHorizontal( ScrollAmount amount )
         {
             UiaCoreApi.ScrollPattern_Scroll(_hPattern, amount, ScrollAmount.NoAmount);
@@ -133,11 +118,6 @@ namespace System.Windows.Automation
         /// Request to scroll vertically by the specified amount
         /// </summary>
         /// <param name="amount">Amount to scroll by</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void ScrollVertical( ScrollAmount amount )
         {
             UiaCoreApi.ScrollPattern_Scroll(_hPattern, ScrollAmount.NoAmount, amount);
@@ -278,11 +258,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// Get the current horizontal scroll position
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double HorizontalScrollPercent
             {
                 get
@@ -294,11 +269,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// Get the current vertical scroll position
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double VerticalScrollPercent
             {
                 get
@@ -310,11 +280,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// Equal to the horizontal percentage of the entire control that is currently viewable.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double HorizontalViewSize
             {
                 get
@@ -326,11 +291,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// Equal to the horizontal percentage of the entire control that is currently viewable.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public double VerticalViewSize
             {
                 get
@@ -342,11 +302,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// True if control can scroll horizontally
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool HorizontallyScrollable
             {
                 get
@@ -358,11 +313,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// True if control can scroll vertically
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool VerticallyScrollable
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/SelectionItemPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/SelectionItemPattern.cs
@@ -86,11 +86,6 @@ namespace System.Windows.Automation
         /// Sets the current element as the selection
         /// This clears the selection from other elements in the container 
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Select()
         {
             UiaCoreApi.SelectionItemPattern_Select(_hPattern);
@@ -98,11 +93,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Adds current element to selection
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void AddToSelection()
         {
             UiaCoreApi.SelectionItemPattern_AddToSelection(_hPattern);
@@ -111,11 +101,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Removes current element from selection
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void RemoveFromSelection()
         {
             UiaCoreApi.SelectionItemPattern_RemoveFromSelection(_hPattern);
@@ -258,11 +243,6 @@ namespace System.Windows.Automation
             /// Check whether an element is selected
             /// </summary>
             /// <returns>returns true if the element is selected</returns>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsSelected
             {
                 get
@@ -275,11 +255,6 @@ namespace System.Windows.Automation
             /// The logical element that supports the SelectionPattern for this Item
             /// </summary>
             /// <returns>returns an AutomationElement</returns>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement SelectionContainer
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/SelectionPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/SelectionPattern.cs
@@ -215,11 +215,6 @@ namespace System.Windows.Automation
             /// Get the currently selected elements
             /// </summary>
             /// <returns>An AutomationElement array containing the currently selected elements</returns>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement[] GetSelection()
             {
                 return (AutomationElement[])_el.GetPatternPropertyValue(SelectionProperty, _useCache);
@@ -240,11 +235,6 @@ namespace System.Windows.Automation
             /// </summary>
             /// <returns>Boolean indicating whether the control allows more than one element to be selected</returns>
             /// <remarks>If this is false, then the control is a single-select ccntrol</remarks>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanSelectMultiple
             {
                 get
@@ -258,11 +248,6 @@ namespace System.Windows.Automation
             /// </summary>
             /// <returns>Boolean indicating whether the control requires at least one element to be selected</returns>
             /// <remarks>If this is false, then the control allows all elements to be unselected</remarks>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsSelectionRequired
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TableItemPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TableItemPattern.cs
@@ -201,11 +201,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// the row number of the element.  This is zero based.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int Row
             {
                 get
@@ -217,11 +212,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// the column number of the element.  This is zero based.
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int Column
             {
                 get
@@ -234,11 +224,6 @@ namespace System.Windows.Automation
             /// count of how many rows the element spans
             /// -- non merged cells should always return 1
             /// </summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int RowSpan
             {
                 get
@@ -251,11 +236,6 @@ namespace System.Windows.Automation
             /// count of how many columns the element spans
             /// -- non merged cells should always return 1
             ///</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int ColumnSpan
             {
                 get
@@ -267,11 +247,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// The logical element that supports the GripPattern for this Item
             ///</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement ContainingGrid
             {
                 get
@@ -281,22 +256,12 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Collection of all row headers for this cell</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement[] GetRowHeaderItems()
             {
                 return (AutomationElement[])_el.GetPatternPropertyValue(RowHeaderItemsProperty, _useCache);
             }
 
             /// <summary>Collection of all column headers for this cell</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement[] GetColumnHeaderItems()
             {
                 return (AutomationElement[])_el.GetPatternPropertyValue(ColumnHeaderItemsProperty, _useCache);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TablePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TablePattern.cs
@@ -189,22 +189,12 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>Collection of all row headers for this table</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement[] GetRowHeaders()
             {
                 return (AutomationElement[])_el.GetPatternPropertyValue(RowHeadersProperty, _useCache);
             }
 
             /// <summary>Collection of all column headers for this table</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public AutomationElement[] GetColumnHeaders()
             {
                 return (AutomationElement[])_el.GetPatternPropertyValue(ColumnHeadersProperty, _useCache);
@@ -213,11 +203,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// number of rows in the grid
             /// </summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int RowCount
             {
                 get
@@ -229,11 +214,6 @@ namespace System.Windows.Automation
             /// <summary>
             /// number of columns in the grid
             /// </summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public int ColumnCount
             {
                 get
@@ -243,11 +223,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Indicates if the data is best presented by row or column</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public RowOrColumnMajor RowOrColumnMajor
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TogglePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TogglePattern.cs
@@ -65,11 +65,6 @@ namespace System.Windows.Automation
         /// <summary>
         /// Request to change the state that this UI element is currently representing
         /// </summary>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Toggle()
         {
             UiaCoreApi.TogglePattern_Toggle(_hPattern);
@@ -209,11 +204,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>Value of a toggleable control, as a ToggleState enum</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public ToggleState ToggleState
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TransformPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TransformPattern.cs
@@ -75,11 +75,6 @@ namespace System.Windows.Automation
         /// 
         /// <param name="x">absolute on-screen position of the top left corner</param>
         /// <param name="y">absolute on-screen position of the top left corner</param>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Move( double x, double y )
         {
             UiaCoreApi.TransformPattern_Move(_hPattern, x, y);
@@ -93,10 +88,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="width">The requested width of the window.</param>
         /// <param name="height">The requested height of the window.</param>
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Resize( double width, double height )
         {
             UiaCoreApi.TransformPattern_Resize(_hPattern, width, height);
@@ -107,10 +98,6 @@ namespace System.Windows.Automation
         /// </summary>
         /// <param name="degrees">The requested degrees to rotate the element.  A positive number rotates clockwise
         /// a negative number rotates counter clockwise</param>
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Rotate( double degrees )
         {
             UiaCoreApi.TransformPattern_Rotate(_hPattern, degrees);
@@ -251,11 +238,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>Returns true if the element can be moved otherwise returns false.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanMove
             {
                 get
@@ -265,11 +247,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Returns true if the element can be resized otherwise returns false.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanResize
             {
                 get
@@ -279,11 +256,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Returns true if the element can be rotated otherwise returns false.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanRotate
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
@@ -70,11 +70,6 @@ namespace System.Windows.Automation
         /// Request to set the value that this UI element is representing
         /// </summary>
         /// <param name="value">Value to set the UI to, the provider is responsible for converting from a string into the appropriate data type</param>
-        /// 
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetValue( string value )
         {
             Misc.ValidateArgumentNonNull(value, "value");
@@ -231,11 +226,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             ///<summary>Value of a value control, as a a string.</summary>
-            /// 
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public string Value
             {
                 get
@@ -251,11 +241,6 @@ namespace System.Windows.Automation
 
             ///<summary>Indicates that the value can only be read, not modified.
             ///returns True if the control is read-only</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsReadOnly
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/WindowPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/WindowPattern.cs
@@ -90,11 +90,6 @@ namespace System.Windows.Automation
         /// Changes the State of the window based on the passed enum.
         /// </summary>
         /// <param name="state">The requested state of the window.</param>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void SetWindowVisualState( WindowVisualState state )
         {
             UiaCoreApi.WindowPattern_SetWindowVisualState(_hPattern, state);
@@ -106,11 +101,6 @@ namespace System.Windows.Automation
         /// split), it may or may not also close all other panes related to the 
         /// document/content/etc. This behavior is application dependent.
         /// </summary>
-        ///
-        /// <outside_see conditional="false">
-        /// This API does not work inside the secure execution environment.
-        /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-        /// </outside_see>
         public void Close()
         {
             UiaCoreApi.WindowPattern_Close(_hPattern);
@@ -276,11 +266,6 @@ namespace System.Windows.Automation
             #region Public Properties
 
             /// <summary>Is this window Maximizable</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanMaximize
             {
                 get
@@ -290,11 +275,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Is this window Minimizable</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool CanMinimize
             {
                 get
@@ -304,11 +284,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Is this is a modal window.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsModal
             {
                 get
@@ -318,11 +293,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Is the Window Maximized, Minimized, or Normal (aka restored)</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public WindowVisualState WindowVisualState
             {
                 get
@@ -332,11 +302,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Is the Window Closing, ReadyForUserInteraction, BlockedByModalWindow or NotResponding.</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public WindowInteractionState WindowInteractionState
             {
                 get
@@ -346,11 +311,6 @@ namespace System.Windows.Automation
             }
 
             /// <summary>Is this window is always on top</summary>
-            ///
-            /// <outside_see conditional="false">
-            /// This API does not work inside the secure execution environment.
-            /// <exception cref="System.Security.Permissions.SecurityPermission"/>
-            /// </outside_see>
             public bool IsTopmost
             {
                 get

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcher.cs
@@ -61,9 +61,6 @@ namespace System.Windows.Interop
         /// Returns true if one or more components has gone modal.
         /// Although once one component is modal a 2nd shouldn't.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static bool IsThreadModal
         {
             get
@@ -76,9 +73,6 @@ namespace System.Windows.Interop
         /// <summary>
         /// Returns "current" message.   More exactly the last MSG Raised.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static MSG CurrentKeyboardMessage
         {
             get
@@ -110,9 +104,6 @@ namespace System.Windows.Interop
         /// <summary>
         /// A component calls this to go modal.  Current thread wide only.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static void PushModal()
         {
             CriticalPushModal();
@@ -130,9 +121,6 @@ namespace System.Windows.Interop
         /// <summary>
         /// A component calls this to end being modal.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static void PopModal()
         {
             CriticalPopModal();
@@ -150,9 +138,6 @@ namespace System.Windows.Interop
         /// <summary>
         /// The message loop pumper calls this when it is time to do idle processing.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
         public static void RaiseIdle()
         {
@@ -163,9 +148,6 @@ namespace System.Windows.Interop
         /// <summary>
         /// The message loop pumper calls this for every keyboard message.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate")]
         [SuppressMessage("Microsoft.Design", "CA1045:DoNotPassTypesByReference")]
         public static bool RaiseThreadMessage(ref MSG msg)
@@ -180,9 +162,6 @@ namespace System.Windows.Interop
         /// Components register delegates with this event to handle
         /// thread idle processing.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static event EventHandler ThreadIdle
         {
             add {
@@ -197,9 +176,6 @@ namespace System.Windows.Interop
         /// Components register delegates with this event to handle
         /// Keyboard Messages (first chance processing).
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly")]
         public static event ThreadMessageEventHandler ThreadFilterMessage
         {
@@ -215,9 +191,6 @@ namespace System.Windows.Interop
         /// Components register delegates with this event to handle
         /// Keyboard Messages (second chance processing).
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         [SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly")]
         public static event ThreadMessageEventHandler ThreadPreprocessMessage
         {
@@ -252,9 +225,6 @@ namespace System.Windows.Interop
         /// Components register delegates with this event to handle
         /// a component on this thread has "gone modal", when previously none were.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static event EventHandler EnterThreadModal
         {
             add {
@@ -269,9 +239,6 @@ namespace System.Windows.Interop
         /// Components register delegates with this event to handle
         /// all components on this thread are done being modal.
         ///</summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static event EventHandler LeaveThreadModal
         {
             add

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -243,9 +243,6 @@ namespace System.Windows.Threading
         /// <summary>
         ///     Begins the process of shutting down the dispatcher.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public void InvokeShutdown()
         {
 
@@ -295,7 +292,6 @@ namespace System.Windows.Threading
         /// </summary>
         /// <remarks>
         ///     This frame will continue until the dispatcher is shut down.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public static void Run()
         {
@@ -308,9 +304,6 @@ namespace System.Windows.Threading
         /// <param name="frame">
         ///     The frame for the dispatcher to process.
         /// </param>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static void PushFrame(DispatcherFrame frame)
         {
             if(frame == null)
@@ -340,9 +333,6 @@ namespace System.Windows.Threading
         /// <summary>
         ///     Requests that all nested frames exit.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
-        /// </remarks>
         public static void ExitAllFrames()
         {
 
@@ -1598,7 +1588,6 @@ namespace System.Windows.Threading
         ///     <p/>
         ///     This method is public so that any thread can probe to
         ///     see if it has access to the DispatcherObject.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         /// <returns>
         ///     True if the calling thread has access to this object.
@@ -1637,7 +1626,6 @@ namespace System.Windows.Threading
         ///     creating secondary exceptions and to catch any that occur.
         ///     It is recommended to avoid allocating memory or doing any
         ///     heavylifting if possible.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherUnhandledExceptionFilterEventHandler UnhandledExceptionFilter
         {
@@ -1849,11 +1837,6 @@ namespace System.Windows.Threading
                 // Because we may have to defer the actual shutting-down until
                 // later, we need to remember the execution context we started
                 // the shutdown from.
-                //
-                // Note that we demanded permissions when BeginInvokeShutdown
-                // or InvokeShutdown were called.  So if there were not enough
-                // permissions, we would have thrown then.
-                //
                 CulturePreservingExecutionContext shutdownExecutionContext = CulturePreservingExecutionContext.Capture();
                 _shutdownExecutionContext = new SecurityCriticalDataClass<CulturePreservingExecutionContext>(shutdownExecutionContext);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherHooks.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherHooks.cs
@@ -20,7 +20,6 @@ namespace System.Windows.Threading
         ///     <P/>
         ///     Note also that this event could come before the last operation is
         ///     invoked, because that is when we determine that the queue is empty.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event EventHandler DispatcherInactive
         {
@@ -51,7 +50,6 @@ namespace System.Windows.Threading
         ///     <P/>
         ///     Note that any thread can post operations, so this event can be
         ///     raised by any thread.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherHookEventHandler OperationPosted
         {
@@ -82,7 +80,6 @@ namespace System.Windows.Threading
         ///     <P/>
         ///     Note that any thread can post operations, so this event can be
         ///     raised by any thread.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherHookEventHandler OperationStarted
         {
@@ -113,7 +110,6 @@ namespace System.Windows.Threading
         ///
         ///     Note that this event will be raised by the dispatcher thread after
         ///     the operation has completed.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherHookEventHandler OperationCompleted
         {
@@ -139,7 +135,6 @@ namespace System.Windows.Threading
         /// <remarks>
         ///     Note that any thread can change the priority of operations,
         ///     so this event can be raised by any thread.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherHookEventHandler OperationPriorityChanged
         {
@@ -165,7 +160,6 @@ namespace System.Windows.Threading
         /// <remarks>
         ///     Note that any thread can abort an operation, so this event
         ///     can be raised by any thread.
-        ///     Callers must have UIPermission(PermissionState.Unrestricted) to call this API.
         /// </remarks>
         public event DispatcherHookEventHandler OperationAborted
         {


### PR DESCRIPTION
Issue #1108 
Cleaned up `System.Security.Permissions` using directives and more permission related comments.
Also removed the PackageReference to `System.Security.Permissions` from the `TestProjects.targets` file

Ran full DRT pass and verified that everything is at baseline