### PR TITLE
Add `ThemeInfoAttribute` to application project templates

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/AssemblyInfo.cs
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/AssemblyInfo.vb
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/AssemblyInfo.vb
@@ -1,0 +1,11 @@
+Imports System.Windows
+
+'The ThemeInfo attribute describes where any theme specific and generic resource dictionaries can be found.
+'1st parameter: where theme specific resource dictionaries are located
+'(used if a resource is not found in the page,
+' or application resource dictionaries)
+
+'2nd parameter: where the generic resource dictionary is located
+'(used if a resource is not found in the page,
+'app, and any theme specific resource dictionaries)
+<Assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)>


### PR DESCRIPTION
Fixes #1699, #1966 

### Description 

Adding `generic.xaml` to a .NET Core application doesn't work out of the box because the default application template doesn't include `ThemeInfoAttribute` the way it used to in .NET Framework.

This can create subtle problems like https://github.com/dotnet/wpf/issues/1966

This change adds back `ThemeInfoAttribute` that was inadvertently left out of the .NET Core application templates.

### Customer Impact

`generic.xaml` is used to supply default styles, often for custom controls etc. For it to function so, the application must have the `ThemeInfoAttribute` set. This was always the case in .NET Framework given the fact that WPF's application template set this attribute by default. 

In .NET core, we inadvertently dropped this attribute from the application project-templates (they are still correctly retained by the .NET Core _User Control_ and _Custom Control_ project templates). 

This can certainly be worked-around by a developer by adding an attribute in a `.cs` files, but identifying the cause of app misbehavior (owing to the missing `ThemeInfo` attribute in itself would be a confusing and difficult process. This is a confusion we would very much like to prevent in the ecosystem. 

### Regression 

Yes, from .NET Framework.

### Risk

Low. (a) Does not impact WPF product (isolated to project templates), and (b) easy to test the locally built project templates. 

Note that the fix to the VB project template in this branch is for completeness' sake only. VB project templates are not enabled in this branch at this time. 