### PR TITLE
Fix for #1198 - fixes potential crashes in high-DPI applications

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
@@ -92,6 +92,11 @@ namespace MS.Internal
                 bool updateIfWindowIsSystemAwareOrUnaware,
                 IntPtr hWnd)
             {
+                if (dpiAwarenessContextValue == DpiAwarenessContextValue.Invalid)
+                {
+                    return;
+                }
+
                 if (!OperationSupported)
                 {
                     return;


### PR DESCRIPTION
Addresses #1198. 

#### [Watson] clr20r3: CLR_EXCEPTION_System.Collections.Generic.KeyNotFoundException_80131577_PresentationCore.dll!MS.Internal.DpiUtil+DpiAwarenessScope..ctor

--

When a caller passes in `dpiAwarenessContextValue==Invalid`, `new DpiAwarenessContextHandle(dpiAwarenssContextValue)` throws `KeyNotFoundException`.

This happens because we do not have a pre-created pseudo-_HANDLE_  corresponding to `Invalid` in our internal map of pseudo-handles in `DpiAwarenessContextHandle.WellKnownContextValues`. Such a pseudo-handle cannot be created either.

When `dpiAwarenessContextValue=Invalid` is passed, the correct behavior is to treat it as a no-op and simply `return`. The corresponding `Dispose()` will also run benignly and the caller will get the correct behavior - which is that no changes will be made to the thread-state.