### PR TITLE
Remove support for `UseLegacyDangerousClipboardDeserializationMode`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -337,25 +337,6 @@ namespace MS.Internal
 
         #endregion
 
-        #region EnableLegacyDangerousClipboardDeserializationMode
-
-        internal const string EnableLegacyDangerousClipboardDeserializationModeSwitchName = "Switch.System.Windows.EnableLegacyDangerousClipboardDeserializationMode";
-        private static int _enableLegacyDangerousClipboardDeserializationMode;
-        public static bool EnableLegacyDangerousClipboardDeserializationMode
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                /// <summary>
-                /// Malicious managed objects could be placed in the clipboard lying about its format, 
-                /// to fix this OleConverter now restricts object deserialization in some cases.
-                /// When this switch is enabled behavior falls back to deserializing without restriction.
-                /// </summary>
-                return LocalAppContext.GetCachedSwitchValue(EnableLegacyDangerousClipboardDeserializationModeSwitchName, ref _enableLegacyDangerousClipboardDeserializationMode);
-            }
-        }
-
-        #endregion
     }
 #pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
@@ -60,7 +60,6 @@ namespace System
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStationSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotUsePresentationDpiCapabilityTier3OrGreaterSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.AllowExternalProcessToBlockAccessToTemporaryFilesSwitchName, false);
-            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.EnableLegacyDangerousClipboardDeserializationModeSwitchName, false);
         }
     }
 #pragma warning restore 436

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -491,17 +491,6 @@ namespace System.Windows
         //------------------------------------------------------
 
         /// <summary>
-        /// Determines whether the legacy dangerous clipboard deserialization mode should be used based on the AppContext switch and Device Guard policies.
-        /// </summary>
-        /// <returns>
-        /// If Device Guard is enabled this method returns false, otherwise it returns the AppContext switch value.
-        /// </returns>
-        internal static bool UseLegacyDangerousClipboardDeserializationMode()
-        {
-            return !IsDeviceGuardEnabled && CoreAppContextSwitches.EnableLegacyDangerousClipboardDeserializationMode;
-        }
-
-        /// <summary>
         /// Places data on the system Clipboard and uses copy to specify whether the data 
         /// should remain on the Clipboard after the application exits.
         /// </summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -2882,6 +2882,10 @@ namespace System.Windows
                     // * Out of these, we will disallow deserialization of 
                     // DataFormats.StringFormat to prevent potentially malicious objects from
                     // being deserialized as part of a "text" copy-paste or drag-drop.
+                    // TypeRestrictingSerializationBinder will throw when it encounters 
+                    // anything other than strings and primitives - this ensures that we will
+                    // continue successfully deserializing basic strings while rejecting other 
+                    // data types that advertise themselves as DataFormats.StringFormat.
                     // 
                     // The rest of the following formats are pre-defined in the OS, 
                     // they are not managed objects - an so we will not attempt to deserialize them. 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -2863,7 +2863,7 @@ namespace System.Windows
                     {
                         data = ReadBitmapSourceFromHandle(hglobal);
                     }
-                    // Limit deserialization to only primitive types, which consist of the following:
+                    // Limit deserialization to DataFormats that correspond to primitives, which are:
                     //
                     // DataFormats.CommaSeparatedValue
                     // DataFormats.FileDrop
@@ -2877,9 +2877,9 @@ namespace System.Windows
                     // DataFormats.WaveAudio
                     // DataFormats.Xaml
                     // DataFormats.XamlPackage 
-                    // DataFormats.StringFormat
+                    // DataFormats.StringFormat *
                     // 
-                    // Out of these primitive types, we will disallow deserialization of 
+                    // * Out of these, we will disallow deserialization of 
                     // DataFormats.StringFormat to prevent potentially malicious objects from
                     // being deserialized as part of a "text" copy-paste or drag-drop.
                     // 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -2863,13 +2863,29 @@ namespace System.Windows
                     {
                         data = ReadBitmapSourceFromHandle(hglobal);
                     }
-                    //  Restrict deserialization to only primitives 
-                    // and strings here to prevent potentially malicious objects from
+                    // Limit deserialization to only primitive types, which consist of the following:
+                    //
+                    // DataFormats.CommaSeparatedValue
+                    // DataFormats.FileDrop
+                    // DataFormats.Html
+                    // DataFormats.OemText
+                    // DataFormats.PenData
+                    // DataFormats.Rtf
+                    // DataFormats.Serializable
+                    // DataFormats.Text
+                    // DataFormats.UnicodeText
+                    // DataFormats.WaveAudio
+                    // DataFormats.Xaml
+                    // DataFormats.XamlPackage 
+                    // DataFormats.StringFormat
+                    // 
+                    // Out of these primitive types, we will disallow deserialization of 
+                    // DataFormats.StringFormat to prevent potentially malicious objects from
                     // being deserialized as part of a "text" copy-paste or drag-drop.
+                    // 
                     // The rest of the following formats are pre-defined in the OS, 
-                    // they are not managed objects so we shouldn't try to deserialize them as such,
-                    // allow primitives in a best effort for compat, but restrict other types.
-                    else if (!Clipboard.UseLegacyDangerousClipboardDeserializationMode())
+                    // they are not managed objects - an so we will not attempt to deserialize them. 
+                    else
                     {
                         bool restrictDeserialization =
                           (IsFormatEqual(format, DataFormats.StringFormat) ||
@@ -2888,11 +2904,7 @@ namespace System.Windows
 
                         data = ReadObjectFromHandle(hglobal, restrictDeserialization);
                     }
-                    else
-                    {
-                        data = ReadObjectFromHandle(hglobal, restrictDeserialization: false);
-                    }
-}
+                }
 
                 return data;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/XamlClipboardData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/XamlClipboardData.cs
@@ -100,8 +100,7 @@ namespace MS.Internal.Ink
 
             if ( !String.IsNullOrEmpty(xml) )
             {
-                bool useRestrictiveXamlReader = !Clipboard.UseLegacyDangerousClipboardDeserializationMode();
-                UIElement element = XamlReader.Load(new System.Xml.XmlTextReader(new System.IO.StringReader(xml)), useRestrictiveXamlReader) as UIElement;
+                UIElement element = XamlReader.Load(new System.Xml.XmlTextReader(new System.IO.StringReader(xml)), useRestrictiveXamlReader: true) as UIElement;
                 if (element != null)
                 {
                     ElementList.Add(element);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
@@ -923,8 +923,7 @@ namespace System.Windows.Documents
                 try
                 {
                     // Parse the fragment into a separate subtree
-                    bool useRestrictiveXamlReader = !Clipboard.UseLegacyDangerousClipboardDeserializationMode();
-                    object xamlObject = XamlReader.Load(new XmlTextReader(new System.IO.StringReader(pasteXaml)), useRestrictiveXamlReader);
+                    object xamlObject = XamlReader.Load(new XmlTextReader(new System.IO.StringReader(pasteXaml)), useRestrictiveXamlReader: true);
                     TextElement flowContent = xamlObject as TextElement;
 
                     success = flowContent == null ? false : PasteTextElement(This, flowContent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WpfPayload.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/WpfPayload.cs
@@ -343,8 +343,7 @@ namespace System.Windows.Documents
                     parserContext.BaseUri = entryPartUri;
 
                     // Call xaml parser
-                    bool useRestrictiveXamlReader = !Clipboard.UseLegacyDangerousClipboardDeserializationMode();
-                    xamlObject = XamlReader.Load(xamlEntryPart.GetStream(), parserContext, useRestrictiveXamlReader);
+                    xamlObject = XamlReader.Load(xamlEntryPart.GetStream(), parserContext, useRestrictiveXamlReader: true);
 
                     // Remove the temporary uri from the PackageStore
                     PackageStore.RemovePackage(packageUri);


### PR DESCRIPTION
Remove support for `UseLegacyDangerousClipboardDeserializationMode` and permanently disallow deserialization of dangerous types.

- Removes support for AppContext flag `UseLegacyDangerousClipboardDeserializationMode`
- Permanently limits clipboard-deserialziation to primitive non-text types only.

Fixes #1132

PS: Creating a WIP PR since this hasn't gone through enough testing yet. 