### PR TITLE
Use correct PresentationBuildTasks.dll for VS and MSBuild builds

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,8 +56,8 @@
   </PropertyGroup>
   <!-- Other Packages that require manual updating-->
   <PropertyGroup>
-    <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>16.3</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>16.3</MicrosoftBuildUtilitiesCorePackageVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
     <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion>$(XUnitVersion)</XUnitRunnerVisualStudioVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,8 +56,8 @@
   </PropertyGroup>
   <!-- Other Packages that require manual updating-->
   <PropertyGroup>
-    <MicrosoftBuildFrameworkPackageVersion>16.3</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>16.3</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>15.9.20</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>15.9.20</MicrosoftBuildUtilitiesCorePackageVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
     <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion>$(XUnitVersion)</XUnitRunnerVisualStudioVersion>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -1,10 +1,13 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+ <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
 
     <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_PresentationBuildTasksTfm>
     <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_PresentationBuildTasksTfm>
     <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll</_PresentationBuildTasksAssembly>
+    
+    <!-- The .NET Framework version of Microsoft.WinFX.Targets uses BuildTasksAssembly to define the path to PresentationBuildTasks.dll. Override that definition here --> 
+    <BuildTaskAssembly>$([System.IO.Path]::GetFullPath('$(_PresentationBuildTasksAssembly)'))</BuildTaskAssembly>
 
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(AlwaysCompileMarkupFilesInSeparateDomain)' == ''">true</AlwaysCompileMarkupFilesInSeparateDomain>
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -1,4 +1,4 @@
- <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
 
@@ -7,7 +7,7 @@
     <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll</_PresentationBuildTasksAssembly>
     
     <!-- The .NET Framework version of Microsoft.WinFX.Targets uses BuildTasksAssembly to define the path to PresentationBuildTasks.dll. Override that definition here --> 
-    <BuildTaskAssembly>$([System.IO.Path]::GetFullPath('$(_PresentationBuildTasksAssembly)'))</BuildTaskAssembly>
+    <BuildTaskAssembly Condition="'$(BuildTaskAssembly)' != ''">$([System.IO.Path]::GetFullPath('$(_PresentationBuildTasksAssembly)'))</BuildTaskAssembly>
 
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(AlwaysCompileMarkupFilesInSeparateDomain)' == ''">true</AlwaysCompileMarkupFilesInSeparateDomain>
 
@@ -17,13 +17,14 @@
 
   </PropertyGroup>
 
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass1" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.UidManager" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.ResourcesGenerator" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.FileClassifier" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass2" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <!-- Do not define these tasks if they have been defined previously by .NET Framework version of Microsoft.WinFx.targets -->
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass1" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''"/>
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.UidManager" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.ResourcesGenerator" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.FileClassifier" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass2" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives" AssemblyFile="$(_PresentationBuildTasksAssembly)" Condition="'$(BuildTaskAssembly)' == ''" />
 
 
   <!-- Some Default Settings -->


### PR DESCRIPTION
This is a port of https://github.com/dotnet/wpf/pull/1999 from **master**
Fixes #1998 

The PresentationBuildTasks.dll built out of the .NET Core codebase is not being used for msbuild based builds (i.e., when `$(MSBuildRuntimeType)==Full`) of WPF projects that use WindowsDesktop SDK. Instead, the PresentationBuildTasks.dll from GAC, i.e., the DLL that shipped with .NET Framework, is being used for builds instead.

This is because the *first* occurance of an `UsingTask` element that applies to a `TaskName` will always be used - it can not be overridden by subsequent `UsingTask` entries (this is unlike `Property` and `Item` behavior). See note in https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/msbuild/usingtask-element-msbuild.md immediate after the **Syntax** section (Note: The msbuild team added this note after identifying this behavior as part of investiaging this PresentationBuildTasks.dll issue).

The fix ensures that the `UsingTask` declarations supplied by the WindowsDesktop SDK precede those supplied by .NET Framework's copy of `Microsoft.WinFX.targets` by introducing a new `.props` file - `Microsoft.WinFX.props` - and moving a small number of `Property` and `UsingTask` declartions into it. Since `.props` are imported before `targets`, the `UsingTask` declarations supplied by WindowsDesktop SDK will thus take precedence.

Note that `Pbt.props` is used only for building this repo - it doesn't ship. 
