### PR TITLE
Add RaisePropertyChanged extension for INotifyPropertyChanged

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace System.ComponentModel
+{
+    using System.Reflection;
+    using System.Runtime.CompilerServices;
+
+    public static class PropertyChangedExtensions
+    {
+        public static void RaisePropertyChanged(this INotifyPropertyChanged @this, [CallerMemberName] string propertyName = null)
+        {
+            var declaringType = @this.GetType().GetEvent(nameof(INotifyPropertyChanged.PropertyChanged)).DeclaringType;
+            var propertyChangedFieldInfo = declaringType.GetField(nameof(INotifyPropertyChanged.PropertyChanged), BindingFlags.Instance | BindingFlags.NonPublic);
+            var propertyChangedEventHandler = propertyChangedFieldInfo.GetValue(@this) as PropertyChangedEventHandler;
+            propertyChangedEventHandler?.Invoke(@this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -168,6 +168,7 @@
     <Compile Include="System\ComponentModel\IItemProperties.cs" />
     <Compile Include="System\ComponentModel\GroupDescription.cs" />
     <Compile Include="System\ComponentModel\PropertyChangedEventManager.cs" />
+    <Compile Include="System\ComponentModel\PropertyChangedExtensions.cs" />
     <Compile Include="System\ComponentModel\PropertyFilterFlags.cs" />
     <Compile Include="System\ComponentModel\PropertyFilterAttribute.cs" />
     <Compile Include="System\ComponentModel\SortDescription.cs" />


### PR DESCRIPTION
This extension makes it much easier to raise `PropertyChanged`.

You also save a lot of time writing your own `RaisePropertyChanged` method for each class or invoking the `PropertyChanged` event with the right arguments.

**How to use the `RaisePropertyChanged` extension:**
```C#
using System.ComponentModel;

public class Foo : INotifyPropertyChanged
{
    private object _bar;

    public event PropertyChangedEventHandler PropertyChanged;

    public object Bar
    {
        get => _bar;
        set
        {
            _bar = value;
            this.RaisePropertyChanged();
        }
    }
}
```

**Some examples of how to raise `PropertyChanged` the old way:**

1. Saves you a lot of writing. Also, if you forget the conditional access an exception will be thrown if there is no subscribers to `PropertyChanged`.
 
```C#
using System.ComponentModel;

public class Foo : INotifyPropertyChanged
{
    private object _bar;

    public event PropertyChangedEventHandler PropertyChanged;

    public object Bar
    {
        get => _bar;
        set
        {
            _bar = value;
            RaisePropertyChanged();
        }
    }

    public void RaisePropertyChanged([CallerMemberName] string propertyName = null)
    {
        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
    }
}
```

2. Saves you even more writing, if you have a lot of properties. Also, if you forget the conditional access an exception will be thrown if there is no subscribers to `PropertyChanged`.

```C#
using System.ComponentModel;

public class Foo : INotifyPropertyChanged
{
    private object _bar;

    public event PropertyChangedEventHandler PropertyChanged;

    public object Bar
    {
        get => _bar;
        set
        {
            _bar = value;
            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Bar)));
        }
    }
}
```

3. Saves a garbage reference to `GalaSoft.MvvmLight` and avoids inheritance.
```C#
using GalaSoft.MvvmLight;

public class Foo : ViewModelBase
{
    private object _bar;

    public object Bar
    {
        get => _bar;
        set
        {
            _bar = value;
            RaisePropertyChanged();
        }
    }
}
```