### PR TITLE
Update Intellisense XML data 

### DIFF
--- a/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
+++ b/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
@@ -46,7 +46,7 @@
           Outputs="$(IntellisenseXmlDir)$(AssemblyName).xml">
     <PropertyGroup>
       <!-- Also in global.json -->
-      <DotNetApiDocsNetCoreApp30>0.0.0.1</DotNetApiDocsNetCoreApp30>
+      <DotNetApiDocsNetCoreApp30>0.0.0.2</DotNetApiDocsNetCoreApp30>
       <IntellisenseXmlDir>$(RepositoryToolsDir)native\bin\dotnet-api-docs_netcoreapp3.0\$(DotNetApiDocsNetCoreApp30)\_intellisense\netcore-3.0\</IntellisenseXmlDir>
     </PropertyGroup>
     

--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
-    "dotnet-api-docs_netcoreapp3.0": "0.0.0.1",
+    "dotnet-api-docs_netcoreapp3.0": "0.0.0.2",
     "msvcurt-c1xx": "0.0.0.8"
   }
 }


### PR DESCRIPTION
#### Description

Updates Intellisense XML data from a latest build from https://ops.microsoft.com/#/sites/Docs/docsets/dotnet-api-docs?tabName=builds. 

Intellisense data for `WindowsBase.dll` was not being generated correctly until recently. `WindowsBase.dll` in `Microsoft.NetCore.App` was _hiding_ `WindowsBase.dll` in `Microsoft.WindowsDesktop.App`. 

This problem was recently fixed in `dotnet/dotnet-api-docs`, and this PR incorporates updated intellisense XML's generated from a recent build from `dotnet/dotnet-api-docs` repo. 

#### Customer impact

Intellisense XML's for API's exposed through WindowsBase.dll will now be available through the SDK.

#### Regression? 

No

#### Risk

Very low.

#### Severity

Medium - doesn't affect WPF directly, but affects the overall IDE experience.

#### Workaround

None.

Related: https://github.com/dotnet/dotnet-api-docs/issues/2602
Fixes: https://github.com/dotnet/wpf/issues/1597

