### PR TITLE
Fixup to WPF to adapt to removal of legacy API's from WinForms

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-preview1.19552.1">
+    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-preview1.19557.7">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>4475da4f210f28bff944084d5b3e96880f1c51f8</Sha>
+      <Sha>4333978975ea1302e28e732b16fc59ce7ecb1ded</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
@@ -75,9 +75,9 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>281e5dab8db6d7e30d1529039143aa4c463b1a65</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="4.8.1-preview2.19522.8">
+    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="4.8.1-preview2.19553.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
-      <Sha>925b388d6078d1d013ddbc80fa363858c84974b6</Sha>
+      <Sha>90e4d4d634d385b0213347e8c1e43a8ca0a002c2</Sha>
     </Dependency>
     <Dependency Name="System.IO.Packaging" Version="4.7.0-preview3.19551.2" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <!-- NuGet Package Versions -->
   <PropertyGroup>
-    <MicrosoftPrivateWinformsVersion>4.8.1-preview1.19552.1</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>4.8.1-preview1.19557.7</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/coreclr -->
   <PropertyGroup>
@@ -114,6 +114,6 @@
       It is worth reiterating that this package *should not* be consumed to build the product.
   -->
   <PropertyGroup>
-    <MicrosoftDotNetWpfDncEngVersion>4.8.1-preview2.19522.8</MicrosoftDotNetWpfDncEngVersion>
+    <MicrosoftDotNetWpfDncEngVersion>4.8.1-preview2.19553.2</MicrosoftDotNetWpfDncEngVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/System/Windows/Integration/ElementHost.cs
@@ -903,7 +903,6 @@ namespace System.Windows.Forms.Integration
             this.AutoSizeChanged += this.OnPropertyChangedAutoSize;
             this.BindingContextChanged += this.OnPropertyChangedBindingContext;
             this.CausesValidationChanged += this.OnPropertyChangedCausesValidation;
-            this.ContextMenuChanged += this.OnPropertyChangedContextMenu;
             this.ContextMenuStripChanged += this.OnPropertyChangedContextMenuStrip;
             this.DockChanged += this.OnPropertyChangedDock;
             this.LocationChanged += this.OnPropertyChangedLocation;
@@ -981,10 +980,6 @@ namespace System.Windows.Forms.Integration
         private void OnPropertyChangedCausesValidation(object sender, System.EventArgs e)
         {
             OnPropertyChanged("CausesValidation", this.CausesValidation);
-        }
-        private void OnPropertyChangedContextMenu(object sender, System.EventArgs e)
-        {
-            OnPropertyChanged("ContextMenu", this.ContextMenu);
         }
         private void OnPropertyChangedContextMenuStrip(object sender, System.EventArgs e)
         {


### PR DESCRIPTION
### Description 

Fixes #2169 

This is a fixup to WPF to adapt to legacy api removal in WinForms (see https://github.com/dotnet/winforms/pull/2157). 

### Risk 
Low - minor changes to ElementHost. 

### Customer Impact. 

Doesn't seem like very much of an impact from WPF directly. Indirect impact from WinForms changes are off-topic here. 

### Testing 

None - this builds. 

Related: We need this to get https://github.com/dotnet/wpf/pull/2161 going. 

/cc @RussKie 