### PR TITLE
Embed Commit SHA as a string resource in native DLLs

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <NativeVersionFile Condition="'$(NativeVersionFile)'==''">$(IntermediateOutputPath)NativeVersion.rc</NativeVersionFile>
     <NativeVersionFileDirectory>$([System.IO.Path]::GetDirectoryName($(NativeVersionFile)))</NativeVersionFileDirectory>
+    <NativeResourceFileWithVersionInformation Condition="'$(NativeResourceFileWithVersionInformation)' == ''">$(IntermediateOutputPath)ExtendedNativeVersion.rc</NativeResourceFileWithVersionInformation>
   </PropertyGroup>
 
   <Import Project="Wpf.Cpp.PrivateTools.targets" Condition="Exists('Wpf.Cpp.PrivateTools.targets') And '$(UsePrivateCppTools)'=='true'"/>
@@ -50,6 +51,55 @@
 
   <Target Name="CreateNativeVersionFile" BeforeTargets="ResourceCompile" Outputs="$(NativeVersionFile)" Condition="!Exists('$(NativeVersionFile)')">
     <CallTarget Targets="GenerateNativeVersionFile" />
+  </Target>
+
+  <!-- Target only runs for projects that already include .rc files in their build -->
+  <Target Name="CreateNativeResourceFileWithVersionInformation"
+          AfterTargets="CreateNativeVersionFile"
+          BeforeTargets="ResourceCompile"
+          DependsOnTargets="_InitializeAssemblyVersion;InitializeSourceControlInformationFromSourceControlManager"
+          Outputs="$(NativeResourceFileWithVersionInformation)"
+          Returns="@(ResourceCompile)"
+          Condition="('$(ConfigurationType)' == 'DynamicLibrary' Or '$(ConfigurationType)' == 'Application') And '$(ManagedCxx)' != 'true' And '$(IsRedistProject)' != 'true'">
+    
+    <PropertyGroup>
+      <_WindowsFileVersion>$(FileVersion.Replace('.', ','))</_WindowsFileVersion>
+      <_SourceBuildInfo> %40Commit: $(SourceRevisionId)</_SourceBuildInfo>
+      
+      <_ExtendedNativeVersionFileContents>
+        <![CDATA[
+        
+#if !defined(IDS_STRING_PRODUCT_VER)
+#define IDS_STRING_PRODUCT_VER 1001
+#endif 
+
+#if !defined(IDS_STRING_REPO_URL)
+#define IDS_STRING_REPO_URL 1002
+#endif 
+
+// String Table
+STRINGTABLE 
+BEGIN
+    IDS_STRING_PRODUCT_VER "$(_WindowsFileVersion)$(_SourceBuildInfo)"
+    IDS_STRING_REPO_URL "RepoUrl: $(ScmRepositoryUrl)"
+    
+END
+        ]]>
+      </_ExtendedNativeVersionFileContents>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ExtendenNativeVersionFileLines Include="$(_ExtendedNativeVersionFileContents)" />
+    </ItemGroup>
+    
+    <WriteLinesToFile Lines="@(_ExtendenNativeVersionFileLines)"
+                      File="$(NativeResourceFileWithVersionInformation)"
+                      Overwrite="true" />
+
+    <ItemGroup>
+      <ResourceCompile Remove="$(NativeResourceFileWithVersionInformation)" />
+      <ResourceCompile Include="$(NativeResourceFileWithVersionInformation)" />
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes #1491 

Embeds a new RC file containing a string table for any native DLL or EXE project. This string table will contain **two** pieces of information:
- Commit SHA
- Repo name that built this assembly. 

![image](https://user-images.githubusercontent.com/20246435/62249278-dfa75180-b39e-11e9-97b6-81c88652c539.png)

![image](https://user-images.githubusercontent.com/20246435/62249303-efbf3100-b39e-11e9-96af-155879c82c11.png)


