### PR TITLE
Adding PresentationUI to RefAssembly list in build-props.

### DIFF
--- a/eng/WpfArcadeSdk/tools/ApiCompat.props
+++ b/eng/WpfArcadeSdk/tools/ApiCompat.props
@@ -60,6 +60,7 @@
       System.Xaml;
       WindowsBase;
       WindowsFormsIntegration;
+      PresentationUI;
     </RefApiCompatNeededProjects>
 
     <!-- TODO:  

--- a/eng/WpfArcadeSdk/tools/ShippingProjects.props
+++ b/eng/WpfArcadeSdk/tools/ShippingProjects.props
@@ -95,12 +95,17 @@
       System.Windows.Controls.Ribbon-ref;
       System.Windows.Presentation-ref;
       WindowsFormsIntegration-ref;
+      PresentationUI-ref;
     </InternalHandCraftedReferenceProjects>
+
+    <HandCraftedReferenceProjects>
+      $(ExternalHandCraftedReferenceProjects);
+      $(InternalHandCraftedReferenceProjects)
+    </HandCraftedReferenceProjects>
 
     <HelperProjects>
       $(CycleBreakerProjects);
-      $(ExternalHandCraftedReferenceProjects);
-      $(InternalHandCraftedReferenceProjects);
+      $(HandCraftedReferenceProjects);
     </HelperProjects>
 
     <!--


### PR DESCRIPTION
Helps with addressing #1423 - adding back PresentationUI ref-assembly.

Adding PUI to RefAssembly list in props.