### PR TITLE
Update private C++ tools version to 0.0.0.8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
         Also in global.json 
         Used in Wpf.Cpp.PrivateTools.props/targets 
     -->
-    <MsvcurtC1xxVersion>0.0.0.7</MsvcurtC1xxVersion>
+    <MsvcurtC1xxVersion>0.0.0.8</MsvcurtC1xxVersion>
     <!--
     This is the version of the test infrastructure package is compiled against. This should be
     removed as part of https://github.com/dotnet/wpf/issues/816 

--- a/global.json
+++ b/global.json
@@ -19,6 +19,6 @@
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.1",
-    "msvcurt-c1xx": "0.0.0.7"
+    "msvcurt-c1xx": "0.0.0.8"
   }
 }


### PR DESCRIPTION
Addresses #634 

These updated C++ tools address the last of dangling type-refs in DirectWriteForwarder and System.Printing. 

