### PR TITLE
Move System.Xaml.sln into System.Xaml directory

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.sln
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2048
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Xaml", "System.Xaml\System.Xaml.csproj", "{9AC36357-34B7-40A1-95CA-FE9F46D089A7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Xaml", "System.Xaml.csproj", "{9AC36357-34B7-40A1-95CA-FE9F46D089A7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This was done to align with the solution files in the `PresentationBuildTasks` and `WindowsBase` directories.