### PR TITLE
WPF TextBox insertion caret does not render when moved to lower DPI monitor in a PMAv2 process.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -1858,6 +1858,9 @@ namespace System.Windows
 
                         int caretWidth = 0;
 
+#if NEVER
+                        // this code would work if the OS treated SPI_GETCARETWIDTH
+                        // like all the other metrics, scaling it to the primary monitor's DPI
                         if (UnsafeNativeMethods.SystemParametersInfo(NativeMethods.SPI_GETCARETWIDTH, 0, ref caretWidth, 0))
                         {
                             _caretWidth = ConvertPixel(caretWidth);
@@ -1867,6 +1870,24 @@ namespace System.Windows
                             _cacheValid[(int)CacheSlot.CaretWidth] = false;
                             throw new Win32Exception();
                         }
+#else
+                        // the OS doesn't scale SPI_GETCARETWIDTH to the primary monitor's DPI,
+                        // so we should not apply the ConvertPixel adjustment [DDVSO 973208].
+                        // Call SPI in "unaware" mode;  this ensures we won't break
+                        // if the OS decides to "fix" their anomalous behavior.
+                        using (DpiUtil.WithDpiAwarenessContext(MS.Utility.DpiAwarenessContextValue.Unaware))
+                        {
+                            if (UnsafeNativeMethods.SystemParametersInfo(NativeMethods.SPI_GETCARETWIDTH, 0, ref caretWidth, 0))
+                            {
+                                _caretWidth = (double)caretWidth;
+                            }
+                            else
+                            {
+                                _cacheValid[(int)CacheSlot.CaretWidth] = false;
+                                throw new Win32Exception();
+                            }
+                        }
+#endif
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -1872,7 +1872,7 @@ namespace System.Windows
                         }
 #else
                         // the OS doesn't scale SPI_GETCARETWIDTH to the primary monitor's DPI,
-                        // so we should not apply the ConvertPixel adjustment [DDVSO 973208].
+                        // so we should not apply the ConvertPixel adjustment.
                         // Call SPI in "unaware" mode;  this ensures we won't break
                         // if the OS decides to "fix" their anomalous behavior.
                         using (DpiUtil.WithDpiAwarenessContext(MS.Utility.DpiAwarenessContextValue.Unaware))


### PR DESCRIPTION
Ask Mode Template:  

Description 

TextBox insertion caret fails to render when on a lower DPI monitor than primary when per-monitor awareness is enabled. 

Customer Impact 

VS features that rely on Text Caret position (search controls, commit messages, Editor, etc) are unable to easily tell where their focus is when using these features if PMA support is enabled and the text box is rendered off the primary display. 

Regression 

No.   (Port of .NET 4.8 servicing fix)

Risk 

Low 

Fixes #1774 
WPF TextBox insertion caret does not render when moved to lower DPI monitor in a PMAv2 process.  

 