### PR TITLE
Update localized strings that render \r\n as text

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -1027,10 +1027,12 @@
     <value>Too many files selected. Select fewer files and try again.</value>
   </data>
   <data name="FileDialogCreatePrompt" xml:space="preserve">
-    <value>'{0}' does not exist.\r\nDo you want to create it?</value>
+    <value>'{0}' does not exist.
+Do you want to create it?</value>
   </data>
   <data name="FileDialogFileNotFound" xml:space="preserve">
-    <value>'{0}' does not exist.\r\nVerify that the file name is correct.</value>
+    <value>'{0}' does not exist.
+Verify that the file name is correct.</value>
   </data>
   <data name="FileDialogInvalidFileName" xml:space="preserve">
     <value>'{0}' is not a valid file name.</value>
@@ -1042,7 +1044,8 @@
     <value>Filter index is not valid.</value>
   </data>
   <data name="FileDialogOverwritePrompt" xml:space="preserve">
-    <value>'{0}' already exists.\r\nDo you want to replace it?</value>
+    <value>'{0}' already exists.
+Do you want to replace it?</value>
   </data>
   <data name="FileDialogSubClassFailure" xml:space="preserve">
     <value>Cannot subclass a file dialog because sufficient memory is not available.</value>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">Prvek {0} neexistuje.\r\nChcete ho vytvořit?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">Prvek {0} neexistuje.
+Chcete ho vytvořit?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">Prvek {0} neexistuje.\r\nOvěřte, zda je správný název souboru.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">Prvek {0} neexistuje.
+Ověřte, zda je správný název souboru.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">Prvek {0} již existuje.\r\nChcete ho nahradit?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">Prvek {0} již existuje.
+Chcete ho nahradit?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" ist nicht vorhanden.\r\nMöchten Sie das Element erstellen?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">"{0}" ist nicht vorhanden.
+Möchten Sie das Element erstellen?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" ist nicht vorhanden.\r\nÜberprüfen Sie den Dateinamen.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">"{0}" ist nicht vorhanden.
+Überprüfen Sie den Dateinamen.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">"{0}" ist bereits vorhanden.\r\nMöchten Sie das Element ersetzen?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">"{0}" ist bereits vorhanden.
+Möchten Sie das Element ersetzen?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" no existe.\r\n¿Desea crearlo?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">"{0}" no existe.
+¿Desea crearlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" no existe.\r\nCompruebe que el nombre de archivo sea correcto.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">"{0}" no existe.
+Compruebe que el nombre de archivo sea correcto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">{0} ya existe.\r\n¿Desea reemplazarlo?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">{0} ya existe.
+¿Desea reemplazarlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' n'existe pas.\r\nVoulez-vous le créer ?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' n'existe pas.
+Voulez-vous le créer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' n'existe pas.\r\nVérifiez que le nom de fichier est correct.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' n'existe pas.
+Vérifiez que le nom de fichier est correct.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' existe déjà.\r\nVoulez-vous le remplacer ?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' existe déjà.
+Voulez-vous le remplacer ?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' non esiste.\r\nCrearlo?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' non esiste.
+Crearlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' non esiste.\r\nVerificare che il nome file sia corretto.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' non esiste.
+Verificare che il nome file sia corretto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' già esistente.\r\nSostituirlo?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' già esistente.
+Sostituirlo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' が存在しません。\r\n作成しますか?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' が存在しません。
+作成しますか?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' は存在しません。\r\nファイル名が正しいことをご確認ください。</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' は存在しません。
+ファイル名が正しいことをご確認ください。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' は既に存在します。\r\n置き換えますか?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' は既に存在します。
+置き換えますか?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}'이(가) 없습니다.\r\n만드시겠습니까?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}'이(가) 없습니다.
+만드시겠습니까?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}'이(가) 없습니다.\r\n파일 이름이 올바른지 확인하세요.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}'이(가) 없습니다.
+파일 이름이 올바른지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">’{0}'이(가) 이미 있습니다.\r\n바꾸시겠습니까?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">’{0}'이(가) 이미 있습니다.
+바꾸시겠습니까?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">Element „{0}” nie istnieje.\r\nCzy chcesz go utworzyć?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">Element „{0}” nie istnieje.
+Czy chcesz go utworzyć?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">Element „{0}” nie istnieje.\r\nSprawdź, czy nazwa pliku jest prawidłowa.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">Element „{0}” nie istnieje.
+Sprawdź, czy nazwa pliku jest prawidłowa.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">Element „{0}” już istnieje.\r\nCzy chcesz go zastąpić?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">Element „{0}” już istnieje.
+Czy chcesz go zastąpić?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' não existe.\r\nDeseja criá-lo?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' não existe.
+Deseja criá-lo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' não existe.\r\nVerifique se o nome de arquivo está correto.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' não existe.
+Verifique se o nome de arquivo está correto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' já existe.\r\nDeseja substituí-lo?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' já existe.
+Deseja substituí-lo?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">"{0}" не существует.\r\nВы хотите создать его?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">"{0}" не существует.
+Вы хотите создать его?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">"{0}" не существует.\r\nПроверьте имя файла.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">"{0}" не существует.
+Проверьте имя файла.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">"{0}" уже существует.\r\nВы хотите заменить его?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">"{0}" уже существует.
+Вы хотите заменить его?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' yok.\r\nOluşturmak istiyor musunuz?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' yok.
+Oluşturmak istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' yok.\r\nDosya adının doğru olduğunu kontrol edin.</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' yok.
+Dosya adının doğru olduğunu kontrol edin.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' zaten var.\r\nDeğiştirmek istiyor musunuz?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' zaten var.
+Değiştirmek istiyor musunuz?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">“{0}”不存在。\r\n是否创建?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">“{0}”不存在。
+是否创建?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">“{0}”不存在。\r\n请验证文件名是否正确。</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">“{0}”不存在。
+请验证文件名是否正确。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">“{0}”已存在。\r\n是否替换它?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">“{0}”已存在。
+是否替换它?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -1613,13 +1613,17 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogCreatePrompt">
-        <source>'{0}' does not exist.\r\nDo you want to create it?</source>
-        <target state="translated">'{0}' 不存在。\r\n要建立嗎?</target>
+        <source>'{0}' does not exist.
+Do you want to create it?</source>
+        <target state="translated">'{0}' 不存在。
+要建立嗎?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogFileNotFound">
-        <source>'{0}' does not exist.\r\nVerify that the file name is correct.</source>
-        <target state="translated">'{0}' 不存在。\r\n請確認檔案名稱正確。</target>
+        <source>'{0}' does not exist.
+Verify that the file name is correct.</source>
+        <target state="translated">'{0}' 不存在。
+請確認檔案名稱正確。</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogInvalidFileName">
@@ -1638,8 +1642,10 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
-        <source>'{0}' already exists.\r\nDo you want to replace it?</source>
-        <target state="translated">'{0}' 已存在。\r\n要取代掉嗎?</target>
+        <source>'{0}' already exists.
+Do you want to replace it?</source>
+        <target state="translated">'{0}' 已存在。
+要取代掉嗎?</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubClassFailure">


### PR DESCRIPTION
 **Problem description:**
When you use an Open File Dialog and provide an invalid file OR if you use a Save File Dialog and try to overwrite an existing file the messagebox renders the \r\n as text instead of  a line break.

See issue #977 for a full description. 

Confirmed these updates fix File Dialog messages in English and German.  (Fixes #977.)  