### PR TITLE
Add `ThemeInfoAttribute` to application project templates

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/AssemblyInfo.cs
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/AssemblyInfo.vb
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/AssemblyInfo.vb
@@ -1,0 +1,11 @@
+Imports System.Windows
+
+'The ThemeInfo attribute describes where any theme specific and generic resource dictionaries can be found.
+'1st parameter: where theme specific resource dictionaries are located
+'(used if a resource is not found in the page,
+' or application resource dictionaries)
+
+'2nd parameter: where the generic resource dictionary is located
+'(used if a resource is not found in the page,
+'app, and any theme specific resource dictionaries)
+<Assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)>


### PR DESCRIPTION
Adding `generic.xaml` a .NET Core application doesn't work out of the box because the default application template doesn't include `ThemeInfoAttribute` the way it used to in .NET Framework.

This can create unexpected problems like https://github.com/dotnet/wpf/issues/1966

This change adds back `ThemeInfoAttribute` that was inadvertently left out of the .NET Core application templates.

This needs to be ported to release/3.1

Addresses #1699, #1966 

/cc @weltkante, @mysteryx93  