### PR TITLE
remove dnceng ref from TestServices

### DIFF
--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/TestServices.csproj
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/TestServices.csproj
@@ -17,6 +17,5 @@
   <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Private_Winforms)\lib\$(TargetFramework)\Accessibility.dll" />
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
-    <PackageReference Include="$(MicrosoftDotNetWpfDncEngPackage)" Version="$(MicrosoftDotNetWpfDncEngVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There was a conflict with https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int/commit/3837b2d11c6d9bf2fc7af85e6d06cd31b0a332aa/?refName=refs%2Fheads%2Fmaster

And since GitHub got the update to the `Microsoft.DotNet.Wpf.DncEng` package that contained the `PresentationUI` ref assembly in it, we now get an error. TestServices doesn't need to reference the `DncEng` package, now that all managed assemblies are in dotnet/wpf