### PR TITLE
Adding border to ToggleButton when checked in high-contrast themes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
@@ -124,6 +124,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/themes/Aero.NormalColor.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -38,7 +35,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Button
     ==================================================================-->
     <!-- Normal -->
@@ -119,7 +116,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#212;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#212;}"
@@ -132,15 +147,12 @@ To automatically copy the files, set the environment variable
            BasedOn="{StaticResource &#212;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <!--=================================================================
             Calendar
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -166,19 +178,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -189,10 +201,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -214,10 +226,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -233,7 +245,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#214;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#214;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -319,7 +331,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -330,31 +342,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#214;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#214;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#216;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#216;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#215;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#215;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -431,9 +443,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -745,7 +757,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
-                    <BulletDecorator Background="Transparent" 
+                    <BulletDecorator Background="Transparent"
                                      SnapsToDevicePixels="true">
                         <BulletDecorator.Bullet>
                             <theme:BulletChrome Background="{TemplateBinding Background}"
@@ -790,17 +802,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#230;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -844,11 +856,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -856,7 +868,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -919,32 +931,32 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Grid.ColumnSpan="2" Margin="1,0"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <Rectangle Fill="#F1F1F1"
-                                           HorizontalAlignment="Left"
-                                           Width="28"
-                                           Margin="1,2"
-                                           RadiusX="2"
-                                           RadiusY="2"/>
-                                <Rectangle HorizontalAlignment="Left"
-                                           Width="1"
-                                           Margin="29,2,0,2"
-                                           Fill="#E2E3E3"/>
-                                <Rectangle HorizontalAlignment="Left"
-                                           Width="1"
-                                           Margin="30,2,0,2"
-                                           Fill="White"/>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <Rectangle Fill="#F1F1F1"
+                                               HorizontalAlignment="Left"
+                                               Width="28"
+                                               Margin="1,2"
+                                               RadiusX="2"
+                                               RadiusY="2"/>
+                                    <Rectangle HorizontalAlignment="Left"
+                                               Width="1"
+                                               Margin="29,2,0,2"
+                                               Fill="#E2E3E3"/>
+                                    <Rectangle HorizontalAlignment="Left"
+                                               Width="1"
+                                               Margin="30,2,0,2"
+                                               Fill="White"/>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -976,7 +988,7 @@ To automatically copy the files, set the environment variable
 
 
 
- 
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -1049,7 +1061,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
     </Style>
-    
+
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
     ==================================================================-->
@@ -1106,68 +1118,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1180,23 +1192,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#232;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#233;" />
@@ -1321,10 +1333,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1415,7 +1427,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1481,7 +1493,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1524,11 +1536,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#232;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#232;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1651,9 +1663,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1667,7 +1679,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1778,20 +1790,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#238;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1800,9 +1812,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1821,22 +1833,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1889,12 +1901,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1914,7 +1926,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1978,7 +1990,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#253;" Color="Transparent"/>
     <SolidColorBrush x:Key="&#254;" Color="#666"/>
 
-    
+
     <!--=================================================================
         Expander
     ==================================================================-->
@@ -1996,9 +2008,9 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>        
-    
-    
+    </Style>
+
+
     <Style x:Key="&#256;"
            TargetType="{x:Type ToggleButton}">
         <Setter Property="Template">
@@ -2062,7 +2074,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#250;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#251;}"
                                     TargetName="arrow"/>
@@ -2070,15 +2082,15 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#252;}" 
+                                    Value="{StaticResource &#252;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#253;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#254;}" 
-                                    TargetName="arrow"/>                        
-                        </Trigger>                                    
+                                    Value="{StaticResource &#254;}"
+                                    TargetName="arrow"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -2143,7 +2155,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#247;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#248;}"
                                     TargetName="arrow"/>
@@ -2158,7 +2170,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#250;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#251;}"
                                     TargetName="arrow"/>
@@ -2166,15 +2178,15 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#252;}" 
+                                    Value="{StaticResource &#252;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#253;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#254;}" 
+                                    Value="{StaticResource &#254;}"
                                     TargetName="arrow"/>
-                        </Trigger>                                    
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -2239,7 +2251,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#247;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#248;}"
                                     TargetName="arrow"/>
@@ -2262,14 +2274,14 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#252;}" 
+                                    Value="{StaticResource &#252;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#253;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#254;}" 
-                                    TargetName="arrow"/>     
+                                    Value="{StaticResource &#254;}"
+                                    TargetName="arrow"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2331,49 +2343,49 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsMouseOver"
                                  Value="true">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#246;}" 
+                                    Value="{StaticResource &#246;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#247;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#248;}" 
+                                    Value="{StaticResource &#248;}"
                                     TargetName="arrow"/>
                         </Trigger>
                         <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#249;}" 
+                                    Value="{StaticResource &#249;}"
                                     TargetName="circle"/>
                             <Setter Property="StrokeThickness"
                                     Value="1.5"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#250;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#251;}" 
+                                    Value="{StaticResource &#251;}"
                                     TargetName="arrow"/>
                         </Trigger>
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#252;}" 
+                                    Value="{StaticResource &#252;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#253;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#254;}" 
+                                    Value="{StaticResource &#254;}"
                                     TargetName="arrow"/>
-                        </Trigger>                        
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    
+
+
     <Style x:Key="{x:Type Expander}"
            TargetType="{x:Type Expander}">
         <Setter Property="Foreground"
@@ -2480,7 +2492,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2498,43 +2510,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#260;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#261;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2631,15 +2643,15 @@ To automatically copy the files, set the environment variable
                                         CornerRadius="2"/>
                             </Border>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,1,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </Border>
                         <!-- Primary content for GroupBox -->
@@ -2701,33 +2713,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2787,7 +2799,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#272;"
                      Color="#828790"/>
 
@@ -2840,10 +2853,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2856,17 +2869,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#273;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -2923,11 +2936,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#273;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#273;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -3292,10 +3305,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -3317,7 +3330,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <LinearGradientBrush x:Key="&#280;"
                          StartPoint="0,0"
                          EndPoint="0,1">
@@ -3358,7 +3371,7 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-   
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -3553,7 +3566,7 @@ To automatically copy the files, set the environment variable
                            Fill="White"/>
 
                 <ContentPresenter Grid.ColumnSpan="2" Margin="1,0"/>
-           </Grid>
+            </Grid>
         </Border>
     </ControlTemplate>
     <Style x:Key="&#290;"
@@ -3700,7 +3713,7 @@ To automatically copy the files, set the environment variable
 
 
 
- <!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <LinearGradientBrush x:Key="&#291;"
@@ -3882,34 +3895,34 @@ To automatically copy the files, set the environment variable
                         <ScrollViewer Name="SubMenuScrollViewer"
                                       Margin="1,0"
                                       Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                    Fill="{StaticResource &#289;}" />
-                            </Canvas>
-                            <Rectangle Fill="#F1F1F1"
-                                       HorizontalAlignment="Left"
-                                       Width="28"
-                                       Margin="1,2"
-                                       RadiusX="2"
-                                       RadiusY="2"/>
-                            <Rectangle HorizontalAlignment="Left"
-                                       Width="1"
-                                       Margin="29,2,0,2"
-                                       Fill="#E2E3E3"/>
-                            <Rectangle HorizontalAlignment="Left"
-                                       Width="1"
-                                       Margin="30,2,0,2"
-                                       Fill="White"/>
-                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                            KeyboardNavigation.TabNavigation="Cycle"
-                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            Grid.IsSharedSizeScope="true"/>
-                           </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                        Fill="{StaticResource &#289;}" />
+                                </Canvas>
+                                <Rectangle Fill="#F1F1F1"
+                                           HorizontalAlignment="Left"
+                                           Width="28"
+                                           Margin="1,2"
+                                           RadiusX="2"
+                                           RadiusY="2"/>
+                                <Rectangle HorizontalAlignment="Left"
+                                           Width="1"
+                                           Margin="29,2,0,2"
+                                           Fill="#E2E3E3"/>
+                                <Rectangle HorizontalAlignment="Left"
+                                           Width="1"
+                                           Margin="30,2,0,2"
+                                           Fill="White"/>
+                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Grid.IsSharedSizeScope="true"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -4186,34 +4199,34 @@ To automatically copy the files, set the environment variable
                         <ScrollViewer Name="SubMenuScrollViewer"
                                       Margin="1,0"
                                       Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                    Fill="{StaticResource &#289;}" />
-                            </Canvas>
-                            <Rectangle Fill="#F1F1F1"
-                                       HorizontalAlignment="Left"
-                                       Width="28"
-                                       Margin="1,2"
-                                       RadiusX="2"
-                                       RadiusY="2"/>
-                            <Rectangle HorizontalAlignment="Left"
-                                       Width="1"
-                                       Margin="29,2,0,2"
-                                       Fill="#E2E3E3"/>
-                            <Rectangle HorizontalAlignment="Left"
-                                       Width="1"
-                                       Margin="30,2,0,2"
-                                       Fill="White"/>
-                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                            KeyboardNavigation.TabNavigation="Cycle"
-                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            Grid.IsSharedSizeScope="true"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                        Fill="{StaticResource &#289;}" />
+                                </Canvas>
+                                <Rectangle Fill="#F1F1F1"
+                                           HorizontalAlignment="Left"
+                                           Width="28"
+                                           Margin="1,2"
+                                           RadiusX="2"
+                                           RadiusY="2"/>
+                                <Rectangle HorizontalAlignment="Left"
+                                           Width="1"
+                                           Margin="29,2,0,2"
+                                           Fill="#E2E3E3"/>
+                                <Rectangle HorizontalAlignment="Left"
+                                           Width="1"
+                                           Margin="30,2,0,2"
+                                           Fill="White"/>
+                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Grid.IsSharedSizeScope="true"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -4232,8 +4245,8 @@ To automatically copy the files, set the environment variable
                         Property="Stroke"
                         Value="#D1DBF4FF"/>
             </Trigger>
-             <Trigger Property="Icon"
-                     Value="{x:Null}">
+            <Trigger Property="Icon"
+                    Value="{x:Null}">
                 <Setter TargetName="Icon"
                         Property="Visibility"
                         Value="Collapsed"/>
@@ -4409,7 +4422,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#297;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4422,7 +4435,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#298;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -4431,7 +4444,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#299;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4443,7 +4456,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#300;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4464,14 +4477,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#301;" 
+    <SolidColorBrush x:Key="&#301;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#266;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -4563,9 +4576,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#265;" 
+    <Style x:Key="&#265;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -4591,33 +4604,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -4645,13 +4658,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -4670,11 +4683,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -4692,11 +4705,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -4712,16 +4725,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -4731,9 +4744,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#297;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#298;}"
@@ -4755,13 +4768,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#294;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#295;}"
@@ -4780,30 +4793,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#293;}"
                                  Stroke="{StaticResource &#297;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#298;}"
@@ -4816,7 +4829,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#296;}"
@@ -4831,13 +4844,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#294;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#295;}"
@@ -4873,7 +4886,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#264;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4883,9 +4896,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#267;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4893,14 +4906,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4928,19 +4941,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#268;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#269;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4999,8 +5012,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -5131,7 +5144,7 @@ To automatically copy the files, set the environment variable
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="&#313;" 
+    <LinearGradientBrush x:Key="&#313;"
                          StartPoint="0,0"
                          EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
@@ -5145,7 +5158,7 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-        
+
     <Style x:Key="{x:Type ProgressBar}"
            TargetType="{x:Type ProgressBar}">
         <Setter Property="Foreground"
@@ -5188,7 +5201,7 @@ To automatically copy the files, set the environment variable
                                 <!-- Animated Background -->
                                 <Grid x:Name="Animation" ClipToBounds="true">
                                     <!-- Animated White glow -->
-                                    <Rectangle x:Name="PART_GlowRect" Width="100" 
+                                    <Rectangle x:Name="PART_GlowRect" Width="100"
                                                 Fill="{StaticResource &#313;}"
                                                 Margin="-100,0,0,0"
                                                 HorizontalAlignment="Left">
@@ -5237,7 +5250,7 @@ To automatically copy the files, set the environment variable
                                             Grid.ColumnSpan="3"
                                             Background="{StaticResource &#307;}"/>
                                     <Border x:Name="Highlight2"
-                                            Grid.RowSpan="2" 
+                                            Grid.RowSpan="2"
                                             Grid.ColumnSpan="3"
                                             Background="{StaticResource &#305;}"/>
                                 </Grid>
@@ -5292,7 +5305,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-     
+
     <!--=================================================================
         RadioButton
     ==================================================================-->
@@ -5372,8 +5385,8 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
                     <Grid SnapsToDevicePixels="true" Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Margin="0,0,2,2"
                               Data="M 9,0 L 11,0 L 11,11 L 0,11 L 0,9 L 3,9 L 3,6 L 6,6 L 6,3 L 9,3 z">
 
@@ -5402,7 +5415,7 @@ To automatically copy the files, set the environment variable
 
 
 
-  <!--=================================================================
+    <!--=================================================================
         HorizontalScrollBar and VerticalScrollBar
     ==================================================================-->
     <!--
@@ -5673,21 +5686,21 @@ To automatically copy the files, set the environment variable
     <!-- End ScrollBar Styles -->
 
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -5713,31 +5726,38 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-  
-     <!--=================================================================
+
+    <!--=================================================================
         VerticalSlider and HorizontalSlider
     ==================================================================-->
     <!-- Pointed Thumb-->
-    <Geometry x:Key="&#322;">M 4.5,-7.5 A 1 1 0 0 0 3.5,-8.5 L -3.5,-8.5 A 1 1 0 0 0 -4.5,-7.5 L -4.5,4.5 L -0.5,8.5 L 0.5,8.5 L 4.5,4.5 Z
+    <Geometry x:Key="&#322;">
+        M 4.5,-7.5 A 1 1 0 0 0 3.5,-8.5 L -3.5,-8.5 A 1 1 0 0 0 -4.5,-7.5 L -4.5,4.5 L -0.5,8.5 L 0.5,8.5 L 4.5,4.5 Z
     </Geometry>
-    
-    <Geometry x:Key="&#323;">M 3.5,-7.5 L -3.5,-7.5 L -3.5,4.5 L 0,8 L 3.5,4.5 Z
+
+    <Geometry x:Key="&#323;">
+        M 3.5,-7.5 L -3.5,-7.5 L -3.5,4.5 L 0,8 L 3.5,4.5 Z
     </Geometry>
-    
-    <Geometry x:Key="&#324;">M 2.5,-6.5 L -2.5,-6.5 L -2.5,4.5 L 0,7 L 2.5 4.5 Z
+
+    <Geometry x:Key="&#324;">
+        M 2.5,-6.5 L -2.5,-6.5 L -2.5,4.5 L 0,7 L 2.5 4.5 Z
     </Geometry>
-    
-    <Geometry x:Key="&#325;">M 4.5,-8.5 L -4.5,-8.5 L -4.5,4.5 L -0.5,8.5 L 0.5,8.5 L 4.5,4.5 Z
+
+    <Geometry x:Key="&#325;">
+        M 4.5,-8.5 L -4.5,-8.5 L -4.5,4.5 L -0.5,8.5 L 0.5,8.5 L 4.5,4.5 Z
     </Geometry>
 
     <!-- Rectangular Thumb -->
-    <Geometry x:Key="&#326;">M -5,-9.5 A 1 1 0 0 1 -4,-10.5 L 4,-10.5 A 1 1 0 0 1 5,-9.5 L 5,9.5 A 1 1 0 0 1 4,10.5 L -4,10.5 A 1 1 0 0 1 -5,9.5 Z
+    <Geometry x:Key="&#326;">
+        M -5,-9.5 A 1 1 0 0 1 -4,-10.5 L 4,-10.5 A 1 1 0 0 1 5,-9.5 L 5,9.5 A 1 1 0 0 1 4,10.5 L -4,10.5 A 1 1 0 0 1 -5,9.5 Z
     </Geometry>
 
-    <Geometry x:Key="&#327;">M -4,-9.5 L 4,-9.5 L 4,9.5 L -4,9.5 Z
+    <Geometry x:Key="&#327;">
+        M -4,-9.5 L 4,-9.5 L 4,9.5 L -4,9.5 Z
     </Geometry>
 
-    <Geometry x:Key="&#328;">M -5,-10.5 L 5,-10.5 L 5,10.5 L -5,10.5 Z
+    <Geometry x:Key="&#328;">
+        M -5,-10.5 L 5,-10.5 L 5,10.5 L -5,10.5 Z
     </Geometry>
     <!--=================================================================
             HorizontalSlider Resources
@@ -5793,7 +5813,7 @@ To automatically copy the files, set the environment variable
                           Offset=".8"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-   
+
     <!-- Hover -->
     <LinearGradientBrush x:Key="&#333;"
                          EndPoint="0,1"
@@ -5846,7 +5866,7 @@ To automatically copy the files, set the environment variable
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-  
+
     <SolidColorBrush x:Key="&#337;" Color="#3C7FB1"/>
 
     <LinearGradientBrush x:Key="&#338;"
@@ -6646,7 +6666,7 @@ To automatically copy the files, set the environment variable
                                         </Canvas>
                                     </Border>
 
-                                        <!-- MainPartsPanel -->
+                                    <!-- MainPartsPanel -->
                                     <Track Grid.Column="1"
                                            Name="PART_Track">
                                         <Track.DecreaseRepeatButton>
@@ -6963,8 +6983,8 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- 
-   
+
+
     <Style x:Key="&#354;">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -6979,8 +6999,8 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-   
-   
+
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -7159,10 +7179,10 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- <!--=================================================================
+    <!--=================================================================
         ListBox
     ==================================================================-->
-     <!-- This color is shared between ComboBox and TextBox -->
+    <!-- This color is shared between ComboBox and TextBox -->
     <LinearGradientBrush x:Key="&#229;"
                          StartPoint="0,0"
                          EndPoint="0,20"
@@ -7176,13 +7196,13 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-         
+
     <!--=================================================================
         TextBoxBase
     ==================================================================-->
     <Style x:Key="{x:Type TextBoxBase}"
            TargetType="{x:Type TextBoxBase}"
-           BasedOn="{x:Null}">        
+           BasedOn="{x:Null}">
         <Setter Property="Foreground"
                 Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
         <Setter Property="Background"
@@ -7259,7 +7279,7 @@ To automatically copy the files, set the environment variable
     ==================================================================-->
     <Style x:Key="{x:Type RichTextBox}"
            BasedOn="{StaticResource {x:Type TextBoxBase}}"
-           TargetType="{x:Type RichTextBox}">        
+           TargetType="{x:Type RichTextBox}">
         <Style.Resources>
             <Style x:Key="{x:Type FlowDocument}"
                    TargetType="{x:Type FlowDocument}">
@@ -7364,7 +7384,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -7405,7 +7425,7 @@ TODO:
     </Style>
 
 
- <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <LinearGradientBrush x:Key="&#385;"
@@ -7532,38 +7552,38 @@ TODO:
                                     Property="Background"
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
-                      <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                               Value="true">
-                        <Setter TargetName="_tv_scrollviewer_"
-                                Property="CanContentScroll"
-                                Value="true"/>
-                      </Trigger>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
-<SolidColorBrush x:Key="&#386;" Color="#FF989898"/>
-<SolidColorBrush x:Key="&#387;" Color="Transparent"/>
-<SolidColorBrush x:Key="&#388;" Color="#FF1BBBFA"/>
-<SolidColorBrush x:Key="&#389;" Color="Transparent"/>
-<SolidColorBrush x:Key="&#390;" Color="#FF262626"/>
-<SolidColorBrush x:Key="&#391;" Color="#FF595959"/>
-<SolidColorBrush x:Key="&#392;" Color="#FF262626"/>
-<SolidColorBrush x:Key="&#393;" Color="#FF595959"/>
+    <SolidColorBrush x:Key="&#386;" Color="#FF989898"/>
+    <SolidColorBrush x:Key="&#387;" Color="Transparent"/>
+    <SolidColorBrush x:Key="&#388;" Color="#FF1BBBFA"/>
+    <SolidColorBrush x:Key="&#389;" Color="Transparent"/>
+    <SolidColorBrush x:Key="&#390;" Color="#FF262626"/>
+    <SolidColorBrush x:Key="&#391;" Color="#FF595959"/>
+    <SolidColorBrush x:Key="&#392;" Color="#FF262626"/>
+    <SolidColorBrush x:Key="&#393;" Color="#FF595959"/>
 
 
 
@@ -7630,7 +7650,7 @@ TODO:
                                     Property="Stroke"
                                     Value="{StaticResource &#390;}"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter TargetName="ExpandPath"
                                     Property="Stroke"
@@ -7764,21 +7784,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -7802,7 +7822,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -7920,18 +7940,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7952,7 +7972,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -7985,11 +8005,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -8020,9 +8040,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -8676,28 +8696,28 @@ TODO:
     <Style x:Key="&#224;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -8728,7 +8748,7 @@ TODO:
 
 
 
-     <!--=================================================================
+    <!--=================================================================
         ComboBox
     ==================================================================-->
 
@@ -8809,12 +8829,12 @@ TODO:
                                         RenderPressed="{TemplateBinding IsPressed}"
                                         RoundCorners="false"
                                         SnapsToDevicePixels="true">
-                            <Path Name="Arrow"
-                                  Margin="0,1,0,0"
-                                  Fill="Black"
-                                  Data="{StaticResource &#225;}"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"/>
+                        <Path Name="Arrow"
+                              Margin="0,1,0,0"
+                              Fill="Black"
+                              Data="{StaticResource &#225;}"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"/>
                     </theme:ButtonChrome>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked"
@@ -8855,22 +8875,22 @@ TODO:
                                               Color="Transparent"
                                               MinWidth="{Binding ElementName=Placement,Path=ActualWidth}"
                                               MaxHeight="{TemplateBinding MaxDropDownHeight}">
-                   <Border x:Name="DropDownBorder"
-                            BorderThickness="1"
-                            BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"
-                            Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
+                    <Border x:Name="DropDownBorder"
+                             BorderThickness="1"
+                             BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"
+                             Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
                         <ScrollViewer Name="DropDownScrollViewer">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                            </Canvas>
-                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                </Canvas>
+                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -8920,10 +8940,10 @@ TODO:
                         Value="#FFF4F4F4"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="PART_Popup"
@@ -9000,20 +9020,20 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}"
                                         Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
-                             </theme:SystemDropShadowChrome>
+                            </theme:SystemDropShadowChrome>
                         </Popup>
                         <ToggleButton Grid.ColumnSpan="2"
                                       Background="{TemplateBinding Background}"
@@ -9056,10 +9076,10 @@ TODO:
                                     Value="#FFF4F4F4"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="DropDownScrollViewer"
@@ -9120,7 +9140,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#264;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -9130,9 +9150,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#267;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -9140,14 +9160,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -9178,16 +9198,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#268;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#269;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -9625,19 +9645,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#362;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9731,16 +9751,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#369;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -9832,10 +9852,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -10168,28 +10188,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#375;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#375;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -10240,16 +10260,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -10415,28 +10435,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#375;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#375;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -10482,16 +10502,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -10562,15 +10582,15 @@ TODO:
     </Style>
     <Style x:Key="&#383;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#377;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#377;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10623,15 +10643,15 @@ TODO:
     </Style>
     <Style x:Key="&#384;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#378;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#378;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10685,180 +10705,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#374;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#383;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#370;}"
-                                        BorderBrush="{StaticResource &#369;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#380;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#382;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#374;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#383;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#370;}"
+                                            BorderBrush="{StaticResource &#369;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#380;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#382;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#384;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#375;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#384;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#375;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#373;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
@@ -7240,6 +7240,7 @@ TODO:
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -28,7 +25,7 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -54,19 +51,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -77,10 +74,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -102,10 +99,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -121,7 +118,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#223;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#223;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -207,7 +204,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -218,31 +215,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#223;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#223;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#225;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#225;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#224;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#224;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -319,9 +316,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -560,7 +557,7 @@ To automatically copy the files, set the environment variable
         <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}"/>
     </DataTemplate>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -623,32 +620,32 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Grid.ColumnSpan="2" Margin="1,0"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <Rectangle Fill="#F1F1F1"
-                                           HorizontalAlignment="Left"
-                                           Width="28"
-                                           Margin="1,2"
-                                           RadiusX="2"
-                                           RadiusY="2"/>
-                                <Rectangle HorizontalAlignment="Left"
-                                           Width="1"
-                                           Margin="29,2,0,2"
-                                           Fill="#E2E3E3"/>
-                                <Rectangle HorizontalAlignment="Left"
-                                           Width="1"
-                                           Margin="30,2,0,2"
-                                           Fill="White"/>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <Rectangle Fill="#F1F1F1"
+                                               HorizontalAlignment="Left"
+                                               Width="28"
+                                               Margin="1,2"
+                                               RadiusX="2"
+                                               RadiusY="2"/>
+                                    <Rectangle HorizontalAlignment="Left"
+                                               Width="1"
+                                               Margin="29,2,0,2"
+                                               Fill="#E2E3E3"/>
+                                    <Rectangle HorizontalAlignment="Left"
+                                               Width="1"
+                                               Margin="30,2,0,2"
+                                               Fill="White"/>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -680,7 +677,7 @@ To automatically copy the files, set the environment variable
 
 
 
- 
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -753,7 +750,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
     </Style>
-    
+
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
     ==================================================================-->
@@ -810,68 +807,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -884,23 +881,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#285;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#286;" />
@@ -1025,10 +1022,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1119,7 +1116,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1185,7 +1182,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1228,11 +1225,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#285;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#285;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1355,9 +1352,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1371,7 +1368,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1482,20 +1479,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#291;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1504,9 +1501,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1525,22 +1522,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1593,12 +1590,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1618,7 +1615,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1645,7 +1642,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#303;" Color="#FFE6E6E6"/>
     <SolidColorBrush x:Key="&#304;" Color="#FF707070"/>
 
-    
+
     <!--=================================================================
         Expander
     ==================================================================-->
@@ -1663,9 +1660,9 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>        
-    
-    
+    </Style>
+
+
     <Style x:Key="&#306;"
            TargetType="{x:Type ToggleButton}">
         <Setter Property="Template">
@@ -1729,7 +1726,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#300;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#301;}"
                                     TargetName="arrow"/>
@@ -1737,15 +1734,15 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#302;}" 
+                                    Value="{StaticResource &#302;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#303;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#304;}" 
-                                    TargetName="arrow"/>                        
-                        </Trigger>                                    
+                                    Value="{StaticResource &#304;}"
+                                    TargetName="arrow"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -1810,7 +1807,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#297;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#298;}"
                                     TargetName="arrow"/>
@@ -1825,7 +1822,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#300;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#301;}"
                                     TargetName="arrow"/>
@@ -1833,15 +1830,15 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#302;}" 
+                                    Value="{StaticResource &#302;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#303;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#304;}" 
+                                    Value="{StaticResource &#304;}"
                                     TargetName="arrow"/>
-                        </Trigger>                                    
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -1906,7 +1903,7 @@ To automatically copy the files, set the environment variable
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#297;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
                                     Value="{StaticResource &#298;}"
                                     TargetName="arrow"/>
@@ -1929,14 +1926,14 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#302;}" 
+                                    Value="{StaticResource &#302;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#303;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#304;}" 
-                                    TargetName="arrow"/>     
+                                    Value="{StaticResource &#304;}"
+                                    TargetName="arrow"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1998,49 +1995,49 @@ To automatically copy the files, set the environment variable
                         <Trigger Property="IsMouseOver"
                                  Value="true">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#296;}" 
+                                    Value="{StaticResource &#296;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#297;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#298;}" 
+                                    Value="{StaticResource &#298;}"
                                     TargetName="arrow"/>
                         </Trigger>
                         <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#299;}" 
+                                    Value="{StaticResource &#299;}"
                                     TargetName="circle"/>
                             <Setter Property="StrokeThickness"
                                     Value="1.5"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#300;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#301;}" 
+                                    Value="{StaticResource &#301;}"
                                     TargetName="arrow"/>
                         </Trigger>
                         <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#302;}" 
+                                    Value="{StaticResource &#302;}"
                                     TargetName="circle"/>
                             <Setter Property="Fill"
                                     Value="{StaticResource &#303;}"
-                                    TargetName="circle"/>                                    
+                                    TargetName="circle"/>
                             <Setter Property="Stroke"
-                                    Value="{StaticResource &#304;}" 
+                                    Value="{StaticResource &#304;}"
                                     TargetName="arrow"/>
-                        </Trigger>                        
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
-    
+
+
     <Style x:Key="{x:Type Expander}"
            TargetType="{x:Type Expander}">
         <Setter Property="Foreground"
@@ -2147,7 +2144,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2165,43 +2162,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#310;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#311;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2320,15 +2317,15 @@ To automatically copy the files, set the environment variable
                                         CornerRadius="2"/>
                             </Border>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,1,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </Border>
                         <!-- Primary content for GroupBox -->
@@ -2390,33 +2387,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2476,7 +2473,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#322;"
                      Color="#828790"/>
 
@@ -2519,10 +2517,10 @@ To automatically copy the files, set the environment variable
                             <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource &#328;}" />
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2557,14 +2555,14 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                    <Border x:Name="Bd" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        Padding="{TemplateBinding Padding}" 
+                    <Border x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
                         SnapsToDevicePixels="true">
-                        <ContentPresenter 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
@@ -2957,10 +2955,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2982,7 +2980,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <LinearGradientBrush x:Key="&#343;"
                          StartPoint="0,0"
                          EndPoint="0,1">
@@ -3023,7 +3021,7 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-   
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -3153,7 +3151,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#359;" Color="#21000000" />
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
 
@@ -3209,7 +3207,7 @@ To automatically copy the files, set the environment variable
         </Border>
     </ControlTemplate>
 
-     <!--=================================================================
+    <!--=================================================================
         ScrollViewer inside a MenuItem or ContextMenu
     ==================================================================-->
     <Style x:Key="&#364;" TargetType="{x:Type RepeatButton}" BasedOn="{x:Null}" >
@@ -3298,7 +3296,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-<!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="{x:Type Separator}">
@@ -3779,7 +3777,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#369;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3792,7 +3790,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#370;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -3801,7 +3799,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#371;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3813,7 +3811,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#372;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3834,14 +3832,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#373;" 
+    <SolidColorBrush x:Key="&#373;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#316;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -3933,9 +3931,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#315;" 
+    <Style x:Key="&#315;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -3961,33 +3959,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -4015,13 +4013,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -4040,11 +4038,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -4062,11 +4060,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -4082,16 +4080,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -4101,9 +4099,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#369;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#370;}"
@@ -4125,13 +4123,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#366;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#367;}"
@@ -4150,30 +4148,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#365;}"
                                  Stroke="{StaticResource &#369;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#370;}"
@@ -4186,7 +4184,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#368;}"
@@ -4201,13 +4199,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#366;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#367;}"
@@ -4243,7 +4241,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#314;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4253,9 +4251,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#317;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4263,14 +4261,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4298,19 +4296,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#318;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#319;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4369,8 +4367,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -4388,78 +4386,78 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-	<SolidColorBrush x:Key="&#375;" Color="#FF06B025" />
-	<SolidColorBrush x:Key="&#376;" Color="#FFE6E6E6" />
-	<SolidColorBrush x:Key="&#377;" Color="#FFBCBCBC" />
+    <SolidColorBrush x:Key="&#375;" Color="#FF06B025" />
+    <SolidColorBrush x:Key="&#376;" Color="#FFE6E6E6" />
+    <SolidColorBrush x:Key="&#377;" Color="#FFBCBCBC" />
 
-	<Style TargetType="{x:Type ProgressBar}">
-		<Setter Property="Foreground" Value="{StaticResource &#375;}" />
-		<Setter Property="Background" Value="{StaticResource &#376;}" />
-		<Setter Property="BorderBrush" Value="{StaticResource &#377;}" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type ProgressBar}">
-					<Grid x:Name="TemplateRoot">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Determinate"/>
-								<VisualState x:Name="Indeterminate">
-									<Storyboard RepeatBehavior="Forever">
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="Animation">
-											<EasingDoubleKeyFrame KeyTime="0" Value="0.25"/>
-											<EasingDoubleKeyFrame KeyTime="0:0:1" Value="0.25"/>
-											<EasingDoubleKeyFrame KeyTime="0:0:2" Value="0.25"/>
-										</DoubleAnimationUsingKeyFrames>
-										<PointAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransformOrigin)" Storyboard.TargetName="Animation">
-											<EasingPointKeyFrame KeyTime="0" Value="-0.5,0.5"/>
-											<EasingPointKeyFrame KeyTime="0:0:1" Value="0.5,0.5"/>
-											<EasingPointKeyFrame KeyTime="0:0:2" Value="1.5,0.5"/>
-										</PointAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<Border 
-						    BorderThickness="{TemplateBinding BorderThickness}" 
-						    BorderBrush="{TemplateBinding BorderBrush}" 
+    <Style TargetType="{x:Type ProgressBar}">
+        <Setter Property="Foreground" Value="{StaticResource &#375;}" />
+        <Setter Property="Background" Value="{StaticResource &#376;}" />
+        <Setter Property="BorderBrush" Value="{StaticResource &#377;}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ProgressBar}">
+                    <Grid x:Name="TemplateRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Determinate"/>
+                                <VisualState x:Name="Indeterminate">
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="Animation">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="0.25"/>
+                                            <EasingDoubleKeyFrame KeyTime="0:0:1" Value="0.25"/>
+                                            <EasingDoubleKeyFrame KeyTime="0:0:2" Value="0.25"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <PointAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransformOrigin)" Storyboard.TargetName="Animation">
+                                            <EasingPointKeyFrame KeyTime="0" Value="-0.5,0.5"/>
+                                            <EasingPointKeyFrame KeyTime="0:0:1" Value="0.5,0.5"/>
+                                            <EasingPointKeyFrame KeyTime="0:0:2" Value="1.5,0.5"/>
+                                        </PointAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Border
+						    BorderThickness="{TemplateBinding BorderThickness}"
+						    BorderBrush="{TemplateBinding BorderBrush}"
 						    Background="{TemplateBinding Background}" />
-						<Rectangle x:Name="PART_Track"/>
-						<Grid x:Name="PART_Indicator"
+                        <Rectangle x:Name="PART_Track"/>
+                        <Grid x:Name="PART_Indicator"
 						    HorizontalAlignment="Left"
 						    ClipToBounds="true">
-							<Rectangle x:Name="Indicator" 
+                            <Rectangle x:Name="Indicator"
 							    Fill="{TemplateBinding Foreground}" />
-							<Rectangle x:Name="Animation" 
-							    RenderTransformOrigin="0.5,0.5" 
+                            <Rectangle x:Name="Animation"
+							    RenderTransformOrigin="0.5,0.5"
 							    Fill="{TemplateBinding Foreground}">
-								<Rectangle.RenderTransform>
-									<TransformGroup>
-										<ScaleTransform/>
-										<SkewTransform/>
-										<RotateTransform/>
-										<TranslateTransform/>
-									</TransformGroup>
-								</Rectangle.RenderTransform>
-							</Rectangle>
-						</Grid>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="Orientation" Value="Vertical">
-							<Setter Property="LayoutTransform" TargetName="TemplateRoot">
-								<Setter.Value>
-									<RotateTransform Angle="-90"/>
-								</Setter.Value>
-							</Setter>
-						</Trigger>
-						<Trigger Property="IsIndeterminate" Value="true">
-							<Setter Property="Visibility" TargetName="Indicator" Value="Collapsed"/>
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <ScaleTransform/>
+                                        <SkewTransform/>
+                                        <RotateTransform/>
+                                        <TranslateTransform/>
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                        </Grid>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Orientation" Value="Vertical">
+                            <Setter Property="LayoutTransform" TargetName="TemplateRoot">
+                                <Setter.Value>
+                                    <RotateTransform Angle="-90"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsIndeterminate" Value="true">
+                            <Setter Property="Visibility" TargetName="Indicator" Value="Collapsed"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 
 
@@ -4491,25 +4489,25 @@ To automatically copy the files, set the environment variable
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Border x:Name="radioButtonBorder" 
-                            Margin="1,1,2,1" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="radioButtonBorder"
+                            Margin="1,1,2,1"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             CornerRadius="100">
                             <Grid x:Name="markGrid" Margin="2">
                                 <Ellipse x:Name="optionMark" Opacity="0" MinWidth="6" MinHeight="6" Fill="{StaticResource &#380;}"/>
                             </Grid>
                         </Border>
-                        <ContentPresenter x:Name="contentPresenter" 
-                            RecognizesAccessKey="True" 
-                            Grid.Column="1" 
-                            Margin="{TemplateBinding Padding}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter x:Name="contentPresenter"
+                            RecognizesAccessKey="True"
+                            Grid.Column="1"
+                            Margin="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Focusable="False"/>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -4531,7 +4529,7 @@ To automatically copy the files, set the environment variable
                             <Setter Property="Background" Value="{StaticResource &#384;}" TargetName="radioButtonBorder" />
                             <Setter Property="BorderBrush" Value="{StaticResource &#385;}" TargetName="radioButtonBorder" />
                             <Setter Property="Fill" Value="{StaticResource &#386;}" TargetName="optionMark" />
-                        </Trigger>                        
+                        </Trigger>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter Property="Opacity" Value="1" TargetName="optionMark" />
                         </Trigger>
@@ -4574,8 +4572,8 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
                     <Grid SnapsToDevicePixels="true" Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Margin="0,0,2,2"
                               Data="M 9,0 L 11,0 L 11,11 L 0,11 L 0,9 L 3,9 L 3,6 L 6,6 L 6,3 L 9,3 z">
 
@@ -4690,14 +4688,14 @@ To automatically copy the files, set the environment variable
             Fill="{StaticResource &#394;}"
             Height="{TemplateBinding Height}"
             Width="{TemplateBinding Width}"/>
-            <ControlTemplate.Triggers>
-                <Trigger Property="IsMouseOver" Value="true">
-                    <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#398;}" />
-                </Trigger>
-                <Trigger Property="IsDragging" Value="true">
-                    <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#401;}" />
-                </Trigger>
-            </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#398;}" />
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="true">
+                            <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#401;}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -4709,19 +4707,19 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-            <Rectangle x:Name="rectangle"
-            SnapsToDevicePixels="True"
-            Fill="{StaticResource &#394;}"
-            Height="{TemplateBinding Height}"
-            Width="{TemplateBinding Width}"/>
-            <ControlTemplate.Triggers>
-            <Trigger Property="IsMouseOver" Value="true">
-                <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#398;}" />
-            </Trigger>
-            <Trigger Property="IsDragging" Value="true">
-                <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#401;}" />
-            </Trigger>
-            </ControlTemplate.Triggers>
+                    <Rectangle x:Name="rectangle"
+                    SnapsToDevicePixels="True"
+                    Fill="{StaticResource &#394;}"
+                    Height="{TemplateBinding Height}"
+                    Width="{TemplateBinding Width}"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#398;}" />
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="true">
+                            <Setter TargetName="rectangle" Property="Fill" Value="{StaticResource &#401;}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -4732,7 +4730,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Stylus.IsFlicksEnabled" Value="false"/>
         <Setter Property="Background" Value="{StaticResource &#391;}" />
         <Setter Property="BorderBrush" Value="{StaticResource &#392;}" />
-    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
         <Setter Property="BorderThickness" Value="1,0" />
         <Setter Property="Width" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
         <Setter Property="MinWidth" Value="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
@@ -4786,41 +4784,41 @@ To automatically copy the files, set the environment variable
                                 Fill="{StaticResource &#393;}" />
                         </RepeatButton>
                     </Grid>
-            <ControlTemplate.Triggers>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsMouseOver}" Value="true" />
-                    <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsPressed}" Value="true" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#402;}" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsMouseOver}" Value="true" />
-                    <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsPressed}" Value="true" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#402;}" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsMouseOver}" Value="true" />
-                    <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsPressed}" Value="false" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#397;}" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsMouseOver}" Value="true" />
-                    <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsPressed}" Value="false" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#397;}" />
-            </MultiDataTrigger>
-            <Trigger Property="IsEnabled" Value="false">
-                <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#405;}" />
-                <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#405;}" />
-            </Trigger>
-            </ControlTemplate.Triggers>
-        </ControlTemplate>
+                    <ControlTemplate.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsMouseOver}" Value="true" />
+                                <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsPressed}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#402;}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsMouseOver}" Value="true" />
+                                <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsPressed}" Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#402;}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsMouseOver}" Value="true" />
+                                <Condition Binding="{Binding ElementName=PART_LineDownButton, Path=IsPressed}" Value="false" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#397;}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsMouseOver}" Value="true" />
+                                <Condition Binding="{Binding ElementName=PART_LineUpButton, Path=IsPressed}" Value="false" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#397;}" />
+                        </MultiDataTrigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter TargetName="ArrowTop" Property="Fill" Value="{StaticResource &#405;}" />
+                            <Setter TargetName="ArrowBottom" Property="Fill" Value="{StaticResource &#405;}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
@@ -4879,40 +4877,40 @@ To automatically copy the files, set the environment variable
                     Fill="{StaticResource &#393;}" />
                                 </RepeatButton>
                             </Grid>
-                <ControlTemplate.Triggers>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsMouseOver}" Value="true" />
-                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsPressed}" Value="true" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#402;}" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsMouseOver}" Value="true" />
-                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsPressed}" Value="true" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#402;}" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsMouseOver}" Value="true" />
-                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsPressed}" Value="false" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#397;}" />
-                </MultiDataTrigger>
-                <MultiDataTrigger>
-                    <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsMouseOver}" Value="true" />
-                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsPressed}" Value="false" />
-                    </MultiDataTrigger.Conditions>
-                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#397;}" />
-                </MultiDataTrigger>
-                <Trigger Property="IsEnabled" Value="false">
-                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#405;}" />
-                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#405;}" />
-                </Trigger>
-                </ControlTemplate.Triggers>
+                            <ControlTemplate.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsMouseOver}" Value="true" />
+                                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsPressed}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#402;}" />
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsMouseOver}" Value="true" />
+                                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsPressed}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#402;}" />
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsMouseOver}" Value="true" />
+                                        <Condition Binding="{Binding ElementName=PART_LineRightButton, Path=IsPressed}" Value="false" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#397;}" />
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsMouseOver}" Value="true" />
+                                        <Condition Binding="{Binding ElementName=PART_LineLeftButton, Path=IsPressed}" Value="false" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#397;}" />
+                                </MultiDataTrigger>
+                                <Trigger Property="IsEnabled" Value="false">
+                                    <Setter TargetName="ArrowLeft" Property="Fill" Value="{StaticResource &#405;}" />
+                                    <Setter TargetName="ArrowRight" Property="Fill" Value="{StaticResource &#405;}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
@@ -4921,21 +4919,21 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -4975,368 +4973,368 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#421;" Color="#FFD6D6D6" />
 
     <ControlTemplate x:Key="&#422;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,0 C0,0 11,0 11,0 11,0 11,18 11,18 11,18 0,18 0,18 0,18 0,0 0,0 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#411;}"
-             Stroke="{StaticResource &#412;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,0 C0,0 11,0 11,0 11,0 11,18 11,18 11,18 0,18 0,18 0,18 0,0 0,0 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#411;}"
+                Stroke="{StaticResource &#412;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#423;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,6 C0,6 5.5,0 5.5,0 5.5,0 11,6 11,6 11,6 11,18 11,18 11,18 0,18 0,18 0,18 0,6 0,6 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#411;}"
-             Stroke="{StaticResource &#412;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,6 C0,6 5.5,0 5.5,0 5.5,0 11,6 11,6 11,6 11,18 11,18 11,18 0,18 0,18 0,18 0,6 0,6 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#411;}"
+                Stroke="{StaticResource &#412;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#424;" TargetType="{x:Type Thumb}">
-     <Grid HorizontalAlignment="Center" VerticalAlignment="Center" UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,12 C0,12 5.5,18 5.5,18 5.5,18 11,12 11,12 11,12 11,0 11,0 11,0 0,0 0,0 0,0 0,12 0,12 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#411;}"
-             Stroke="{StaticResource &#412;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid HorizontalAlignment="Center" VerticalAlignment="Center" UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,12 C0,12 5.5,18 5.5,18 5.5,18 11,12 11,12 11,12 11,0 11,0 11,0 0,0 0,0 0,0 0,12 0,12 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#411;}"
+                Stroke="{StaticResource &#412;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#425;" TargetType="{x:Type Slider}">
-        <Border x:Name="border" 
+        <Border x:Name="border"
                  SnapsToDevicePixels="True"
                  Background="{TemplateBinding Background}"
                  BorderBrush="{TemplateBinding BorderBrush}"
                  BorderThickness="{TemplateBinding BorderThickness}">
-             <Grid>
-                 <Grid.RowDefinitions>
-                     <RowDefinition Height="Auto"/>
-                     <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}"/>
-                     <RowDefinition Height="Auto"/>
-                 </Grid.RowDefinitions>
-                 <TickBar x:Name="TopTick" 
-                     Height="4" 
-                     Placement="Top" 
-                     Grid.Row="0" 
-                     Visibility="Collapsed" 
-                     Margin="0,0,0,2" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <TickBar x:Name="BottomTick" 
-                     Height="4" 
-                     Placement="Bottom" 
-                     Grid.Row="2" 
-                     Visibility="Collapsed" 
-                     Margin="0,2,0,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <Border x:Name="TrackBackground" 
-                     BorderThickness="1" 
-                     Height="4.0" 
-                     Margin="5,0" 
-                     Grid.Row="1" 
-                     VerticalAlignment="center"
-                     BorderBrush="{StaticResource &#421;}" 
-                     Background="{StaticResource &#420;}">
-                     <Canvas Margin="-6,-1">
-                         <Rectangle x:Name="PART_SelectionRange" 
-                             Height="4.0" 
-                             Visibility="Hidden" 
-                             Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                     </Canvas>
-                 </Border>
-                 <Track x:Name="PART_Track" Grid.Row="1">
-                     <Track.DecreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.DecreaseLarge}" 
-                             Style="{StaticResource &#407;}"/>
-                     </Track.DecreaseRepeatButton>
-                     <Track.IncreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.IncreaseLarge}" 
-                             Style="{StaticResource &#407;}"/>
-                     </Track.IncreaseRepeatButton>
-                     <Track.Thumb>
-                         <Thumb x:Name="Thumb" 
-                             OverridesDefaultStyle="True" 
-                             Focusable="False" 
-                             VerticalAlignment="Center" 
-                             Template="{StaticResource &#422;}" 
-                             Width="11" 
-                             Height="18"/>
-                     </Track.Thumb>
-                 </Track>
-             </Grid>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TickBar x:Name="TopTick"
+                    Height="4"
+                    Placement="Top"
+                    Grid.Row="0"
+                    Visibility="Collapsed"
+                    Margin="0,0,0,2"
+                    Fill="{TemplateBinding Foreground}" />
+                <TickBar x:Name="BottomTick"
+                    Height="4"
+                    Placement="Bottom"
+                    Grid.Row="2"
+                    Visibility="Collapsed"
+                    Margin="0,2,0,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <Border x:Name="TrackBackground"
+                    BorderThickness="1"
+                    Height="4.0"
+                    Margin="5,0"
+                    Grid.Row="1"
+                    VerticalAlignment="center"
+                    BorderBrush="{StaticResource &#421;}"
+                    Background="{StaticResource &#420;}">
+                    <Canvas Margin="-6,-1">
+                        <Rectangle x:Name="PART_SelectionRange"
+                            Height="4.0"
+                            Visibility="Hidden"
+                            Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                    </Canvas>
+                </Border>
+                <Track x:Name="PART_Track" Grid.Row="1">
+                    <Track.DecreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.DecreaseLarge}"
+                            Style="{StaticResource &#407;}"/>
+                    </Track.DecreaseRepeatButton>
+                    <Track.IncreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.IncreaseLarge}"
+                            Style="{StaticResource &#407;}"/>
+                    </Track.IncreaseRepeatButton>
+                    <Track.Thumb>
+                        <Thumb x:Name="Thumb"
+                            OverridesDefaultStyle="True"
+                            Focusable="False"
+                            VerticalAlignment="Center"
+                            Template="{StaticResource &#422;}"
+                            Width="11"
+                            Height="18"/>
+                    </Track.Thumb>
+                </Track>
+            </Grid>
         </Border>
-     <ControlTemplate.Triggers>
-         <Trigger Property="TickPlacement" Value="TopLeft">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#423;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="5,2,5,0"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="BottomRight">
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#424;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="5,0,5,2"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="Both">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsSelectionRangeEnabled" Value="true">
-             <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsKeyboardFocused" Value="true">
-             <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <ControlTemplate.Triggers>
+            <Trigger Property="TickPlacement" Value="TopLeft">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#423;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="5,2,5,0"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="BottomRight">
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#424;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="5,0,5,2"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="Both">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsSelectionRangeEnabled" Value="true">
+                <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#426;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M0.5,0.5 L18.5,0.5 18.5,11.5 0.5,11.5z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#412;}"
-             Fill="{StaticResource &#411;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M0.5,0.5 L18.5,0.5 18.5,11.5 0.5,11.5z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#412;}"
+                Fill="{StaticResource &#411;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#427;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 6,11 C6,11 0,5.5 0,5.5 0,5.5 6,0 6,0 6,0 18,0 18,0 18,0 18,11 18,11 18,11 6,11 6,11 z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#412;}"
-             Fill="{StaticResource &#411;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 6,11 C6,11 0,5.5 0,5.5 0,5.5 6,0 6,0 6,0 18,0 18,0 18,0 18,11 18,11 18,11 6,11 6,11 z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#412;}"
+                Fill="{StaticResource &#411;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#428;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 12,11 C12,11 18,5.5 18,5.5 18,5.5 12,0 12,0 12,0 0,0 0,0 0,0 0,11 0,11 0,11 12,11 12,11 z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#412;}"
-             Fill="{StaticResource &#411;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 12,11 C12,11 18,5.5 18,5.5 18,5.5 12,0 12,0 12,0 0,0 0,0 0,0 0,11 0,11 0,11 12,11 12,11 z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#412;}"
+                Fill="{StaticResource &#411;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#414;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#415;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#416;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#417;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#418;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#419;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#429;" TargetType="{x:Type Slider}">
-        <Border x:Name="border" 
+        <Border x:Name="border"
                  SnapsToDevicePixels="True"
                  Background="{TemplateBinding Background}"
                  BorderBrush="{TemplateBinding BorderBrush}"
                  BorderThickness="{TemplateBinding BorderThickness}">
-             <Grid>
-                 <Grid.ColumnDefinitions>
-                     <ColumnDefinition Width="Auto"/>
-                     <ColumnDefinition MinWidth="{TemplateBinding MinWidth}" Width="Auto"/>
-                     <ColumnDefinition Width="Auto"/>
-                 </Grid.ColumnDefinitions>
-                 <TickBar x:Name="TopTick" 
-                     Grid.Column="0" 
-                     Placement="Left" 
-                     Visibility="Collapsed" 
-                     Width="4" 
-                     Margin="0,0,2,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <TickBar x:Name="BottomTick" 
-                     Grid.Column="2" 
-                     Placement="Right" 
-                     Visibility="Collapsed" 
-                     Width="4" 
-                     Margin="2,0,0,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <Border x:Name="TrackBackground" 
-                     BorderThickness="1" 
-                     Grid.Column="1" 
-                     HorizontalAlignment="center" 
-                     Margin="0,5" 
-                     Width="4.0" 
-                     BorderBrush="{StaticResource &#421;}" 
-                     Background="{StaticResource &#420;}">
-                     <Canvas Margin="-1,-6">
-                         <Rectangle x:Name="PART_SelectionRange" 
-                             Visibility="Hidden" 
-                             Width="4.0" 
-                             Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                     </Canvas>
-                 </Border>
-                 <Track x:Name="PART_Track" Grid.Column="1">
-                     <Track.DecreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.DecreaseLarge}" 
-                             Style="{StaticResource &#407;}"/>
-                     </Track.DecreaseRepeatButton>
-                     <Track.IncreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.IncreaseLarge}" 
-                             Style="{StaticResource &#407;}"/>
-                     </Track.IncreaseRepeatButton>
-                     <Track.Thumb>
-                         <Thumb x:Name="Thumb" 
-                             OverridesDefaultStyle="True" 
-                             Focusable="False" 
-                             VerticalAlignment="Top" 
-                             Width="18" 
-                             Height="11" 
-                             Template="{StaticResource &#426;}"/>
-                     </Track.Thumb>
-                 </Track>
-             </Grid>
-         </Border>
-     <ControlTemplate.Triggers>
-         <Trigger Property="TickPlacement" Value="TopLeft">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#427;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="2,5,0,5"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="BottomRight">
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#428;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="0,5,2,5"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="Both">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsSelectionRangeEnabled" Value="true">
-             <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsKeyboardFocused" Value="true">
-             <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-         </Trigger>
-     </ControlTemplate.Triggers>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition MinWidth="{TemplateBinding MinWidth}" Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TickBar x:Name="TopTick"
+                    Grid.Column="0"
+                    Placement="Left"
+                    Visibility="Collapsed"
+                    Width="4"
+                    Margin="0,0,2,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <TickBar x:Name="BottomTick"
+                    Grid.Column="2"
+                    Placement="Right"
+                    Visibility="Collapsed"
+                    Width="4"
+                    Margin="2,0,0,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <Border x:Name="TrackBackground"
+                    BorderThickness="1"
+                    Grid.Column="1"
+                    HorizontalAlignment="center"
+                    Margin="0,5"
+                    Width="4.0"
+                    BorderBrush="{StaticResource &#421;}"
+                    Background="{StaticResource &#420;}">
+                    <Canvas Margin="-1,-6">
+                        <Rectangle x:Name="PART_SelectionRange"
+                            Visibility="Hidden"
+                            Width="4.0"
+                            Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                    </Canvas>
+                </Border>
+                <Track x:Name="PART_Track" Grid.Column="1">
+                    <Track.DecreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.DecreaseLarge}"
+                            Style="{StaticResource &#407;}"/>
+                    </Track.DecreaseRepeatButton>
+                    <Track.IncreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.IncreaseLarge}"
+                            Style="{StaticResource &#407;}"/>
+                    </Track.IncreaseRepeatButton>
+                    <Track.Thumb>
+                        <Thumb x:Name="Thumb"
+                            OverridesDefaultStyle="True"
+                            Focusable="False"
+                            VerticalAlignment="Top"
+                            Width="18"
+                            Height="11"
+                            Template="{StaticResource &#426;}"/>
+                    </Track.Thumb>
+                </Track>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="TickPlacement" Value="TopLeft">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#427;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="2,5,0,5"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="BottomRight">
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#428;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="0,5,2,5"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="Both">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsSelectionRangeEnabled" Value="true">
+                <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <Style TargetType="{x:Type Slider}">
-     <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-     <Setter Property="Background" Value="Transparent" />
-     <Setter Property="BorderBrush" Value="Transparent" />
-     <Setter Property="Foreground" Value="{StaticResource &#413;}" />
-     <Setter Property="Template" Value="{StaticResource &#425;}" />
-     <Style.Triggers>
-         <Trigger Property="Orientation" Value="Vertical">
-             <Setter Property="Template" Value="{StaticResource &#429;}" />
-         </Trigger>
-     </Style.Triggers>
+        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource &#413;}" />
+        <Setter Property="Template" Value="{StaticResource &#425;}" />
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Vertical">
+                <Setter Property="Template" Value="{StaticResource &#429;}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
-<!-- End of Aero2 Slider -->
+    <!-- End of Aero2 Slider -->
 
 
-  
+
 
     <!--=================================================================
         StatusBar
@@ -5541,188 +5539,188 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
                     <Grid x:Name="templateRoot" SnapsToDevicePixels="true">
-                        <Border x:Name="mainBorder" 
-                            BorderThickness="1,1,1,0" 
+                        <Border x:Name="mainBorder"
+                            BorderThickness="1,1,1,0"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Margin="0">
-                            <Border x:Name="innerBorder" 
-                                BorderThickness="1,1,1,0" 
+                            <Border x:Name="innerBorder"
+                                BorderThickness="1,1,1,0"
                                 Background="{StaticResource &#434;}"
                                 BorderBrush="{StaticResource &#435;}"
                                 Margin="-1"
                                 Opacity="0" />
-                        </Border>                           
-                        <ContentPresenter x:Name="contentPresenter" 
-                            ContentSource="Header" 
-                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
-                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            Focusable="False" 
+                        </Border>
+                        <ContentPresenter x:Name="contentPresenter"
+                            ContentSource="Header"
+                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Focusable="False"
                             Margin="{TemplateBinding Padding}"
                             RecognizesAccessKey="True"/>
                     </Grid>
                     <ControlTemplate.Triggers>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
                             <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#433;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
                             <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#433;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
                             <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#433;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#432;}" />
                             <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#433;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
-                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
-                <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
                             <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
                             <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
-                        <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
-                            <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
                             <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
-                                <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
-                </MultiDataTrigger.Conditions>
-                <Setter Property="Panel.ZIndex" Value="1"/>
+                            <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
+                            <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="contentPresenter" Property="Opacity" Value="0.56" />
+                            <Setter TargetName="mainBorder" Property="Background" Value="{StaticResource &#436;}" />
+                            <Setter TargetName="mainBorder" Property="BorderBrush" Value="{StaticResource &#437;}" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Panel.ZIndex" Value="1"/>
                             <Setter Property="Margin" Value="-2,-2,0,-2"/>
-                                <Setter TargetName="innerBorder" Property="Opacity" Value="1" /> 
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
-                </MultiDataTrigger.Conditions>
-                <Setter Property="Panel.ZIndex" Value="1"/>
+                            <Setter TargetName="innerBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,0,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Panel.ZIndex" Value="1"/>
                             <Setter Property="Margin" Value="-2,0,-2,-2"/>
-                                <Setter TargetName="innerBorder" Property="Opacity" Value="1" /> 
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
-                </MultiDataTrigger.Conditions>
-                <Setter Property="Panel.ZIndex" Value="1"/>
-                                <Setter Property="Margin" Value="0,-2,-2,-2"/>
-                                <Setter TargetName="innerBorder" Property="Opacity" Value="1" /> 
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
-                    <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
-                </MultiDataTrigger.Conditions>
-                <Setter Property="Panel.ZIndex" Value="1"/>
+                            <Setter TargetName="innerBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,0,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,0,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Panel.ZIndex" Value="1"/>
+                            <Setter Property="Margin" Value="0,-2,-2,-2"/>
+                            <Setter TargetName="innerBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="0,1,1,1" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="0,1,1,1" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="false" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}" Value="true" />
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Top" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Panel.ZIndex" Value="1"/>
                             <Setter Property="Margin" Value="-2,-2,-2,0"/>
-                                <Setter TargetName="innerBorder" Property="Opacity" Value="1" /> 
-                <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
-                <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
-            </MultiDataTrigger>
+                            <Setter TargetName="innerBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="innerBorder" Property="BorderThickness" Value="1,1,1,0" />
+                            <Setter TargetName="mainBorder" Property="BorderThickness" Value="1,1,1,0" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -5758,9 +5756,9 @@ To automatically copy the files, set the environment variable
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                            Focusable="false" 
-                            HorizontalScrollBarVisibility="Hidden" 
+                        <ScrollViewer x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden" />
                     </Border>
                     <ControlTemplate.Triggers>
@@ -5796,7 +5794,7 @@ To automatically copy the files, set the environment variable
             </MultiTrigger>
         </Style.Triggers>
     </Style>
-    
+
     <!--=================================================================
         PasswordBox
     ==================================================================-->
@@ -5821,9 +5819,9 @@ To automatically copy the files, set the environment variable
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                            Focusable="false" 
-                            HorizontalScrollBarVisibility="Hidden" 
+                        <ScrollViewer x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden" />
                     </Border>
                     <ControlTemplate.Triggers>
@@ -5903,7 +5901,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -5966,15 +5964,15 @@ TODO:
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
-                    <Border Name="Border" 
-                        Background="{TemplateBinding Background}" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
+                    <Border Name="Border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ContentPresenter 
-                            Margin="{TemplateBinding Padding}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                     </Border>
                 </ControlTemplate>
@@ -6036,38 +6034,38 @@ TODO:
                                     Property="Background"
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
-                      <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                               Value="true">
-                        <Setter TargetName="_tv_scrollviewer_"
-                                Property="CanContentScroll"
-                                Value="true"/>
-                      </Trigger>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
-<SolidColorBrush x:Key="&#469;" Color="#FF818181"/>
-<SolidColorBrush x:Key="&#470;" Color="#FFFFFFFF"/>
-<SolidColorBrush x:Key="&#471;" Color="#FF27C7F7"/>
-<SolidColorBrush x:Key="&#472;" Color="#FFCCEEFB"/>
-<SolidColorBrush x:Key="&#473;" Color="#FF262626"/>
-<SolidColorBrush x:Key="&#474;" Color="#FF595959"/>
-<SolidColorBrush x:Key="&#475;" Color="#FF1CC4F7"/>
-<SolidColorBrush x:Key="&#476;" Color="#FF82DFFB"/>
+    <SolidColorBrush x:Key="&#469;" Color="#FF818181"/>
+    <SolidColorBrush x:Key="&#470;" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="&#471;" Color="#FF27C7F7"/>
+    <SolidColorBrush x:Key="&#472;" Color="#FFCCEEFB"/>
+    <SolidColorBrush x:Key="&#473;" Color="#FF262626"/>
+    <SolidColorBrush x:Key="&#474;" Color="#FF595959"/>
+    <SolidColorBrush x:Key="&#475;" Color="#FF1CC4F7"/>
+    <SolidColorBrush x:Key="&#476;" Color="#FF82DFFB"/>
 
 
 
@@ -6135,7 +6133,7 @@ TODO:
                                     Property="Stroke"
                                     Value="{StaticResource &#473;}"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter TargetName="ExpandPath"
                                     Property="Stroke"
@@ -6269,21 +6267,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -6307,7 +6305,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -6425,18 +6423,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -6457,7 +6455,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -6490,11 +6488,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -6525,9 +6523,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -7234,7 +7232,25 @@ TODO:
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#220;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#220;}"
@@ -7247,9 +7263,6 @@ TODO:
            BasedOn="{StaticResource &#220;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <SolidColorBrush x:Key="&#226;" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="&#227;" Color="#FF707070" />
     <SolidColorBrush x:Key="&#228;" Color="#FF212121" />
@@ -7261,7 +7274,7 @@ TODO:
     <SolidColorBrush x:Key="&#234;" Color="#FF212121" />
     <SolidColorBrush x:Key="&#235;" Color="#FFE6E6E6" />
     <SolidColorBrush x:Key="&#236;" Color="#FFBCBCBC" />
-    <SolidColorBrush x:Key="&#237;" Color="#FF707070" />    
+    <SolidColorBrush x:Key="&#237;" Color="#FF707070" />
 
 
     <Style TargetType="{x:Type CheckBox}">
@@ -7278,25 +7291,25 @@ TODO:
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Border x:Name="checkBoxBorder" 
-                            Margin="1" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border x:Name="checkBoxBorder"
+                            Margin="1"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}">
                             <Grid x:Name="markGrid">
                                 <Path x:Name="optionMark" Opacity="0" Stretch="None" Margin="1" Fill="{StaticResource &#228;}" Data="F1 M 9.97498,1.22334L 4.6983,9.09834L 4.52164,9.09834L 0,5.19331L 1.27664,3.52165L 4.255,6.08833L 8.33331,1.52588e-005L 9.97498,1.22334 Z "/>
                                 <Rectangle x:Name="indeterminateMark" Margin="2" Opacity="0" Fill="{StaticResource &#228;}" />
                             </Grid>
                         </Border>
-                        <ContentPresenter x:Name="contentPresenter" 
-                            RecognizesAccessKey="True" 
-                            Grid.Column="1" 
-                            Margin="{TemplateBinding Padding}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter x:Name="contentPresenter"
+                            RecognizesAccessKey="True"
+                            Grid.Column="1"
+                            Margin="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Focusable="False"/>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -7335,7 +7348,7 @@ TODO:
             </Setter.Value>
         </Setter>
     </Style>
-    
+
 
 
     <Style x:Key="&#239;">
@@ -7355,28 +7368,28 @@ TODO:
     <Style x:Key="&#240;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -7637,10 +7650,10 @@ TODO:
                 <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
@@ -7716,10 +7729,10 @@ TODO:
                 <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
@@ -7763,7 +7776,7 @@ TODO:
     <SolidColorBrush x:Key="&#281;" Color="#FF26A0DA" />
     <SolidColorBrush x:Key="&#282;" Color="#5426A0DA" />
     <SolidColorBrush x:Key="&#283;" Color="#FF26A0DA" />
-    
+
 
     <Style TargetType="{x:Type ComboBoxItem}">
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -7777,14 +7790,14 @@ TODO:
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                    <Border x:Name="Bd" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        Padding="{TemplateBinding Padding}" 
+                    <Border x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
                         SnapsToDevicePixels="true">
-                        <ContentPresenter 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
@@ -7843,7 +7856,7 @@ TODO:
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Bd" Property="Background" Value="{StaticResource &#282;}" />
                             <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource &#283;}" />
-                        </MultiTrigger>                        
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -7874,7 +7887,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#314;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -7884,9 +7897,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#317;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -7894,14 +7907,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -7932,16 +7945,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#318;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#319;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -8302,19 +8315,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#443;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -8408,16 +8421,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#450;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -8509,10 +8522,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -8845,28 +8858,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#456;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#456;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -8917,16 +8930,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9092,28 +9105,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#456;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#456;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -9159,16 +9172,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9239,15 +9252,15 @@ TODO:
     </Style>
     <Style x:Key="&#464;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#458;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#458;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -9300,15 +9313,15 @@ TODO:
     </Style>
     <Style x:Key="&#465;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#459;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#459;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -9362,180 +9375,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#455;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#464;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#451;}"
-                                        BorderBrush="{StaticResource &#450;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#461;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#463;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#455;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#464;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#451;}"
+                                            BorderBrush="{StaticResource &#450;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#461;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#463;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#465;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#456;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#465;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#456;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#454;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -30,7 +27,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="{ComponentResourceKey TypeInTargetAssembly={x:Type Calendar}, ResourceId=CalendarBackgroundBrush}" Color="White" />
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />        
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type Calendar}, ResourceId=CalendarBackgroundBrush}}" />
         <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}" />
         <Setter Property="BorderThickness" Value="1" />
@@ -38,12 +35,12 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
@@ -61,10 +58,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -86,9 +83,9 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Background="{TemplateBinding Background}">
                             <Border BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -101,10 +98,10 @@ To automatically copy the files, set the environment variable
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-    
+
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#223;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#223;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -131,9 +128,9 @@ To automatically copy the files, set the environment variable
                                                 </Grid>
                                             </Grid>
                                         </ControlTemplate>
-    
+
                                         <!-- End: Previous button template -->
-    
+
                                         <!-- Start: Next button template -->
                                         <ControlTemplate x:Key="&#224;" TargetType="Button">
                                             <Grid Cursor="Hand">
@@ -162,9 +159,9 @@ To automatically copy the files, set the environment variable
                                                 </Grid>
                                             </Grid>
                                         </ControlTemplate>
-    
+
                                         <!-- End: Next button template -->
-    
+
                                         <!-- Start: Header button template -->
                                         <ControlTemplate x:Key="&#225;" TargetType="Button">
                                             <Grid Cursor="Hand">
@@ -190,46 +187,46 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="{DynamicResource {x:Static SystemColors.ControlDarkDarkColorKey}}"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
                                             </Grid>
                                         </ControlTemplate>
-    
+
                                         <!-- End: Header button template -->
                                     </Grid.Resources>
-    
+
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#223;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#223;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
-    
+
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#225;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#225;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
-    
+
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#224;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#224;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
-    
+
                                     <!-- Start: Month Content Grid -->
                                     <Grid x:Name="PART_MonthView" Grid.Row="1" Grid.ColumnSpan="3" Visibility="Visible" Margin="6,-1,6,6" HorizontalAlignment="Center">
                                         <Grid.RowDefinitions>
@@ -252,7 +249,7 @@ To automatically copy the files, set the environment variable
                                         </Grid.ColumnDefinitions>
                                     </Grid>
                                     <!-- End: Month Content Grid -->
-    
+
                                     <!-- End: Year Content Grid -->
                                     <Grid x:Name="PART_YearView" Grid.Row="1" Grid.ColumnSpan="3" Visibility="Hidden" Margin="6,-3,7,6" HorizontalAlignment="Center">
                                         <Grid.RowDefinitions>
@@ -302,7 +299,7 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
 
     <!--CalendarDayButton-->
@@ -534,7 +531,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
 
     <!--=================================================================
         CollectionViewGroup
@@ -543,7 +540,7 @@ To automatically copy the files, set the environment variable
         <ContentPresenter Content="{Binding Path=Name}" ContentStringFormat="{TemplateBinding ContentStringFormat}"/>
     </DataTemplate>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -560,7 +557,7 @@ To automatically copy the files, set the environment variable
 
 
 
- 
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -633,7 +630,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
     </Style>
-    
+
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
     ==================================================================-->
@@ -690,68 +687,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -764,23 +761,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#250;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#251;" />
@@ -905,10 +902,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -999,7 +996,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1065,7 +1062,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1108,11 +1105,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#250;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#250;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1245,20 +1242,20 @@ To automatically copy the files, set the environment variable
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" 
-                                    HorizontalAlignment="Center" 
+                                <Path x:Name="arrow"
+                                    HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    Data="M 1,1.5 L 4.5,5 L 8,1.5" 
-                                    Stroke="{StaticResource &#259;}" 
+                                    Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                    Stroke="{StaticResource &#259;}"
                                     StrokeThickness="2"
                                     SnapsToDevicePixels="false" />
                             </Grid>
-                            <ContentPresenter 
-                                Grid.Row="1" 
+                            <ContentPresenter
+                                Grid.Row="1"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Top"
-                                Margin="0,4,0,0" 
-                                RecognizesAccessKey="True" 
+                                Margin="0,4,0,0"
+                                RecognizesAccessKey="True"
                                 SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
@@ -1297,20 +1294,20 @@ To automatically copy the files, set the environment variable
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" 
-                                    HorizontalAlignment="Center" 
+                                <Path x:Name="arrow"
+                                    HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    Data="M 1,1.5 L 4.5,5 L 8,1.5" 
-                                    Stroke="{StaticResource &#259;}" 
+                                    Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                    Stroke="{StaticResource &#259;}"
                                     StrokeThickness="2"
                                     SnapsToDevicePixels="false" />
                             </Grid>
-                            <ContentPresenter 
-                                Grid.Column="1" 
-                                HorizontalAlignment="Left" 
+                            <ContentPresenter
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
-                                Margin="4,0,0,0" 
-                                RecognizesAccessKey="True" 
+                                Margin="4,0,0,0"
+                                RecognizesAccessKey="True"
                                 SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
@@ -1349,20 +1346,20 @@ To automatically copy the files, set the environment variable
                                         </TransformGroup.Children>
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
-                                <Path x:Name="arrow" 
-                                    HorizontalAlignment="Center" 
+                                <Path x:Name="arrow"
+                                    HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    Data="M 1,1.5 L 4.5,5 L 8,1.5" 
-                                    Stroke="{StaticResource &#259;}" 
-                                    StrokeThickness="2" 
+                                    Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                    Stroke="{StaticResource &#259;}"
+                                    StrokeThickness="2"
                                     SnapsToDevicePixels="false" />
                             </Grid>
-                            <ContentPresenter 
+                            <ContentPresenter
                                 Grid.Row="1"
-                                HorizontalAlignment="Center" 
+                                HorizontalAlignment="Center"
                                 VerticalAlignment="Top"
                                 Margin="0,4,0,0"
-                                RecognizesAccessKey="True" 
+                                RecognizesAccessKey="True"
                                 SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
@@ -1391,19 +1388,19 @@ To automatically copy the files, set the environment variable
                                 <ColumnDefinition Width="19"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <Path x:Name="arrow" 
+                            <Path x:Name="arrow"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
-                                Data="M 1,1.5 L 4.5,5 L 8,1.5"  
-                                Stroke="{StaticResource &#259;}" 
+                                Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                Stroke="{StaticResource &#259;}"
                                 StrokeThickness="2"
                                 SnapsToDevicePixels="false" />
-                            <ContentPresenter 
-                                Grid.Column="1" 
-                                HorizontalAlignment="Left" 
+                            <ContentPresenter
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
-                                Margin="4,0,0,0" 
-                                RecognizesAccessKey="True" 
+                                Margin="4,0,0,0"
+                                RecognizesAccessKey="True"
                                 SnapsToDevicePixels="True" />
                         </Grid>
                     </Border>
@@ -1422,7 +1419,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <Style TargetType="{x:Type Expander}">
         <Setter Property="Foreground" Value="{StaticResource &#258;}" />
         <Setter Property="Background" Value="Transparent" />
@@ -1435,12 +1432,12 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Expander}">
                     <DockPanel x:Name="RootVisual">
-                        <ToggleButton x:Name="HeaderSite" 
-                            ContentTemplate="{TemplateBinding HeaderTemplate}" 
-                            ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
-                            Content="{TemplateBinding Header}" 
-                            FocusVisualStyle="{StaticResource &#262;}" 
-                            IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" 
+                        <ToggleButton x:Name="HeaderSite"
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                            Content="{TemplateBinding Header}"
+                            FocusVisualStyle="{StaticResource &#262;}"
+                            IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                             Foreground="{TemplateBinding Foreground}"
                             Padding="{TemplateBinding Padding}"
                             FontFamily="{TemplateBinding FontFamily}"
@@ -1448,21 +1445,21 @@ To automatically copy the files, set the environment variable
                             FontStyle="{TemplateBinding FontStyle}"
                             FontStretch="{TemplateBinding FontStretch}"
                             FontWeight="{TemplateBinding FontWeight}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" 
-                            DockPanel.Dock="Top" 
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            DockPanel.Dock="Top"
                             Style="{StaticResource &#266;}"
                             BorderBrush="{TemplateBinding BorderBrush}" />
-                        <Border x:Name="ExpandSiteBorder" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border x:Name="ExpandSiteBorder"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}"
                             Visibility="Collapsed"
                             DockPanel.Dock="Bottom">
-                            <ContentPresenter x:Name="ExpandSite" 
-                                Focusable="false" 
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                            <ContentPresenter x:Name="ExpandSite"
+                                Focusable="false"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </Border>
                     </DockPanel>
@@ -1496,7 +1493,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -1514,43 +1511,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#267;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#268;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -1608,7 +1605,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#278;" Color="#FFA3A3A3" />
 
     <BorderGapMaskConverter x:Key="&#279;"/>
-    
+
     <Style x:Key="{x:Type GroupBox}" TargetType="{x:Type GroupBox}">
         <Setter Property="BorderBrush" Value="{StaticResource &#278;}"/>
         <Setter Property="BorderThickness" Value="1"/>
@@ -1636,7 +1633,7 @@ To automatically copy the files, set the environment variable
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 BorderBrush="Transparent"
                                 Background="{TemplateBinding Background}"/>
-    
+
                         <Border Grid.Row="1"
                                 Grid.RowSpan="3"
                                 Grid.ColumnSpan="4"
@@ -1654,15 +1651,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </Border.OpacityMask>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </Border>
                         <!-- Primary content for GroupBox -->
@@ -1723,33 +1720,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -1810,7 +1807,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    <SolidColorBrush x:Key="&#280;" 
+    <SolidColorBrush x:Key="&#280;"
                      Color="#FFCCCCCC" />
 
 
@@ -1862,10 +1859,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -1898,14 +1895,14 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                    <Border x:Name="Bd" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        Padding="{TemplateBinding Padding}" 
+                    <Border x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
                         SnapsToDevicePixels="true">
-                        <ContentPresenter 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
@@ -2058,7 +2055,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <Style x:Key="{x:Type GridViewColumnHeader}" TargetType="{x:Type GridViewColumnHeader}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -2113,7 +2110,7 @@ To automatically copy the files, set the environment variable
                     <Setter.Value>
                         <!--The same as normal header, just no gripper.-->
                         <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
-                            <Border 
+                            <Border
                                 Background="{TemplateBinding Background}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 BorderBrush="{TemplateBinding BorderBrush}" />
@@ -2158,12 +2155,12 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListView}">
-                    <Border x:Name="Bd" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border x:Name="Bd"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
                         SnapsToDevicePixels="true">
-                        <ScrollViewer 
+                        <ScrollViewer
                             Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}"
                             Focusable="false"
                             Padding="{TemplateBinding Padding}">
@@ -2175,10 +2172,10 @@ To automatically copy the files, set the environment variable
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2200,11 +2197,11 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
-                    <Border x:Name="Bd" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        Padding="{TemplateBinding Padding}" 
+                    <Border x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
                         SnapsToDevicePixels="true">
                         <!--remove the HorizontalAlignment due to HeaderRowPresenter does not have the ability to align to center or right-->
                         <GridViewRowPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -2261,7 +2258,7 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#301;" Color="#FF1E395B" />
     <SolidColorBrush x:Key="&#302;" Color="#FF0C12A1" />
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
 
@@ -2316,7 +2313,7 @@ To automatically copy the files, set the environment variable
         </Border>
     </ControlTemplate>
 
-     <!--=================================================================
+    <!--=================================================================
         ScrollViewer inside a MenuItem or ContextMenu
     ==================================================================-->
     <Style x:Key="&#307;" TargetType="{x:Type RepeatButton}" BasedOn="{x:Null}" >
@@ -2411,7 +2408,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-<!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
@@ -2894,7 +2891,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#312;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -2907,7 +2904,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#313;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -2916,7 +2913,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#314;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -2928,7 +2925,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#315;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -2949,14 +2946,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#316;" 
+    <SolidColorBrush x:Key="&#316;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#273;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -3048,9 +3045,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#272;" 
+    <Style x:Key="&#272;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -3076,33 +3073,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -3130,13 +3127,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -3155,11 +3152,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -3177,11 +3174,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -3197,16 +3194,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -3216,9 +3213,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#312;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#313;}"
@@ -3240,13 +3237,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#309;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#310;}"
@@ -3265,30 +3262,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#308;}"
                                  Stroke="{StaticResource &#312;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#313;}"
@@ -3301,7 +3298,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#311;}"
@@ -3316,13 +3313,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#309;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#310;}"
@@ -3358,7 +3355,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#271;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -3368,9 +3365,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#274;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -3378,14 +3375,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -3413,19 +3410,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#275;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#276;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -3484,8 +3481,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -3503,80 +3500,80 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-	<SolidColorBrush x:Key="&#318;" Color="#FF00D228" />
-	<SolidColorBrush x:Key="&#319;" Color="#FFDBDBDB" />
-	<SolidColorBrush x:Key="&#320;" Color="#FFA1A1A1" />
+    <SolidColorBrush x:Key="&#318;" Color="#FF00D228" />
+    <SolidColorBrush x:Key="&#319;" Color="#FFDBDBDB" />
+    <SolidColorBrush x:Key="&#320;" Color="#FFA1A1A1" />
 
-	<Style TargetType="{x:Type ProgressBar}">
-		<Setter Property="Foreground" Value="{StaticResource &#318;}" />
-		<Setter Property="Background" Value="{StaticResource &#319;}" />
-		<Setter Property="BorderBrush" Value="{StaticResource &#320;}" />
-		<Setter Property="BorderThickness" Value="1" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type ProgressBar}">
-					<Grid x:Name="TemplateRoot">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Determinate"/>
-								<VisualState x:Name="Indeterminate">
-									<Storyboard RepeatBehavior="Forever">
-										<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="Animation">
-											<EasingDoubleKeyFrame KeyTime="0" Value="0.25"/>
-											<EasingDoubleKeyFrame KeyTime="0:0:1" Value="0.25"/>
-											<EasingDoubleKeyFrame KeyTime="0:0:2" Value="0.25"/>
-										</DoubleAnimationUsingKeyFrames>
-										<PointAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransformOrigin)" Storyboard.TargetName="Animation">
-											<EasingPointKeyFrame KeyTime="0" Value="-0.5,0.5"/>
-											<EasingPointKeyFrame KeyTime="0:0:1" Value="0.5,0.5"/>
-											<EasingPointKeyFrame KeyTime="0:0:2" Value="1.5,0.5"/>
-										</PointAnimationUsingKeyFrames>
-									</Storyboard>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<Border 
-						    BorderThickness="{TemplateBinding BorderThickness}" 
-						    BorderBrush="{TemplateBinding BorderBrush}" 
+    <Style TargetType="{x:Type ProgressBar}">
+        <Setter Property="Foreground" Value="{StaticResource &#318;}" />
+        <Setter Property="Background" Value="{StaticResource &#319;}" />
+        <Setter Property="BorderBrush" Value="{StaticResource &#320;}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ProgressBar}">
+                    <Grid x:Name="TemplateRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Determinate"/>
+                                <VisualState x:Name="Indeterminate">
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="Animation">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="0.25"/>
+                                            <EasingDoubleKeyFrame KeyTime="0:0:1" Value="0.25"/>
+                                            <EasingDoubleKeyFrame KeyTime="0:0:2" Value="0.25"/>
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <PointAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransformOrigin)" Storyboard.TargetName="Animation">
+                                            <EasingPointKeyFrame KeyTime="0" Value="-0.5,0.5"/>
+                                            <EasingPointKeyFrame KeyTime="0:0:1" Value="0.5,0.5"/>
+                                            <EasingPointKeyFrame KeyTime="0:0:2" Value="1.5,0.5"/>
+                                        </PointAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Border
+						    BorderThickness="{TemplateBinding BorderThickness}"
+						    BorderBrush="{TemplateBinding BorderBrush}"
 						    Background="{TemplateBinding Background}" />
-						<Rectangle x:Name="PART_Track"/>
-						<Grid x:Name="PART_Indicator"
+                        <Rectangle x:Name="PART_Track"/>
+                        <Grid x:Name="PART_Indicator"
 						    HorizontalAlignment="Left"
 						    ClipToBounds="true">
-							<Rectangle x:Name="Indicator" 
+                            <Rectangle x:Name="Indicator"
 							    Fill="{TemplateBinding Foreground}" />
-							<Rectangle x:Name="Animation" 
-							    RenderTransformOrigin="0.5,0.5" 
+                            <Rectangle x:Name="Animation"
+							    RenderTransformOrigin="0.5,0.5"
 							    Fill="{TemplateBinding Foreground}">
-								<Rectangle.RenderTransform>
-									<TransformGroup>
-										<ScaleTransform/>
-										<SkewTransform/>
-										<RotateTransform/>
-										<TranslateTransform/>
-									</TransformGroup>
-								</Rectangle.RenderTransform>
-							</Rectangle>
-						</Grid>
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="Orientation" Value="Vertical">
-							<Setter Property="LayoutTransform" TargetName="TemplateRoot">
-								<Setter.Value>
-									<RotateTransform Angle="-90"/>
-								</Setter.Value>
-							</Setter>
-						</Trigger>
-						<Trigger Property="IsIndeterminate" Value="true">
-							<Setter Property="Visibility" TargetName="Indicator" Value="Collapsed"/>
-						</Trigger>
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
+                                <Rectangle.RenderTransform>
+                                    <TransformGroup>
+                                        <ScaleTransform/>
+                                        <SkewTransform/>
+                                        <RotateTransform/>
+                                        <TranslateTransform/>
+                                    </TransformGroup>
+                                </Rectangle.RenderTransform>
+                            </Rectangle>
+                        </Grid>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Orientation" Value="Vertical">
+                            <Setter Property="LayoutTransform" TargetName="TemplateRoot">
+                                <Setter.Value>
+                                    <RotateTransform Angle="-90"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsIndeterminate" Value="true">
+                            <Setter Property="Visibility" TargetName="Indicator" Value="Collapsed"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
-    
+
     <SolidColorBrush x:Key="&#321;" Color="#FFAFAFAF" />
 
 
@@ -3595,8 +3592,8 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
                     <Grid SnapsToDevicePixels="true" Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Margin="0,0,2,2"
                               Data="M 9,0 L 11,0 L 11,11 L 0,11 L 0,9 L 3,9 L 3,6 L 6,6 L 6,3 L 9,3 z">
 
@@ -3846,21 +3843,21 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -3900,363 +3897,363 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#342;" Color="#FFB0B0B0" />
 
     <ControlTemplate x:Key="&#343;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,0 C0,0 11,0 11,0 11,0 11,18 11,18 11,18 0,18 0,18 0,18 0,0 0,0 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#332;}"
-             Stroke="{StaticResource &#333;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,0 C0,0 11,0 11,0 11,0 11,18 11,18 11,18 0,18 0,18 0,18 0,0 0,0 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#332;}"
+                Stroke="{StaticResource &#333;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#344;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,6 C0,6 5.5,0 5.5,0 5.5,0 11,6 11,6 11,6 11,18 11,18 11,18 0,18 0,18 0,18 0,6 0,6 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#332;}"
-             Stroke="{StaticResource &#333;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,6 C0,6 5.5,0 5.5,0 5.5,0 11,6 11,6 11,6 11,18 11,18 11,18 0,18 0,18 0,18 0,6 0,6 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#332;}"
+                Stroke="{StaticResource &#333;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#345;" TargetType="{x:Type Thumb}">
-     <Grid HorizontalAlignment="Center" VerticalAlignment="Center" UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 0,12 C0,12 5.5,18 5.5,18 5.5,18 11,12 11,12 11,12 11,0 11,0 11,0 0,0 0,0 0,0 0,12 0,12 z" 
-             SnapsToDevicePixels="True" 
-             StrokeThickness="1" 
-             VerticalAlignment="Center" 
-             UseLayoutRounding="True" 
-             Stretch="Fill"
-             Fill="{StaticResource &#332;}"
-             Stroke="{StaticResource &#333;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid HorizontalAlignment="Center" VerticalAlignment="Center" UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 0,12 C0,12 5.5,18 5.5,18 5.5,18 11,12 11,12 11,12 11,0 11,0 11,0 0,0 0,0 0,0 0,12 0,12 z"
+                SnapsToDevicePixels="True"
+                StrokeThickness="1"
+                VerticalAlignment="Center"
+                UseLayoutRounding="True"
+                Stretch="Fill"
+                Fill="{StaticResource &#332;}"
+                Stroke="{StaticResource &#333;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#346;" TargetType="{x:Type Slider}">
-        <Border x:Name="border" 
+        <Border x:Name="border"
                  SnapsToDevicePixels="True"
                  Background="{TemplateBinding Background}"
                  BorderBrush="{TemplateBinding BorderBrush}"
                  BorderThickness="{TemplateBinding BorderThickness}">
-             <Grid>
-                 <Grid.RowDefinitions>
-                     <RowDefinition Height="Auto"/>
-                     <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}"/>
-                     <RowDefinition Height="Auto"/>
-                 </Grid.RowDefinitions>
-                 <TickBar x:Name="TopTick" 
-                     Height="4" 
-                     Placement="Top" 
-                     Grid.Row="0" 
-                     Visibility="Collapsed" 
-                     Margin="0,0,0,2" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <TickBar x:Name="BottomTick" 
-                     Height="4" 
-                     Placement="Bottom" 
-                     Grid.Row="2" 
-                     Visibility="Collapsed" 
-                     Margin="0,2,0,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <Border x:Name="TrackBackground" 
-                     BorderThickness="1" 
-                     Height="4.0" 
-                     Margin="5,0" 
-                     Grid.Row="1" 
-                     VerticalAlignment="center"
-                     BorderBrush="{StaticResource &#342;}" 
-                     Background="{StaticResource &#341;}">
-                     <Canvas Margin="-6,-1">
-                         <Rectangle x:Name="PART_SelectionRange" 
-                             Height="4.0" 
-                             Visibility="Hidden" 
-                             Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                     </Canvas>
-                 </Border>
-                 <Track x:Name="PART_Track" Grid.Row="1">
-                     <Track.DecreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.DecreaseLarge}" 
-                             Style="{StaticResource &#328;}"/>
-                     </Track.DecreaseRepeatButton>
-                     <Track.IncreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.IncreaseLarge}" 
-                             Style="{StaticResource &#328;}"/>
-                     </Track.IncreaseRepeatButton>
-                     <Track.Thumb>
-                         <Thumb x:Name="Thumb" 
-                             OverridesDefaultStyle="True" 
-                             Focusable="False" 
-                             VerticalAlignment="Center" 
-                             Template="{StaticResource &#343;}" 
-                             Width="11" 
-                             Height="18"/>
-                     </Track.Thumb>
-                 </Track>
-             </Grid>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto" MinHeight="{TemplateBinding MinHeight}"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TickBar x:Name="TopTick"
+                    Height="4"
+                    Placement="Top"
+                    Grid.Row="0"
+                    Visibility="Collapsed"
+                    Margin="0,0,0,2"
+                    Fill="{TemplateBinding Foreground}" />
+                <TickBar x:Name="BottomTick"
+                    Height="4"
+                    Placement="Bottom"
+                    Grid.Row="2"
+                    Visibility="Collapsed"
+                    Margin="0,2,0,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <Border x:Name="TrackBackground"
+                    BorderThickness="1"
+                    Height="4.0"
+                    Margin="5,0"
+                    Grid.Row="1"
+                    VerticalAlignment="center"
+                    BorderBrush="{StaticResource &#342;}"
+                    Background="{StaticResource &#341;}">
+                    <Canvas Margin="-6,-1">
+                        <Rectangle x:Name="PART_SelectionRange"
+                            Height="4.0"
+                            Visibility="Hidden"
+                            Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                    </Canvas>
+                </Border>
+                <Track x:Name="PART_Track" Grid.Row="1">
+                    <Track.DecreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.DecreaseLarge}"
+                            Style="{StaticResource &#328;}"/>
+                    </Track.DecreaseRepeatButton>
+                    <Track.IncreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.IncreaseLarge}"
+                            Style="{StaticResource &#328;}"/>
+                    </Track.IncreaseRepeatButton>
+                    <Track.Thumb>
+                        <Thumb x:Name="Thumb"
+                            OverridesDefaultStyle="True"
+                            Focusable="False"
+                            VerticalAlignment="Center"
+                            Template="{StaticResource &#343;}"
+                            Width="11"
+                            Height="18"/>
+                    </Track.Thumb>
+                </Track>
+            </Grid>
         </Border>
-     <ControlTemplate.Triggers>
-         <Trigger Property="TickPlacement" Value="TopLeft">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#344;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="5,2,5,0"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="BottomRight">
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#345;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="5,0,5,2"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="Both">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsSelectionRangeEnabled" Value="true">
-             <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsKeyboardFocused" Value="true">
-             <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <ControlTemplate.Triggers>
+            <Trigger Property="TickPlacement" Value="TopLeft">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#344;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="5,2,5,0"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="BottomRight">
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#345;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="5,0,5,2"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="Both">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsSelectionRangeEnabled" Value="true">
+                <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#347;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M0.5,0.5 L18.5,0.5 18.5,11.5 0.5,11.5z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#333;}"
-             Fill="{StaticResource &#332;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M0.5,0.5 L18.5,0.5 18.5,11.5 0.5,11.5z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#333;}"
+                Fill="{StaticResource &#332;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#348;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 6,11 C6,11 0,5.5 0,5.5 0,5.5 6,0 6,0 6,0 18,0 18,0 18,0 18,11 18,11 18,11 6,11 6,11 z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#333;}"
-             Fill="{StaticResource &#332;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 6,11 C6,11 0,5.5 0,5.5 0,5.5 6,0 6,0 6,0 18,0 18,0 18,0 18,11 18,11 18,11 6,11 6,11 z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#333;}"
+                Fill="{StaticResource &#332;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#349;" TargetType="{x:Type Thumb}">
-     <Grid 
-         HorizontalAlignment="Center" 
-         VerticalAlignment="Center" 
-         UseLayoutRounding="True">
-         <Path x:Name="grip" 
-             Data="M 12,11 C12,11 18,5.5 18,5.5 18,5.5 12,0 12,0 12,0 0,0 0,0 0,0 0,11 0,11 0,11 12,11 12,11 z" 
-             Stretch="Fill"
-             Stroke="{StaticResource &#333;}"
-             Fill="{StaticResource &#332;}" />
-     </Grid>
-     <ControlTemplate.Triggers>
-         <Trigger Property="IsMouseOver" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
-         </Trigger>
-         <Trigger Property="IsDragging" Value="true">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
-         </Trigger>
-         <Trigger Property="IsEnabled" Value="false">
-             <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
-             <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
-         </Trigger>
-     </ControlTemplate.Triggers>
+        <Grid
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            UseLayoutRounding="True">
+            <Path x:Name="grip"
+                Data="M 12,11 C12,11 18,5.5 18,5.5 18,5.5 12,0 12,0 12,0 0,0 0,0 0,0 0,11 0,11 0,11 12,11 12,11 z"
+                Stretch="Fill"
+                Stroke="{StaticResource &#333;}"
+                Fill="{StaticResource &#332;}" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#335;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#336;}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="true">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#337;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#338;}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter TargetName="grip" Property="Fill" Value="{StaticResource &#339;}" />
+                <Setter TargetName="grip" Property="Stroke" Value="{StaticResource &#340;}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="&#350;" TargetType="{x:Type Slider}">
-        <Border x:Name="border" 
+        <Border x:Name="border"
                  SnapsToDevicePixels="True"
                  Background="{TemplateBinding Background}"
                  BorderBrush="{TemplateBinding BorderBrush}"
                  BorderThickness="{TemplateBinding BorderThickness}">
-             <Grid>
-                 <Grid.ColumnDefinitions>
-                     <ColumnDefinition Width="Auto"/>
-                     <ColumnDefinition MinWidth="{TemplateBinding MinWidth}" Width="Auto"/>
-                     <ColumnDefinition Width="Auto"/>
-                 </Grid.ColumnDefinitions>
-                 <TickBar x:Name="TopTick" 
-                     Grid.Column="0" 
-                     Placement="Left" 
-                     Visibility="Collapsed" 
-                     Width="4" 
-                     Margin="0,0,2,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <TickBar x:Name="BottomTick" 
-                     Grid.Column="2" 
-                     Placement="Right" 
-                     Visibility="Collapsed" 
-                     Width="4" 
-                     Margin="2,0,0,0" 
-                     Fill="{TemplateBinding Foreground}" />
-                 <Border x:Name="TrackBackground" 
-                     BorderThickness="1" 
-                     Grid.Column="1" 
-                     HorizontalAlignment="center" 
-                     Margin="0,5" 
-                     Width="4.0" 
-                     BorderBrush="{StaticResource &#342;}" 
-                     Background="{StaticResource &#341;}">
-                     <Canvas Margin="-1,-6">
-                         <Rectangle x:Name="PART_SelectionRange" 
-                             Visibility="Hidden" 
-                             Width="4.0" 
-                             Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                     </Canvas>
-                 </Border>
-                 <Track x:Name="PART_Track" Grid.Column="1">
-                     <Track.DecreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.DecreaseLarge}" 
-                             Style="{StaticResource &#328;}"/>
-                     </Track.DecreaseRepeatButton>
-                     <Track.IncreaseRepeatButton>
-                         <RepeatButton 
-                             Command="{x:Static Slider.IncreaseLarge}" 
-                             Style="{StaticResource &#328;}"/>
-                     </Track.IncreaseRepeatButton>
-                     <Track.Thumb>
-                         <Thumb x:Name="Thumb" 
-                             OverridesDefaultStyle="True" 
-                             Focusable="False" 
-                             VerticalAlignment="Top" 
-                             Width="18" 
-                             Height="11" 
-                             Template="{StaticResource &#347;}"/>
-                     </Track.Thumb>
-                 </Track>
-             </Grid>
-         </Border>
-     <ControlTemplate.Triggers>
-         <Trigger Property="TickPlacement" Value="TopLeft">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#348;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="2,5,0,5"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="BottomRight">
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-             <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#349;}"/>
-             <Setter Property="Margin" TargetName="TrackBackground" Value="0,5,2,5"/>
-         </Trigger>
-         <Trigger Property="TickPlacement" Value="Both">
-             <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
-             <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsSelectionRangeEnabled" Value="true">
-             <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
-         </Trigger>
-         <Trigger Property="IsKeyboardFocused" Value="true">
-             <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-         </Trigger>
-     </ControlTemplate.Triggers>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition MinWidth="{TemplateBinding MinWidth}" Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TickBar x:Name="TopTick"
+                    Grid.Column="0"
+                    Placement="Left"
+                    Visibility="Collapsed"
+                    Width="4"
+                    Margin="0,0,2,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <TickBar x:Name="BottomTick"
+                    Grid.Column="2"
+                    Placement="Right"
+                    Visibility="Collapsed"
+                    Width="4"
+                    Margin="2,0,0,0"
+                    Fill="{TemplateBinding Foreground}" />
+                <Border x:Name="TrackBackground"
+                    BorderThickness="1"
+                    Grid.Column="1"
+                    HorizontalAlignment="center"
+                    Margin="0,5"
+                    Width="4.0"
+                    BorderBrush="{StaticResource &#342;}"
+                    Background="{StaticResource &#341;}">
+                    <Canvas Margin="-1,-6">
+                        <Rectangle x:Name="PART_SelectionRange"
+                            Visibility="Hidden"
+                            Width="4.0"
+                            Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                    </Canvas>
+                </Border>
+                <Track x:Name="PART_Track" Grid.Column="1">
+                    <Track.DecreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.DecreaseLarge}"
+                            Style="{StaticResource &#328;}"/>
+                    </Track.DecreaseRepeatButton>
+                    <Track.IncreaseRepeatButton>
+                        <RepeatButton
+                            Command="{x:Static Slider.IncreaseLarge}"
+                            Style="{StaticResource &#328;}"/>
+                    </Track.IncreaseRepeatButton>
+                    <Track.Thumb>
+                        <Thumb x:Name="Thumb"
+                            OverridesDefaultStyle="True"
+                            Focusable="False"
+                            VerticalAlignment="Top"
+                            Width="18"
+                            Height="11"
+                            Template="{StaticResource &#347;}"/>
+                    </Track.Thumb>
+                </Track>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="TickPlacement" Value="TopLeft">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#348;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="2,5,0,5"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="BottomRight">
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+                <Setter Property="Template" TargetName="Thumb" Value="{StaticResource &#349;}"/>
+                <Setter Property="Margin" TargetName="TrackBackground" Value="0,5,2,5"/>
+            </Trigger>
+            <Trigger Property="TickPlacement" Value="Both">
+                <Setter Property="Visibility" TargetName="TopTick" Value="Visible"/>
+                <Setter Property="Visibility" TargetName="BottomTick" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsSelectionRangeEnabled" Value="true">
+                <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
+            </Trigger>
+            <Trigger Property="IsKeyboardFocused" Value="true">
+                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <Style TargetType="{x:Type Slider}">
-     <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-     <Setter Property="Background" Value="Transparent" />
-     <Setter Property="BorderBrush" Value="Transparent" />
-     <Setter Property="Foreground" Value="{StaticResource &#334;}" />
-     <Setter Property="Template" Value="{StaticResource &#346;}" />
-     <Style.Triggers>
-         <Trigger Property="Orientation" Value="Vertical">
-             <Setter Property="Template" Value="{StaticResource &#350;}" />
-         </Trigger>
-     </Style.Triggers>
+        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource &#334;}" />
+        <Setter Property="Template" Value="{StaticResource &#346;}" />
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Vertical">
+                <Setter Property="Template" Value="{StaticResource &#350;}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
@@ -4454,24 +4451,24 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
                     <Grid x:Name="templateRoot" SnapsToDevicePixels="true">
-                        <Border x:Name="mainBorder" 
-                            BorderThickness="1" 
+                        <Border x:Name="mainBorder"
+                            BorderThickness="1"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Margin="0">
-                            <Border x:Name="innerBorder" 
-                                BorderThickness="1" 
+                            <Border x:Name="innerBorder"
+                                BorderThickness="1"
                                 Background="{StaticResource &#355;}"
                                 BorderBrush="{StaticResource &#356;}"
-                                Margin="-1" 
+                                Margin="-1"
                                 Opacity="0" />
-                        </Border>                           
-                        <ContentPresenter x:Name="contentPresenter" 
-                            ContentSource="Header" 
-                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
-                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            Focusable="False" 
+                        </Border>
+                        <ContentPresenter x:Name="contentPresenter"
+                            ContentSource="Header"
+                            HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                            VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Focusable="False"
                             Margin="{TemplateBinding Padding}"
                             RecognizesAccessKey="True"/>
                     </Grid>
@@ -4523,9 +4520,9 @@ To automatically copy the files, set the environment variable
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                            Focusable="false" 
-                            HorizontalScrollBarVisibility="Hidden" 
+                        <ScrollViewer x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden" />
                     </Border>
                     <ControlTemplate.Triggers>
@@ -4561,7 +4558,7 @@ To automatically copy the files, set the environment variable
             </MultiTrigger>
         </Style.Triggers>
     </Style>
-    
+
     <!--=================================================================
         PasswordBox
     ==================================================================-->
@@ -4586,9 +4583,9 @@ To automatically copy the files, set the environment variable
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                            Focusable="false" 
-                            HorizontalScrollBarVisibility="Hidden" 
+                        <ScrollViewer x:Name="PART_ContentHost"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
                             VerticalScrollBarVisibility="Hidden" />
                     </Border>
                     <ControlTemplate.Triggers>
@@ -4667,7 +4664,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <Style x:Key="{x:Type Thumb}" TargetType="{x:Type Thumb}">
@@ -4710,15 +4707,15 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
-                    <Border Name="Border" 
-                        Background="{TemplateBinding Background}" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
+                    <Border Name="Border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         SnapsToDevicePixels="True">
-                        <ContentPresenter 
-                            Margin="{TemplateBinding Padding}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                     </Border>
                 </ControlTemplate>
@@ -4780,28 +4777,28 @@ To automatically copy the files, set the environment variable
                                     Property="Background"
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
-                      <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                               Value="true">
-                        <Setter TargetName="_tv_scrollviewer_"
-                                Property="CanContentScroll"
-                                Value="true"/>
-                      </Trigger>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
@@ -4811,30 +4808,30 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
                     <Grid Width="15" Height="13" Background="Transparent" Margin="0,1,0,0">
-                        <Path x:Name="Collapsed" 
-                            Width="5" 
-                            Height="9" 
-                            Data="M 0,9 C0,9 5,4.5 5,4.5 5,4.5 0,0 0,0 0,0 0,9 0,9 z" 
-                            Stretch="Fill" 
-                            Stroke="{TemplateBinding Foreground}" 
-                            StrokeThickness="1" 
-                            Margin="2,1,1,1" 
-                            HorizontalAlignment="Left" 
-                            VerticalAlignment="Center" 
-                            Opacity="0.4" 
+                        <Path x:Name="Collapsed"
+                            Width="5"
+                            Height="9"
+                            Data="M 0,9 C0,9 5,4.5 5,4.5 5,4.5 0,0 0,0 0,0 0,9 0,9 z"
+                            Stretch="Fill"
+                            Stroke="{TemplateBinding Foreground}"
+                            StrokeThickness="1"
+                            Margin="2,1,1,1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Opacity="0.4"
                             SnapsToDevicePixels="True" />
-                        <Path x:Name="Expanded" 
-                            Width="6" 
-                            Height="6" 
-                            Data="M 0,6 C0,6 6,6 6,6 6,6 6,0 6,0 6,0 0,6 0,6 z" 
-                            Fill="#FFA3A3A3" 
-                            Stroke="{TemplateBinding Foreground}" 
-                            StrokeThickness="1" 
-                            Stretch="Fill" 
-                            HorizontalAlignment="Left" 
-                            VerticalAlignment="Center" 
-                            SnapsToDevicePixels="True" 
-                            Visibility="Hidden" 
+                        <Path x:Name="Expanded"
+                            Width="6"
+                            Height="6"
+                            Data="M 0,6 C0,6 6,6 6,6 6,6 6,0 6,0 6,0 0,6 0,6 z"
+                            Fill="#FFA3A3A3"
+                            Stroke="{TemplateBinding Foreground}"
+                            StrokeThickness="1"
+                            Stretch="Fill"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            SnapsToDevicePixels="True"
+                            Visibility="Hidden"
                             Margin="1,2,1,1"/>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -4882,27 +4879,27 @@ To automatically copy the files, set the environment variable
                             <RowDefinition />
                         </Grid.RowDefinitions>
                         <Border Name="Border"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Grid.ColumnSpan="2" />
-                        <Border x:Name="Bd" 
-                            Grid.Column="1" 
+                        <Border x:Name="Bd"
+                            Grid.Column="1"
                             Margin="{TemplateBinding Padding}">
-                            <ContentPresenter x:Name="PART_Header" 
-                                ContentSource="Header" 
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                            <ContentPresenter x:Name="PART_Header"
+                                ContentSource="Header"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 VerticalAlignment="Center"/>
                         </Border>
-                        <ToggleButton x:Name="Expander" 
-                            Style="{StaticResource &#388;}" 
-                            ClickMode="Press" 
-                            IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" 
+                        <ToggleButton x:Name="Expander"
+                            Style="{StaticResource &#388;}"
+                            ClickMode="Press"
+                            IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                             Foreground="{TemplateBinding Foreground}"/>
-                        <ItemsPresenter x:Name="ItemsHost" 
-                            Grid.Row="1" 
-                            Grid.Column="1" 
+                        <ItemsPresenter x:Name="ItemsHost"
+                            Grid.Row="1"
+                            Grid.Column="1"
                             Visibility="Collapsed" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -4929,7 +4926,7 @@ To automatically copy the files, set the environment variable
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background" Value="{StaticResource &#246;}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource &#247;}" />
-                        </MultiTrigger>                     
+                        </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
@@ -4942,7 +4939,7 @@ To automatically copy the files, set the environment variable
                         </MultiTrigger>
                         <Trigger Property="HasItems" Value="false">
                             <Setter TargetName="Expander" Property="Visibility" Value="Hidden" />
-                        </Trigger>                        
+                        </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="HasHeader" Value="false" />
@@ -4963,18 +4960,18 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
-              <Setter Property="ItemsPanel">
-                <Setter.Value>
-                  <ItemsPanelTemplate>
-                    <VirtualizingStackPanel />
-                  </ItemsPanelTemplate>
-                </Setter.Value>
-              </Setter>
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
             </Trigger>
         </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -4998,7 +4995,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -5116,18 +5113,18 @@ To automatically copy the files, set the environment variable
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -5148,7 +5145,7 @@ To automatically copy the files, set the environment variable
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -5181,11 +5178,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -5216,9 +5213,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -5925,7 +5922,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#220;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#220;}"
@@ -5937,9 +5952,6 @@ To automatically copy the files, set the environment variable
     <Style x:Key="{x:Type Button}"
            BasedOn="{StaticResource &#220;}"
            TargetType="{x:Type Button}"/>
-
-
-
 
     <SolidColorBrush x:Key="&#226;" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="&#227;" Color="#FF707070" />
@@ -5961,25 +5973,25 @@ To automatically copy the files, set the environment variable
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Border x:Name="checkBoxBorder" 
-                            Margin="1" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border x:Name="checkBoxBorder"
+                            Margin="1"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}">
                             <Grid x:Name="markGrid">
                                 <Path x:Name="optionMark" Data="M 1,3 C1,3 1,6 1,6 1,6 4,9 4,9 4,9 9,3 9,3 9,3 9,0 9,0 9,0 4,6 4,6 4,6 1,3 1,3 z" Stretch="Uniform" Margin="2,1,1,1" Opacity="0" Fill="{TemplateBinding TextElement.Foreground}" />
                                 <Rectangle x:Name="indeterminateMark" Margin="2" Opacity="0" Fill="{TemplateBinding TextElement.Foreground}" />
                             </Grid>
                         </Border>
-                        <ContentPresenter x:Name="contentPresenter" 
-                            RecognizesAccessKey="True" 
-                            Grid.Column="1" 
-                            Margin="{TemplateBinding Padding}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter x:Name="contentPresenter"
+                            RecognizesAccessKey="True"
+                            Grid.Column="1"
+                            Margin="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Focusable="False"/>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -6009,8 +6021,8 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
-    
+
+
 
     <Style x:Key="&#232;">
         <Setter Property="Control.Template">
@@ -6029,28 +6041,28 @@ To automatically copy the files, set the environment variable
     <Style x:Key="&#233;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -6211,10 +6223,10 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
@@ -6290,10 +6302,10 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Height" TargetName="DropDownBorder" Value="95"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger Property="ScrollViewer.CanContentScroll" SourceName="DropDownScrollViewer" Value="false">
@@ -6338,14 +6350,14 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                    <Border x:Name="Bd" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        Padding="{TemplateBinding Padding}" 
+                    <Border x:Name="Bd"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        Padding="{TemplateBinding Padding}"
                         SnapsToDevicePixels="true">
-                        <ContentPresenter 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                        <ContentPresenter
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
@@ -6388,23 +6400,23 @@ To automatically copy the files, set the environment variable
                         Padding="2">
                         <ScrollViewer Name="ContextMenuScrollViewer"
                                       Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=Border,Path=ActualHeight}"
-                                    Width="{Binding ElementName=Border,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=Border,Path=Background}" />
-                            </Canvas>
-                            <Rectangle HorizontalAlignment="Left"
-                                       Width="1"
-                                       Margin="29,2,0,2"
-                                       Fill="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"/>
-                            <ItemsPresenter Name="ItemsPresenter"
-                                Margin="{TemplateBinding Padding}"
-                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=Border,Path=ActualHeight}"
+                                        Width="{Binding ElementName=Border,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=Border,Path=Background}" />
+                                </Canvas>
+                                <Rectangle HorizontalAlignment="Left"
+                                           Width="1"
+                                           Margin="29,2,0,2"
+                                           Fill="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"/>
+                                <ItemsPresenter Name="ItemsPresenter"
+                                    Margin="{TemplateBinding Padding}"
+                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -6436,9 +6448,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -6452,7 +6464,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -6517,20 +6529,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#256;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -6539,9 +6551,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -6560,21 +6572,21 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-       <Style.Triggers>
-         <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-           <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                       Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          </DataTrigger>
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
@@ -6628,9 +6640,9 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
                                 Opacity="1">
@@ -6652,7 +6664,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -6663,7 +6675,7 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    
+    </Style>
     <!--=================================================================
         Frame
     ==================================================================-->
@@ -6689,7 +6701,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#271;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -6699,9 +6711,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#274;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -6709,14 +6721,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -6747,16 +6759,16 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#275;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#276;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -6827,25 +6839,25 @@ To automatically copy the files, set the environment variable
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Border x:Name="radioButtonBorder" 
-                            Margin="1,1,2,1" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="radioButtonBorder"
+                            Margin="1,1,2,1"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             CornerRadius="100">
                             <Grid x:Name="markGrid" Margin="2">
                                 <Ellipse x:Name="optionMark" Opacity="0" MinWidth="6" MinHeight="6" Fill="{TemplateBinding TextElement.Foreground}"/>
                             </Grid>
                         </Border>
-                        <ContentPresenter x:Name="contentPresenter" 
-                            RecognizesAccessKey="True" 
-                            Grid.Column="1" 
-                            Margin="{TemplateBinding Padding}" 
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                        <ContentPresenter x:Name="contentPresenter"
+                            RecognizesAccessKey="True"
+                            Grid.Column="1"
+                            Margin="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Focusable="False"/>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -7198,19 +7210,19 @@ To automatically copy the files, set the environment variable
                                     Property="Fill"
                                     Value="{StaticResource &#362;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -7304,16 +7316,16 @@ To automatically copy the files, set the environment variable
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#369;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7405,10 +7417,10 @@ To automatically copy the files, set the environment variable
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -7741,28 +7753,28 @@ To automatically copy the files, set the environment variable
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#375;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#375;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -7813,16 +7825,16 @@ To automatically copy the files, set the environment variable
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -7988,28 +8000,28 @@ To automatically copy the files, set the environment variable
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#375;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#375;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -8055,16 +8067,16 @@ To automatically copy the files, set the environment variable
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -8135,15 +8147,15 @@ To automatically copy the files, set the environment variable
     </Style>
     <Style x:Key="&#383;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#377;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#377;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -8196,15 +8208,15 @@ To automatically copy the files, set the environment variable
     </Style>
     <Style x:Key="&#384;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#378;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#378;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -8258,180 +8270,180 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#374;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#383;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#370;}"
-                                        BorderBrush="{StaticResource &#369;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#380;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#382;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#374;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#383;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#370;}"
+                                            BorderBrush="{StaticResource &#369;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#380;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#382;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#384;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#375;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#384;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#375;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#373;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Themes/AeroLite.NormalColor.xaml
@@ -5930,6 +5930,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
@@ -746,6 +746,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -43,7 +40,7 @@ To automatically copy the files, set the environment variable
 
 
 
-    
+
     <!--
             **********************************************************
             * BrowserWindow Styles                                   *
@@ -570,7 +567,7 @@ To automatically copy the files, set the environment variable
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}">
             <DockPanel>
-                <Grid 
+                <Grid
                       FlowDirection="{x:Static theme:PlatformCulture.FlowDirection}"
                       DockPanel.Dock="Top"
                       Height="30">
@@ -625,24 +622,24 @@ To automatically copy the files, set the environment variable
 
 
 
-<Style x:Key="&#206;">
-    <Setter Property="Control.Template">
-        <Setter.Value>
-            <ControlTemplate>
-                <Border>
-                    <Rectangle Margin="4"
-                               StrokeThickness="1"
-                               Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                               StrokeDashArray="1 2"
-                               SnapsToDevicePixels="true"/>
-                </Border>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
-</Style>
+    <Style x:Key="&#206;">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border>
+                        <Rectangle Margin="4"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                   StrokeDashArray="1 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Button
     ==================================================================-->
     <Style x:Key="&#207;"
@@ -709,27 +706,27 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:437426
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437426
                                When in high contrast and the button is disabled, set the BorderBrush to Foreground in order to match
                                Win32 button behavior. -->
-                          <Setter Property="BorderBrush" Value="{Binding Path=Foreground, RelativeSource={x:Static RelativeSource.Self}}"/>
+                            <Setter Property="BorderBrush" Value="{Binding Path=Foreground, RelativeSource={x:Static RelativeSource.Self}}"/>
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:437425
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437425
                                  When in high contrast and we have KB focus, set the appropriate fore/background colors to match
                                  Win32 button behavior. -->
-                          <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
-                          <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+                            <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -738,9 +735,28 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
+
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#207;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#207;}"
@@ -752,9 +768,6 @@ To automatically copy the files, set the environment variable
     <Style x:Key="{x:Type Button}"
            BasedOn="{StaticResource &#207;}"
            TargetType="{x:Type Button}"/>
-
-
-
     <!--=================================================================
         Calendar
     ==================================================================-->
@@ -768,26 +781,26 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="{StaticResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" />        
+        <Setter Property="Foreground" Value="{StaticResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type Calendar}, ResourceId=CalendarBackgroundBrush}}" />
         <Setter Property="BorderThickness" Value="1"></Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -798,10 +811,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -823,9 +836,9 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Background="{TemplateBinding Background}" >
                             <Grid>
                                 <Grid.RowDefinitions>
@@ -864,7 +877,7 @@ To automatically copy the files, set the environment variable
                                               Margin="1,4,1,9"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                 <TextElement.Foreground>
+                                                <TextElement.Foreground>
                                                     <SolidColorBrush Color="{DynamicResource {x:Static SystemColors.ActiveCaptionTextColorKey}}"/>
                                                 </TextElement.Foreground>
                                             </ContentPresenter>
@@ -874,43 +887,43 @@ To automatically copy the files, set the environment variable
                                 </Grid.Resources>
 
                                 <!-- Start: Previous button content -->
-                                <Button x:Name="PART_PreviousButton" 
+                                <Button x:Name="PART_PreviousButton"
                                         Grid.Row="0" Grid.Column="0"
                                         Height="15" Width="20"
                                         Margin="8,0,0,0"
-                                        HorizontalAlignment="Left" 
+                                        HorizontalAlignment="Left"
                                         Focusable="False">
-                                        <Grid>
-                                            <Path Height="10" Width="6" VerticalAlignment="Center" 
-                                                                        HorizontalAlignment="Center" 
-                                                                        Stretch="Fill"
-                                                                        Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"
-                                                                        Data="M288.75,232.25 L288.75,240.625 L283,236.625 z" />
-                                        </Grid>
-                                    </Button>
+                                    <Grid>
+                                        <Path Height="10" Width="6" VerticalAlignment="Center"
+                                                                    HorizontalAlignment="Center"
+                                                                    Stretch="Fill"
+                                                                    Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"
+                                                                    Data="M288.75,232.25 L288.75,240.625 L283,236.625 z" />
+                                    </Grid>
+                                </Button>
                                 <!-- End: Previous button content -->
 
                                 <!-- Start: Header button content -->
-                                <Button x:Name="PART_HeaderButton"                                             
-                                        Grid.Row="0" Grid.Column="1" 
-                                        Template="{StaticResource &#209;}" 
-                                        HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                        FontWeight="Bold" FontSize="10.5" 
+                                <Button x:Name="PART_HeaderButton"
+                                        Grid.Row="0" Grid.Column="1"
+                                        Template="{StaticResource &#209;}"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        FontWeight="Bold" FontSize="10.5"
                                         Focusable="False"
                                         />
                                 <!-- End: Header button content -->
 
                                 <!-- Start: Next button content -->
-                                <Button x:Name="PART_NextButton" 
-                                        Grid.Row="0" Grid.Column="2" 
+                                <Button x:Name="PART_NextButton"
+                                        Grid.Row="0" Grid.Column="2"
                                         Height="15" Width="20"
                                         Margin="0,0,8,0"
-                                        HorizontalAlignment="Right" 
+                                        HorizontalAlignment="Right"
                                         Focusable="False">
                                     <Grid>
-                                        <Path Height="10" Width="6" VerticalAlignment="Center" 
-                                                                    HorizontalAlignment="Center" 
-                                                                    Stretch="Fill" 
+                                        <Path Height="10" Width="6" VerticalAlignment="Center"
+                                                                    HorizontalAlignment="Center"
+                                                                    Stretch="Fill"
                                                                     Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"
                                                                     Data="M282.875,231.875 L282.875,240.375 L288.625,236 z"/>
                                     </Grid>
@@ -988,9 +1001,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -1222,7 +1235,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    
+
 
     <!--=================================================================
         CollectionViewGroup
@@ -1249,28 +1262,28 @@ To automatically copy the files, set the environment variable
     <Style x:Key="&#217;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -1302,23 +1315,24 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#218;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="4,4,21,4"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="4,4,21,4"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
         ComboBox
     ==================================================================-->
-    <Geometry x:Key="&#219;">M 0 0 L 3.5 4 L 7 0 Z
+    <Geometry x:Key="&#219;">
+        M 0 0 L 3.5 4 L 7 0 Z
     </Geometry>
 
     <Style x:Key="&#220;"
@@ -1404,17 +1418,17 @@ To automatically copy the files, set the environment variable
                                     BorderThickness="1"
                                     BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                 <ScrollViewer Name="DropDownScrollViewer">
-                                  <Grid RenderOptions.ClearTypeHint="Enabled">
-                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                        <Rectangle
-                                            Name="OpaqueRect"
-                                            Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                            Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                            Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                    </Canvas>
-                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                  </Grid>
+                                    <Grid RenderOptions.ClearTypeHint="Enabled">
+                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                            <Rectangle
+                                                Name="OpaqueRect"
+                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                        </Canvas>
+                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Grid>
                                 </ScrollViewer>
                             </Border>
                         </theme:SystemDropShadowChrome>
@@ -1468,10 +1482,10 @@ To automatically copy the files, set the environment variable
                         Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="DropDownScrollViewer"
@@ -1540,17 +1554,17 @@ To automatically copy the files, set the environment variable
                                                 BorderThickness="1"
                                                 BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                             <ScrollViewer Name="DropDownScrollViewer">
-                                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                    <Rectangle
-                                                        Name="OpaqueRect"
-                                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                                </Canvas>
-                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                              </Grid>
+                                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                        <Rectangle
+                                                            Name="OpaqueRect"
+                                                            Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                            Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                            Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                                    </Canvas>
+                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                </Grid>
                                             </ScrollViewer>
                                         </Border>
                                     </theme:SystemDropShadowChrome>
@@ -1614,10 +1628,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="PART_Popup"
@@ -1641,19 +1655,19 @@ To automatically copy the files, set the environment variable
                                     Value="{Binding ElementName=DropDownScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#218;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#218;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1675,17 +1689,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#222;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -1729,11 +1743,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#222;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#222;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -1741,7 +1755,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -1801,18 +1815,18 @@ To automatically copy the files, set the environment variable
                                                       BorderThickness="{TemplateBinding BorderThickness}">
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=Border,Path=ActualHeight}"
-                                        Width="{Binding ElementName=Border,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=Border,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=Border,Path=ActualHeight}"
+                                            Width="{Binding ElementName=Border,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=Border,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </theme:ClassicBorderDecorator>
                     </theme:SystemDropShadowChrome>
@@ -1968,69 +1982,69 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
 
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -2043,23 +2057,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#223;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#224;" />
@@ -2184,10 +2198,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -2278,7 +2292,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -2344,7 +2358,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -2387,11 +2401,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#223;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#223;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -2514,9 +2528,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -2530,7 +2544,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -2641,20 +2655,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#229;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -2663,9 +2677,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -2684,22 +2698,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -2752,12 +2766,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -2777,7 +2791,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -2806,15 +2820,15 @@ To automatically copy the files, set the environment variable
                                    StrokeDashArray="1 2"
                                    SnapsToDevicePixels="true"/>
                     </Border>
-                  <ControlTemplate.Triggers>
-                    <MultiDataTrigger>
-                      <MultiDataTrigger.Conditions>
-                        <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                        <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                      </MultiDataTrigger.Conditions>
-                      <Setter TargetName="ExpanderHeaderFocusVisualRectangle" Property="Stroke" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-                    </MultiDataTrigger> 
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ExpanderHeaderFocusVisualRectangle" Property="Stroke" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -3179,7 +3193,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -3197,43 +3211,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#214;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#215;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -3266,7 +3280,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-  
+
     <!--=================================================================
         GroupBox
     ==================================================================-->
@@ -3322,15 +3336,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </theme:ClassicBorderDecorator.OpacityMask>
                         </theme:ClassicBorderDecorator>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </Border>
                         <!-- Primary content for GroupBox -->
@@ -3344,7 +3358,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-    
+
 
     <!--=================================================================
         GroupItem
@@ -3391,33 +3405,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -3526,10 +3540,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -3540,17 +3554,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#246;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -3607,11 +3621,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#246;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#246;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -3889,10 +3903,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -3901,7 +3915,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-     
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -3959,7 +3973,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
     <Style x:Key="{x:Type Menu}"
@@ -4034,7 +4048,7 @@ To automatically copy the files, set the environment variable
         </theme:ClassicBorderDecorator>
     </ControlTemplate>
 
-     <!--=================================================================
+    <!--=================================================================
         ScrollViewer inside a MenuItem or ContextMenu
     ==================================================================-->
     <Style x:Key="&#253;"
@@ -4148,7 +4162,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-<!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
@@ -4273,18 +4287,18 @@ To automatically copy the files, set the environment variable
                                                       BorderThickness="2">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </theme:ClassicBorderDecorator>
                     </theme:SystemDropShadowChrome>
@@ -4319,8 +4333,8 @@ To automatically copy the files, set the environment variable
                         Property="BorderStyle"
                         Value="ThinRaised"/>
             </Trigger>
-             <Trigger Property="IsKeyboardFocused"
-                     Value="true">
+            <Trigger Property="IsKeyboardFocused"
+                    Value="true">
                 <Setter TargetName="ClassicBorder"
                         Property="BorderStyle"
                         Value="ThinPressed"/>
@@ -4485,22 +4499,22 @@ To automatically copy the files, set the environment variable
                                                       BorderThickness="2">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                Grid.IsSharedSizeScope="true"/>
-                               </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </theme:ClassicBorderDecorator>
                     </theme:SystemDropShadowChrome>
-            </Popup>
+                </Popup>
             </Grid>
         </Border>
         <ControlTemplate.Triggers>
@@ -4686,7 +4700,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#258;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4699,7 +4713,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#259;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -4708,7 +4722,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#260;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4720,7 +4734,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#261;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -4741,14 +4755,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#262;" 
+    <SolidColorBrush x:Key="&#262;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#240;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -4840,9 +4854,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#239;" 
+    <Style x:Key="&#239;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -4868,33 +4882,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -4922,13 +4936,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -4947,11 +4961,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -4969,11 +4983,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -4989,16 +5003,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -5008,9 +5022,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#258;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#259;}"
@@ -5032,13 +5046,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#255;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#256;}"
@@ -5057,30 +5071,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#254;}"
                                  Stroke="{StaticResource &#258;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#259;}"
@@ -5093,7 +5107,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#257;}"
@@ -5108,13 +5122,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#255;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#256;}"
@@ -5150,7 +5164,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#238;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -5160,9 +5174,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#241;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -5170,14 +5184,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -5205,19 +5219,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#242;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#243;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -5295,8 +5309,8 @@ To automatically copy the files, set the environment variable
 
 
 
-  
-   
+
+
     <!--=================================================================
         ProgressBar
     ==================================================================-->
@@ -5377,8 +5391,8 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
                     <Grid SnapsToDevicePixels="true" Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Data="M 11,0 L 12,0 L 12,12 L 0,12 L 0,11 z"
                               Margin="0,0,2,2">
                             <Path.Fill>
@@ -5407,7 +5421,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-     <!--
+    <!--
             **************************************************************
             * Base style for HorizontalScrollBar LineLeft/Right buttons  *
             * and VerticalScrollBar LineUp/Down button                   *
@@ -5679,16 +5693,16 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
@@ -5717,7 +5731,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-<!--=================================================================
+    <!--=================================================================
         Slider
     ==================================================================-->
     <Style x:Key="&#269;"
@@ -5912,7 +5926,7 @@ To automatically copy the files, set the environment variable
                                                   Background="{TemplateBinding Background}"
                                                   BorderBrush="{x:Static theme:ClassicBorderDecorator.ClassicBorderBrush}"
                                                   BorderThickness="3">
-                        <Rectangle 
+                        <Rectangle
                                    Fill="{TemplateBinding Foreground}"
                                    Opacity="0.5"
                                    Margin="-1"/>
@@ -6434,7 +6448,7 @@ To automatically copy the files, set the environment variable
 
 
 
-     <!--=================================================================
+    <!--=================================================================
         TabControl
     ==================================================================-->
     <Style x:Key="{x:Type TabControl}"
@@ -6606,8 +6620,8 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-  
-    
+
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -6741,7 +6755,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Foreground"
                 Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"/>
         <Setter Property="Background"
-                Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>       
+                Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
         <Setter Property="Padding"
                 Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
@@ -6949,7 +6963,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -7375,19 +7389,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#280;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -7481,16 +7495,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#287;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7582,10 +7596,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -7918,28 +7932,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#293;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#293;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -7990,16 +8004,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -8165,28 +8179,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#293;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#293;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -8232,16 +8246,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -8312,15 +8326,15 @@ TODO:
     </Style>
     <Style x:Key="&#301;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#295;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#295;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -8373,15 +8387,15 @@ TODO:
     </Style>
     <Style x:Key="&#302;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#296;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#296;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -8435,183 +8449,183 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#292;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#301;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#288;}"
-                                        BorderBrush="{StaticResource &#287;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#298;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#300;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#292;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#301;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#288;}"
+                                            BorderBrush="{StaticResource &#287;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#298;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#300;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#302;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#293;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#302;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#293;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#291;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
-     <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <Style x:Key="{x:Type ToolTip}"
@@ -8716,33 +8730,33 @@ TODO:
                             <ItemsPresenter/>
                         </ScrollViewer>
                     </theme:ClassicBorderDecorator>
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                             Value="true">
-                      <Setter TargetName="_tv_scrollviewer_"
-                              Property="CanContentScroll"
-                              Value="true"/>
-                    </Trigger>
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
-        <!--=================================================================
+    <!--=================================================================
         TreeViewItem
     ==================================================================-->
     <Style x:Key="&#303;"
@@ -8891,21 +8905,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -8929,7 +8943,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -9137,24 +9151,24 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:431603
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:431603
                                Scope these changes to high contrast but override values for enabled controls. -->
-                          <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Control}}}" />
+                            <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Control}}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:431603
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:431603
                                Scope these changes to high contrast but override values for disabled controls. -->
-                          <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrush}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrush}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -9173,23 +9187,23 @@ TODO:
                             <Setter Property="FocusVisualStyle" Value="{StaticResource &#213;}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                            <Condition Binding="{Binding Path=HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#214;}" />
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                                <Condition Binding="{Binding Path=HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#214;}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                            <Condition Binding="{Binding Path=HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#215;}" />
-                       </MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                                <Condition Binding="{Binding Path=HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#215;}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9222,7 +9236,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#238;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -9232,9 +9246,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#241;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -9242,14 +9256,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -9280,16 +9294,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#242;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#243;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -9408,25 +9422,25 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:431603
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:431603
                                  When enabled in high contrast, inherit the foreground of the nearest ancestor control.
                                  This ensures selection highlights are appropriately respected. -->
-                          <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Control}}}" />
+                            <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Control}}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:431603
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:431603
                                  When disabled in high contrast we should directly use the ControlTextBrush color. -->
-                          <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrush}}" />
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrush}}" />
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -9443,23 +9457,23 @@ TODO:
                                 <Condition Binding="{Binding Path=HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
                             </MultiDataTrigger.Conditions>
                             <Setter Property="FocusVisualStyle" Value="{StaticResource &#213;}" />
-                        </MultiDataTrigger>                        
-                        <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#214;}"/>
                         </MultiDataTrigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                          <Condition Binding="{Binding HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
-                        </MultiDataTrigger.Conditions>
-                        <Setter Property="FocusVisualStyle" Value="{StaticResource &#215;}" />
-                      </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#214;}"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx471CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                                <Condition Binding="{Binding HasContent, RelativeSource={x:Static RelativeSource.Self}}" Value="false"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#215;}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Classic/Themes/Classic.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
@@ -117,6 +117,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.HomeStead.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -112,7 +109,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#212;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#212;}"
@@ -125,15 +140,12 @@ To automatically copy the files, set the environment variable
            BasedOn="{StaticResource &#212;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <!--=================================================================
             Calendar
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -159,19 +171,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -182,10 +194,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -207,10 +219,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -226,7 +238,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#214;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#214;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -312,7 +324,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -323,31 +335,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#214;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#214;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#216;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#216;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#215;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#215;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -424,9 +436,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -796,17 +808,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#228;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -850,11 +862,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -862,7 +874,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -881,7 +893,7 @@ To automatically copy the files, set the environment variable
 
 
 
- <!--=================================================================
+    <!--=================================================================
         ContextMenu
     ==================================================================-->
     <Style x:Key="{x:Type ContextMenu}"
@@ -925,18 +937,18 @@ To automatically copy the files, set the environment variable
                                 BorderThickness="{TemplateBinding BorderThickness}">
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -1097,68 +1109,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1170,23 +1182,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#230;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#231;" />
@@ -1311,10 +1323,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1405,7 +1417,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1471,7 +1483,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1514,11 +1526,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1643,9 +1655,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1659,7 +1671,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1770,20 +1782,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#236;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1792,9 +1804,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1813,22 +1825,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1881,12 +1893,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1906,7 +1918,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -2340,7 +2352,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2358,43 +2370,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#244;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#245;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2427,13 +2439,13 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <SolidColorBrush x:Key="&#255;" 
+    <SolidColorBrush x:Key="&#255;"
                      Color="#D0D0BF"/>
 
-    <SolidColorBrush x:Key="&#256;" 
+    <SolidColorBrush x:Key="&#256;"
                      Color="#99540A"/>
 
- 
+
     <!--=================================================================
         GroupBox
     ==================================================================-->
@@ -2490,15 +2502,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </Border.OpacityMask>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               TextElement.Foreground="{StaticResource &#256;}"/>
                         </Border>
@@ -2560,33 +2572,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2646,7 +2658,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#227;"
                      Color="#FFA4B97F"/>
 
@@ -2699,10 +2712,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2715,17 +2728,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#258;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -2782,11 +2795,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2794,7 +2807,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-     
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -2852,7 +2865,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
     <Style x:Key="{x:Type Menu}"
@@ -2896,7 +2909,7 @@ To automatically copy the files, set the environment variable
 
 
 
-   <PathGeometry x:Key="&#273;">
+    <PathGeometry x:Key="&#273;">
         <PathGeometry.Figures>
             <PathFigureCollection>
                 <PathFigure StartPoint="0 2"
@@ -2917,7 +2930,7 @@ To automatically copy the files, set the environment variable
     </PathGeometry>
 
 
-  <!--=================================================================
+    <!--=================================================================
         ScrollViewer inside a MenuItem or ContextMenu
     ==================================================================-->
     <Style x:Key="&#274;"
@@ -3062,7 +3075,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- <!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
@@ -3174,20 +3187,20 @@ To automatically copy the files, set the environment variable
                                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                               </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3354,20 +3367,20 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
                                 <!-- TODO: Metric for Margin? -->
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3557,7 +3570,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#279;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3570,7 +3583,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#280;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -3579,7 +3592,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#281;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3591,7 +3604,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#282;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3612,14 +3625,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#283;" 
+    <SolidColorBrush x:Key="&#283;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#250;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -3711,9 +3724,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#249;" 
+    <Style x:Key="&#249;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -3739,33 +3752,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -3793,13 +3806,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -3818,11 +3831,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -3840,11 +3853,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -3860,16 +3873,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -3879,9 +3892,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -3903,13 +3916,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -3928,30 +3941,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#275;}"
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -3964,7 +3977,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#278;}"
@@ -3979,13 +3992,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -4021,7 +4034,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4031,9 +4044,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4041,14 +4054,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4076,19 +4089,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4147,8 +4160,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -4166,7 +4179,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- <!--=================================================================
+    <!--=================================================================
         ProgressBar
     ==================================================================-->
     <LinearGradientBrush x:Key="&#285;"
@@ -4181,7 +4194,7 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-   
+
 
 
     <Style x:Key="{x:Type ProgressBar}"
@@ -4251,7 +4264,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         RadioButton
     ==================================================================-->
     <Style x:Key="{x:Type RadioButton}"
@@ -4316,16 +4329,16 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
-                    <Grid SnapsToDevicePixels="True" 
+                    <Grid SnapsToDevicePixels="True"
                           Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="White"
                               Margin="0,0,2,2"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
 
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="{StaticResource &#286;}"
                               Margin="0,0,3,3"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
@@ -4731,21 +4744,21 @@ To automatically copy the files, set the environment variable
     </Style>
     <!-- End ScrollBar Styles -->
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -4775,9 +4788,9 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#301;" Color="#F3F3EF"/>
 
 
-     <LinearGradientBrush x:Key="&#302;"
-                         StartPoint="0,0"
-                         EndPoint="1,0">
+    <LinearGradientBrush x:Key="&#302;"
+                        StartPoint="0,0"
+                        EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#40FFFFFF"
                           Offset="0"/>
@@ -4819,28 +4832,34 @@ To automatically copy the files, set the environment variable
 
 
 
-<!--=================================================================
+    <!--=================================================================
         VerticalSlider and HorizontalSlider
     ==================================================================-->
     <!-- Pointed Thumb-->
-    <Geometry x:Key="&#305;">M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
-    
+    <Geometry x:Key="&#305;">
+        M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
+
     </Geometry>
-    <Geometry x:Key="&#306;">M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
-    
+    <Geometry x:Key="&#306;">
+        M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
+
     </Geometry>
-    <Geometry x:Key="&#307;">M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
-    
+    <Geometry x:Key="&#307;">
+        M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
+
     </Geometry>
     <!-- Rectangular Thumb -->
-    <Geometry x:Key="&#308;">M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
-    
+    <Geometry x:Key="&#308;">
+        M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
+
     </Geometry>
-    <Geometry x:Key="&#309;">M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
-    
+    <Geometry x:Key="&#309;">
+        M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
+
     </Geometry>
-    <Geometry x:Key="&#310;">M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
-    
+    <Geometry x:Key="&#310;">
+        M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
+
     </Geometry>
     <!--=================================================================
             HorizontalSlider Resources
@@ -5765,7 +5784,7 @@ To automatically copy the files, set the environment variable
                                                Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
                                 </Canvas>
                             </Border>
-                                
+
                             <!-- MainPartsPanel -->
                             <Track Grid.Row="1"
                                    Name="PART_Track">
@@ -5877,7 +5896,7 @@ To automatically copy the files, set the environment variable
                                                        Visibility="Hidden"
                                                        StrokeThickness="1.0"
                                                        Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
-                                    </Canvas>
+                                        </Canvas>
 
                                     </Border>
                                     <!-- MainPartsPanel -->
@@ -6255,10 +6274,10 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    
-    
-    
-  
+
+
+
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -6647,7 +6666,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -6688,7 +6707,7 @@ TODO:
     </Style>
 
 
-     <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <Style x:Key="{x:Type ToolTip}"
@@ -6792,29 +6811,29 @@ TODO:
                             <ItemsPresenter/>
                         </ScrollViewer>
                     </Border>
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                             Value="true">
-                      <Setter TargetName="_tv_scrollviewer_"
-                              Property="CanContentScroll"
-                              Value="true"/>
-                    </Trigger>
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <!--=================================================================
@@ -6977,21 +6996,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -7015,7 +7034,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -7133,18 +7152,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7165,7 +7184,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -7198,11 +7217,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -7233,9 +7252,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -7889,28 +7908,28 @@ TODO:
     <Style x:Key="&#224;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -8030,17 +8049,17 @@ TODO:
                             BorderThickness="1"
                             BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                         <ScrollViewer Name="DropDownScrollViewer">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                            </Canvas>
-                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                </Canvas>
+                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -8063,10 +8082,10 @@ TODO:
                         Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="PART_Popup"
@@ -8166,17 +8185,17 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -8225,10 +8244,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="DropDownScrollViewer"
@@ -8285,7 +8304,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -8295,9 +8314,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -8305,14 +8324,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -8343,16 +8362,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -8741,10 +8760,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -9141,19 +9160,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#364;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9247,16 +9266,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#371;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -9348,10 +9367,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -9684,28 +9703,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#377;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#377;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -9756,16 +9775,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9931,28 +9950,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#377;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#377;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -9998,16 +10017,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -10078,15 +10097,15 @@ TODO:
     </Style>
     <Style x:Key="&#385;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#379;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#379;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10139,15 +10158,15 @@ TODO:
     </Style>
     <Style x:Key="&#386;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#380;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#380;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10201,180 +10220,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#376;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#385;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#372;}"
-                                        BorderBrush="{StaticResource &#371;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#382;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#384;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#376;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#385;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#372;}"
+                                            BorderBrush="{StaticResource &#371;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#382;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#384;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#386;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#377;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#386;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#377;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#375;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
@@ -119,6 +119,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -39,7 +36,7 @@ To automatically copy the files, set the environment variable
 
 
 
-  <!--=================================================================
+    <!--=================================================================
         Button
     ==================================================================-->
     <LinearGradientBrush x:Key="&#210;"
@@ -114,7 +111,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#212;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#212;}"
@@ -127,15 +142,12 @@ To automatically copy the files, set the environment variable
            BasedOn="{StaticResource &#212;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <!--=================================================================
             Calendar
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -161,19 +173,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -184,10 +196,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -209,10 +221,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -228,7 +240,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#214;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#214;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -314,7 +326,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -325,31 +337,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#214;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#214;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#216;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#216;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#215;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#215;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -426,9 +438,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -798,17 +810,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#228;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -852,11 +864,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -864,7 +876,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -883,7 +895,7 @@ To automatically copy the files, set the environment variable
 
 
 
- <!--=================================================================
+    <!--=================================================================
         ContextMenu
     ==================================================================-->
     <Style x:Key="{x:Type ContextMenu}"
@@ -927,18 +939,18 @@ To automatically copy the files, set the environment variable
                                 BorderThickness="{TemplateBinding BorderThickness}">
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -968,10 +980,10 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
 
 
- 
+
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -1043,7 +1055,7 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Floater}">
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
-    </Style> 
+    </Style>
 
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
@@ -1101,68 +1113,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1175,23 +1187,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#230;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#231;" />
@@ -1316,10 +1328,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1410,7 +1422,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1476,7 +1488,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1519,11 +1531,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1648,9 +1660,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1664,7 +1676,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1775,20 +1787,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#236;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1797,9 +1809,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1818,22 +1830,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1886,12 +1898,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1911,7 +1923,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1924,8 +1936,8 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
-  <!--=================================================================
+
+    <!--=================================================================
         Expander
     ==================================================================-->
     <Style x:Key="&#238;">
@@ -2344,7 +2356,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2362,43 +2374,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#244;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#245;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2431,13 +2443,13 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <SolidColorBrush x:Key="&#255;" 
+    <SolidColorBrush x:Key="&#255;"
                      Color="#BFB8BF"/>
 
-    <SolidColorBrush x:Key="&#256;" 
+    <SolidColorBrush x:Key="&#256;"
                      Color="#0046D5"/>
 
- 
+
     <!--=================================================================
         GroupBox
     ==================================================================-->
@@ -2494,15 +2506,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </Border.OpacityMask>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               TextElement.Foreground="{StaticResource &#256;}"/>
                         </Border>
@@ -2564,33 +2576,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2650,7 +2662,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#227;"
                      Color="#FFA5ACB2"/>
 
@@ -2703,10 +2716,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2719,17 +2732,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#258;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -2786,11 +2799,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2798,7 +2811,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-     
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -2856,7 +2869,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
     <Style x:Key="{x:Type Menu}"
@@ -2900,7 +2913,7 @@ To automatically copy the files, set the environment variable
 
 
 
-   <PathGeometry x:Key="&#273;">
+    <PathGeometry x:Key="&#273;">
         <PathGeometry.Figures>
             <PathFigureCollection>
                 <PathFigure StartPoint="0 2"
@@ -3064,7 +3077,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-<!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
@@ -3179,20 +3192,20 @@ To automatically copy the files, set the environment variable
                                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3359,20 +3372,20 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
                                 <!-- TODO: Metric for Margin? -->
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3562,7 +3575,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#279;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3575,7 +3588,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#280;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -3584,7 +3597,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#281;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3596,7 +3609,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#282;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3617,14 +3630,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#283;" 
+    <SolidColorBrush x:Key="&#283;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#250;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -3716,9 +3729,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#249;" 
+    <Style x:Key="&#249;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -3744,33 +3757,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -3798,13 +3811,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -3823,11 +3836,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -3845,11 +3858,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -3865,16 +3878,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -3884,9 +3897,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -3908,13 +3921,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -3933,30 +3946,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#275;}"
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -3969,7 +3982,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#278;}"
@@ -3984,13 +3997,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -4026,7 +4039,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4036,9 +4049,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4046,14 +4059,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4081,19 +4094,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4152,8 +4165,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -4170,8 +4183,8 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
-    
+
+
     <!--=================================================================
         ProgressBar
     ==================================================================-->
@@ -4191,7 +4204,7 @@ To automatically copy the files, set the environment variable
                           Offset="1"/>
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
-    
+
 
     <Style x:Key="{x:Type ProgressBar}"
            TargetType="{x:Type ProgressBar}">
@@ -4260,7 +4273,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         RadioButton
     ==================================================================-->
     <Style x:Key="{x:Type RadioButton}"
@@ -4325,16 +4338,16 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
-                    <Grid SnapsToDevicePixels="True" 
+                    <Grid SnapsToDevicePixels="True"
                           Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="White"
                               Margin="0,0,2,2"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
 
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="{StaticResource &#286;}"
                               Margin="0,0,3,3"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
@@ -4707,21 +4720,21 @@ To automatically copy the files, set the environment variable
     </Style>
     <!-- End ScrollBar Styles -->
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -4748,7 +4761,7 @@ To automatically copy the files, set the environment variable
 
 
 
-    <LinearGradientBrush x:Key="&#298;" 
+    <LinearGradientBrush x:Key="&#298;"
                          StartPoint="0,0"
                          EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
@@ -4765,7 +4778,7 @@ To automatically copy the files, set the environment variable
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="&#299;" 
+    <LinearGradientBrush x:Key="&#299;"
                          StartPoint="1,0"
                          EndPoint="0,0">
         <LinearGradientBrush.GradientStops>
@@ -4783,9 +4796,9 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
 
-     <LinearGradientBrush x:Key="&#300;"
-                         StartPoint="0,0"
-                         EndPoint="1,0">
+    <LinearGradientBrush x:Key="&#300;"
+                        StartPoint="0,0"
+                        EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#40FFFFFF"
                           Offset="0"/>
@@ -4827,28 +4840,34 @@ To automatically copy the files, set the environment variable
 
 
 
-<!--=================================================================
+    <!--=================================================================
         VerticalSlider and HorizontalSlider
     ==================================================================-->
     <!-- Pointed Thumb-->
-    <Geometry x:Key="&#303;">M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
-    
+    <Geometry x:Key="&#303;">
+        M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
+
     </Geometry>
-    <Geometry x:Key="&#304;">M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
-    
+    <Geometry x:Key="&#304;">
+        M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
+
     </Geometry>
-    <Geometry x:Key="&#305;">M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
-    
+    <Geometry x:Key="&#305;">
+        M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
+
     </Geometry>
     <!-- Rectangular Thumb -->
-    <Geometry x:Key="&#306;">M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
-    
+    <Geometry x:Key="&#306;">
+        M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
+
     </Geometry>
-    <Geometry x:Key="&#307;">M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
-    
+    <Geometry x:Key="&#307;">
+        M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
+
     </Geometry>
-    <Geometry x:Key="&#308;">M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
-    
+    <Geometry x:Key="&#308;">
+        M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
+
     </Geometry>
     <!--=================================================================
             HorizontalSlider Resources
@@ -5773,7 +5792,7 @@ To automatically copy the files, set the environment variable
                                                Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
                                 </Canvas>
                             </Border>
-                                
+
                             <!-- MainPartsPanel -->
                             <Track Grid.Row="1"
                                    Name="PART_Track">
@@ -5885,7 +5904,7 @@ To automatically copy the files, set the environment variable
                                                        Visibility="Hidden"
                                                        StrokeThickness="1.0"
                                                        Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
-                                    </Canvas>
+                                        </Canvas>
 
                                     </Border>
                                     <!-- MainPartsPanel -->
@@ -6249,7 +6268,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
- 
+
 
 
     <Style x:Key="&#352;">
@@ -6266,7 +6285,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -6650,7 +6669,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -6691,7 +6710,7 @@ TODO:
     </Style>
 
 
-     <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <Style x:Key="{x:Type ToolTip}"
@@ -6795,33 +6814,33 @@ TODO:
                             <ItemsPresenter/>
                         </ScrollViewer>
                     </Border>
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                             Value="true">
-                      <Setter TargetName="_tv_scrollviewer_"
-                              Property="CanContentScroll"
-                              Value="true"/>
-                    </Trigger>
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
-        <!--=================================================================
+    <!--=================================================================
         TreeViewItem
     ==================================================================-->
     <Style x:Key="&#385;"
@@ -6982,21 +7001,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -7020,7 +7039,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -7138,18 +7157,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7170,7 +7189,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -7203,11 +7222,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -7238,9 +7257,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -7894,28 +7913,28 @@ TODO:
     <Style x:Key="&#224;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -8035,17 +8054,17 @@ TODO:
                             BorderThickness="1"
                             BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                         <ScrollViewer Name="DropDownScrollViewer">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                            </Canvas>
-                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                </Canvas>
+                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -8068,10 +8087,10 @@ TODO:
                         Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="PART_Popup"
@@ -8171,17 +8190,17 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -8230,10 +8249,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="DropDownScrollViewer"
@@ -8290,7 +8309,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -8300,9 +8319,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -8310,14 +8329,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -8348,16 +8367,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -8746,10 +8765,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -9171,19 +9190,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#362;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9277,16 +9296,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#369;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -9378,10 +9397,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -9714,28 +9733,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#375;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#375;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -9786,16 +9805,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9961,28 +9980,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#375;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#375;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -10028,16 +10047,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -10108,15 +10127,15 @@ TODO:
     </Style>
     <Style x:Key="&#383;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#377;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#377;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10169,15 +10188,15 @@ TODO:
     </Style>
     <Style x:Key="&#384;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#378;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#378;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10231,180 +10250,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#374;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#383;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#370;}"
-                                        BorderBrush="{StaticResource &#369;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#380;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#382;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#374;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#383;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#370;}"
+                                            BorderBrush="{StaticResource &#369;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#380;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#382;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#384;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#375;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#384;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#375;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#373;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.Metallic.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
@@ -118,6 +118,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Themes/Luna.NormalColor.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -113,7 +110,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#212;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#212;}"
@@ -126,15 +141,12 @@ To automatically copy the files, set the environment variable
            BasedOn="{StaticResource &#212;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <!--=================================================================
             Calendar
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -160,19 +172,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -183,10 +195,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -208,10 +220,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -227,7 +239,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#214;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#214;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -313,7 +325,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -324,31 +336,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#214;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#214;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#216;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#216;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#215;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#215;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -425,9 +437,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -797,17 +809,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#228;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -851,11 +863,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -863,7 +875,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -882,7 +894,7 @@ To automatically copy the files, set the environment variable
 
 
 
- <!--=================================================================
+    <!--=================================================================
         ContextMenu
     ==================================================================-->
     <Style x:Key="{x:Type ContextMenu}"
@@ -926,18 +938,18 @@ To automatically copy the files, set the environment variable
                                 BorderThickness="{TemplateBinding BorderThickness}">
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -968,7 +980,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-  
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -1041,7 +1053,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
     </Style>
-    
+
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
     ==================================================================-->
@@ -1099,68 +1111,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1172,23 +1184,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#230;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#231;" />
@@ -1313,10 +1325,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1407,7 +1419,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1473,7 +1485,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1516,11 +1528,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1643,9 +1655,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1659,7 +1671,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1770,20 +1782,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#236;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1792,9 +1804,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1813,22 +1825,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1881,12 +1893,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1906,7 +1918,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1920,8 +1932,8 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-  
-     <!--=================================================================
+
+    <!--=================================================================
         Expander
     ==================================================================-->
     <Style x:Key="&#238;">
@@ -2340,7 +2352,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2358,43 +2370,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#244;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#245;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2427,13 +2439,13 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <SolidColorBrush x:Key="&#255;" 
+    <SolidColorBrush x:Key="&#255;"
                      Color="#D0D0BF"/>
 
-    <SolidColorBrush x:Key="&#256;" 
+    <SolidColorBrush x:Key="&#256;"
                      Color="#0046D5"/>
 
- 
+
     <!--=================================================================
         GroupBox
     ==================================================================-->
@@ -2490,15 +2502,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </Border.OpacityMask>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               TextElement.Foreground="{StaticResource &#256;}"/>
                         </Border>
@@ -2560,33 +2572,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2646,7 +2658,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#227;"
                      Color="#FF7F9DB9"/>
 
@@ -2699,10 +2712,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2715,17 +2728,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#258;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -2782,11 +2795,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2794,7 +2807,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-     
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -2852,7 +2865,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
     <Style x:Key="{x:Type Menu}"
@@ -2896,7 +2909,7 @@ To automatically copy the files, set the environment variable
 
 
 
-   <PathGeometry x:Key="&#273;">
+    <PathGeometry x:Key="&#273;">
         <PathGeometry.Figures>
             <PathFigureCollection>
                 <PathFigure StartPoint="0 2"
@@ -3197,20 +3210,20 @@ To automatically copy the files, set the environment variable
                                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3406,20 +3419,20 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
                                 <!-- TODO: Metric for Margin? -->
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3610,7 +3623,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#279;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3623,7 +3636,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#280;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -3632,7 +3645,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#281;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3644,7 +3657,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#282;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3665,14 +3678,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#283;" 
+    <SolidColorBrush x:Key="&#283;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#250;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -3764,9 +3777,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#249;" 
+    <Style x:Key="&#249;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -3792,33 +3805,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -3846,13 +3859,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -3871,11 +3884,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -3893,11 +3906,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -3913,16 +3926,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -3932,9 +3945,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -3956,13 +3969,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -3981,30 +3994,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#275;}"
                                  Stroke="{StaticResource &#279;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#280;}"
@@ -4017,7 +4030,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#278;}"
@@ -4032,13 +4045,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#276;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#277;}"
@@ -4074,7 +4087,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4084,9 +4097,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4094,14 +4107,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4129,19 +4142,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4200,8 +4213,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -4219,8 +4232,8 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-  
-    
+
+
     <!--=================================================================
         ProgressBar
     ==================================================================-->
@@ -4304,7 +4317,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         RadioButton
     ==================================================================-->
     <Style x:Key="{x:Type RadioButton}"
@@ -4369,16 +4382,16 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
-                    <Grid SnapsToDevicePixels="True" 
+                    <Grid SnapsToDevicePixels="True"
                           Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="White"
                               Margin="0,0,2,2"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
 
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="{StaticResource &#286;}"
                               Margin="0,0,3,3"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
@@ -4731,21 +4744,21 @@ To automatically copy the files, set the environment variable
     </Style>
     <!-- End ScrollBar Styles -->
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -4775,9 +4788,9 @@ To automatically copy the files, set the environment variable
     <SolidColorBrush x:Key="&#299;" Color="#F3F3EF"/>
 
 
-     <LinearGradientBrush x:Key="&#300;"
-                         StartPoint="0,0"
-                         EndPoint="1,0">
+    <LinearGradientBrush x:Key="&#300;"
+                        StartPoint="0,0"
+                        EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#40FFFFFF"
                           Offset="0"/>
@@ -4819,28 +4832,34 @@ To automatically copy the files, set the environment variable
 
 
 
-<!--=================================================================
+    <!--=================================================================
         VerticalSlider and HorizontalSlider
     ==================================================================-->
     <!-- Pointed Thumb-->
-    <Geometry x:Key="&#303;">M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
-    
+    <Geometry x:Key="&#303;">
+        M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
+
     </Geometry>
-    <Geometry x:Key="&#304;">M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
-    
+    <Geometry x:Key="&#304;">
+        M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
+
     </Geometry>
-    <Geometry x:Key="&#305;">M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
-    
+    <Geometry x:Key="&#305;">
+        M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
+
     </Geometry>
     <!-- Rectangular Thumb -->
-    <Geometry x:Key="&#306;">M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
-    
+    <Geometry x:Key="&#306;">
+        M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
+
     </Geometry>
-    <Geometry x:Key="&#307;">M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
-    
+    <Geometry x:Key="&#307;">
+        M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
+
     </Geometry>
-    <Geometry x:Key="&#308;">M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
-    
+    <Geometry x:Key="&#308;">
+        M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
+
     </Geometry>
     <!--=================================================================
             HorizontalSlider Resources
@@ -5765,7 +5784,7 @@ To automatically copy the files, set the environment variable
                                                Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
                                 </Canvas>
                             </Border>
-                                
+
                             <!-- MainPartsPanel -->
                             <Track Grid.Row="1"
                                    Name="PART_Track">
@@ -5877,7 +5896,7 @@ To automatically copy the files, set the environment variable
                                                        Visibility="Hidden"
                                                        StrokeThickness="1.0"
                                                        Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
-                                    </Canvas>
+                                        </Canvas>
 
                                     </Border>
                                     <!-- MainPartsPanel -->
@@ -6243,26 +6262,26 @@ To automatically copy the files, set the environment variable
 
 
 
- 
+
     <Style x:Key="&#352;">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
-                   <Rectangle Margin="3,3,3,1"
-                               StrokeThickness="1"
-                               Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                               StrokeDashArray="1 2"
-                               SnapsToDevicePixels="true"/>
+                    <Rectangle Margin="3,3,3,1"
+                                StrokeThickness="1"
+                                Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                StrokeDashArray="1 2"
+                                SnapsToDevicePixels="true"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 
-    
-   
 
-  
-  
+
+
+
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -6652,7 +6671,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -6693,7 +6712,7 @@ TODO:
     </Style>
 
 
-     <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <Style x:Key="{x:Type ToolTip}"
@@ -6797,34 +6816,34 @@ TODO:
                             <ItemsPresenter/>
                         </ScrollViewer>
                     </Border>
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                             Value="true">
-                      <Setter TargetName="_tv_scrollviewer_"
-                              Property="CanContentScroll"
-                              Value="true"/>
-                    </Trigger>
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
 
-       <!--=================================================================
+    <!--=================================================================
         TreeViewItem
     ==================================================================-->
     <Style x:Key="&#385;"
@@ -6985,21 +7004,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -7023,7 +7042,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -7141,18 +7160,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7173,7 +7192,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -7206,11 +7225,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -7241,9 +7260,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -7897,28 +7916,28 @@ TODO:
     <Style x:Key="&#224;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -8038,17 +8057,17 @@ TODO:
                             BorderThickness="1"
                             BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                         <ScrollViewer Name="DropDownScrollViewer">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                            </Canvas>
-                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                </Canvas>
+                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -8071,10 +8090,10 @@ TODO:
                         Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="PART_Popup"
@@ -8174,17 +8193,17 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -8233,10 +8252,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="DropDownScrollViewer"
@@ -8293,7 +8312,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -8303,9 +8322,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -8313,14 +8332,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -8351,16 +8370,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -8749,10 +8768,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -9148,19 +9167,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#362;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9254,16 +9273,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#369;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -9355,10 +9374,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -9691,28 +9710,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#375;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#375;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -9763,16 +9782,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9938,28 +9957,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#375;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#375;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -10005,16 +10024,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -10085,15 +10104,15 @@ TODO:
     </Style>
     <Style x:Key="&#383;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#377;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#377;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10146,15 +10165,15 @@ TODO:
     </Style>
     <Style x:Key="&#384;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#378;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#378;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10208,180 +10227,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#374;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#383;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#370;}"
-                                        BorderBrush="{StaticResource &#369;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#380;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#382;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#374;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#383;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#370;}"
+                                            BorderBrush="{StaticResource &#369;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#380;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#382;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#384;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#375;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#384;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#375;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#373;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
@@ -1,8 +1,5 @@
-
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.
@@ -117,7 +114,25 @@ To automatically copy the files, set the environment variable
 
     <Style x:Key="{x:Type ToggleButton}"
            BasedOn="{StaticResource &#212;}"
-           TargetType="{x:Type ToggleButton}"/>
+           TargetType="{x:Type ToggleButton}">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
 
     <Style x:Key="{x:Type RepeatButton}"
            BasedOn="{StaticResource &#212;}"
@@ -130,15 +145,12 @@ To automatically copy the files, set the environment variable
            BasedOn="{StaticResource &#212;}"
            TargetType="{x:Type Button}"/>
 
-
-
-
     <!--=================================================================
             Calendar
         ==================================================================-->
 
     <Style TargetType="Calendar">
-        <Setter Property="Foreground" Value="#FF333333" />        
+        <Setter Property="Foreground" Value="#FF333333" />
         <Setter Property="Background">
             <Setter.Value>
                 <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
@@ -164,19 +176,19 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate TargetType="Calendar">
                     <StackPanel Name="PART_Root" HorizontalAlignment="Center">
-                        <CalendarItem 
-                            Name="PART_CalendarItem" 
+                        <CalendarItem
+                            Name="PART_CalendarItem"
                             Style="{TemplateBinding CalendarItemStyle}"
-                            Background="{TemplateBinding Background}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}"                            
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             />
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <!--CalendarItem-->
     <Style TargetType="CalendarItem">
         <Setter Property="Margin" Value="0,3,0,3" />
@@ -187,10 +199,10 @@ To automatically copy the files, set the environment variable
                         <!-- Start: Data template for header button -->
                         <DataTemplate x:Key="{x:Static CalendarItem.DayTitleTemplateResourceKey}">
                             <TextBlock
-                                FontWeight="Bold" 
-                                FontFamily="Verdana" 
-                                FontSize="9.5" 
-                                Foreground="#FF333333" 
+                                FontWeight="Bold"
+                                FontFamily="Verdana"
+                                FontSize="9.5"
+                                Foreground="#FF333333"
                                 HorizontalAlignment="Center"
                                 Text="{Binding}"
                                 Margin="0,6,0,6"
@@ -212,10 +224,10 @@ To automatically copy the files, set the environment variable
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Border 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                        <Border
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             CornerRadius="1">
                             <Border CornerRadius="1" BorderBrush="#FFFFFFFF" BorderThickness="2">
                                 <Grid>
@@ -231,7 +243,7 @@ To automatically copy the files, set the environment variable
 
                                     <Grid.Resources>
                                         <!-- Start: Previous button template -->
-                                        <ControlTemplate x:Key="&#214;" TargetType="Button">                                            
+                                        <ControlTemplate x:Key="&#214;" TargetType="Button">
                                             <Grid Cursor="Hand">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup Name="CommonStates">
@@ -317,7 +329,7 @@ To automatically copy the files, set the environment variable
                                                   Margin="1,4,1,9"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                                     <TextElement.Foreground>
+                                                    <TextElement.Foreground>
                                                         <SolidColorBrush Color="#FF333333"/>
                                                     </TextElement.Foreground>
                                                 </ContentPresenter>
@@ -328,31 +340,31 @@ To automatically copy the files, set the environment variable
                                     </Grid.Resources>
 
                                     <!-- Start: Previous button content -->
-                                    <Button x:Name="PART_PreviousButton" 
+                                    <Button x:Name="PART_PreviousButton"
                                             Grid.Row="0" Grid.Column="0"
-                                            Template="{StaticResource &#214;}" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Left" 
+                                            Template="{StaticResource &#214;}"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Left"
                                             Focusable="False"
                                             />
                                     <!-- End: Previous button content -->
 
                                     <!-- Start: Header button content -->
-                                    <Button x:Name="PART_HeaderButton"                                             
-                                            Grid.Row="0" Grid.Column="1" 
-                                            Template="{StaticResource &#216;}" 
-                                            HorizontalAlignment="Center" VerticalAlignment="Center" 
-                                            FontWeight="Bold" FontSize="10.5" 
+                                    <Button x:Name="PART_HeaderButton"
+                                            Grid.Row="0" Grid.Column="1"
+                                            Template="{StaticResource &#216;}"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                                            FontWeight="Bold" FontSize="10.5"
                                             Focusable="False"
                                             />
                                     <!-- End: Header button content -->
 
                                     <!-- Start: Next button content -->
-                                    <Button x:Name="PART_NextButton" 
-                                            Grid.Row="0" Grid.Column="2" 
-                                            Height="20" Width="28" 
-                                            HorizontalAlignment="Right" 
-                                            Template="{StaticResource &#215;}" 
+                                    <Button x:Name="PART_NextButton"
+                                            Grid.Row="0" Grid.Column="2"
+                                            Height="20" Width="28"
+                                            HorizontalAlignment="Right"
+                                            Template="{StaticResource &#215;}"
                                             Focusable="False"
                                             />
                                     <!-- End: Next button content -->
@@ -429,9 +441,9 @@ To automatically copy the files, set the environment variable
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
-        </Setter>        
+        </Setter>
     </Style>
-    
+
     <!--CalendarDayButton-->
     <Style TargetType="CalendarDayButton">
         <Setter Property="MinWidth" Value="5"/>
@@ -801,17 +813,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#228;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -855,11 +867,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#228;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -867,7 +879,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- 
+
     <!--=================================================================
         ContentControl
     ==================================================================-->
@@ -886,7 +898,7 @@ To automatically copy the files, set the environment variable
 
 
 
- <!--=================================================================
+    <!--=================================================================
         ContextMenu
     ==================================================================-->
     <Style x:Key="{x:Type ContextMenu}"
@@ -930,18 +942,18 @@ To automatically copy the files, set the environment variable
                                 BorderThickness="{TemplateBinding BorderThickness}">
                             <ScrollViewer Name="ContextMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=ContextMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=ContextMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=ContextMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="{TemplateBinding Padding}"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -973,8 +985,8 @@ To automatically copy the files, set the environment variable
 
 
 
-   
-   
+
+
     <!--=================================================================
         FlowDocument
     ==================================================================-->
@@ -1047,8 +1059,8 @@ To automatically copy the files, set the environment variable
         <Setter Property="HorizontalAlignment"
                 Value="Right"/>
     </Style>
-    
-  
+
+
     <!--=================================================================
         FlowDocument - Handled by FlowDocumentReader
     ==================================================================-->
@@ -1105,68 +1117,68 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DocumentViewer}">
-                  <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
-                    <Grid Background="{TemplateBinding Background}"
-                          KeyboardNavigation.TabNavigation="Local">
-                      <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                      </Grid.ColumnDefinitions>
-                      <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
-                      </Grid.RowDefinitions>
-                      <!-- One column for both the toolbar and the content -->
-                      <!-- Top row, auto height for the Toolbar -->
-                      <!-- Middle row, full height for the Content area -->
-                      <!-- Bottom row, auto height for the find Toolbar -->
-                      <!-- DocumentViewer's ToolBar, docked to the Top -->
-                      <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
-                                      Grid.Row="0"
-                                      Grid.Column="0"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      TabIndex="0"/>
-                      <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
-                      <ScrollViewer Grid.Row="1"
-                                    Grid.Column="0"
-                                    CanContentScroll="true"
-                                    HorizontalScrollBarVisibility="Auto"
-                                    x:Name="PART_ContentHost"
-                                    Focusable="{TemplateBinding Focusable}"
-                                    IsTabStop="true"
-                                    TabIndex="1"/>
-                      <!-- Toolbar shadow -->
-                      <DockPanel Grid.Row="1">
-                        <!-- saves space for the scrollbar -->
-                        <FrameworkElement DockPanel.Dock="Right"
-                                          Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
-                        <Rectangle x:Name="ToolbarShadow"
-                                   Visibility="Visible"
-                                   VerticalAlignment="top"
-                                   Height="10">
-                          <Rectangle.Fill>
-                            <LinearGradientBrush StartPoint="0,0"
-                                                 EndPoint="0,1">
-                              <GradientBrush.GradientStops>
-                                <GradientStopCollection>
-                                  <GradientStop Color="#66000000"
-                                                Offset="0"/>
-                                  <GradientStop Color="Transparent"
-                                                Offset="1"/>
-                                </GradientStopCollection>
-                              </GradientBrush.GradientStops>
-                            </LinearGradientBrush>
-                          </Rectangle.Fill>
-                        </Rectangle>
-                      </DockPanel>
-                      <!-- Find ToolBar, docked to the bottom -->
-                      <ContentControl Grid.Row="2"
-                                      Grid.Column="0"
-                                      TabIndex="2"
-                                      Focusable="{TemplateBinding Focusable}"
-                                      x:Name="PART_FindToolBarHost"/>
-                    </Grid>
-                  </Border>
+                    <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Focusable="False">
+                        <Grid Background="{TemplateBinding Background}"
+                              KeyboardNavigation.TabNavigation="Local">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <!-- One column for both the toolbar and the content -->
+                            <!-- Top row, auto height for the Toolbar -->
+                            <!-- Middle row, full height for the Content area -->
+                            <!-- Bottom row, auto height for the find Toolbar -->
+                            <!-- DocumentViewer's ToolBar, docked to the Top -->
+                            <ContentControl Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type ui:PresentationUIStyleResources},                                 ResourceId=PUIDocumentViewerToolBarStyleKey}}"
+                                            Grid.Row="0"
+                                            Grid.Column="0"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            TabIndex="0"/>
+                            <!-- Define the Content area and its paging/scrolling controls inside the Grid -->
+                            <ScrollViewer Grid.Row="1"
+                                          Grid.Column="0"
+                                          CanContentScroll="true"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          x:Name="PART_ContentHost"
+                                          Focusable="{TemplateBinding Focusable}"
+                                          IsTabStop="true"
+                                          TabIndex="1"/>
+                            <!-- Toolbar shadow -->
+                            <DockPanel Grid.Row="1">
+                                <!-- saves space for the scrollbar -->
+                                <FrameworkElement DockPanel.Dock="Right"
+                                                  Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}"/>
+                                <Rectangle x:Name="ToolbarShadow"
+                                           Visibility="Visible"
+                                           VerticalAlignment="top"
+                                           Height="10">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0"
+                                                             EndPoint="0,1">
+                                            <GradientBrush.GradientStops>
+                                                <GradientStopCollection>
+                                                    <GradientStop Color="#66000000"
+                                                                  Offset="0"/>
+                                                    <GradientStop Color="Transparent"
+                                                                  Offset="1"/>
+                                                </GradientStopCollection>
+                                            </GradientBrush.GradientStops>
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </DockPanel>
+                            <!-- Find ToolBar, docked to the bottom -->
+                            <ContentControl Grid.Row="2"
+                                            Grid.Column="0"
+                                            TabIndex="2"
+                                            Focusable="{TemplateBinding Focusable}"
+                                            x:Name="PART_FindToolBarHost"/>
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -1176,23 +1188,23 @@ To automatically copy the files, set the environment variable
         ==================================================================-->
 
     <Style x:Key="&#230;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,1,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,1,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <BooleanToVisibilityConverter x:Key="&#231;" />
@@ -1317,10 +1329,10 @@ To automatically copy the files, set the environment variable
         </Setter>
         <Style.Triggers>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
         </Style.Triggers>
@@ -1411,7 +1423,7 @@ To automatically copy the files, set the environment variable
             <Setter.Value>
                 <ControlTemplate>
                     <TextBlock Margin="2,0,0,0" VerticalAlignment="Center" Foreground="Red" Text="!" />
-            </ControlTemplate>
+                </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
@@ -1477,7 +1489,7 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
-                    <Border Name="Bd" 
+                    <Border Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderBrush="{TemplateBinding BorderBrush}"
                       BorderThickness="{TemplateBinding BorderThickness}"
@@ -1520,11 +1532,11 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
             <MultiDataTrigger>
-              <MultiDataTrigger.Conditions>
-                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              </MultiDataTrigger.Conditions>
-              <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="FocusVisualStyle" Value="{StaticResource &#230;}"/>
             </MultiDataTrigger>
         </Style.Triggers>
     </Style>
@@ -1647,9 +1659,9 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}" 
+                            Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup Name="CommonStates">
@@ -1663,7 +1675,7 @@ To automatically copy the files, set the environment variable
                         </VisualStateManager.VisualStateGroups>
                         <Border.Child>
                             <Grid x:Name="PART_Root"
-                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <Grid.Resources>
                                     <!-- Main DatePicker Brushes -->
@@ -1774,20 +1786,20 @@ To automatically copy the files, set the environment variable
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="PART_Button" Grid.Row="0" Grid.Column="1"
                                         Template="{StaticResource &#236;}"
-                                        Foreground="{TemplateBinding Foreground}" 
+                                        Foreground="{TemplateBinding Foreground}"
                                         Width="20"
-                                        Margin="3,0,3,0" 
-                                        Focusable="False" 
+                                        Margin="3,0,3,0"
+                                        Focusable="False"
                                         VerticalAlignment="Top"
                                         HorizontalAlignment="Left" />
-                                <DatePickerTextBox x:Name="PART_TextBox" 
-                                    Grid.Row="0" Grid.Column="0" 
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                    Grid.Row="0" Grid.Column="0"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Focusable="{TemplateBinding Focusable}" />
-                                <Grid x:Name="PART_DisabledVisual" 
-                                      Opacity="0" 
-                                      IsHitTestVisible="False" 
+                                <Grid x:Name="PART_DisabledVisual"
+                                      Opacity="0"
+                                      IsHitTestVisible="False"
                                       Grid.Row="0" Grid.Column="0"
                                       Grid.ColumnSpan="2">
                                     <Grid.ColumnDefinitions>
@@ -1796,9 +1808,9 @@ To automatically copy the files, set the environment variable
                                     </Grid.ColumnDefinitions>
                                     <Rectangle Grid.Row="0" Grid.Column="0" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF"/>
                                     <Rectangle Grid.Row="0" Grid.Column="1" RadiusX="1" RadiusY="1" Fill="#A5FFFFFF" Height="18" Width="19" Margin="3,0,3,0" />
-                                    <Popup x:Name="PART_Popup" 
+                                    <Popup x:Name="PART_Popup"
                                            PlacementTarget="{Binding ElementName=PART_TextBox}"
-                                           Placement="Bottom" 
+                                           Placement="Bottom"
                                            StaysOpen="False"
                                            AllowsTransparency="True" />
                                 </Grid>
@@ -1817,22 +1829,22 @@ To automatically copy the files, set the environment variable
 
     <!-- DatePickerTextBox -->
     <Style TargetType="{x:Type DatePickerTextBox}">
-      <Style.Triggers>
-        <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
-          <Setter Property="AutomationProperties.Name"
-                Value="{Binding Path=(AutomationProperties.Name),
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.LabeledBy"
-                  Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-          <Setter Property="AutomationProperties.HelpText"
-                  Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}"/>
-        </DataTrigger>
-      </Style.Triggers>
+            </DataTrigger>
+        </Style.Triggers>
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -1885,12 +1897,12 @@ To automatically copy the files, set the environment variable
 
 
                         <!--Start UI-->
-                        <Border x:Name="Border" 
-                                Background="{TemplateBinding Background}" 
-                                BorderBrush="{TemplateBinding BorderBrush}" 
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
-                                CornerRadius="1" 
+                                CornerRadius="1"
                                 Opacity="1">
                             <Grid x:Name="WatermarkContent"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -1910,7 +1922,7 @@ To automatically copy the files, set the environment variable
                                                         IsHitTestVisible="False"
                                                         Padding="2"/>
                                 </Border>
-                                <ScrollViewer x:Name="PART_ContentHost" 
+                                <ScrollViewer x:Name="PART_ContentHost"
                                               Margin="0"
                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1925,7 +1937,7 @@ To automatically copy the files, set the environment variable
 
 
 
-      <!--=================================================================
+    <!--=================================================================
         Expander
     ==================================================================-->
     <Style x:Key="&#238;">
@@ -2343,7 +2355,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
- 
+
     <!--=================================================================
         FocusVisual
     ==================================================================-->
@@ -2361,43 +2373,43 @@ To automatically copy the files, set the environment variable
     </Style>
 
     <Style x:Key="&#244;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="13,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="13,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="&#245;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Grid>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                         SnapsToDevicePixels="true"/>
-              <Rectangle Margin="1,0,1,1"
-                         StrokeThickness="1"
-                         Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
-                         StrokeDashArray="2 2"
-                         SnapsToDevicePixels="true"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                                   SnapsToDevicePixels="true"/>
+                        <Rectangle Margin="1,0,1,1"
+                                   StrokeThickness="1"
+                                   Stroke="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}"
+                                   StrokeDashArray="2 2"
+                                   SnapsToDevicePixels="true"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 
@@ -2430,13 +2442,13 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <SolidColorBrush x:Key="&#255;" 
+    <SolidColorBrush x:Key="&#255;"
                      Color="#D6D5D9"/>
 
-    <SolidColorBrush x:Key="&#256;" 
+    <SolidColorBrush x:Key="&#256;"
                      Color="#335EA8"/>
 
- 
+
     <!--=================================================================
         GroupBox
     ==================================================================-->
@@ -2493,15 +2505,15 @@ To automatically copy the files, set the environment variable
                                 </MultiBinding>
                             </Border.OpacityMask>
                         </Border>
-                        
+
                         <!-- ContentPresenter for the header -->
                         <Border x:Name="Header"
                                 Padding="3,0,3,0"
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Grid.Column="1">
-                            <ContentPresenter ContentSource="Header" 
-                                              RecognizesAccessKey="True" 
+                            <ContentPresenter ContentSource="Header"
+                                              RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               TextElement.Foreground="{StaticResource &#256;}"/>
                         </Border>
@@ -2563,33 +2575,33 @@ To automatically copy the files, set the environment variable
         <Setter Property="TextDecorations"
                 Value="Underline"/>
         <Style.Triggers>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <MultiDataTrigger>
-            <MultiDataTrigger.Conditions>
-              <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
-              <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-              <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-            </MultiDataTrigger.Conditions>
-            <Setter Property="Foreground" Value="Red"/>
-          </MultiDataTrigger>
-          <Trigger Property="IsEnabled"
-                   Value="false">
-            <Setter Property="Foreground"
-                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-          </Trigger>
-          <Trigger Property="IsEnabled"
-                   Value="true">
-            <Setter Property="Cursor"
-                    Value="Hand"/>
-          </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="false"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="true"/>
+                    <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground" Value="Red"/>
+            </MultiDataTrigger>
+            <Trigger Property="IsEnabled"
+                     Value="false">
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+            </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="true">
+                <Setter Property="Cursor"
+                        Value="Hand"/>
+            </Trigger>
         </Style.Triggers>
-    </Style> 
+    </Style>
     <!--=================================================================
         ItemsControl
     ==================================================================-->
@@ -2649,7 +2661,8 @@ To automatically copy the files, set the environment variable
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    <!-- This color is shared between ListBox and TextBox -->
+    </Style>
+    <!-- This color is shared between ListBox and TextBox -->
     <SolidColorBrush x:Key="&#227;"
                      Color="#FFA7A6AA"/>
 
@@ -2702,10 +2715,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -2718,17 +2731,17 @@ To automatically copy the files, set the environment variable
 
 
     <Style x:Key="&#258;">
-      <Setter Property="Control.Template">
-        <Setter.Value>
-          <ControlTemplate>
-            <Rectangle Margin="0,1,0,1"
-                       StrokeThickness="1"
-                       Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
-                       StrokeDashArray="1 2"
-                       SnapsToDevicePixels="true"/>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Margin="0,1,0,1"
+                               StrokeThickness="1"
+                               Stroke="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"
+                               StrokeDashArray="1 2"
+                               SnapsToDevicePixels="true"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!--=================================================================
@@ -2785,11 +2798,11 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
                         </Trigger>
                         <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                            <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource &#258;}"/>
                         </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -3077,10 +3090,10 @@ To automatically copy the files, set the environment variable
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
@@ -3088,7 +3101,7 @@ To automatically copy the files, set the environment variable
             </Setter.Value>
         </Setter>
     </Style>
-     
+
     <!--=================================================================
         ListViewItem
     ==================================================================-->
@@ -3146,7 +3159,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Menu
     ==================================================================-->
     <Style x:Key="{x:Type Menu}"
@@ -3190,7 +3203,7 @@ To automatically copy the files, set the environment variable
 
 
 
-   <PathGeometry x:Key="&#265;">
+    <PathGeometry x:Key="&#265;">
         <PathGeometry.Figures>
             <PathFigureCollection>
                 <PathFigure StartPoint="0 2"
@@ -3359,7 +3372,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
- <!--=================================================================
+    <!--=================================================================
         MenuItem
     ==================================================================-->
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}"
@@ -3473,20 +3486,20 @@ To automatically copy the files, set the environment variable
                                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3652,20 +3665,20 @@ To automatically copy the files, set the environment variable
                             <ScrollViewer Name="SubMenuScrollViewer"
                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
                                 <!-- TODO: Metric for Margin? -->
-                              <Grid RenderOptions.ClearTypeHint="Enabled">
-                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                    <Rectangle
-                                        Name="OpaqueRect"
-                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                </Canvas>
-                                <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Grid.IsSharedSizeScope="true"/>
-                              </Grid>
+                                <Grid RenderOptions.ClearTypeHint="Enabled">
+                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                        <Rectangle
+                                            Name="OpaqueRect"
+                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                    </Canvas>
+                                    <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Grid.IsSharedSizeScope="true"/>
+                                </Grid>
                             </ScrollViewer>
                         </Border>
                     </theme:SystemDropShadowChrome>
@@ -3779,7 +3792,7 @@ To automatically copy the files, set the environment variable
                 <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
-    </Style.Triggers>
+        </Style.Triggers>
     </Style>
 
 
@@ -3855,7 +3868,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#271;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <GradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3868,7 +3881,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#272;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#8AB1FB" Offset="0"/>
@@ -3877,7 +3890,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#273;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3889,7 +3902,7 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="&#274;"
-                         StartPoint="0,0" 
+                         StartPoint="0,0"
                          EndPoint="0,1">
         <LinearGradientBrush.GradientStops>
             <GradientStopCollection>
@@ -3910,14 +3923,14 @@ To automatically copy the files, set the environment variable
         </GradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <SolidColorBrush x:Key="&#275;" 
+    <SolidColorBrush x:Key="&#275;"
                      Color="{StaticResource {x:Static SystemColors.HighlightColorKey}}"
                      Opacity="0.25"/>
 
     <!-- Navigation Window back/fwd button Drop Down style-->
     <Style x:Key="&#250;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="Header"
                 Value="{Binding Path=(JournalEntry.Name)}"/>
@@ -4009,9 +4022,9 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-    <Style x:Key="&#249;" 
+    <Style x:Key="&#249;"
            TargetType="{x:Type MenuItem}">
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="ScrollViewer.PanningMode"
                 Value="Both"/>
@@ -4037,33 +4050,33 @@ To automatically copy the files, set the environment variable
 
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
                         </Popup>
-                        
-                        <Grid x:Name="Panel" 
-                              Width="26" 
+
+                        <Grid x:Name="Panel"
+                              Width="26"
                               Background="Transparent"
                               HorizontalAlignment="Right" >
-   
-                            <Border SnapsToDevicePixels="True" 
-                                    Visibility="Hidden" 
-                                    Name="HighlightBorder" 
-                                    BorderThickness="1,1,1,1" 
-                                    BorderBrush="#B0B5BACE" 
+
+                            <Border SnapsToDevicePixels="True"
+                                    Visibility="Hidden"
+                                    Name="HighlightBorder"
+                                    BorderThickness="1,1,1,1"
+                                    BorderBrush="#B0B5BACE"
                                     CornerRadius="2" >
                                 <Border.Background>
                                     <LinearGradientBrush StartPoint="0,0"
@@ -4091,13 +4104,13 @@ To automatically copy the files, set the environment variable
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsHighlighted" Value="true">
-                            <Setter TargetName="HighlightBorder" 
-                                    Property="Visibility" 
+                            <Setter TargetName="HighlightBorder"
+                                    Property="Visibility"
                                     Value="Visible"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" 
-                                    Property="Fill" 
+                            <Setter TargetName="Arrow"
+                                    Property="Fill"
                                     Value="#A5AABE"/>
                         </Trigger>
                         <Trigger SourceName="PART_Popup"
@@ -4116,11 +4129,11 @@ To automatically copy the files, set the environment variable
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -4138,11 +4151,11 @@ To automatically copy the files, set the environment variable
                 </ItemsPanelTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
         <Setter Property="KeyboardNavigation.TabNavigation"
                 Value="None"/>
-        <Setter Property="IsMainMenu" 
+        <Setter Property="IsMainMenu"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -4158,16 +4171,16 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseBack"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
@@ -4177,9 +4190,9 @@ To automatically copy the files, set the environment variable
                                  Stroke="{StaticResource &#271;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#272;}"
@@ -4201,13 +4214,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#268;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#269;}"
@@ -4226,30 +4239,30 @@ To automatically copy the files, set the environment variable
            TargetType="{x:Type Button}">
         <!-- We will need to find out the size of button and menu height from system resources -->
         <!-- Opened work item #22122 to track this-->
-        <Setter Property="OverridesDefaultStyle" 
+        <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
-        <Setter Property="Command" 
+        <Setter Property="Command"
                 Value="NavigationCommands.BrowseForward"/>
-        <Setter Property="Focusable" 
+        <Setter Property="Focusable"
                 Value="false"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Width="24" 
+                    <Grid Width="24"
                           Height="24"
                           Background="Transparent">
                         <!-- Circle -->
                         <Ellipse Name="Circle"
-                                 Grid.Column="0"      
+                                 Grid.Column="0"
                                  StrokeThickness="1"
                                  Fill="{StaticResource &#267;}"
                                  Stroke="{StaticResource &#271;}" />
 
                         <!-- Arrow -->
-                        <Path Name="Arrow" 
-                              Grid.Column="0"      
-                              VerticalAlignment="Center" 
-                              HorizontalAlignment="Center" 
+                        <Path Name="Arrow"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
                               StrokeThickness="0.75"
                               Data="M0.37,7.69 L5.74,14.20 A1.5,1.5,0,1,0,10.26,12.27 L8.42,10.42 14.90,10.39 A1.5,1.5,0,1,0,14.92,5.87 L8.44,5.90 10.31,4.03 A1.5,1.5,0,1,0,5.79,1.77 z"
                               Stroke="{StaticResource &#272;}"
@@ -4262,7 +4275,7 @@ To automatically copy the files, set the environment variable
 
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" 
+                        <Trigger Property="IsEnabled"
                                  Value="false">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#270;}"
@@ -4277,13 +4290,13 @@ To automatically copy the files, set the environment variable
                                     Value="#D0FFFFFF"
                                     TargetName="Arrow"/>
                         </Trigger>
-                        <Trigger Property="IsMouseOver" 
+                        <Trigger Property="IsMouseOver"
                                  Value="true">
-                            <Setter Property="Fill" 
+                            <Setter Property="Fill"
                                     Value="{StaticResource &#268;}"
                                     TargetName="Circle"/>
                         </Trigger>
-                        <Trigger Property="IsPressed" 
+                        <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter Property="Fill"
                                     Value="{StaticResource &#269;}"
@@ -4319,7 +4332,7 @@ To automatically copy the files, set the environment variable
                           Grid.ColumnSpan="3"
                           Height="23"
                           Margin="1,0,0,1"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,5,0"
@@ -4329,9 +4342,9 @@ To automatically copy the files, set the environment variable
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.BackStack)" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="(NavigationWindow.ForwardStack)" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -4339,14 +4352,14 @@ To automatically copy the files, set the environment variable
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -4374,19 +4387,19 @@ To automatically copy the files, set the environment variable
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,2,0" 
+                            Margin="3,0,2,0"
                             Grid.Column="0"/>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="2,0,0,0" 
+                            Margin="2,0,0,0"
                             Grid.Column="1"/>
                 </Grid>
                 <Grid>
-                    <AdornerDecorator>                    
-                        <ContentPresenter Name="PART_NavWinCP" 
+                    <AdornerDecorator>
+                        <ContentPresenter Name="PART_NavWinCP"
                                           ClipToBounds="true"/>
-                                          
+
                     </AdornerDecorator>
 
 
@@ -4445,8 +4458,8 @@ To automatically copy the files, set the environment variable
 
 
 
- 
-   
+
+
     <!--=================================================================
         Page
     ==================================================================-->
@@ -4555,7 +4568,7 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-<!--=================================================================
+    <!--=================================================================
         RadioButton
     ==================================================================-->
     <Style x:Key="{x:Type RadioButton}"
@@ -4620,16 +4633,16 @@ To automatically copy the files, set the environment variable
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ResizeGrip}">
-                    <Grid SnapsToDevicePixels="True" 
+                    <Grid SnapsToDevicePixels="True"
                           Background="{TemplateBinding Background}">
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="White"
                               Margin="0,0,2,2"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
 
-                        <Path HorizontalAlignment="Right" 
-                              VerticalAlignment="Bottom" 
+                        <Path HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
                               Fill="{StaticResource &#278;}"
                               Margin="0,0,3,3"
                               Data="M 8,0 L 10,0 L 10,2 L 8,2 Z M 4,4 L 6,4 L 6,6 L 4,6 Z M 8,4 L 10,4 L 10,6 L 8,6 Z M 0,8 L 2,8 L 2,10 L 0,10 Z M 4,8 L 6,8 L 6,10 L 4,10 Z M 8,8 L 10,8 L 10,10 L 8,10 Z" />
@@ -4640,7 +4653,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-   <!--=================================================================
+    <!--=================================================================
         HorizontalScrollBar and VerticalScrollBar
     ==================================================================-->
     <!--
@@ -4947,21 +4960,21 @@ To automatically copy the files, set the environment variable
     </Style>
     <!-- End ScrollBar Styles -->
 
- 
+
     <!--=================================================================
         ScrollViewer
     ==================================================================-->
-    <Style x:Key="{x:Type ScrollViewer}" 
+    <Style x:Key="{x:Type ScrollViewer}"
            TargetType="{x:Type ScrollViewer}">
         <Style.Triggers>
-            <Trigger Property="IsEnabled" 
+            <Trigger Property="IsEnabled"
                      Value="false">
-                <Setter Property="Foreground" 
+                <Setter Property="Foreground"
                         Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
- 
+
     <!--=================================================================
         Separator
     ==================================================================-->
@@ -4988,7 +5001,7 @@ To automatically copy the files, set the environment variable
 
 
 
-    <LinearGradientBrush x:Key="&#287;" 
+    <LinearGradientBrush x:Key="&#287;"
                          StartPoint="0,0"
                          EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
@@ -5005,7 +5018,7 @@ To automatically copy the files, set the environment variable
         </LinearGradientBrush.GradientStops>
     </LinearGradientBrush>
 
-    <LinearGradientBrush x:Key="&#288;" 
+    <LinearGradientBrush x:Key="&#288;"
                          StartPoint="1,0"
                          EndPoint="0,0">
         <LinearGradientBrush.GradientStops>
@@ -5023,9 +5036,9 @@ To automatically copy the files, set the environment variable
     </LinearGradientBrush>
 
 
-     <LinearGradientBrush x:Key="&#289;"
-                         StartPoint="0,0"
-                         EndPoint="1,0">
+    <LinearGradientBrush x:Key="&#289;"
+                        StartPoint="0,0"
+                        EndPoint="1,0">
         <LinearGradientBrush.GradientStops>
             <GradientStop Color="#40FFFFFF"
                           Offset="0"/>
@@ -5067,28 +5080,34 @@ To automatically copy the files, set the environment variable
 
 
 
-<!--=================================================================
+    <!--=================================================================
         VerticalSlider and HorizontalSlider
     ==================================================================-->
     <!-- Pointed Thumb-->
-    <Geometry x:Key="&#292;">M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
-    
+    <Geometry x:Key="&#292;">
+        M 5,-8 A 1.5 1.5 0 0 0 3.5,-9.5 L -3.5,-9.5 A 1.5 1.5 0 0 0 -5,-8 L -5,5.5 L 0,10.5 L 5,5.5 Z
+
     </Geometry>
-    <Geometry x:Key="&#293;">M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
-    
+    <Geometry x:Key="&#293;">
+        M 4.5,-6 L 4.5,-9 L -4.5,-9 L -4.5,-6 Z
+
     </Geometry>
-    <Geometry x:Key="&#294;">M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
-    
+    <Geometry x:Key="&#294;">
+        M 4.5,4 L 0,8.5 L -4.5,4 L -4.5,5 L 0,10 L 4.5,5 Z
+
     </Geometry>
     <!-- Rectangular Thumb -->
-    <Geometry x:Key="&#295;">M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
-    
+    <Geometry x:Key="&#295;">
+        M 5,-9 A 1.5 1.5 0 0 0 3.5,-10.5 L -3.5,-10.5 A 1.5 1.5 0 0 0 -5,-9 L -5,9 A 1.5 1.5 0 0 0 -3.5,10.5 L 3.5,10.5 A 1.5 1.5 0 0 0 5,9 Z
+
     </Geometry>
-    <Geometry x:Key="&#296;">M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
-    
+    <Geometry x:Key="&#296;">
+        M 4.5,-8 L 4.5,-10 L -4.5,-10 L -4.5,-8 Z
+
     </Geometry>
-    <Geometry x:Key="&#297;">M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
-    
+    <Geometry x:Key="&#297;">
+        M 4.5,8 L 4.5,10 L -4.5,10 L -4.5,8 Z
+
     </Geometry>
     <!--=================================================================
             HorizontalSlider Resources
@@ -6013,7 +6032,7 @@ To automatically copy the files, set the environment variable
                                                Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
                                 </Canvas>
                             </Border>
-                                
+
                             <!-- MainPartsPanel -->
                             <Track Grid.Row="1"
                                    Name="PART_Track">
@@ -6125,7 +6144,7 @@ To automatically copy the files, set the environment variable
                                                        Visibility="Hidden"
                                                        StrokeThickness="1.0"
                                                        Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}"/>
-                                    </Canvas>
+                                        </Canvas>
 
                                     </Border>
                                     <!-- MainPartsPanel -->
@@ -6197,7 +6216,7 @@ To automatically copy the files, set the environment variable
         </Style.Triggers>
     </Style>
     <!-- End VerticalSlider and HorizontalSlider Styles -->
-     
+
     <!--=================================================================
         StatusBar
     ==================================================================-->
@@ -6490,7 +6509,7 @@ To automatically copy the files, set the environment variable
 
 
 
-    
+
     <Style x:Key="&#342;">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -6505,8 +6524,8 @@ To automatically copy the files, set the environment variable
         </Setter>
     </Style>
 
-   
- 
+
+
     <!--=================================================================
         TabItem
     ==================================================================-->
@@ -6897,7 +6916,7 @@ To automatically copy the files, set the environment variable
     </Style>
 
 
-<!--=================================================================
+    <!--=================================================================
         Thumb
     ==================================================================-->
     <!--
@@ -6938,7 +6957,7 @@ TODO:
     </Style>
 
 
-     <!--=================================================================
+    <!--=================================================================
         ToolTip
     ==================================================================-->
     <Style x:Key="{x:Type ToolTip}"
@@ -7042,34 +7061,34 @@ TODO:
                             <ItemsPresenter/>
                         </ScrollViewer>
                     </Border>
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                             Value="true">
-                      <Setter TargetName="_tv_scrollviewer_"
-                              Property="CanContentScroll"
-                              Value="true"/>
-                    </Trigger>
-                  </ControlTemplate.Triggers>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                                 Value="true">
+                            <Setter TargetName="_tv_scrollviewer_"
+                                    Property="CanContentScroll"
+                                    Value="true"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 
 
-        <!--=================================================================
+    <!--=================================================================
         TreeViewItem
     ==================================================================-->
     <Style x:Key="&#376;"
@@ -7231,21 +7250,21 @@ TODO:
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-      <Style.Triggers>
-        <Trigger Property="VirtualizingPanel.IsVirtualizing"
-                 Value="true">
-          <Setter Property="ItemsPanel">
-            <Setter.Value>
-              <ItemsPanelTemplate>
-                <VirtualizingStackPanel/>
-              </ItemsPanelTemplate>
-            </Setter.Value>
-          </Setter>
-        </Trigger>
-      </Style.Triggers>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing"
+                     Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
- 
+
     <!--=================================================================
         UserControl
     ==================================================================-->
@@ -7269,7 +7288,7 @@ TODO:
     </Style>
 
 
-   
+
     <!--=================================================================
         Window
     ==================================================================-->
@@ -7387,18 +7406,18 @@ TODO:
                                         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}" 
-                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}" 
-                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" Margin="2"
-                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                        KeyboardNavigation.DirectionalNavigation="Cycle"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" Margin="2"
+                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                            KeyboardNavigation.DirectionalNavigation="Cycle"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -7419,7 +7438,7 @@ TODO:
                                     Property="PopupAnimation"
                                     Value="None"/>
                         </Trigger>
-                       
+
                         <Trigger Property="IsHighlighted"
                                  Value="true">
                             <Setter TargetName="Arrow"
@@ -7452,11 +7471,11 @@ TODO:
                         <Trigger SourceName="SubMenuScrollViewer"
                                  Property="ScrollViewer.CanContentScroll"
                                  Value="false" >
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Top" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Top"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=VerticalOffset}" />
-                            <Setter TargetName="OpaqueRect" 
-                                    Property="Canvas.Left" 
+                            <Setter TargetName="OpaqueRect"
+                                    Property="Canvas.Left"
                                     Value="{Binding ElementName=SubMenuScrollViewer, Path=HorizontalOffset}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -7487,9 +7506,9 @@ TODO:
         </Setter>
     </Style>
 
-  
 
-  
+
+
     <!--=================================================================
         BrowserWindow
     ==================================================================-->
@@ -8143,28 +8162,28 @@ TODO:
     <Style x:Key="&#224;"
            TargetType="{x:Type TextBox}">
         <Style.Triggers>
-          <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
-            <Setter Property="AutomationProperties.Name"
-                  Value="{Binding Path=(AutomationProperties.Name),
+            <DataTrigger Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name"
+                      Value="{Binding Path=(AutomationProperties.Name),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.LabeledBy"
-                    Value="{Binding Path=(AutomationProperties.LabeledBy),
+                <Setter Property="AutomationProperties.LabeledBy"
+                        Value="{Binding Path=(AutomationProperties.LabeledBy),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-            <Setter Property="AutomationProperties.HelpText"
-                    Value="{Binding Path=(AutomationProperties.HelpText),
+                <Setter Property="AutomationProperties.HelpText"
+                        Value="{Binding Path=(AutomationProperties.HelpText),
                                   Mode=OneWay, 
                                   RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type ComboBox}}}"/>
-          </DataTrigger>
-          <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
-              <!-- DDVSO:572332
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.UseAdornerForTextboxSelectionRendering)}" Value="false">
+                <!-- DDVSO:572332
                     Ensure that the proper text selection colors are used per theme if non-ardorner selection is enabled.
                     ComboBoxes override the styles of the base TextBox when they are editable, so we have to add the trigger back to
                     ensure the selection brushes are updated. -->
-              <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-              <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
-          </DataTrigger>
+                <Setter Property="SelectionBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                <Setter Property="SelectionTextBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+            </DataTrigger>
         </Style.Triggers>
         <Setter Property="OverridesDefaultStyle"
                 Value="true"/>
@@ -8284,17 +8303,17 @@ TODO:
                             BorderThickness="1"
                             BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                         <ScrollViewer Name="DropDownScrollViewer">
-                          <Grid RenderOptions.ClearTypeHint="Enabled">
-                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                <Rectangle
-                                    Name="OpaqueRect"
-                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                            </Canvas>
-                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                          </Grid>
+                            <Grid RenderOptions.ClearTypeHint="Enabled">
+                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                    <Rectangle
+                                        Name="OpaqueRect"
+                                        Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                        Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                        Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                </Canvas>
+                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </Grid>
                         </ScrollViewer>
                     </Border>
                 </theme:SystemDropShadowChrome>
@@ -8323,10 +8342,10 @@ TODO:
                         Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
             </Trigger>
             <MultiTrigger>
-            <MultiTrigger.Conditions>
-                <Condition Property="IsGrouping" Value="true" />
-                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-            </MultiTrigger.Conditions>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
                 <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
             </MultiTrigger>
             <Trigger SourceName="PART_Popup"
@@ -8426,17 +8445,17 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{DynamicResource {x:Static SystemColors.WindowFrameBrushKey}}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"
+                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -8491,10 +8510,10 @@ TODO:
                                     Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <Trigger SourceName="DropDownScrollViewer"
@@ -8549,7 +8568,7 @@ TODO:
                           Grid.ColumnSpan="3"
                           Height="16"
                           Margin="1,0,0,0"
-                          VerticalAlignment="Center" 
+                          VerticalAlignment="Center"
                           Style="{StaticResource &#248;}">
 
                         <MenuItem Padding="0,2,4,0"
@@ -8559,9 +8578,9 @@ TODO:
                             <MenuItem.ItemsSource>
                                 <MultiBinding Converter="{StaticResource &#251;}">
                                     <MultiBinding.Bindings>
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="BackStack" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}" 
+                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                                  Path="ForwardStack" />
                                     </MultiBinding.Bindings>
                                 </MultiBinding>
@@ -8569,14 +8588,14 @@ TODO:
                         </MenuItem>
                     </Menu>
 
-                    <Path Grid.Column="0" 
+                    <Path Grid.Column="0"
                           SnapsToDevicePixels="false"
                           IsHitTestVisible="false"
                           Margin="2,0,0,0"
                           Grid.ColumnSpan="3"
-                          StrokeThickness="1" 
-                          HorizontalAlignment="Left" 
-                          VerticalAlignment="Center" 
+                          StrokeThickness="1"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Center"
                           Data="M22.5767,21.035 Q27,19.37 31.424,21.035 A12.5,12.5,0,0,0,53.5,13 A12.5,12.5,0,0,0,37.765,0.926 Q27,4.93 16.235,0.926 A12.5,12.5,0,0,0,0.5,13 A12.5,12.5,0,0,0,22.5767,21.035 z">
                         <Path.Fill>
                             <LinearGradientBrush StartPoint="0,0"
@@ -8607,16 +8626,16 @@ TODO:
                     </Path>
 
                     <Button Style="{StaticResource &#252;}"
-                            Margin="3,0,1,0" 
+                            Margin="3,0,1,0"
                             Grid.Column="0">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
                         </Button.LayoutTransform>
                     </Button>
-                    
+
 
                     <Button Style="{StaticResource &#253;}"
-                            Margin="1,0,0,0" 
+                            Margin="1,0,0,0"
                             Grid.Column="1">
                         <Button.LayoutTransform>
                             <ScaleTransform ScaleX="0.667" ScaleY="0.667"/>
@@ -9060,19 +9079,19 @@ TODO:
                                     Property="Fill"
                                     Value="{StaticResource &#353;}"/>
                         </Trigger>
-                      <MultiDataTrigger>
-                        <MultiDataTrigger.Conditions>
-                          <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
-                          <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
-                          <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
-                        </MultiDataTrigger.Conditions>
-                        <!-- DDVSO:437424
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
+                                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={x:Static RelativeSource.Self}}" Value="true"/>
+                            </MultiDataTrigger.Conditions>
+                            <!-- DDVSO:437424
                              In high contrast, set the arrow fill to the foreground of the templated parent in order to match the enabled colors.
                              This fixes an issue where the arrow would not be visible in certain high contrast scenarios.
                              Also ensure the outline is drawn to the appropriate control color. -->
-                        <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                        <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-                      </MultiDataTrigger>
+                            <Setter TargetName="ArrowDownPath" Property="Fill" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -9166,16 +9185,16 @@ TODO:
                                         BorderThickness="1"
                                         BorderBrush="{StaticResource &#360;}">
                                     <ScrollViewer Name="DropDownScrollViewer">
-                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Rectangle
-                                                Name="OpaqueRect"
-                                                Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
-                                                Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
-                                                Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
-                                        </Canvas>
-                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
-                                      </Grid>
+                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                <Rectangle
+                                                    Name="OpaqueRect"
+                                                    Height="{Binding ElementName=DropDownBorder,Path=ActualHeight}"
+                                                    Width="{Binding ElementName=DropDownBorder,Path=ActualWidth}"
+                                                    Fill="{Binding ElementName=DropDownBorder,Path=Background}" />
+                                            </Canvas>
+                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                        </Grid>
                                     </ScrollViewer>
                                 </Border>
                             </theme:SystemDropShadowChrome>
@@ -9267,10 +9286,10 @@ TODO:
                                     Value="95"/>
                         </Trigger>
                         <MultiTrigger>
-                        <MultiTrigger.Conditions>
-                            <Condition Property="IsGrouping" Value="true" />
-                            <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
-                        </MultiTrigger.Conditions>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false"/>
                         </MultiTrigger>
                         <MultiTrigger>
@@ -9603,28 +9622,28 @@ TODO:
                                                                        Width="{Binding ElementName=Header, Path=ActualWidth}" />
                                                             <ScrollViewer Name="SubMenuScrollViewer"
                                                                           Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                              <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
-                                                                  <Grid.ColumnDefinitions>
-                                                                      <ColumnDefinition MinWidth="24"
-                                                                                        Width="Auto"
-                                                                                        SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                                      <ColumnDefinition Width="*"/>
-                                                                  </Grid.ColumnDefinitions>
-                                                                <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                                    <Rectangle
-                                                                        Name="OpaqueRect"
-                                                                        Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                        Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                        Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                                </Canvas>
-                                                                <Rectangle Fill="{StaticResource &#366;}"
-                                                                           Margin="0,1"/>
-                                                                <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                                Grid.ColumnSpan="2"
-                                                                                KeyboardNavigation.TabNavigation="Cycle"
-                                                                                Margin="0,0,0,1"
-                                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                              </Grid>
+                                                                <Grid RenderOptions.ClearTypeHint="Enabled" Grid.IsSharedSizeScope="true">
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition MinWidth="24"
+                                                                                          Width="Auto"
+                                                                                          SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                        <Rectangle
+                                                                            Name="OpaqueRect"
+                                                                            Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                            Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                            Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                                    </Canvas>
+                                                                    <Rectangle Fill="{StaticResource &#366;}"
+                                                                               Margin="0,1"/>
+                                                                    <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                                    Grid.ColumnSpan="2"
+                                                                                    KeyboardNavigation.TabNavigation="Cycle"
+                                                                                    Margin="0,0,0,1"
+                                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                                </Grid>
                                                             </ScrollViewer>
                                                         </Grid>
                                                     </Border>
@@ -9675,16 +9694,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9850,28 +9869,28 @@ TODO:
                                                         Grid.IsSharedSizeScope="true">
                                                     <ScrollViewer Name="SubMenuScrollViewer"
                                                                   Style="{DynamicResource {ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}}">
-                                                      <Grid RenderOptions.ClearTypeHint="Enabled">
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition MinWidth="24"
-                                                                              Width="Auto"
-                                                                              SharedSizeGroup="MenuItemIconColumnGroup"/>
-                                                            <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
-                                                        <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                            <Rectangle
-                                                                Name="OpaqueRect"
-                                                                Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
-                                                                Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
-                                                                Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
-                                                        </Canvas>
-                                                        <Rectangle Fill="{StaticResource &#366;}"
-                                                                   Margin="0,1"/>
-                                                        <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                                        Grid.ColumnSpan="2"
-                                                                        KeyboardNavigation.TabNavigation="Cycle"
-                                                                        Margin="0,0,0,1"
-                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                                      </Grid>
+                                                        <Grid RenderOptions.ClearTypeHint="Enabled">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition MinWidth="24"
+                                                                                  Width="Auto"
+                                                                                  SharedSizeGroup="MenuItemIconColumnGroup"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Canvas Height="0" Width="0" HorizontalAlignment="Left" VerticalAlignment="Top">
+                                                                <Rectangle
+                                                                    Name="OpaqueRect"
+                                                                    Height="{Binding ElementName=SubMenuBorder,Path=ActualHeight}"
+                                                                    Width="{Binding ElementName=SubMenuBorder,Path=ActualWidth}"
+                                                                    Fill="{Binding ElementName=SubMenuBorder,Path=Background}" />
+                                                            </Canvas>
+                                                            <Rectangle Fill="{StaticResource &#366;}"
+                                                                       Margin="0,1"/>
+                                                            <ItemsPresenter Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                            Grid.ColumnSpan="2"
+                                                                            KeyboardNavigation.TabNavigation="Cycle"
+                                                                            Margin="0,0,0,1"
+                                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                                        </Grid>
                                                     </ScrollViewer>
                                                 </Border>
                                             </theme:SystemDropShadowChrome>
@@ -9917,16 +9936,16 @@ TODO:
                                         <Trigger SourceName="PART_Popup"
                                                   Property="Popup.HasDropShadow"
                                                   Value="true">
-                                             <Setter TargetName="Shdw"
-                                                     Property="Margin"
-                                                     Value="0,0,5,5"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="SnapsToDevicePixels"
-                                                     Value="true"/>
-                                             <Setter TargetName="Shdw"
-                                                     Property="Color"
-                                                     Value="#71000000"/>
-                                         </Trigger>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Margin"
+                                                    Value="0,0,5,5"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="SnapsToDevicePixels"
+                                                    Value="true"/>
+                                            <Setter TargetName="Shdw"
+                                                    Property="Color"
+                                                    Value="#71000000"/>
+                                        </Trigger>
                                         <Trigger Property="IsEnabled"
                                                  Value="false">
                                             <Setter Property="Foreground"
@@ -9997,15 +10016,15 @@ TODO:
     </Style>
     <Style x:Key="&#374;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#368;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#368;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10058,15 +10077,15 @@ TODO:
     </Style>
     <Style x:Key="&#375;"
            TargetType="{x:Type ToggleButton}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background"
-                Value="{StaticResource &#369;}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background"
+                    Value="{StaticResource &#369;}"/>
         <Setter Property="MinHeight"
                 Value="0"/>
         <Setter Property="MinWidth"
@@ -10120,180 +10139,180 @@ TODO:
 
     <Style x:Key="{x:Type ToolBar}"
            TargetType="{x:Type ToolBar}">
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-    <Setter Property="Background" Value="{StaticResource &#365;}"/>
-    <Setter Property="Template">
-        <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ToolBar}">
-                <Grid Name="Grid"
-                      Margin="3,1,1,1"
-                      SnapsToDevicePixels="true">
-                    <Grid HorizontalAlignment="Right"
-                          x:Name="OverflowGrid">
-                        <ToggleButton x:Name="OverflowButton"
-                                      FocusVisualStyle="{x:Null}"
-                                      IsEnabled="{TemplateBinding HasOverflowItems}"
-                                      Style="{StaticResource &#374;}"
-                                      IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
-                                      ClickMode="Press"/>
-                        <Popup x:Name="OverflowPopup"
-                               AllowsTransparency="true"
-                               Placement="Bottom"
-                               IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
-                               StaysOpen="false"
-                               Focusable="false"
-                               PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
-                            <theme:SystemDropShadowChrome Name="Shdw"
-                                                          Color="Transparent">
-                                <Border Background="{StaticResource &#361;}"
-                                        BorderBrush="{StaticResource &#360;}"
-                                        BorderThickness="1"
-                                        RenderOptions.ClearTypeHint="Enabled"
-                                        x:Name="ToolBarSubMenuBorder">
-                                    <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
-                                                          Margin="2"
-                                                          WrapWidth="200"
-                                                          Focusable="true"
-                                                          FocusVisualStyle="{x:Null}"
-                                                          KeyboardNavigation.TabNavigation="Cycle"
-                                                          KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                                </Border>
-                            </theme:SystemDropShadowChrome>
-                        </Popup>
-                    </Grid>
-                    <Border x:Name="MainPanelBorder"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource &#371;}">
-                        <DockPanel KeyboardNavigation.TabIndex="1"
-                                   KeyboardNavigation.TabNavigation="Local">
-                            <Thumb x:Name="ToolBarThumb"
-                                   Style="{StaticResource &#373;}"
-                                   Margin="-3,-1,0,0"
-                                   Width="10"
-                                   Padding="6,5,1,6"/>
-                            <ContentPresenter x:Name="ToolBarHeader"
-                                              ContentSource="Header"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Margin="4,0,4,0"
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+        <Setter Property="Background" Value="{StaticResource &#365;}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <Grid Name="Grid"
+                          Margin="3,1,1,1"
+                          SnapsToDevicePixels="true">
+                        <Grid HorizontalAlignment="Right"
+                              x:Name="OverflowGrid">
+                            <ToggleButton x:Name="OverflowButton"
+                                          FocusVisualStyle="{x:Null}"
+                                          IsEnabled="{TemplateBinding HasOverflowItems}"
+                                          Style="{StaticResource &#374;}"
+                                          IsChecked="{Binding Path=IsOverflowOpen,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <Popup x:Name="OverflowPopup"
+                                   AllowsTransparency="true"
+                                   Placement="Bottom"
+                                   IsOpen="{Binding Path=IsOverflowOpen,RelativeSource={RelativeSource TemplatedParent}}"
+                                   StaysOpen="false"
+                                   Focusable="false"
+                                   PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
+                                <theme:SystemDropShadowChrome Name="Shdw"
+                                                              Color="Transparent">
+                                    <Border Background="{StaticResource &#361;}"
+                                            BorderBrush="{StaticResource &#360;}"
+                                            BorderThickness="1"
+                                            RenderOptions.ClearTypeHint="Enabled"
+                                            x:Name="ToolBarSubMenuBorder">
+                                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                                              Margin="2"
+                                                              WrapWidth="200"
+                                                              Focusable="true"
+                                                              FocusVisualStyle="{x:Null}"
+                                                              KeyboardNavigation.TabNavigation="Cycle"
+                                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                    </Border>
+                                </theme:SystemDropShadowChrome>
+                            </Popup>
+                        </Grid>
+                        <Border x:Name="MainPanelBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource &#371;}">
+                            <DockPanel KeyboardNavigation.TabIndex="1"
+                                       KeyboardNavigation.TabNavigation="Local">
+                                <Thumb x:Name="ToolBarThumb"
+                                       Style="{StaticResource &#373;}"
+                                       Margin="-3,-1,0,0"
+                                       Width="10"
+                                       Padding="6,5,1,6"/>
+                                <ContentPresenter x:Name="ToolBarHeader"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Margin="4,0,4,0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel"
+                                              IsItemsHost="true"
+                                              Margin="0,1,2,2"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                            <ToolBarPanel x:Name="PART_ToolBarPanel"
-                                          IsItemsHost="true"
-                                          Margin="0,1,2,2"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <ControlTemplate.Triggers>
-                    <Trigger Property="IsOverflowOpen"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="IsEnabled"
-                                Value="false"/>
-                    </Trigger>
-                    <Trigger Property="Header"
-                             Value="{x:Null}">
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger Property="ToolBarTray.IsLocked"
-                             Value="true">
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Visibility"
-                                Value="Collapsed"/>
-                    </Trigger>
-                    <Trigger SourceName="OverflowPopup"
-                             Property="Popup.HasDropShadow"
-                             Value="true">
-                        <Setter TargetName="Shdw"
-                                Property="Margin"
-                                Value="0,0,5,5"/>
-                        <Setter TargetName="Shdw"
-                                Property="SnapsToDevicePixels"
-                                Value="true"/>
-                        <Setter TargetName="Shdw"
-                                Property="Color"
-                                Value="#71000000"/>
-                    </Trigger>
-                    <Trigger Property="Orientation"
-                             Value="Vertical">
-                        <Setter TargetName="Grid"
-                                Property="Margin"
-                                Value="1,3,1,1"/>
-                        <Setter TargetName="OverflowButton"
-                                Property="Style"
-                                Value="{StaticResource &#375;}"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Height"
-                                Value="10"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Width"
-                                Value="Auto"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Margin"
-                                Value="-1,-3,0,0"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="Padding"
-                                Value="5,6,6,1"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="Margin"
-                                Value="0,0,0,4"/>
-                        <Setter TargetName="PART_ToolBarPanel"
-                                Property="Margin"
-                                Value="1,0,2,2"/>
-                        <Setter TargetName="ToolBarThumb"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="ToolBarHeader"
-                                Property="DockPanel.Dock"
-                                Value="Top"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="HorizontalAlignment"
-                                Value="Stretch"/>
-                        <Setter TargetName="OverflowGrid"
-                                Property="VerticalAlignment"
-                                Value="Bottom"/>
-                        <Setter TargetName="OverflowPopup"
-                                Property="Placement"
-                                Value="Right"/>
-                        <Setter TargetName="MainPanelBorder"
-                                Property="Margin"
-                                Value="0,0,0,11"/>
-                        <Setter Property="Background"
-                                Value="{StaticResource &#366;}"/>
-                    </Trigger>
-                    <Trigger Property="IsEnabled"
-                             Value="false">
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                    </Trigger>
-                </ControlTemplate.Triggers>
-            </ControlTemplate>
-        </Setter.Value>
-    </Setter>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsOverflowOpen"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="IsEnabled"
+                                    Value="false"/>
+                        </Trigger>
+                        <Trigger Property="Header"
+                                 Value="{x:Null}">
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="ToolBarTray.IsLocked"
+                                 Value="true">
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Visibility"
+                                    Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger SourceName="OverflowPopup"
+                                 Property="Popup.HasDropShadow"
+                                 Value="true">
+                            <Setter TargetName="Shdw"
+                                    Property="Margin"
+                                    Value="0,0,5,5"/>
+                            <Setter TargetName="Shdw"
+                                    Property="SnapsToDevicePixels"
+                                    Value="true"/>
+                            <Setter TargetName="Shdw"
+                                    Property="Color"
+                                    Value="#71000000"/>
+                        </Trigger>
+                        <Trigger Property="Orientation"
+                                 Value="Vertical">
+                            <Setter TargetName="Grid"
+                                    Property="Margin"
+                                    Value="1,3,1,1"/>
+                            <Setter TargetName="OverflowButton"
+                                    Property="Style"
+                                    Value="{StaticResource &#375;}"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Height"
+                                    Value="10"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Width"
+                                    Value="Auto"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Margin"
+                                    Value="-1,-3,0,0"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="Padding"
+                                    Value="5,6,6,1"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="Margin"
+                                    Value="0,0,0,4"/>
+                            <Setter TargetName="PART_ToolBarPanel"
+                                    Property="Margin"
+                                    Value="1,0,2,2"/>
+                            <Setter TargetName="ToolBarThumb"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="ToolBarHeader"
+                                    Property="DockPanel.Dock"
+                                    Value="Top"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="HorizontalAlignment"
+                                    Value="Stretch"/>
+                            <Setter TargetName="OverflowGrid"
+                                    Property="VerticalAlignment"
+                                    Value="Bottom"/>
+                            <Setter TargetName="OverflowPopup"
+                                    Property="Placement"
+                                    Value="Right"/>
+                            <Setter TargetName="MainPanelBorder"
+                                    Property="Margin"
+                                    Value="0,0,0,11"/>
+                            <Setter Property="Background"
+                                    Value="{StaticResource &#366;}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="false">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="{x:Type ToolBarTray}" TargetType="{x:Type ToolBarTray}">
         <Setter Property="Background"
                 Value="{StaticResource &#364;}"/>
-    <Style.Triggers>
-        <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
-            <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
-            <Setter Property="Background"
-                        Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        </DataTrigger>
-    </Style.Triggers>
-</Style>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Source={x:Static SystemParameters.HighContrast}}" Value="true">
+                <!-- This trigger on a SystemParameter works because switching into high contrast mode requires a re-evaluation of theme -->
+                <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
 
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
@@ -122,6 +122,7 @@ To automatically copy the files, set the environment variable
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                     <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                    <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
                 </MultiDataTrigger.Conditions>
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
             </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Themes/Royale.NormalColor.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 This file was generated from individual xaml files found
    in WPF\src\Themes\XAML\, please do not edit it directly.

--- a/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
@@ -1,5 +1,7 @@
 <!--=================================================================
-Copyright (C) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ==================================================================-->
 
 <!-- [[Aero.NormalColor]] -->

--- a/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
@@ -680,6 +680,7 @@
             <MultiDataTrigger.Conditions>
                 <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                 <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="false"/>
             </MultiDataTrigger.Conditions>
             <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
         </MultiDataTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/XAML/Button.xaml
@@ -1,40 +1,38 @@
 <!--=================================================================
-Licensed to the .NET Foundation under one or more agreements.
-The .NET Foundation licenses this file to you under the MIT license.
-See the LICENSE file in the project root for more information.
+Copyright (C) Microsoft Corporation.  All rights reserved.
 ==================================================================-->
 
 <!-- [[Aero.NormalColor]] -->
 
-    <Style x:Key="ButtonFocusVisual">
-        <Setter Property="Control.Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Rectangle Margin="2"
-                               StrokeThickness="1"
-                               Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                               StrokeDashArray="1 2"
-                               SnapsToDevicePixels="true"/>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<Style x:Key="ButtonFocusVisual">
+    <Setter Property="Control.Template">
+        <Setter.Value>
+            <ControlTemplate>
+                <Rectangle Margin="2"
+                           StrokeThickness="1"
+                           Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                           StrokeDashArray="1 2"
+                           SnapsToDevicePixels="true"/>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Luna.Homestead, Luna.Metallic, Luna.NormalColor, Royale.NormalColor]] -->
 
-    <Style x:Key="ButtonFocusVisual">
-        <Setter Property="Control.Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Rectangle Margin="3"
-                               StrokeThickness="1"
-                               Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                               StrokeDashArray="1 2"
-                               SnapsToDevicePixels="true"/>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<Style x:Key="ButtonFocusVisual">
+    <Setter Property="Control.Template">
+        <Setter.Value>
+            <ControlTemplate>
+                <Rectangle Margin="3"
+                           StrokeThickness="1"
+                           Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                           StrokeDashArray="1 2"
+                           SnapsToDevicePixels="true"/>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Classic]] -->
 
@@ -59,632 +57,648 @@ See the LICENSE file in the project root for more information.
 <!--=================================================================
         Button
     ==================================================================-->
-    <!-- Normal -->
-    <LinearGradientBrush x:Key="ButtonNormalBackground"
-                         StartPoint="0,0"
-                         EndPoint="0,1">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#F3F3F3"
-                          Offset="0"/>
-            <GradientStop Color="#EBEBEB"
-                          Offset="0.5"/>
-            <GradientStop Color="#DDDDDD"
-                          Offset="0.5"/>
-            <GradientStop Color="#CDCDCD"
-                          Offset="1"/>
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
-    <SolidColorBrush x:Key="ButtonNormalBorder"
-                     Color="#FF707070"/>
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{StaticResource ButtonNormalBackground}"/>
-        <Setter Property="BorderBrush"
-                Value="{StaticResource ButtonNormalBorder}"/>
-        <Setter Property="BorderThickness"
-                Value="1"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Padding"
-                Value="1"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ButtonChrome Name="Chrome"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
-                                        RenderMouseOver="{TemplateBinding IsMouseOver}"
-                                        RenderPressed="{TemplateBinding IsPressed}"
-                                        SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ButtonChrome>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderDefaulted"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderPressed"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="#ADADAD"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<!-- Normal -->
+<LinearGradientBrush x:Key="ButtonNormalBackground"
+                     StartPoint="0,0"
+                     EndPoint="0,1">
+    <LinearGradientBrush.GradientStops>
+        <GradientStop Color="#F3F3F3"
+                      Offset="0"/>
+        <GradientStop Color="#EBEBEB"
+                      Offset="0.5"/>
+        <GradientStop Color="#DDDDDD"
+                      Offset="0.5"/>
+        <GradientStop Color="#CDCDCD"
+                      Offset="1"/>
+    </LinearGradientBrush.GradientStops>
+</LinearGradientBrush>
+<SolidColorBrush x:Key="ButtonNormalBorder"
+                 Color="#FF707070"/>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{StaticResource ButtonNormalBackground}"/>
+    <Setter Property="BorderBrush"
+            Value="{StaticResource ButtonNormalBorder}"/>
+    <Setter Property="BorderThickness"
+            Value="1"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Padding"
+            Value="1"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ButtonChrome Name="Chrome"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
+                                    RenderMouseOver="{TemplateBinding IsMouseOver}"
+                                    RenderPressed="{TemplateBinding IsPressed}"
+                                    SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ButtonChrome>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderDefaulted"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderPressed"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="#ADADAD"/>
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Classic]] -->
 
 <!--=================================================================
         Button
     ==================================================================-->
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="BorderBrush"
-                Value="{x:Static theme:ClassicBorderDecorator.ClassicBorderBrush}"/>
-        <Setter Property="BorderThickness"
-                Value="3"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Padding"
-                Value="0,0,1,1"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ClassicBorderDecorator x:Name="ContentContainer"
-                                                  BorderStyle="Raised"
-                                                  Background="{TemplateBinding Background}"
-                                                  BorderThickness="3"
-                                                  BorderBrush="{TemplateBinding BorderBrush}"
-                                                  SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ClassicBorderDecorator>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter Property="BorderStyle"
-                                    Value="RaisedFocused"
-                                    TargetName="ContentContainer"/>
-                        </Trigger>
-                        <Trigger Property="Button.IsDefaulted"
-                                 Value="true">
-                            <Setter Property="BorderStyle"
-                                    Value="RaisedFocused"
-                                    TargetName="ContentContainer"/>
-                        </Trigger>
-                        <Trigger Property="IsPressed"
-                                 Value="true">
-                            <Setter Property="BorderStyle"
-                                    Value="RaisedPressed"
-                                    TargetName="ContentContainer"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter Property="BorderStyle"
-                                    Value="RaisedPressed"
-                                    TargetName="ContentContainer"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                        </Trigger>
-                        <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="BorderBrush"
+            Value="{x:Static theme:ClassicBorderDecorator.ClassicBorderBrush}"/>
+    <Setter Property="BorderThickness"
+            Value="3"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Padding"
+            Value="0,0,1,1"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ClassicBorderDecorator x:Name="ContentContainer"
+                                              BorderStyle="Raised"
+                                              Background="{TemplateBinding Background}"
+                                              BorderThickness="3"
+                                              BorderBrush="{TemplateBinding BorderBrush}"
+                                              SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ClassicBorderDecorator>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter Property="BorderStyle"
+                                Value="RaisedFocused"
+                                TargetName="ContentContainer"/>
+                    </Trigger>
+                    <Trigger Property="Button.IsDefaulted"
+                             Value="true">
+                        <Setter Property="BorderStyle"
+                                Value="RaisedFocused"
+                                TargetName="ContentContainer"/>
+                    </Trigger>
+                    <Trigger Property="IsPressed"
+                             Value="true">
+                        <Setter Property="BorderStyle"
+                                Value="RaisedPressed"
+                                TargetName="ContentContainer"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter Property="BorderStyle"
+                                Value="RaisedPressed"
+                                TargetName="ContentContainer"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
                             <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                             <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="false"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:437426
+                        </MultiDataTrigger.Conditions>
+                        <!-- DDVSO:437426
                                When in high contrast and the button is disabled, set the BorderBrush to Foreground in order to match
                                Win32 button behavior. -->
-                          <Setter Property="BorderBrush" Value="{Binding Path=Foreground, RelativeSource={x:Static RelativeSource.Self}}"/>
-                        </MultiDataTrigger>
-                        <MultiDataTrigger>
-                          <MultiDataTrigger.Conditions>
+                        <Setter Property="BorderBrush" Value="{Binding Path=Foreground, RelativeSource={x:Static RelativeSource.Self}}"/>
+                    </MultiDataTrigger>
+                    <MultiDataTrigger>
+                        <MultiDataTrigger.Conditions>
                             <Condition Binding="{Binding Path=(base:AccessibilitySwitches.UseNetFx47CompatibleAccessibilityFeatures)}" Value="false"/>
                             <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
                             <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
-                          </MultiDataTrigger.Conditions>
-                          <!-- DDVSO:437425
+                        </MultiDataTrigger.Conditions>
+                        <!-- DDVSO:437425
                                  When in high contrast and we have KB focus, set the appropriate fore/background colors to match
                                  Win32 button behavior. -->
-                          <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
-                          <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
-                        </MultiDataTrigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+                        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+                        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                    </MultiDataTrigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
+
 
 <!-- [[AeroLite.NormalColor]] -->
 
-    <!-- Color Resources -->
-    <SolidColorBrush x:Key="Button.Static.Background" Color="#FFDDDDDD" />
-    <SolidColorBrush x:Key="Button.Static.Border" Color="#FF707070" />
-    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFBEE6FD" />
-    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF3C7FB1" />
-    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFC4E5F6" />
-    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF2C628B" />
-    <SolidColorBrush x:Key="Button.Checked.Background" Color="#FFBCDDEE" />
-    <SolidColorBrush x:Key="Button.Checked.Border" Color="#FF245A83" />
-    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFF4F4F4" />
-    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFADB2B5" />
-    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF838383" />
+<!-- Color Resources -->
+<SolidColorBrush x:Key="Button.Static.Background" Color="#FFDDDDDD" />
+<SolidColorBrush x:Key="Button.Static.Border" Color="#FF707070" />
+<SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFBEE6FD" />
+<SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF3C7FB1" />
+<SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFC4E5F6" />
+<SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF2C628B" />
+<SolidColorBrush x:Key="Button.Checked.Background" Color="#FFBCDDEE" />
+<SolidColorBrush x:Key="Button.Checked.Border" Color="#FF245A83" />
+<SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFF4F4F4" />
+<SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFADB2B5" />
+<SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF838383" />
 
-    <!-- Button -->
-    <Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
-        <Setter Property="Background" Value="{StaticResource Button.Static.Background}" />
-        <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}" />
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="1"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <Border x:Name="border"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        SnapsToDevicePixels="true">
-                        <ContentPresenter x:Name="contentPresenter"
-                            RecognizesAccessKey="True"
-                            Margin="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Focusable="False">
-                        </ContentPresenter>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="Button.IsDefaulted" Value="true">
-                            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" Value="{StaticResource Button.MouseOver.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.MouseOver.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" Value="{StaticResource Button.Pressed.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Pressed.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked" Value="true" >
-                            <Setter Property="Background" Value="{StaticResource Button.Checked.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Checked.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Background" Value="{StaticResource Button.Disabled.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Disabled.Border}" TargetName="border" />
-                            <Setter Property="TextElement.Foreground" Value="{StaticResource Button.Disabled.Foreground}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<!-- Button -->
+<Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+    <Setter Property="Background" Value="{StaticResource Button.Static.Background}" />
+    <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}" />
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="HorizontalContentAlignment" Value="Center"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Padding" Value="1"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <Border x:Name="border"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    SnapsToDevicePixels="true">
+                    <ContentPresenter x:Name="contentPresenter"
+                        RecognizesAccessKey="True"
+                        Margin="{TemplateBinding Padding}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                        Focusable="False">
+                    </ContentPresenter>
+                </Border>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="Button.IsDefaulted" Value="true">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsMouseOver" Value="true">
+                        <Setter Property="Background" Value="{StaticResource Button.MouseOver.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.MouseOver.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsPressed" Value="true">
+                        <Setter Property="Background" Value="{StaticResource Button.Pressed.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Pressed.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked" Value="true" >
+                        <Setter Property="Background" Value="{StaticResource Button.Checked.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Checked.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="false">
+                        <Setter Property="Background" Value="{StaticResource Button.Disabled.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Disabled.Border}" TargetName="border" />
+                        <Setter Property="TextElement.Foreground" Value="{StaticResource Button.Disabled.Foreground}" />
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Aero2.NormalColor]] -->
 
-    <!-- Color Resources -->
-    <SolidColorBrush x:Key="Button.Static.Background" Color="#FFDDDDDD" />
-    <SolidColorBrush x:Key="Button.Static.Border" Color="#FF707070" />
-    <SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFBEE6FD" />
-    <SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF3C7FB1" />
-    <SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFC4E5F6" />
-    <SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF2C628B" />
-    <SolidColorBrush x:Key="Button.Checked.Background" Color="#FFBCDDEE" />
-    <SolidColorBrush x:Key="Button.Checked.Border" Color="#FF245A83" />
-    <SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFF4F4F4" />
-    <SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFADB2B5" />
-    <SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF838383" />
+<!-- Color Resources -->
+<SolidColorBrush x:Key="Button.Static.Background" Color="#FFDDDDDD" />
+<SolidColorBrush x:Key="Button.Static.Border" Color="#FF707070" />
+<SolidColorBrush x:Key="Button.MouseOver.Background" Color="#FFBEE6FD" />
+<SolidColorBrush x:Key="Button.MouseOver.Border" Color="#FF3C7FB1" />
+<SolidColorBrush x:Key="Button.Pressed.Background" Color="#FFC4E5F6" />
+<SolidColorBrush x:Key="Button.Pressed.Border" Color="#FF2C628B" />
+<SolidColorBrush x:Key="Button.Checked.Background" Color="#FFBCDDEE" />
+<SolidColorBrush x:Key="Button.Checked.Border" Color="#FF245A83" />
+<SolidColorBrush x:Key="Button.Disabled.Background" Color="#FFF4F4F4" />
+<SolidColorBrush x:Key="Button.Disabled.Border" Color="#FFADB2B5" />
+<SolidColorBrush x:Key="Button.Disabled.Foreground" Color="#FF838383" />
 
-    <!-- Button -->
-    <Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
-        <Setter Property="Background" Value="{StaticResource Button.Static.Background}" />
-        <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}" />
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
-        <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
-        <Setter Property="Padding" Value="1"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <Border x:Name="border"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        SnapsToDevicePixels="true">
-                        <ContentPresenter x:Name="contentPresenter"
-                            RecognizesAccessKey="True"
-                            Margin="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Focusable="False">
-                        </ContentPresenter>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="Button.IsDefaulted" Value="true">
-                            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" Value="{StaticResource Button.MouseOver.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.MouseOver.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" Value="{StaticResource Button.Pressed.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Pressed.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked" Value="true" >
-                            <Setter Property="Background" Value="{StaticResource Button.Checked.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Checked.Border}" TargetName="border" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Background" Value="{StaticResource Button.Disabled.Background}" TargetName="border" />
-                            <Setter Property="BorderBrush" Value="{StaticResource Button.Disabled.Border}" TargetName="border" />
-                            <Setter Property="TextElement.Foreground" Value="{StaticResource Button.Disabled.Foreground}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<!-- Button -->
+<Style x:Key="BaseButtonStyle" TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+    <Setter Property="Background" Value="{StaticResource Button.Static.Background}" />
+    <Setter Property="BorderBrush" Value="{StaticResource Button.Static.Border}" />
+    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="HorizontalContentAlignment" Value="Center"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Padding" Value="1"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <Border x:Name="border"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    SnapsToDevicePixels="true">
+                    <ContentPresenter x:Name="contentPresenter"
+                        RecognizesAccessKey="True"
+                        Margin="{TemplateBinding Padding}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                        Focusable="False">
+                    </ContentPresenter>
+                </Border>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="Button.IsDefaulted" Value="true">
+                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsMouseOver" Value="true">
+                        <Setter Property="Background" Value="{StaticResource Button.MouseOver.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.MouseOver.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsPressed" Value="true">
+                        <Setter Property="Background" Value="{StaticResource Button.Pressed.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Pressed.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked" Value="true" >
+                        <Setter Property="Background" Value="{StaticResource Button.Checked.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Checked.Border}" TargetName="border" />
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="false">
+                        <Setter Property="Background" Value="{StaticResource Button.Disabled.Background}" TargetName="border" />
+                        <Setter Property="BorderBrush" Value="{StaticResource Button.Disabled.Border}" TargetName="border" />
+                        <Setter Property="TextElement.Foreground" Value="{StaticResource Button.Disabled.Foreground}" />
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Luna.Homestead]] -->
 
 
-    <!--=================================================================
+<!--=================================================================
         Button
     ==================================================================-->
-    <LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
-                         EndPoint="0.5,1"
-                         StartPoint="0.5,0">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#FFFFFFFF"
-                          Offset="0"/>
-            <GradientStop Color="#FFF3EEDB"
-                          Offset="0.9"/>
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
-    <SolidColorBrush x:Key="ButtonBorder"
-                     Color="#FF376206"/>
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{StaticResource ButtonNormalBackgroundFill}"/>
-        <Setter Property="BorderBrush"
-                Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ButtonChrome x:Name="Chrome"
-                                        ThemeColor="Homestead"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        Fill="{TemplateBinding Background}"
-                                        RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
-                                        RenderMouseOver="{TemplateBinding IsMouseOver}"
-                                        RenderPressed="{TemplateBinding IsPressed}"
-                                        SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ButtonChrome>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderDefaulted"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderPressed"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
+                     EndPoint="0.5,1"
+                     StartPoint="0.5,0">
+    <LinearGradientBrush.GradientStops>
+        <GradientStop Color="#FFFFFFFF"
+                      Offset="0"/>
+        <GradientStop Color="#FFF3EEDB"
+                      Offset="0.9"/>
+    </LinearGradientBrush.GradientStops>
+</LinearGradientBrush>
+<SolidColorBrush x:Key="ButtonBorder"
+                 Color="#FF376206"/>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{StaticResource ButtonNormalBackgroundFill}"/>
+    <Setter Property="BorderBrush"
+            Value="{StaticResource ButtonBorder}"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ButtonChrome x:Name="Chrome"
+                                    ThemeColor="Homestead"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Fill="{TemplateBinding Background}"
+                                    RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
+                                    RenderMouseOver="{TemplateBinding IsMouseOver}"
+                                    RenderPressed="{TemplateBinding IsPressed}"
+                                    SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ButtonChrome>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderDefaulted"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderPressed"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Luna.Metallic]] -->
 
 
-  <!--=================================================================
+<!--=================================================================
         Button
     ==================================================================-->
-    <LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
-                         EndPoint="0.5,1"
-                         StartPoint="0.5,0">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="White"
-                          Offset="0"/>
-            <GradientStop Color="#FFE3E5F0"
-                          Offset="0.5"/>
-            <GradientStop Color="#FFC6C5D7"
-                          Offset="1.0"/>
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
-    <SolidColorBrush x:Key="ButtonBorder"
-                     Color="#FF003C74"/>
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{StaticResource ButtonNormalBackgroundFill}"/>
-        <Setter Property="BorderBrush"
-                Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ButtonChrome x:Name="Chrome"
-                                        ThemeColor="Metallic"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        Fill="{TemplateBinding Background}"
-                                        RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
-                                        RenderMouseOver="{TemplateBinding IsMouseOver}"
-                                        RenderPressed="{TemplateBinding IsPressed}"
-                                        SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ButtonChrome>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderDefaulted"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderPressed"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
+                     EndPoint="0.5,1"
+                     StartPoint="0.5,0">
+    <LinearGradientBrush.GradientStops>
+        <GradientStop Color="White"
+                      Offset="0"/>
+        <GradientStop Color="#FFE3E5F0"
+                      Offset="0.5"/>
+        <GradientStop Color="#FFC6C5D7"
+                      Offset="1.0"/>
+    </LinearGradientBrush.GradientStops>
+</LinearGradientBrush>
+<SolidColorBrush x:Key="ButtonBorder"
+                 Color="#FF003C74"/>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{StaticResource ButtonNormalBackgroundFill}"/>
+    <Setter Property="BorderBrush"
+            Value="{StaticResource ButtonBorder}"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ButtonChrome x:Name="Chrome"
+                                    ThemeColor="Metallic"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Fill="{TemplateBinding Background}"
+                                    RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
+                                    RenderMouseOver="{TemplateBinding IsMouseOver}"
+                                    RenderPressed="{TemplateBinding IsPressed}"
+                                    SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ButtonChrome>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderDefaulted"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderPressed"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Luna.NormalColor]] -->
 
 
-    <!--=================================================================
+<!--=================================================================
         Button
     ==================================================================-->
-    <LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
-                        EndPoint="0.5,1"
-                        StartPoint="0.5,0">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#FFFFFFFF"
-                          Offset="0"/>
-            <GradientStop Color="#FFF0F0EA"
-                          Offset="0.9"/>
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
+<LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
+                    EndPoint="0.5,1"
+                    StartPoint="0.5,0">
+    <LinearGradientBrush.GradientStops>
+        <GradientStop Color="#FFFFFFFF"
+                      Offset="0"/>
+        <GradientStop Color="#FFF0F0EA"
+                      Offset="0.9"/>
+    </LinearGradientBrush.GradientStops>
+</LinearGradientBrush>
 
-    <SolidColorBrush x:Key="ButtonBorder"
-                 Color="#FF003C74"/>
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{StaticResource ButtonNormalBackgroundFill}"/>
-        <Setter Property="BorderBrush"
-                Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ButtonChrome x:Name="Chrome"
-                                        ThemeColor="NormalColor"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        Fill="{TemplateBinding Background}"
-                                        RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
-                                        RenderMouseOver="{TemplateBinding IsMouseOver}"
-                                        RenderPressed="{TemplateBinding IsPressed}"
-                                        SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ButtonChrome>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderDefaulted"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderPressed"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<SolidColorBrush x:Key="ButtonBorder"
+             Color="#FF003C74"/>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{StaticResource ButtonNormalBackgroundFill}"/>
+    <Setter Property="BorderBrush"
+            Value="{StaticResource ButtonBorder}"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ButtonChrome x:Name="Chrome"
+                                    ThemeColor="NormalColor"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Fill="{TemplateBinding Background}"
+                                    RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
+                                    RenderMouseOver="{TemplateBinding IsMouseOver}"
+                                    RenderPressed="{TemplateBinding IsPressed}"
+                                    SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ButtonChrome>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderDefaulted"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderPressed"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Royale.NormalColor]] -->
 
 
-    <!--=================================================================
+<!--=================================================================
         Button
     ==================================================================-->
-    <LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
-                         EndPoint="0.5,1"
-                         StartPoint="0.5,0">
-        <LinearGradientBrush.GradientStops>
-            <GradientStop Color="#FFFFFFFF"
-                          Offset="0"/>
-            <GradientStop Color="#FFE3EBF3"
-                          Offset="0.5"/>
-            <GradientStop Color="#FFD0DCEB"
-                          Offset="0.5"/>
-            <GradientStop Color="#FFA6B8CF"
-                          Offset="1"/>
-        </LinearGradientBrush.GradientStops>
-    </LinearGradientBrush>
+<LinearGradientBrush x:Key="ButtonNormalBackgroundFill"
+                     EndPoint="0.5,1"
+                     StartPoint="0.5,0">
+    <LinearGradientBrush.GradientStops>
+        <GradientStop Color="#FFFFFFFF"
+                      Offset="0"/>
+        <GradientStop Color="#FFE3EBF3"
+                      Offset="0.5"/>
+        <GradientStop Color="#FFD0DCEB"
+                      Offset="0.5"/>
+        <GradientStop Color="#FFA6B8CF"
+                      Offset="1"/>
+    </LinearGradientBrush.GradientStops>
+</LinearGradientBrush>
 
-    <SolidColorBrush x:Key="ButtonBorder"
-                     Color="#FF2B4F82"/>
+<SolidColorBrush x:Key="ButtonBorder"
+                 Color="#FF2B4F82"/>
 
-    <Style x:Key="BaseButtonStyle"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle"
-                Value="{StaticResource ButtonFocusVisual}"/>
-        <Setter Property="Background"
-                Value="{StaticResource ButtonNormalBackgroundFill}"/>
-        <Setter Property="BorderBrush"
-                Value="{StaticResource ButtonBorder}"/>
-        <Setter Property="Foreground"
-                Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-        <Setter Property="HorizontalContentAlignment"
-                Value="Center"/>
-        <Setter Property="VerticalContentAlignment"
-                Value="Center"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <theme:ButtonChrome x:Name="Chrome"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        Fill="{TemplateBinding Background}"
-                                        RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
-                                        RenderMouseOver="{TemplateBinding IsMouseOver}"
-                                        RenderPressed="{TemplateBinding IsPressed}"
-                                        SnapsToDevicePixels="true">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          RecognizesAccessKey="True"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
-                    </theme:ButtonChrome>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsKeyboardFocused"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderDefaulted"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="ToggleButton.IsChecked"
-                                 Value="true">
-                            <Setter TargetName="Chrome"
-                                    Property="RenderPressed"
-                                    Value="true"/>
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+<Style x:Key="BaseButtonStyle"
+       TargetType="{x:Type ButtonBase}">
+    <Setter Property="FocusVisualStyle"
+            Value="{StaticResource ButtonFocusVisual}"/>
+    <Setter Property="Background"
+            Value="{StaticResource ButtonNormalBackgroundFill}"/>
+    <Setter Property="BorderBrush"
+            Value="{StaticResource ButtonBorder}"/>
+    <Setter Property="Foreground"
+            Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+    <Setter Property="HorizontalContentAlignment"
+            Value="Center"/>
+    <Setter Property="VerticalContentAlignment"
+            Value="Center"/>
+    <Setter Property="Template">
+        <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                <theme:ButtonChrome x:Name="Chrome"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Fill="{TemplateBinding Background}"
+                                    RenderDefaulted="{TemplateBinding Button.IsDefaulted}"
+                                    RenderMouseOver="{TemplateBinding IsMouseOver}"
+                                    RenderPressed="{TemplateBinding IsPressed}"
+                                    SnapsToDevicePixels="true">
+                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      RecognizesAccessKey="True"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                </theme:ButtonChrome>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocused"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderDefaulted"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="ToggleButton.IsChecked"
+                             Value="true">
+                        <Setter TargetName="Chrome"
+                                Property="RenderPressed"
+                                Value="true"/>
+                    </Trigger>
+                    <Trigger Property="IsEnabled"
+                             Value="false">
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+        </Setter.Value>
+    </Setter>
+</Style>
 
 <!-- [[Aero.NormalColor, Aero2.NormalColor, AeroLite.NormalColor, Classic, Luna.Homestead, Luna.Metallic, Luna.NormalColor, Royale.NormalColor]] -->
 
-    <Style x:Key="{x:Type ToggleButton}"
-           BasedOn="{StaticResource BaseButtonStyle}"
-           TargetType="{x:Type ToggleButton}"/>
+<Style x:Key="{x:Type ToggleButton}"
+       BasedOn="{StaticResource BaseButtonStyle}"
+       TargetType="{x:Type ToggleButton}">
+    <Style.Triggers>
+        <MultiDataTrigger>
+            <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+            </MultiDataTrigger.Conditions>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+        </MultiDataTrigger>
+        <MultiDataTrigger>
+            <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="true"/>
+                <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" Value="true"/>
+                <Condition Binding="{Binding Path=IsKeyboardFocused, RelativeSource={RelativeSource Self}}" Value="true"/>
+            </MultiDataTrigger.Conditions>
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}"/>
+        </MultiDataTrigger>
+    </Style.Triggers>
+</Style>
 
-    <Style x:Key="{x:Type RepeatButton}"
-           BasedOn="{StaticResource BaseButtonStyle}"
-           TargetType="{x:Type RepeatButton}">
-        <Setter Property="Stylus.IsPressAndHoldEnabled"
-                Value="false"/>
-    </Style>
+<Style x:Key="{x:Type RepeatButton}"
+       BasedOn="{StaticResource BaseButtonStyle}"
+       TargetType="{x:Type RepeatButton}">
+    <Setter Property="Stylus.IsPressAndHoldEnabled"
+            Value="false"/>
+</Style>
 
-    <Style x:Key="{x:Type Button}"
-           BasedOn="{StaticResource BaseButtonStyle}"
-           TargetType="{x:Type Button}"/>
-
-
-
+<Style x:Key="{x:Type Button}"
+       BasedOn="{StaticResource BaseButtonStyle}"
+       TargetType="{x:Type Button}"/>


### PR DESCRIPTION
In non-high contrast themes, when you check a ToggleButton and navigate to another control, we display the checked status by highlighting the button with a lighter shade of the selection color.

We don't follow this behavior in high contrast themes. The text is slightly-depressed upon checking but that is not visually apparent and would definitely not be to a visually impaired person.
![highcontrastwhitetogglebutton_without_change](https://user-images.githubusercontent.com/5456126/65924723-e6ecda80-e3a2-11e9-860d-66c72212c0e0.png)

In the image above, the 'S', 'C' and 'I' buttons are checked. However, it's barely noticeable that 'S' and 'C' are checked. The checked status of the 'I' button is also not noticeable when it receives focus.


The fix here is to check for a toggle button to be checked when in a high-contrast theme, we then add a border around the button. When a checked button also has keyboard focus, we add a border in the background-color. When the user navigates away, the border color is the same as the selection-color.

In the image below, the 'S', 'C' and 'I' buttons are checked again. Here, it's visually apparent that they are currently checked.
![highcontrastwhitetogglebutton_with_change](https://user-images.githubusercontent.com/5456126/65924964-c709e680-e3a3-11e9-8eab-fd1016e4c3b3.png)

In this pull request, relevant changes are in lines 673:693 in Button.xaml, the remaining files are generated off those changes.