### PR TITLE
Fixing removal of None from Page under certain conditions

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -27,11 +27,26 @@
 
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
                          ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    
-    <!-- In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
-         as Resource, Content, or None items, then remove them from the Page items. -->
-    <Page Remove="@(Resource);@(Content);@(None)"
+
+    <!--
+         In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
+         as Resource, Content then remove them from the Page items.
+         
+         If EnableDefaultApplicationDefinition is false, ApplicationDefinition must also be removed from Page as
+         PresentationBuildTasks will include the generated code for the ApplicationDefinition twice otherwise.
+         We cannot do this in all cases in the props file as ApplicationDefinition won't be available
+         at that point in the evaluation when EnableDefaultApplicationDefinition is false.
+    -->
+    <Page Remove="@(Resource);@(Content);@(ApplicationDefinition)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
+
+    <!--
+         Only remove None from Page in the event that we disable both the default ApplicationDefinition and the DefaultPageItems.
+         Otherwise we can enter a situation where we are explicitly removing page items that should otherwise be included (such as
+         when (EnableDefaultApplicationDefinition xor EnableDefaultPageItems) is true).
+    -->
+    <Page Remove="@(None)"
+          Condition="'$(EnableDefaultApplicationDefinition)' != 'false' and '$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
   <!-- Generate error if there are duplicate page items.  The task comes from the .NET SDK, and this target follows

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -32,7 +32,7 @@
          In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content then remove them from the Page items.
     -->
-    <Page Remove="@(Resource);@(Content);@(ApplicationDefinition)"
+    <Page Remove="@(Resource);@(Content)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
 
     <!--

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -31,15 +31,19 @@
     <!--
          In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content then remove them from the Page items.
-         
-         If EnableDefaultApplicationDefinition is false, ApplicationDefinition must also be removed from Page as
-         PresentationBuildTasks will include the generated code for the ApplicationDefinition twice otherwise.
-         We cannot do this in all cases in the props file as ApplicationDefinition won't be available
-         at that point in the evaluation when EnableDefaultApplicationDefinition is false.
     -->
     <Page Remove="@(Resource);@(Content);@(ApplicationDefinition)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
 
+    <!--
+        If ApplicationDefinition must also be removed from Page as PresentationBuildTasks will include the
+        generated code for the ApplicationDefinition twice otherwise.  We cannot do this in all cases in the
+        props file as ApplicationDefinition won't be available at that point in the evaluation when
+        EnableDefaultApplicationDefinition is false.  We unconditionally remove it here as ApplicationDefinition
+        is considered a special singleton Item that WPF ensures is only where it needs to be.
+    -->
+    <Page Remove="@(ApplicationDefinition)" />
+    
     <!--
          Only remove None from Page in the event that we disable both the default ApplicationDefinition and the DefaultPageItems.
          Otherwise we can enter a situation where we are explicitly removing page items that should otherwise be included (such as

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -36,18 +36,23 @@
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
 
     <!--
-        If ApplicationDefinition must also be removed from Page as PresentationBuildTasks will include the
-        generated code for the ApplicationDefinition twice otherwise.  We cannot do this in all cases in the
-        props file as ApplicationDefinition won't be available at that point in the evaluation when
-        EnableDefaultApplicationDefinition is false.  We unconditionally remove it here as ApplicationDefinition
-        is considered a special singleton Item that WPF ensures is only where it needs to be.
+        ApplicationDefinition must also be removed from Page.  Otherwise, PresentationBuildTasks will include the
+        generated code for the ApplicationDefinition twice.  We cannot do this in all cases in the props file as
+        ApplicationDefinition isn't available at that point in the evaluation when EnableDefaultApplicationDefinition
+        is false.  We unconditionally remove it here as ApplicationDefinition is considered a special singleton Item 
+        in WPF.
     -->
     <Page Remove="@(ApplicationDefinition)" />
     
     <!--
-         Only remove None from Page in the event that we disable both the default ApplicationDefinition and the DefaultPageItems.
-         Otherwise we can enter a situation where we are explicitly removing page items that should otherwise be included (such as
-         when (EnableDefaultApplicationDefinition xor EnableDefaultPageItems) is true).
+         The WindowsDesktop props file removes "**/*.xaml" from None if both EnableDefaultApplicationDefinition and 
+         EnableDefaultPageItems are true.  This is done so that we remove any implicitly globbed XAML files from None
+         in support of Visual Studio.  
+         
+         In the case where one or both of these properties are not true, the WindowsDesktop props file does not remove
+         any XAML files from None.  Under those conditions, removing None from Page here will remove explicitly specified
+         pages causing compilation errors.  We match the condition from the WindowsDesktop props file here so that we only
+         remove None from Page when we are guaranteed to not need those items.
     -->
     <Page Remove="@(None)"
           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' and '$(EnableDefaultPageItems)' != 'false'" />


### PR DESCRIPTION
Addresses #1758

# Description 

Fixing removal of None from Page under certain conditions 

# Issue Details 

Under default circumstances, WindowsDesktop props will remove “**\*.xaml” from the None MSBuild Item in order to support Visual Studio.  Items that are left in None are then removed from Page in the WindowsDesktop targets.  This was a change made to address complaints here about more specific removal criteria that Visual Studio was unable to handle. 

When a developer sets EnableDefaultApplicationDefinition to false, WindowsDesktop props will not remove “**\*.xaml” from None as it cannot only remove the automatically globbed XAML (as we’re no longer globbing all XAML).  This causes issues in the WindowsDesktop targets since removing None from Page now causes compilation errors. 

The solution is to guard the removal of None from Page with the same conditional as the removal of “**\*.xaml” from None so we only do this work in the same fully default configuration.  This change exposes another issue with ApplicationDefinition being multiply included in compilation so we also unconditionally remove ApplicationDefinition from Pages as WPF’s PresentationBuildTasks treats ApplicationDefinition as a special singleton that shouldn’t exist in any other XAML compilation items. 

## Customer Impact

*Severity*:  Medium 

Customers using non-default ApplicationDefinitions (named something other than App.xaml or Application.xaml) will be unable to compile without explicitly adding back removed Page items.  Essentially, this means turning off default ApplicationDefinitions turns off default Page includes as well.  

## Regression? 

Yes, from the work to support VS in https://github.com/dotnet/wpf/issues/685 

## Risk: Low 

### Mitigations: 

* The None item hasn’t changed in semantics so VS still will see the same behavior there 

* The Page item has the same behavior in the default case and fixed behavior in the currently broken case 

* The Page item will no longer carry ApplicationDefinition under any scenario, which is desirable. 

### Validations 

I’ve run builds against combinations of flags using a modified .NET Core 3 RC1 installation (See these tests).  All pass as expected.  I’ll add these tests to our manual test team validations for now and further work can be queued up for .NET 5 to automate these. 