### PR TITLE
Increase .NET version to ensure we are using higher versions of NuGet

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -61,8 +61,10 @@
     <!--
       Temporarily suppress NU3027
       https://github.com/dotnet/arcade/issues/2304
+      
+      NU5131, NU5128 - Our transport packages do not conform to the layout NuGet wants.
     -->
-    <NoWarn>$(NoWarn);NU3027</NoWarn>
+    <NoWarn>$(NoWarn);NU3027;NU5131;NU5128</NoWarn>
     
     <!-- 
         Suppress NU1605 (Package downgrade warnings) when building inside Visual Studio

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-alpha1-014065",
+    "dotnet": "5.0.100-alpha1-015515",
     "runtimes": {
       "dotnet": [
         "2.1.7",


### PR DESCRIPTION
We've been seeing build failures due to a recent update from Arcade (https://github.com/dotnet/arcade/issues/4235) because we are not using a high enough version of .NET in our builds.

Therefore, bumping the version to ensure the publishing step is not using incorrect versions of NuGet.