### PR TITLE
Remove modification of MSBuildAllProjects property

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
@@ -11,10 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <!-- The MicrosoftWindowsDesktopSdkPath is a hook so that you can redirect to a local version of the WPF SDK targets

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.targets
@@ -11,10 +11,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project>
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   
   <Import Project="$(MicrosoftWindowsDesktopSdkPath)\Microsoft.NET.Sdk.WindowsDesktop.targets "/>


### PR DESCRIPTION
Since 16.0, MSBuild automatically prepends the most recently modified import to this property, so there's no need to ensure all imports do this themselves. In fact, doing so actively harms performance as this property's value becomes very large and processing it is expensive.

I assume this SDK does not need to support VS versions earlier than 16.0.