### PR TITLE
Remove outdated README files

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/README.md
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/README.md
@@ -1,2 +1,0 @@
-Note: 
-    Until PresentationFramework is open-sourced, the files under this folder should be modified only with careful coordination with the WPF team. 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/README.md
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/README.md
@@ -1,2 +1,0 @@
-Note: 
-    Until WindowsBase is open-sourced, the files under this folder should be modified only with careful coordination with the WPF team. 


### PR DESCRIPTION
There is no longer any need to warn users about modifying the code in these directories, as it has long since been open-sourced. I have kept the warning file in the Shared directory for now, as code in the remaining native projects may well reference that code.