### PR TITLE
XPS: Use original font when subsetting would grow the font

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/TrueTypeSubsetter/truetype.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/TrueTypeSubsetter/truetype.cpp
@@ -102,8 +102,16 @@ array<System::Byte> ^ TrueTypeSubsetter::ComputeSubset(void * fontData, int file
         Mem_Free(puchDestBuffer);
     }
 
-    if (errCode != NO_ERROR)
+    // If subsetting would grow the font, just use the original one as it's the best we can do.
+    if (errCode == ERR_WOULD_GROW)
+    {
+        retArray = gcnew array<System::Byte>(fileSize);
+        System::Runtime::InteropServices::Marshal::Copy((System::IntPtr)fontData, retArray, 0, fileSize);
+    }
+    else if (errCode != NO_ERROR)
+    {
         throw gcnew FileFormatException(sourceUri);
+    }
 
     return retArray;
 }


### PR DESCRIPTION
When a call to CreateDeltaTTF returns ERR_WOULD_GROW, ComputeSubset should not throw FileFormatException.  Instead, it should copy the original font into the result buffer and return that.

This is so a subsetting attempt that would increase the font size can succeed by using the original font, since that is sufficient to display the file and is more compact than the subsetting algorithm can achieve.

Addresses #1511 