### PR TITLE
Fixing MAS Compliance Issues

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -61,9 +61,9 @@ namespace System.Windows.Automation.Peers
             {
                 iface = this;
             }
-            else if (pattern == PatternInterface.Scroll)
+            else if (pattern == PatternInterface.Scroll && !owner.IsDropDownOpen)
             {
-                if (owner.IsDropDownOpen) iface = this;
+                iface = this;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -51,15 +51,19 @@ namespace System.Windows.Automation.Peers
         override public object GetPattern(PatternInterface pattern)
         {
             object iface = null;
+            ComboBox owner = (ComboBox)Owner;
 
             if (pattern == PatternInterface.Value)
             {
-                ComboBox owner = (ComboBox)Owner;
                 if (owner.IsEditable) iface = this;
             }
             else if(pattern == PatternInterface.ExpandCollapse)
             {
                 iface = this;
+            }
+            else if (pattern == PatternInterface.Scroll)
+            {
+                if (owner.IsDropDownOpen) iface = this;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
@@ -150,7 +150,9 @@ namespace System.Windows.Automation.Peers
                     if (itemsHost == null)
                     {
                         if (_expanderPeer == null)
+                        {
                             return null;
+                        }
                         else
                         {
                             children.Add(_expanderPeer);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
@@ -130,14 +130,7 @@ namespace System.Windows.Automation.Peers
                 ItemsControlAutomationPeer itemsControlAP = itemsControl.CreateAutomationPeer() as ItemsControlAutomationPeer;
                 if (itemsControlAP != null)
                 {
-                    Panel itemsHost = owner.ItemsHost;
-
-                    if (itemsHost == null)
-                        return null;
-
-                    IList childItems = itemsHost.Children;
-                    List<AutomationPeer> children = new List<AutomationPeer>(childItems.Count);
-                    ItemPeersStorage<ItemAutomationPeer> addedChildren = new ItemPeersStorage<ItemAutomationPeer>();
+                    List<AutomationPeer> children = new List<AutomationPeer>();
                     bool useNetFx472CompatibleAccessibilityFeatures = AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures;
 
                     if (!useNetFx472CompatibleAccessibilityFeatures && owner.Expander != null)
@@ -152,6 +145,22 @@ namespace System.Windows.Automation.Peers
                             _expanderPeer.GetChildren();
                         }
                     }
+                    Panel itemsHost = owner.ItemsHost;
+
+                    if (itemsHost == null)
+                    {
+                        if (_expanderPeer == null)
+                            return null;
+                        else
+                        {
+                            children.Add(_expanderPeer);
+                            return children;
+                        }
+                    }
+                        
+                    IList childItems = itemsHost.Children;
+                    ItemPeersStorage<ItemAutomationPeer> addedChildren = new ItemPeersStorage<ItemAutomationPeer>();
+                    
 
                     foreach (UIElement child in childItems)
                     {


### PR DESCRIPTION
Fixes #791, #1015 

This pull request contains two changes.
1. Setting ScrollPattern on ComboBox to only be enabled when its dropdown is opened.
2. Ensuring that expander is added to GroupItemDataAutomationPeer if it is the only child. This ensures that the expander is accessible to screen readers.


