### PR TITLE
Ensure that markup compilation is run for all design time builds

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -106,7 +106,7 @@
   <Target Name="DesignTimeMarkupCompilation">
 
         <!-- Only if we are not actually performing a compile i.e. we are in design mode -->
-        <CallTarget Condition="'$(BuildingProject)' != 'true'"
+        <CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'"
                 Targets="MarkupCompilePass1" />
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/2488

In SDK-style projects the project system will combine design time builds together to improve performance, but depending on timing, this can cause issues. If something like the designer asks for output groups, then the build for that could be combined with the build that produces the intellisense file, but getting output groups sets BuildingProject to true.

This change works around the issue by allowing the intellisense file to generate even if `BuildingProject` is true, as long we're still doing a design time build.