### PR TITLE
Fix for #1198 - support for DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
@@ -92,6 +92,11 @@ namespace MS.Internal
                 bool updateIfWindowIsSystemAwareOrUnaware,
                 IntPtr hWnd)
             {
+                if (dpiAwarenessContextValue == DpiAwarenessContextValue.Invalid)
+                {
+                    return;
+                }
+
                 if (!OperationSupported)
                 {
                     return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+DpiAwarenessScope.cs
@@ -173,6 +173,7 @@ namespace MS.Internal
 
                 return
                     dpiAwarenessContext.Equals(DpiAwarenessContextValue.Unaware) ||
+                    dpiAwarenessContext.Equals(DpiAwarenessContextValue.UnawareGdiScaled) ||
                     dpiAwarenessContext.Equals(DpiAwarenessContextValue.SystemAware);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -1033,9 +1033,9 @@ namespace System.Windows
         /// would be bounded by:
         ///     #(valid DpiAwarenessContextValues) + 2*#(unique DPI values that are observed during calls to <see cref="GetDpiAwarenessCompatibleNotificationWindow(HandleRef)"/>)
         /// The only DpiAwarenessContextValues for which unique DPI values would matter are <see cref="DpiAwarenessContextValue.PerMonitorAware"/> and 
-        /// <see cref="DpiAwarenessContextValue.PerMonitorAwareVersion2"/>. For <see cref="DpiAwarenessContextValue.SystemAware"/> and <see cref="DpiAwarenessContextValue.Unaware"/>,
-        /// the OS would never report back anything other than the System DPI and 96 respectively, and thus we would only ever maintain one entry for those
-        /// DpiAwarenessContextValues.
+        /// <see cref="DpiAwarenessContextValue.PerMonitorAwareVersion2"/>. For <see cref="DpiAwarenessContextValue.SystemAware"/>, <see cref="DpiAwarenessContextValue.Unaware"/>,
+        /// and <see cref="DpiAwarenessContextValue.UnawareGdiScaled"/>, the OS would never report back anything other than the System DPI and 96 respectively, and thus we would 
+        /// only ever maintain one entry for those DpiAwarenessContextValues.
         /// </summary>
         private static void EnsureResourceChangeListener()
         {
@@ -1186,12 +1186,16 @@ namespace System.Windows
         /// <remarks>Defaults to System DPI if an invalid <paramref name="dpiContextValue"/> is supplied</remarks>
         private static DpiScale2 GetDpiScaleForUnawareOrSystemAwareContext(DpiAwarenessContextValue dpiContextValue)
         {
-            Debug.Assert(dpiContextValue == DpiAwarenessContextValue.Unaware || dpiContextValue == DpiAwarenessContextValue.SystemAware);
+            Debug.Assert(
+                dpiContextValue == DpiAwarenessContextValue.Unaware ||
+                dpiContextValue == DpiAwarenessContextValue.UnawareGdiScaled ||
+                dpiContextValue == DpiAwarenessContextValue.SystemAware);
 
             DpiScale2 dpiScale = null;
             switch (dpiContextValue)
             {
                 case DpiAwarenessContextValue.Unaware:
+                case DpiAwarenessContextValue.UnawareGdiScaled:
                     dpiScale = DpiScale2.FromPixelsPerInch(DpiUtil.DefaultPixelsPerInch, DpiUtil.DefaultPixelsPerInch);
                     break;
                 case DpiAwarenessContextValue.SystemAware:

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextHandle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextHandle.cs
@@ -32,6 +32,7 @@ namespace MS.Utility
                 { DpiAwarenessContextValue.SystemAware, new IntPtr((int)DpiAwarenessContextValue.SystemAware) },
                 { DpiAwarenessContextValue.PerMonitorAware, new IntPtr((int)DpiAwarenessContextValue.PerMonitorAware) },
                 { DpiAwarenessContextValue.PerMonitorAwareVersion2, new IntPtr((int)DpiAwarenessContextValue.PerMonitorAwareVersion2) },
+                { DpiAwarenessContextValue.UnawareGdiScaled, new IntPtr((int)DpiAwarenessContextValue.UnawareGdiScaled) },
             };
 
             DPI_AWARENESS_CONTEXT_UNAWARE =
@@ -45,6 +46,9 @@ namespace MS.Utility
 
             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 =
                 new DpiAwarenessContextHandle(WellKnownContextValues[DpiAwarenessContextValue.PerMonitorAwareVersion2]);
+
+            DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED =
+                new DpiAwarenessContextHandle(WellKnownContextValues[DpiAwarenessContextValue.UnawareGdiScaled]);
         }
 
         /// <summary>
@@ -120,6 +124,11 @@ namespace MS.Utility
         /// Gets DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
         /// </summary>
         internal static DpiAwarenessContextHandle DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 { get; }
+
+        /// <summary>
+        /// Gets DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED
+        /// </summary>
+        internal static DpiAwarenessContextHandle DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED { get; }
 
         /// <summary>
         /// Gets map of well-known DPI awareness context handles

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextValue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextValue.cs
@@ -50,6 +50,11 @@ namespace MS.Utility
         /// <summary>
         /// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
         /// </summary>
-        PerMonitorAwareVersion2 = -4
+        PerMonitorAwareVersion2 = -4, 
+
+        /// <summary>
+        /// DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED
+        /// </summary>
+        UnawareGdiScaled = -5
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -7207,6 +7207,18 @@ namespace MS.Win32 {
         /// </remarks>
         internal static readonly DpiAwarenessContextHandle DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = DpiAwarenessContextHandle.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
 
+        /// <summary>
+        /// DPI unaware with improved quality of GDI-based content.
+        /// This mode behaves similarly to DPI_AWARENESS_CONTEXT_UNAWARE, but also enables
+        /// the system to automatically improve the rendering quality of text and other GDI-based
+        /// primitives when the window is displayed on a high-DPI monitor.
+        /// </summary>
+        /// <remarks>
+        /// - DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED was introduced in the October 2018 update of Windows 10 (also known as version 1809).
+        /// - <code><![CDATA[#define DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED ((DPI_AWARENESS_CONTEXT)-5)]]></code>
+        /// </remarks>
+        internal static readonly DpiAwarenessContextHandle DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED = DpiAwarenessContextHandle.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED;
+
 #endif
 
         /// <summary>


### PR DESCRIPTION
Addresses #1198.

#### [Watson] clr20r3: CLR_EXCEPTION_System.Collections.Generic.KeyNotFoundException_80131577_PresentationCore.dll!MS.Internal.DpiUtil+DpiAwarenessScope..ctor

This is a 2nd fix approach for this issue, which is a more complete fix IMO compared to https://github.com/dotnet/wpf/pull/1515. This PR must be paired with the PR to the renderer at https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int/pullrequest/2498?_a=overview


--

When a caller passes in dpiAwarenessContextValue==Invalid, new DpiAwarenessContextHandle(dpiAwarenssContextValue) throws KeyNotFoundException.

This happens because we do not have a pre-created pseudo-HANDLE corresponding to Invalid in our internal map of pseudo-handles in DpiAwarenessContextHandle.WellKnownContextValues. Such a pseudo-handle cannot be created either.

When dpiAwarenessContextValue=Invalid is passed, the correct behavior is to treat it as a no-op and simply return. The corresponding Dispose() will also run benignly and the caller will get the correct behavior - which is that no changes will be made to the thread-state.


==

Ideally, this problem should not have happened when only dealing with 'valid' or 'good' `DpiAwarenessCotnextValue` enums (or equivalently, 'good' `DpiAwarenessContextHandle` values).

"good" has two meanings here.

i. Values recognized by the OS that are valid (as the OS sees it)
ii. Values recognized by WP as valid (i.e.., WPF has enough intelligence available to process this mode).

WPF only knows how to process the following 4 DPI_AWARENESS_CONTEXT_HANDLE values, which were available during active feature development of .NET 4.8.

- DPI_AWARENESS_CONTEXT_UNAWARE
- DPI_AWARENESS_CONTEXT_SYSTEM_AWARE
- DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
- DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2

It looks like one more value was added in Win10 1809 later in the development cycle which WPF has no understanding of.

- DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED

In [SystemResources.cs](https://github.com/dotnet/wpf/blob/ac9d1b7a6b0ee7c44fd2875a1174b820b3940619/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs#L1146), we query HWND's for their DPI related info like this:

```
    var hwndDpiInfo =
        IsPerMonitorDpiScalingActive ?
        DpiUtil.GetExtendedDpiInfoForWindow(hwndNotify.Handle):
        new DpiUtil.HwndDpiInfo(dpiContextValue, GetDpiScaleForUnawareOrSystemAwareContext(dpiContextValue));
```

`DpiUtil.GetExtendedDpiInfoForWindow(hwndNotify.Handle)` eventually calls into `new HwndDpiInfo`, which in turn attempts to map `DpiAwarenessContextHandle` -> `DpiAwarenessCotnextValue`. This mapping (which is acheived by an overloaded cast operator)
only recognizes `DPI_AWARENESS_CONTEXT_HANDLE` values WPF understands. Anything outside of this set is considered `Invalid`.

I’m reasonably confident that this crash happens because we are getting an `HWND` with `DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED` or something else outside the recognized spectrum.