### PR TITLE
Enable SplashScreen build-action for .NET Core 3.0

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -576,7 +576,7 @@
     <Error Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And 
                       '$(_TargetFrameworkVersionWithoutV)' != ''        And 
                       '$(_TargetFrameworkVersionWithoutV)' == '3.0'" 
-           Text="The SplashScreen Build Action is not supported in the selected Target Framework." />
+           Text="The SplashScreen Build Action is not supported on $(TargetFrameworkIdentifier) $(TargetFrameworkVersion)." />
   </Target>
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -573,7 +573,10 @@
   </Target>
 
   <Target Name="SplashScreenValidation" Condition="'@(SplashScreen)' != ''" >
-    <Error Condition="'$(TargetFrameworkVersion)' == 'v3.0'" Text="The SplashScreen Build Action is not supported in the selected Target Framework." />
+    <Error Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And 
+                      '$(_TargetFrameworkVersionWithoutV)' != ''        And 
+                      '$(_TargetFrameworkVersionWithoutV)' == '3.0'" 
+           Text="The SplashScreen Build Action is not supported in the selected Target Framework." />
   </Target>
 
 


### PR DESCRIPTION
Fixes #299 

WinFX.targets has a condition for preventing `SplashScreen` build-action from running on .NET Framework 3.0 - which is specified overly broadly.

Rewriting this condition to be more specific fixes the problem and brings the `SplashScreen` build action back to .NET Core 3.0.