### PR TITLE
Default to 'true' for unset properties owned by WPF

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup>
     <_MicrosoftNetSdkWindowsDesktop>true</_MicrosoftNetSdkWindowsDesktop>
+    <EnableDefaultPageItems Condition="'$(EnableDefaultPageItems)' == ''">true</EnableDefaultPageItems> 
+    <EnableDefaultApplicationDefinition Condition="'$(EnableDefaultApplicationDefinition)' == ''">true</EnableDefaultApplicationDefinition>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Default to 'true' for unset `EnableDefaultPageItems` and `EnableDefaultApplicationDefinition` in `Microsoft.NET.Sdk.WindowsDesktop.props` to allow MSBuild's `CheckForDuplicateItems` to provide a descriptive duplicate `Page` error.  The check was previously no-op'd in the target due to unset properties.  

Builds with duplicate `Page` items now fail with this error: 

C:\Program Files\dotnet\sdk\3.0.100-preview8-013270\Sdks\Microsoft.NET.Sdk.WindowsDesktop\targets\Microsoft.NET.Sdk.WindowsDesktop.targets(21,5): error NETSDK1022: Duplicate 'Page' items were included. The .NET SDK includes 'Page' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultPageItems' property to 'false' if you want to explicitly include them in your project file. For more information, see https://aka.ms/sdkimplicititems. The duplicate items were: 'Themes\Generic.xaml' [I:\test\XSecControls\XSecControls.csproj]

Provides a better error message for #1264.