### PR TITLE
[release/3.1] Use correct PresentationBuildTasks.dll for VS and MSBuild builds

### DIFF
--- a/eng/WpfArcadeSdk/tools/Pbt.props
+++ b/eng/WpfArcadeSdk/tools/Pbt.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <LocalMicrosoftWinFXProps>$(RepoRoot)src\Microsoft.DotNet.Wpf\src\PresentationBuildTasks\Microsoft.WinFX.props</LocalMicrosoftWinFXProps>
     <LocalMicrosoftWinFXTargets>$(RepoRoot)src\Microsoft.DotNet.Wpf\src\PresentationBuildTasks\Microsoft.WinFX.targets</LocalMicrosoftWinFXTargets>
   </PropertyGroup>
 
@@ -34,6 +35,8 @@
             Project="../targets/Microsoft.NET.Sdk.WindowsDesktop.props"
             Condition="!Exists('$(LocalMicrosoftWinFXTargets)') And '$(InternalMarkupCompilation)'=='true'"/>
             
+    We need Microsoft.WinFx.props though, so that's imported here specifically. 
+            
     The use of Microsoft.NET.Sdk.WindowsDesktop doesn't break the source-build promise. 
       - Microsoft.NET.Sdk.WindowsDesktop is built from sources
       - It is used for compilation of assemblies in dotnet-wpf-int (the internal WPF repo), and serves as a 
@@ -42,4 +45,18 @@
         fall back to use local PBT project outputs for their compilation (instead of using WindowsDesktop Sdk package
         as a convenient 'transport package'). 
   -->
+  
+  <!-- 
+    If local PresentationBuildTasks project is present, then import WinFX.props from local sources;
+    otherwise import Microsoft.NET.Sdk.WindowsDesktop.props from Microsoft.NET.Sdk.WindowsDesktop
+    
+    We can not really test for $(InternalMarkupCompilation)==true here. It is usually defined
+    in the csproj - which is included after props (but before targets). 
+  -->
+  <Import Project="$(WpfSourceDir)PresentationBuildTasks\Microsoft.WinFX.props"
+          Condition="Exists('$(LocalMicrosoftWinFXProps)') "/>
+  
+  <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
+        Project="../targets/Microsoft.WinFx.props"
+        Condition="!Exists('$(LocalMicrosoftWinFXProps)')"/>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -204,4 +204,6 @@
     
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
+
+  <Import Project="Microsoft.WinFX.props" />
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.props
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_PresentationBuildTasksTfm>
+    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_PresentationBuildTasksTfm>
+    <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll'))</_PresentationBuildTasksAssembly>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass1" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.UidManager" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.ResourcesGenerator" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.FileClassifier" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass2" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
+  
+</Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.targets
@@ -1,28 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
-
-    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_PresentationBuildTasksTfm>
-    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_PresentationBuildTasksTfm>
-    <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll</_PresentationBuildTasksAssembly>
-
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(BuildingInsideVisualStudio)' == 'true' and '$(AlwaysCompileMarkupFilesInSeparateDomain)' == ''">true</AlwaysCompileMarkupFilesInSeparateDomain>
-
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(AlwaysCompileMarkupFilesInSeparateDomain)' == '' ">true</AlwaysCompileMarkupFilesInSeparateDomain>
-
     <LocalizationDirectivesToLocFile Condition="'$(LocalizationDirectivesToLocFile)' == ''">None</LocalizationDirectivesToLocFile>
-
   </PropertyGroup>
-
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass1" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.UidManager" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.ResourcesGenerator" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.FileClassifier" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass2" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.GenerateTemporaryTargetAssembly" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-  <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MergeLocalizationDirectives" AssemblyFile="$(_PresentationBuildTasksAssembly)" />
-
-
+  
   <!-- Some Default Settings -->
   <PropertyGroup>
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -44,6 +44,7 @@
     content\targets\ 
   -->
   <ItemGroup>
+    <PackagingContent Include="$(MSBuildThisFileDirectory)Microsoft.WinFx.props" SubFolder="root\targets" />
     <PackagingContent Include="$(MSBuildThisFileDirectory)Microsoft.WinFx.targets" SubFolder="root\targets" />
   </ItemGroup>
 


### PR DESCRIPTION
Port of https://github.com/dotnet/wpf/pull/1999
Fixes #1998 

## Description 

The PresentationBuildTasks.dll built out of the .NET Core codebase is not being used for msbuild based builds (i.e., when `$(MSBuildRuntimeType)==Full`) of WPF projects that use WindowsDesktop SDK. Instead, the PresentationBuildTasks.dll from GAC, i.e., the DLL that shipped with .NET Framework, is being used for builds instead.

This is because the *first* occurance of an `UsingTask` element that applies to a `TaskName` will always be used - it can not be overridden by subsequent `UsingTask` entries (this is unlike `Property` and `Item` behavior). See note in https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/docs/msbuild/usingtask-element-msbuild.md immediate after the **Syntax** section (Note: The msbuild team added this note after identifying this behavior as part of investiaging this PresentationBuildTasks.dll issue).

This fix ensures that the `UsingTask` declarations supplied by the WindowsDesktop SDK precede those supplied by .NET Framework's copy of `Microsoft.WinFX.targets` by introducing a new `.props` file - `Microsoft.WinFX.props` - and moving a small number of `Property` and `UsingTask` declartions into it. Since `.props` are imported before `targets`, the `UsingTask` declarations supplied by WindowsDesktop SDK will thus take precedence.

Note that `Pbt.props` is used only for building this repo - it doesn't ship.

## Customer Impact 

Multi-targeted builds targeting .NET Framework will be produced incorrectly under some conditions, specifically when building using VS. There may be no problems initially due to the strong backwards compatibility between .NET Core and .NET Framework WPF assemblies - but errors in XAML/markup compilation may lead to hard-to-identify/debug problems. 

## Regression 

Not a regression. This was a missed corner case not caught until now. 

## Risk 

- The changes are scoped and  safe. 
- They have been tested by building a corpus of WPF samples 
- The fix has been in .NET 5 for 2 weeks now without any adverse reports. 
