### PR TITLE
Mark ProjectTemplates and Microsoft.NET.Sdk.WindowsDesktop as NonShipping

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{BFF6C118-3369-43B5-ACA6-D65ED00EEBE0}</ProjectGuid>
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #1957 

Mark the following packages with `<IsShipping>false</IsShipping>`

- Microsoft.NET.Sdk.WindowsDesktop
- Microsoft.DotNet.Wpf.ProjectTemplates

These are transport packages and ship exclusively via the SDK. Importantly, these should not be marked for publishing to NuGet.