### PR TITLE
Update C++ Tools to VS16.3 Preview 4 

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,67 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-preview1.19523.2">
+    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-preview1.19523.5">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>fb02fe818f8b410259776e4fa6ca0c5cdd43e07c</Sha>
+      <Sha>d890296011263c2fd459a2c4ae63d522d1f651ba</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.Win32.Registry" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.Win32.Registry" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.CodeDom" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Diagnostics.EventLog" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.DirectoryServices" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Drawing.Common" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Emit" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Reflection.Emit" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.AccessControl" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Permissions" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Principal.Windows" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Windows.Extensions" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview1.19459.38" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview2.19523.6" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0d6763312a2754e45d604ebdc69c8ac7e21a2187</Sha>
+      <Sha>10d8d0996dba48164eb035562afb32e8157e8d06</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19474.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -71,29 +71,29 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0e9ffd6464aff37aef2dc41dc2162d258f266e32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.1.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="3.1.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="4.8.1-preview1.19461.39">
+    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="4.8.1-preview2.19522.8">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
-      <Sha>f6c215eeb0663c7c391d459283eac8dbe97f48bc</Sha>
+      <Sha>925b388d6078d1d013ddbc80fa363858c84974b6</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.IO.Packaging" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.1.0-preview1.19459.7" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.1.0-preview2.19522.2" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>d13d1b61de8a28e0d5509273a6ec3de35b1dd258</Sha>
+      <Sha>30583ce8b3816f6855b14f6f855db604db23cfc4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="3.1.0-preview1.19459.7" CoherentParentDependency="Microsoft.NETCore.Runtime.CoreCLR">
+    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="3.1.0-preview2.19522.2" CoherentParentDependency="Microsoft.NETCore.Runtime.CoreCLR">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>d13d1b61de8a28e0d5509273a6ec3de35b1dd258</Sha>
+      <Sha>30583ce8b3816f6855b14f6f855db604db23cfc4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.1.0-preview1.19459.7" CoherentParentDependency="Microsoft.NETCore.Runtime.CoreCLR">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.1.0-preview2.19522.2" CoherentParentDependency="Microsoft.NETCore.Runtime.CoreCLR">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>d13d1b61de8a28e0d5509273a6ec3de35b1dd258</Sha>
+      <Sha>30583ce8b3816f6855b14f6f855db604db23cfc4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19474.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -107,9 +107,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0e9ffd6464aff37aef2dc41dc2162d258f266e32</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="4.7.0-preview1.19459.13" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Resources.Extensions" Version="4.7.0-preview2.19522.18" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>2d38da41c8c153e498ea5fbda88c7532389b2f3f</Sha>
+      <Sha>e342823f6e560b75164b8ab0be68246509f0b648</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
         Also in global.json 
         Used in Wpf.Cpp.PrivateTools.props/targets 
     -->
-    <MsvcurtC1xxVersion>0.0.0.8</MsvcurtC1xxVersion>
+    <MsvcurtC1xxVersion>0.0.0.9</MsvcurtC1xxVersion>
     <!--
     This is the version of the test infrastructure package is compiled against. This should be
     removed as part of https://github.com/dotnet/wpf/issues/816 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,40 +5,40 @@
     <PreReleaseVersionLabel>preview2</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <SystemResourcesExtensionsVersion>4.7.0-preview1.19459.13</SystemResourcesExtensionsVersion>
-    <SystemIOPackagingVersion>4.7.0-preview1.19459.13</SystemIOPackagingVersion>
+    <SystemResourcesExtensionsVersion>4.7.0-preview2.19522.18</SystemResourcesExtensionsVersion>
+    <SystemIOPackagingVersion>4.7.0-preview2.19522.18</SystemIOPackagingVersion>
   </PropertyGroup>
   <!-- NuGet Package Versions -->
   <PropertyGroup>
-    <MicrosoftPrivateWinformsVersion>4.8.1-preview1.19523.2</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>4.8.1-preview1.19523.5</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/coreclr -->
   <PropertyGroup>
-    <MicrosoftNETCoreRuntimeCoreCLRVersion>3.1.0-preview1.19459.7</MicrosoftNETCoreRuntimeCoreCLRVersion>
-    <MicrosoftNETCoreILDAsmVersion>3.1.0-preview1.19459.7</MicrosoftNETCoreILDAsmVersion>
-    <MicrosoftNETCoreILAsmVersion>3.1.0-preview1.19459.7</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRVersion>3.1.0-preview2.19522.2</MicrosoftNETCoreRuntimeCoreCLRVersion>
+    <MicrosoftNETCoreILDAsmVersion>3.1.0-preview2.19522.2</MicrosoftNETCoreILDAsmVersion>
+    <MicrosoftNETCoreILAsmVersion>3.1.0-preview2.19522.2</MicrosoftNETCoreILAsmVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppVersion>3.1.0-preview1.19459.38</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCorePlatformsVersion>3.1.0-preview1.19459.13</MicrosoftNETCorePlatformsVersion>
-    <SystemDrawingCommonVersion>4.7.0-preview1.19459.13</SystemDrawingCommonVersion>
-    <SystemDirectoryServicesVersion>4.7.0-preview1.19459.13</SystemDirectoryServicesVersion>
-    <SystemReflectionMetadataLoadContextVersion>4.7.0-preview1.19459.13</SystemReflectionMetadataLoadContextVersion>
+    <MicrosoftNETCoreAppVersion>3.1.0-preview2.19523.6</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCorePlatformsVersion>3.1.0-preview2.19522.18</MicrosoftNETCorePlatformsVersion>
+    <SystemDrawingCommonVersion>4.7.0-preview2.19522.18</SystemDrawingCommonVersion>
+    <SystemDirectoryServicesVersion>4.7.0-preview2.19522.18</SystemDirectoryServicesVersion>
+    <SystemReflectionMetadataLoadContextVersion>4.7.0-preview2.19522.18</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/corefx via core-setup coherency parent dependency -->
   <PropertyGroup>
-    <MicrosoftWin32RegistryPackageVersion>4.7.0-preview1.19459.13</MicrosoftWin32RegistryPackageVersion>
-    <SystemCodeDomPackageVersion>4.7.0-preview1.19459.13</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>4.7.0-preview1.19459.13</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>4.7.0-preview1.19459.13</SystemDiagnosticsEventLogPackageVersion>
-    <SystemReflectionEmitPackageVersion>4.7.0-preview1.19459.13</SystemReflectionEmitPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>4.7.0-preview2.19522.18</MicrosoftWin32RegistryPackageVersion>
+    <SystemCodeDomPackageVersion>4.7.0-preview2.19522.18</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>4.7.0-preview2.19522.18</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.7.0-preview2.19522.18</SystemDiagnosticsEventLogPackageVersion>
+    <SystemReflectionEmitPackageVersion>4.7.0-preview2.19522.18</SystemReflectionEmitPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview4.19176.11</SystemReflectionTypeExtensionsPackageVersion>
-    <SystemSecurityAccessControlPackageVersion>4.7.0-preview1.19459.13</SystemSecurityAccessControlPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>4.7.0-preview1.19459.13</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>4.7.0-preview1.19459.13</SystemSecurityPermissionsPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>4.7.0-preview1.19459.13</SystemSecurityPrincipalWindowsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>4.7.0-preview1.19459.13</SystemWindowsExtensionsPackageVersion>
+    <SystemSecurityAccessControlPackageVersion>4.7.0-preview2.19522.18</SystemSecurityAccessControlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.7.0-preview2.19522.18</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>4.7.0-preview2.19522.18</SystemSecurityPermissionsPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>4.7.0-preview2.19522.18</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>4.7.0-preview2.19522.18</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/arcade -->
   <PropertyGroup>
@@ -114,6 +114,6 @@
       It is worth reiterating that this package *should not* be consumed to build the product.
   -->
   <PropertyGroup>
-    <MicrosoftDotNetWpfDncEngVersion>4.8.1-preview1.19461.39</MicrosoftDotNetWpfDncEngVersion>
+    <MicrosoftDotNetWpfDncEngVersion>4.8.1-preview2.19522.8</MicrosoftDotNetWpfDncEngVersion>
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/Pbt.props
+++ b/eng/WpfArcadeSdk/tools/Pbt.props
@@ -55,8 +55,13 @@
   -->
   <Import Project="$(WpfSourceDir)PresentationBuildTasks\Microsoft.WinFX.props"
           Condition="Exists('$(LocalMicrosoftWinFXProps)') "/>
-  
+
+  <!-- 
+      Make sure WinFx.props exists when including - we sometimes include Pbt.props 
+      from non-WPF projects (for e.g., C++ .vxproj) where this is a meaningless idea 
+      -->
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
         Project="../targets/Microsoft.WinFx.props"
-        Condition="!Exists('$(LocalMicrosoftWinFXProps)')"/>
+        Condition="!Exists('$(LocalMicrosoftWinFXProps)')  And 
+                   Exists('../targets/Microsoft.WinFx.props')"/>
 </Project>

--- a/global.json
+++ b/global.json
@@ -19,6 +19,6 @@
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.2",
-    "msvcurt-c1xx": "0.0.0.8"
+    "msvcurt-c1xx": "0.0.0.9"
   }
 }


### PR DESCRIPTION
Fixes #2114 
There is a matching PR for [dotnet-wpf-int#3879](https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int/pullrequest/3879?_a=overview) that is needed along-with this change. 

## Description 

This PR updates C++ tools used by WPF to VS 16.3 Preview 4 bits. 

From https://github.com/dotnet/wpf/pull/2105, we now know that C++ toolset containing libs that were built targeting 3.0 could not be used to build against 3.1 libs. 

https://github.com/dotnet/wpf/pull/2105#issuecomment-545746253
> This was fixed in 16.4P3. It's caused by a mismatch between targeting 3.1 and using libs built against 3.0. Updating the tools should fix it and you should no longer need the private tools. 
>
```
##[error]msvcurt_netcore.lib(msilexit.obj)(0,0): error LNK2022: metadata operation failed (80131195) : Custom attributes are not consistent: (0x0c0000f8).
msvcurt_netcore.lib(msilexit.obj) : error LNK2022: metadata operation failed (80131195) : Custom attributes are not consistent: (0x0c0000fb). [F:\workspace\_work\1\s\src\Microsoft.DotNet.Wpf\src\DirectWriteForwarder\DirectWriteForwarder.vcxproj]
```

The toolset in Dev 16.3+ were built against 3.1 libs. 

## Customer Impact 

This blocks .NET Core 3.1 Preview 2 builds. 

## Risk 

- The risk of toolset change without extensive testing on a release/* branch is **medium to high**.
- Some basic  testing of the bits produced using this toolset suggests that the WPF bits are in good shape. I ran a set of high priority tests and did some ad-hoc tests against samples to validate the bits. 

My recommendation is to merge this change now into release/3.1 branch to unblock preview builds, and continue with more testing as soon as a full SDK build is available. 

## Regression 

The root cause for why the compiler team needed to rebuild their tools against 3.1 libs is unclear @tgani-msft mentioned that the compiler team has yet to root-cause it. We should try to understand this further IMO. 