### PR TITLE
Updating issue and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,7 @@ about: Create a report to help us improve
 * .NET Core Version: (e.g. 3.0 Preview1, or daily build number, use `dotnet --info`)
 * Windows version: (`winver`)
 * Does the bug reproduce also in WPF for .NET Framework 4.8?: Yes/No
+* Is this bug related specifically to tooling in Visual Studio (e.g. XAML Designer, Code editing, etc...)? If yes, please file the issue via the instructions here: https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2019
 
  <!-- Read https://github.com/dotnet/wpf/blob/master/Documentation/issue-guide.md -->
  

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,4 +3,6 @@ name: Feature / API request
 about: Suggest an idea for this project
 ---
 
+Is this feature request related specifically to tooling in Visual Studio (e.g. XAML Designer, Code editing, etc...)? If yes, please file the request via the instructions here: https://docs.microsoft.com/visualstudio/ide/suggest-a-feature?view=vs-2019
+
 <!-- Read https://github.com/dotnet/wpf/blob/master/Documentation/issue-guide.md -->


### PR DESCRIPTION
We've observed some tooling related issues filed in the repo that take some additional time to get routed to the right Visual Studio teams. By suggesting developers to file issues on VS directly (for tools related issues), hopefully we can expedite triage and ultimately fixes. 