### PR TITLE
Fix double free in calls to CreateTTFDelta(Ex).

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/TrueTypeSubsetter/TtfDelta/ttfdelta.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/TrueTypeSubsetter/TtfDelta/ttfdelta.cpp
@@ -791,6 +791,12 @@ CONST_TTFACC_FILEBUFFERINFO InputBufferInfo;
     OutputBufferInfo.ulOffsetTableOffset = 0;
     OutputBufferInfo.lpfnReAllocate = lpfnReAllocate;  /* for reallocation */
 
+    // If OutputBufferInfo.puchBuffer goes through a realloc call that moves it, the original buffer pointed to by
+    // *ppuchDestBuffer will be de-allocated.  If there is then an error condition in the call-chain, we can end up
+    // returning a pointer to the de-allocated buffer.  Callers may then double free the buffer as they are none the wiser.
+    // Setting *ppuchDestBuffer to NULL allows us to return NULL in the error case and the non-error case still works as before.
+    *ppuchDestBuffer = NULL;
+
     if (usFormat == TTFDELTA_SUBSET1 || usFormat == TTFDELTA_DELTA)   /* if we will be trying to compact the font */
         usDttfGlyphIndexCount = usGlyphKeepCount;
     


### PR DESCRIPTION
Addresses #1554 

During execution of CreateTTFDeltaEx, the call-chain may re-allocate and move *ppuchDestBuffer.  If this happens and an error condition occurs, we will return the buffer that realloc de-allocated.  Callers may then double-free *ppuchDestBuffer.

To fix this, set *ppuchDestBuffer to NULL after it is stored in OutputBufferInfo.puchBuffer.  After this change, the non-error return will set *ppuchDestBuffer to OutputBufferInfo.puchBuffer as always, but the error case will de-allocate OutputBufferInfo.puchBuffer (as was intended) and return NULL in *ppuchDestBuffer.  Callers then cannot double-free the buffer.