### PR TITLE
Updated GetHashCode for MILColorF structs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
@@ -454,6 +454,15 @@ internal struct MilColorF
     internal float g;
     internal float b;
     internal float a;
+
+    public override int GetHashCode()
+    {
+        return a.GetHashCode() ^ r.GetHashCode() ^ g.GetHashCode() ^ b.GetHashCode();
+    }
+    public override bool Equals(object obj)
+    {
+        return base.Equals(obj);
+    }
 };
 
 /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -1158,6 +1158,15 @@ namespace System.Windows.Media
         private struct MILColorF // this structure is the "milrendertypes.h" structure and should be identical for performance
         {
             public float a, r, g, b;
+
+            public override int GetHashCode()
+            {
+                return a.GetHashCode() ^ r.GetHashCode() ^ g.GetHashCode() ^ b.GetHashCode();
+            }
+            public override bool Equals(object obj)
+            {
+                return base.Equals(obj);
+            }
         };
 
         private MILColorF scRgbColor;


### PR DESCRIPTION
Issue #848 

In CoreCLR, the GetHashCode logic for the MILColorF struct (struct with float values) changed and only uses the first field for hash computation (see [this](https://github.com/dotnet/corefx/issues/35613) for more details). Added custom GetHashCode logic to the MILColorF struct in order to have the GetHashCode computation use all four float values for hash computation (as per recommendation from [here](https://github.com/dotnet/corefx/issues/35613#issuecomment-467726210)).
Opened a [complementary PR in the internal repo](https://dnceng.visualstudio.com/internal/_git/dotnet-wpf-int/pullrequest/2196?_a=overview) to update the MILColorF struct definitions there as well.

- Verified that the failing 2D color test is now passing.
- Ran a full DRT test pass and verified that DRTs are at baseline.
- Logged a new issue for the updating of other structs in the codebase that are affected by the same change [here](https://github.com/dotnet/wpf/issues/1307).