### PR TITLE
Change XPS document creation to use FileAccess.ReadWrite instead of FileAccess.Write

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsDocument.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsDocument.cs
@@ -894,9 +894,13 @@ namespace System.Windows.Xps.Packaging
             Stream     dataStream
             )
         {
+            // In .NET Core 3.0 System.IO.Compression's ZipArchive does not allow creation of ZipArchiveEntries when
+            // a prior ZipArchiveEntry is still open.  XPS Serialization requires this as part of its implementation.
+            // To get around this, XPS creation should occur in with FileAccess.ReadWrite if the underlying stream
+            // supports it.  This allows multiple ZipArchiveEntries to be open concurrently.
             Package package = Package.Open(dataStream,
                                            FileMode.CreateNew,
-                                           FileAccess.Write);
+                                           (dataStream.CanRead) ? FileAccess.ReadWrite : FileAccess.Write);
             XpsDocument document = new XpsDocument(package);
 
             document.OpcPackage = package;

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
@@ -139,9 +139,13 @@ namespace System.Windows.Xps.Packaging
             {
                 if( packageAccess == FileAccess.Write )
                 {
+                    // In .NET Core 3.0 System.IO.Compression's ZipArchive does not allow creation of ZipArchiveEntries when
+                    // a prior ZipArchiveEntry is still open.  XPS Serialization requires this as part of its implementation.
+                    // To get around this, XPS creation should occur in with FileAccess.ReadWrite.  This allows multiple
+                    // ZipArchiveEntries to be open concurrently.
                     package = Package.Open(path,
                                            FileMode.Create,
-                                           packageAccess,
+                                           FileAccess.ReadWrite,
                                            FileShare.None);
                     streaming = true;
                 }


### PR DESCRIPTION
Related to #1985

5.0 PR: https://github.com/dotnet/wpf/pu

# Description

In .NET Core 3.0 System.IO.Compression's ZipArchive does not support multiple ZipArchiveEntries to be open concurrently when using FileAccess.Write. This is a requirement of the XPS serialization stack in WPF. As such, we need to create XPS documents as FileAccess.ReadWrite in order to allow this behavior.

NOTE: We've suggested this as a workaround at the developer level in several instances, this brings this into the code base until we can affect a larger change in our XPS serialization stack to remove the requirement on concurrent PackageParts.

# Customer Impact
XPS creation when a customer chooses FileAccess.Write will get an exception from:
https://github.com/dotnet/corefx/blob/861259bf87d8e4ee2c4f8dab31b73d377faff77d/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs#L411

Developers have been instructed to use FileAccess.ReadWrite as a workaround, but this isn't always applicable to library code.

# Regression
Yes.  This is a regression from .NET Framework 4.8 due to switching to `System.IO.Compression` and `System.IO.Packaging` and can potentially block developers from moving their applications to .NET Core.

# Risk - Low
The public facing functions that need altering here are on creation of an XPS document where there would generally have been Write access.  Switching to ReadWrite should present no problem.  There is potential for some optimizations to be lost from within the compression and packaging libs, but that is preferable to throwing an exception.

The internal functions are being changed as a precaution but are generally concerned with printing streams which are, generally, ReadWrite underneath.  This merely creates the package in the same access mode as the stream.