### PR TITLE
Linker hints for C++/CLI dependencies 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
@@ -1,0 +1,5 @@
+<linker>
+  <!-- Include dependencies of DirectWriteForwarder, which is not
+       analyzed by the linker. -->
+  <assembly fullname="System.Diagnostics.Debug" />
+</linker>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
@@ -2,4 +2,6 @@
   <!-- Include dependencies of DirectWriteForwarder, which is not
        analyzed by the linker. -->
   <assembly fullname="System.Diagnostics.Debug" />
+  <assembly fullname="mscorlib" />
+  <assembly fullname="netstandard" />  
 </linker>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -1448,6 +1448,29 @@
       <XlfInput>false</XlfInput>
       <ManifestResourceName>ColorProfiles</ManifestResourceName>
     </EmbeddedResource>
+    
+    <!-- 
+        Workaround for https://github.com/dotnet/wpf/issues/1385
+        ReadyToRun images of WPF applications crash 
+        
+        When producing ReadyToRun images, the ILLinker is configured to skip 
+        C++/CLI images. See https://github.com/mono/linker/issues/651 and 
+        https://github.com/mono/linker/pull/658. 
+        
+        In turn, this results in the failure of the dependencies of such assemblies from being
+        identified and included in the ReadyToRun images. 
+        
+        This linker hint exists to ensure that such dependencies are included. We need
+        to place these hints in an assembly that has a reference to the corresponding
+        C++/CLI assembly. 
+        
+             PresentationCore -> DirectWriteFowarder
+             ReachFramework -> System.Printing
+    -->    
+    <EmbeddedResource Condition="Exists('ILLinkTrim.xml')" Include="ILLinkTrim.xml">
+      <XlfInput>false</XlfInput>
+      <LogicalName>$(AssemblyName).xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!-- Including the Microsoft.TextTemplating.targets requires us to manually import Sdk.Targets because

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ILLinkTrim.xml
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ILLinkTrim.xml
@@ -2,4 +2,6 @@
   <!-- Include dependencies of System.Printing, which is not
        analyzed by the linker. -->
   <assembly fullname="System.Diagnostics.Debug" />
+  <assembly fullname="mscorlib" />
+  <assembly fullname="netstandard" />
 </linker>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ILLinkTrim.xml
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ILLinkTrim.xml
@@ -1,0 +1,5 @@
+<linker>
+  <!-- Include dependencies of System.Printing, which is not
+       analyzed by the linker. -->
+  <assembly fullname="System.Diagnostics.Debug" />
+</linker>

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ReachFramework.csproj
@@ -21,6 +21,29 @@
       <LogicalName>System.Printing.resources</LogicalName>
       <ManifestResourceName>System.Printing.resources</ManifestResourceName>
     </EmbeddedResource>
+    
+    <!-- 
+        Workaround for https://github.com/dotnet/wpf/issues/1385
+        ReadyToRun images of WPF applications crash 
+        
+        When producing ReadyToRun images, the ILLinker is configured to skip 
+        C++/CLI images. See https://github.com/mono/linker/issues/651 and 
+        https://github.com/mono/linker/pull/658. 
+        
+        In turn, this results in the failure of the dependencies of such assemblies from being
+        identified and included in the ReadyToRun images. 
+        
+        This linker hint exists to ensure that such dependencies are included. We need
+        to place these hints in an assembly that has a reference to the corresponding
+        C++/CLI assembly. 
+        
+             PresentationCore -> DirectWriteFowarder
+             ReachFramework -> System.Printing
+    -->    
+    <EmbeddedResource Condition="Exists('ILLinkTrim.xml')" Include="ILLinkTrim.xml">
+      <XlfInput>false</XlfInput>
+      <LogicalName>$(AssemblyName).xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Fixes #1385 

When producing ReadyToRun images, the ILLinker is configured to skip C++/CLI images. See mono/linker#651 and mono/linker#658.

In turn, this results in a failure of dependencies of such assemblies (like System.Diagnostics.Debug.dll, which is required by DirectWriteForwarder.dll) from being identified and included in the ReadyToRun images.

These linker hints tell ILLinker to include certain dependencies, which we know to be required by DirectWriteForwarder and System.Printing respectively.
