### PR TITLE
Removing separators from SizeOfSet and PositionInSet counts

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -94,13 +94,20 @@ namespace System.Windows.Automation.Peers
         override protected int GetSizeOfSetCore()
         {
             int sizeOfSet = base.GetSizeOfSetCore();
+            MenuItem owner = (MenuItem)Owner;
+            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
             if (sizeOfSet == AutomationProperties.AutomationSizeOfSetDefault)
             {
-                MenuItem owner = (MenuItem)Owner;
-                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
                 sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
+            }
+
+            foreach (var item in parent.Items)
+            {
+                if (item is Separator)
+                {
+                    sizeOfSet -= 1;
+                }
             }
 
             return sizeOfSet;
@@ -118,12 +125,24 @@ namespace System.Windows.Automation.Peers
         override protected int GetPositionInSetCore()
         {
             int positionInSet = base.GetPositionInSetCore();
+            MenuItem owner = (MenuItem)Owner;
+            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
             if (positionInSet == AutomationProperties.AutomationPositionInSetDefault)
             {
-                MenuItem owner = (MenuItem)Owner;
-                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
                 positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
+            }
+
+            foreach (var item in parent.Items)
+            {
+                if (item == owner)
+                {
+                    break;
+                }
+                if (item is Separator)
+                {
+                    positionInSet -= 1;
+                }
             }
 
             return positionInSet;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -94,19 +94,20 @@ namespace System.Windows.Automation.Peers
         override protected int GetSizeOfSetCore()
         {
             int sizeOfSet = base.GetSizeOfSetCore();
-            MenuItem owner = (MenuItem)Owner;
-            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
+            
             if (sizeOfSet == AutomationProperties.AutomationSizeOfSetDefault)
             {
-                sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
-            }
+                MenuItem owner = (MenuItem)Owner;
+                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
-            foreach (var item in parent.Items)
-            {
-                if (item is Separator)
+                sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
+
+                foreach (var item in parent.Items)
                 {
-                    sizeOfSet -= 1;
+                    if (item is Separator)
+                    {
+                        sizeOfSet -= 1;
+                    }
                 }
             }
 
@@ -125,23 +126,24 @@ namespace System.Windows.Automation.Peers
         override protected int GetPositionInSetCore()
         {
             int positionInSet = base.GetPositionInSetCore();
-            MenuItem owner = (MenuItem)Owner;
-            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
+            
             if (positionInSet == AutomationProperties.AutomationPositionInSetDefault)
             {
-                positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
-            }
+                MenuItem owner = (MenuItem)Owner;
+                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
-            foreach (var item in parent.Items)
-            {
-                if (item == owner)
+                positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
+                
+                foreach (var item in parent.Items)
                 {
-                    break;
-                }
-                if (item is Separator)
-                {
-                    positionInSet -= 1;
+                    if (item == owner)
+                    {
+                        break;
+                    }
+                    if (item is Separator)
+                    {
+                        positionInSet -= 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
Screen readers were reading incorrect values of the number of menu items and their position since we were counting separators as MenuItems in the automation tree. 

I filtered for separators in the current MenuItems to fix the SizeofSet count.

I filtered for separators again for PositionInSet but added a short-circuit to break when you're at the element whose position you're trying to find. This short-circuit was added to not remove separators below the relevant MenuItem from the PositionInSet count.

Fixes #1467 