### PR TITLE
[Release/3.1] Hit testing by geometry fails if more than one matrix trasformation is applied to a geometry.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithGeometryDrawingContextWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HitTestWithGeometryDrawingContextWalker.cs
@@ -276,7 +276,7 @@ namespace System.Windows.Media
             else if ((_currentTransform != null) && !_currentTransform.IsIdentity)
             {
                 // Both the current transform and the new one are nontrivial, combine them
-                Matrix combined = _currentTransform.Value * transform.Value;
+                Matrix combined =  transform.Value * _currentTransform.Value;
                 transform = new MatrixTransform(combined);
             }
 


### PR DESCRIPTION
On behalf of @Simon-IT :

This is related to my issue 642. In the hit testing by geometry algotithm, the order in which the transformations are crosses is wrong. In the issue 642 there is a project to test in very simple manner the problem.

3.1 port related to https://github.com/dotnet/wpf/pull/1761