### PR TITLE
Ensure that markup compilation is run for all design time builds

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -106,7 +106,7 @@
   <Target Name="DesignTimeMarkupCompilation">
 
         <!-- Only if we are not actually performing a compile i.e. we are in design mode -->
-        <CallTarget Condition="'$(BuildingProject)' != 'true'"
+        <CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'"
                 Targets="MarkupCompilePass1" />
   </Target>
 


### PR DESCRIPTION
Port of #1895 
Fixes #1915 

/cc @debonte, @davidwengier 

<hr/>

### Description

In SDK-style projects the project system will combine design time builds together to improve performance, but depending on timing, this can cause issues. If something like the designer asks for output groups, then the build for that could be combined with the build that produces the intellisense file, but getting output groups sets `BuildingProject `to `true`, which in turn prevents WPF's markup-compilation from running.

This change works around the issue by allowing the intellisense files to generate irrespective of the value of `BuildingProject `, as long we're doing a design time build.

### Customer Impact

Developers encountering this problem see the following error: 

```
Error: ‘CS0103 - The name ‘InitializeComponent’ does not exist in the current context’
```

This is usually persistent and doesn't go away upon rebuilds. It can sometimes be overcome by persistently cleaning the project, deleting intermediate files etc., and rebuilding. 

We have also been hearing several reports of this on .NET core via //vsfeedback. 

### Regression 

Not a regression. This problem exists in .NET Framework also, but now we understand what's going on and have a fix for this. 

### Risk 

Low risk. 
The fix is very simple, safe and easy to test. It has been in **master**/.NET 5 for a few weeks now. 