### PR TITLE
Fix DebuggableAttribute in InjectModuleInitializer post-build targets

### DIFF
--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -404,6 +404,11 @@
       <ILFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(AssemblyName).il'))</ILFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <DebugEnableJitOptimization>false</DebugEnableJitOptimization>
+      <DebugEnableJitOptimization Condition="'$(Configuration)' == 'Release'">true</DebugEnableJitOptimization>
+    </PropertyGroup>
+
     <!-- 
       Make a backup before overwriting $(TargetFile) 
     -->
@@ -417,6 +422,7 @@
                Out="$(TargetFile)"
                Dll="true"
                Debug="true"
+               DebugEnableJitOptimization="$(DebugEnableJitOptimization)"
                Quiet="true" />
 
     <ILAsmTask ILAsm="$(ILAsm)"
@@ -426,6 +432,7 @@
                Out="$(TargetFile)"
                Dll="true"
                Debug="true"
+               DebugEnableJitOptimization="$(DebugEnableJitOptimization)"
                Quiet="true" />
   </Target>
 

--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -404,6 +404,7 @@
       <ILFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(AssemblyName).il'))</ILFile>
     </PropertyGroup>
 
+    <!-- Ensures the DebuggableAttribute has the appropriate optimizations enabled. -->
     <PropertyGroup>
       <DebugEnableJitOptimization>false</DebugEnableJitOptimization>
       <DebugEnableJitOptimization Condition="'$(Configuration)' == 'Release'">true</DebugEnableJitOptimization>


### PR DESCRIPTION
Addresses #1549 

In the `ReconstituteDll` target, we call ILAsm to merge a module constructor into the assembly we previously disassembled.  We need to enable JIT optimizations here so that we get an appropriate `DebuggableAttribute` on the assembly and don't cause perf problems.

@vatsan-madhavan who helped debug and find this fix.