### PR TITLE
Fixes problems in WindowsDesktop SDK due to _TargetFrameworkVersionWithoutV being undefined sometimes

### DIFF
--- a/eng/WpfArcadeSdk/tools/Pbt.targets
+++ b/eng/WpfArcadeSdk/tools/Pbt.targets
@@ -92,11 +92,20 @@
           Condition="'$(InternalMarkupCompilation)'=='true' And Exists('$(LocalMicrosoftWinFXTargets)') "/>
 
   <!-- 
-    _WindowsDesktopSdkTargetFrameworkVersionFloor is defined in Microsoft.NET.WindowDesktop.props. 
-    This needs to be defined before Microsoft.NET.Sdk.WindowsDesktop.targets is imported. 
+    _WindowsDesktopSdkTargetFrameworkVersionFloor, _UndefinedTargetFrameworkVersion and _TargetFrameworkVersionValue are 
+    defined in Microsoft.NET.WindowDesktop.props. 
+    
+    These need to be defined before Microsoft.NET.Sdk.WindowsDesktop.targets is imported. 
   -->
   <PropertyGroup Condition="'$(InternalMarkupCompilation)'=='true' And !Exists('$(LocalMicrosoftWinFXTargets)') ">
     <_WindowsDesktopSdkTargetFrameworkVersionFloor Condition="'$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' == ''">3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
+    
+    <!--  Represents an undefined TFV value. -->
+    <_UndefinedTargetFrameworkVersion>0.0</_UndefinedTargetFrameworkVersion>
+
+    <!-- Initial/Default value set to 'undefined'. Updated in Microsoft.NET.WindowsDesktop.targets -->
+    <_TargetFrameworkVersionValue>$(_UndefinedTargetFrameworkVersion)</_TargetFrameworkVersionValue>
+    
   </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
           Project="../targets/Microsoft.NET.Sdk.WindowsDesktop.targets"

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -15,12 +15,8 @@
     using the SDK style projects. For e.g., see https://github.com/microsoft/msbuild/issues/1333
     
     Irrespective of whether '$(TargetFrameworkIdentifier)' is '.NETCoreApp' or '.NETFramework', 
-    the minimum value of $(_TargetFrameworkVersionWithoutV) we will be testing for is '3.0'
+    the minimum value of $(_TargetFrameworkVersionValue) we will be testing for is '3.0'
     
-    Note:
-      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of 
-      the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
-      is safe to use here. 
   -->
     <_WindowsDesktopSdkTargetFrameworkVersionFloor>3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
 
@@ -32,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And 
-                         ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+                         ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
@@ -66,8 +62,8 @@
   
   <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And
                       ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And
-                      ('$(_TargetFrameworkVersionWithoutV)' != '') And
-                      ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+                      ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And
+                      ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true"
                         Condition="('$(UseWPF)' == 'true') And ('$(UseWindowsForms)' == 'true')"/>
@@ -101,33 +97,33 @@
                 System.Windows.Controls.Ribbon
 
   -->
-  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 
-                        ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+                        ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
     <!--
-      The following 3 _WpfCommonNetFxReference items normally require Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'", since
+      The following 3 _WpfCommonNetFxReference items normally require Condition="'$(_TargetFrameworkVersionValue)' >= '3.0'", since
       they are supported on .NET Framework 3.0 and above. 
       
-      This condition is implicitly satisfied by '$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' 
+      This condition is implicitly satisfied by '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' 
       in the outer ItemGroup
     -->
     <_WpfCommonNetFxReference Include="WindowsBase" /> 
     <_WpfCommonNetFxReference Include="PresentationCore" />
     <_WpfCommonNetFxReference Include="PresentationFramework" />
 
-    <_WpfCommonNetFxReference Include="System.Xaml" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'">
+    <_WpfCommonNetFxReference Include="System.Xaml" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </_WpfCommonNetFxReference>
-    <_WpfCommonNetFxReference Include="UIAutomationClient" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationClientSideProviders" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationProvider" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationTypes" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationClient" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationClientSideProviders" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationProvider" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationTypes" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
 
-    <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionWithoutV)' >= '4.5'" />
+    <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionValue)' >= '4.5'" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And 
-                        ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+                        ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     
     <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)"
                        Condition="'$(UseWPF)' == 'true'"/>
@@ -159,7 +155,7 @@
     Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
   --> 
   <ItemGroup Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And 
-                        '$(_TargetFrameworkVersionWithoutV)' != '' And '$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+                        '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
 
     <!-- 
         Windows Forms and WPF are supported only on .NET Core 3.0+

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -25,6 +25,11 @@
       to identify when a TFV is undefined
     -->
     <_UndefinedTargetFrameworkVersion>0.0</_UndefinedTargetFrameworkVersion>
+    
+    <!--
+      Initial/Default value set to 'undefined'. Updated in Microsoft.NET.WindowsDesktop.targets
+    --> 
+    <_TargetFrameworkVersionValue>$(_UndefinedTargetFrameworkVersion)</_TargetFrameworkVersionValue>
   </PropertyGroup>
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And 

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -23,6 +23,12 @@
       is safe to use here. 
   -->
     <_WindowsDesktopSdkTargetFrameworkVersionFloor>3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
+
+    <!-- 
+      Represents an undefined TFV value. This will be used in comparisons of _TargetFrameworkVersionValue (defined in Microsoft.NET.WindowsDesktop.targets)
+      to identify when a TFV is undefined
+    -->
+    <_UndefinedTargetFrameworkVersion>0.0</_UndefinedTargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And 

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -28,7 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And 
-                         ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+                         ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+                         ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
       <Generator>MSBuild:Compile</Generator>
@@ -97,7 +98,8 @@
                 System.Windows.Controls.Ribbon
 
   -->
-  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework') And 
+                        ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
                         ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
     <!--
@@ -122,8 +124,10 @@
     <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionValue)' >= '4.5'" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And ('$(TargetFrameworkIdentifier)' == '.NETFramework') And 
-                        ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true') And 
+                        ('$(TargetFrameworkIdentifier)' == '.NETFramework') And 
+                        ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+                        ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     
     <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)"
                        Condition="'$(UseWPF)' == 'true'"/>
@@ -155,7 +159,8 @@
     Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
   --> 
   <ItemGroup Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And 
-                        '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+                        '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And 
+                        '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
 
     <!-- 
         Windows Forms and WPF are supported only on .NET Core 3.0+

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -1,4 +1,23 @@
 <Project>
+  
+  <!-- 
+    $(TargetFrameworkVersion), $(_TargetFrameworkVersionWithoutV) etc. are defined in 
+    Microsoft.NET.Sdk.WindowsDesktop\targets\Microsoft.NET.Sdk.WindowsDesktop.targets. 
+    
+    Microsoft.NET.Sdk.targets is included prior to this file by Sdk.targets, so it is safe to define _TargetFrameworkValue
+    here. 
+    
+    _TargetFrameworkValue will be used in WindowsDesktop SDK as reliable proxy for _TargetFrameworkVersionWithoutV. 
+    _TargetFrameworkVersionWithoutV can be empty ('') or it can be a numeric value (e.g., '3.0') - which makes it hard to work with
+    esp. in outer builds.  _TargetFrameworkValue will always be guaranteed to have a numeric value ('0.0' or a valid TFM). 
+    
+    _TargetFrameworkVersionValue will be used in Microsoft.NET.Sdk.WindowsDesktop.props in Item conditions. This will be valid
+    because Items are evaluated after Properties (see https://docs.microsoft.com/en-us/visualstudio/msbuild/comparing-properties-and-items?view=vs-2019). 
+  -->
+  <PropertyGroup>
+    <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault($(_TargetFrameworkVersionWithoutV), $(_InvalidTargetFrameworkVersion)))</_TargetFrameworkVersionValue>
+  </PropertyGroup>
+  
   <Import Project="Microsoft.WinFX.targets" />
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -13,6 +13,11 @@
     
     _TargetFrameworkVersionValue will be used in Microsoft.NET.Sdk.WindowsDesktop.props in Item conditions. This will be valid
     because Items are evaluated after Properties (see https://docs.microsoft.com/en-us/visualstudio/msbuild/comparing-properties-and-items?view=vs-2019). 
+    
+    Note:
+      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of 
+      the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
+      is safe to use here. 
   -->
   <PropertyGroup>
     <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault($(_TargetFrameworkVersionWithoutV), $(_InvalidTargetFrameworkVersion)))</_TargetFrameworkVersionValue>
@@ -20,8 +25,8 @@
   
   <Import Project="Microsoft.WinFX.targets" />
 
-  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And 
-                         ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+                         ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     
     <!-- In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content, or None items, then remove them from the Page items. -->
@@ -35,7 +40,7 @@
   <Target Name="CheckForDuplicatePageItems" 
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile"
           DependsOnTargets="CheckForDuplicateItems"
-          Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+          Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
 
     <CheckForDuplicateItems
       Items="@(Page)"
@@ -63,7 +68,7 @@
   --> 
   <Target Name="_WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-          Condition="('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+          Condition="('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" 
                    Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'"/>
   </Target>
@@ -77,7 +82,7 @@
   <Target Name="_WindowsDesktopFrameworkRequiresVersion30"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
         Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And 
-                  ('$(_TargetFrameworkVersionWithoutV)' != '') And ('$(_TargetFrameworkVersionWithoutV)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
+                  ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -2,7 +2,7 @@
   
   <!-- 
     $(TargetFrameworkVersion), $(_TargetFrameworkVersionWithoutV) etc. are defined in 
-    Microsoft.NET.Sdk.WindowsDesktop\targets\Microsoft.NET.Sdk.WindowsDesktop.targets. 
+    Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets. 
     
     Microsoft.NET.Sdk.targets is included prior to this file by Sdk.targets, so it is safe to define _TargetFrameworkValue
     here. 
@@ -20,7 +20,7 @@
       is safe to use here. 
   -->
   <PropertyGroup>
-    <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault($(_TargetFrameworkVersionWithoutV), $(_InvalidTargetFrameworkVersion)))</_TargetFrameworkVersionValue>
+    <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault('$(_TargetFrameworkVersionWithoutV)', '$(_UndefinedTargetFrameworkVersion)'))</_TargetFrameworkVersionValue>
   </PropertyGroup>
   
   <Import Project="Microsoft.WinFX.targets" />


### PR DESCRIPTION
[release/3.0 version of #1707] 

Fixes #1651  - Invalid comparison in MSBuild's ignore-conditions mode in outer build of multitargeted project

This change ensures that the WindowsDesktop SDK never deals with undefined numeric values related to TFM.

This solution leverages the fact that `Items` are evaluated after `Properties` by MSBuild. See [Comparing properties and items](https://docs.microsoft.com/en-us/visualstudio/msbuild/comparing-properties-and-items?view=vs-2019)

`_TargetFrameworkVersionValue` - a new Property which is defined for exclusive use within the WindowsDesktop SDK, and which is intended to act as a proxy for `_TargetFrameworkVersionWithoutV` - is defined in `Microsoft.NET.Sdk.WindowsDesktop.targets` _after_ `TargetFrameworkVersionWithoutV` is guaranteed to be defined by `Microsoft.NET.Sdk.targets`. 

Even here, we ensure that a fallback default (`0.0`) is provided - guaranteeing that `_TargetFrameworkVersionValue` will always be numeric. 

When the `Condition`s in the various `Items` in `Microsoft.NET.WindowsDesktop.props` are evaluated (which will happen strictly after all `Properties` are evaluated - whether they appear in `.props` or `.targets`), `_TargetFrameworkVersionValue` would have been (a) well-defined and (b) guaranteed to be a numeric value. This would in turn guarantee that errors of the kind `"A numeric comparison was attempted on "$(_TargetFrameworkVersionValue)" that evaluates to "" instead of a number,"` will no longer appear in outer-builds or in any other context. 

PS: This is a fix for a regression introduced by https://github.com/dotnet/wpf/pull/1027 (which shipped in Preview 6) as part of a set of fixes for improving multi-targeting experience, improved warnings and error messages during build, and improvements to project-system integration. 
