### PR TITLE
Removing separators from SizeOfSet and PositionInSet counts

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -94,13 +94,20 @@ namespace System.Windows.Automation.Peers
         override protected int GetSizeOfSetCore()
         {
             int sizeOfSet = base.GetSizeOfSetCore();
+            MenuItem owner = (MenuItem)Owner;
+            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
             if (sizeOfSet == AutomationProperties.AutomationSizeOfSetDefault)
             {
-                MenuItem owner = (MenuItem)Owner;
-                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
                 sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
+            }
+
+            foreach (var item in parent.Items)
+            {
+                if (item is Separator)
+                {
+                    sizeOfSet -= 1;
+                }
             }
 
             return sizeOfSet;
@@ -118,12 +125,24 @@ namespace System.Windows.Automation.Peers
         override protected int GetPositionInSetCore()
         {
             int positionInSet = base.GetPositionInSetCore();
+            MenuItem owner = (MenuItem)Owner;
+            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
             if (positionInSet == AutomationProperties.AutomationPositionInSetDefault)
             {
-                MenuItem owner = (MenuItem)Owner;
-                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
                 positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
+            }
+
+            foreach (var item in parent.Items)
+            {
+                if (item == owner)
+                {
+                    break;
+                }
+                if (item is Separator)
+                {
+                    positionInSet -= 1;
+                }
             }
 
             return positionInSet;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -94,19 +94,20 @@ namespace System.Windows.Automation.Peers
         override protected int GetSizeOfSetCore()
         {
             int sizeOfSet = base.GetSizeOfSetCore();
-            MenuItem owner = (MenuItem)Owner;
-            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
+            
             if (sizeOfSet == AutomationProperties.AutomationSizeOfSetDefault)
             {
-                sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
-            }
+                MenuItem owner = (MenuItem)Owner;
+                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
-            foreach (var item in parent.Items)
-            {
-                if (item is Separator)
+                sizeOfSet = ItemAutomationPeer.GetSizeOfSetFromItemsControl(parent, owner);
+
+                foreach (var item in parent.Items)
                 {
-                    sizeOfSet -= 1;
+                    if (item is Separator)
+                    {
+                        sizeOfSet -= 1;
+                    }
                 }
             }
 
@@ -125,23 +126,24 @@ namespace System.Windows.Automation.Peers
         override protected int GetPositionInSetCore()
         {
             int positionInSet = base.GetPositionInSetCore();
-            MenuItem owner = (MenuItem)Owner;
-            ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
-
+            
             if (positionInSet == AutomationProperties.AutomationPositionInSetDefault)
             {
-                positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
-            }
+                MenuItem owner = (MenuItem)Owner;
+                ItemsControl parent = ItemsControl.ItemsControlFromItemContainer(owner);
 
-            foreach (var item in parent.Items)
-            {
-                if (item == owner)
+                positionInSet = ItemAutomationPeer.GetPositionInSetFromItemsControl(parent, owner);
+                
+                foreach (var item in parent.Items)
                 {
-                    break;
-                }
-                if (item is Separator)
-                {
-                    positionInSet -= 1;
+                    if (item == owner)
+                    {
+                        break;
+                    }
+                    if (item is Separator)
+                    {
+                        positionInSet -= 1;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #1467

5.0 PR: https://github.com/dotnet/wpf/pull/1977

# Description

Screen readers were reading incorrect values of the number of menu items and their position since we were counting separators as MenuItems in the automation tree.

I filtered for separators in the current MenuItems to fix the SizeOfSet count.

I filtered for separators again for PositionInSet but added a short-circuit to break when you're at the element whose position you're trying to find. This short-circuit was added to not remove separators below the relevant MenuItem from the PositionInSet count.

# Customer Impact

Narrator and other screen readers read the wrong values of SizeOfSet and PositioninSet for each individual menu item. This is confusing for users with visual disabilities as they can not accurately tell what is being visually represented on the screen.

# Regression
No. This was discovered during accessibility testing on .Net Core 3.0

# Risk - Low
The fix is well-contained and has been tested well internally.

We're iterating over the menu items another time in a place where we're already iterating. Running another iteration through an enumerable does invalidate some caching but there doesn't seem to be an obviously better way to make this change. We rejected an approach storing the number of separators in a variable as the memory cost would always be paid and be higher than the time cost of another iteration.