### PR TITLE
Include "ResolveTargetingPackAssets" in AfterTargets; Remove unused Targets

### DIFF
--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -1,4 +1,4 @@
-<Project>
+ <Project>
   <ItemGroup>
     <PackageReference Include="$(MicrosoftPrivateWinformsPackage)"
                       Version="$(MicrosoftPrivateWinformsVersion)"
@@ -30,45 +30,18 @@
 
   <PropertyGroup>
     <ResolveAssemblyReferencesDependsOn>
-      ResolveMicrosoftNetCoreAppReferences;
-      ResolveMicrosoftWindowsDesktopAppReferences;
       ResolveMicrosoftDotNetWpfGitHubReferences;
       ResolveWinFormsReferences;
       $(ResolveAssemblyReferencesDependsOn)
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
-  <Target
-    Name="ResolveMicrosoftNetCoreAppReferences"
-    Returns="@(Reference)"
-    Condition="'$(PkgMicrosoft_NETCore_App)'!='' And '@(NetCoreReference)'!='' and $(TargetFramework.StartsWith('netcoreapp3')) and '$(DoNotLimitMicrosoftNetCoreReferences)'!='true'">
-    <!-- 
-    In your project, Add a references to assemblies from Microsoft.NETCore.App like this
-      <ItemGroup>
-        <NetCoreReference Include="netstandard" />
-        <NetCoreReference Include="System.IO" />
-      </ItemGroup>
-      
-      It will get translated into something like this:
-      <ItemGroup>
-        <Reference Include="C:\Users\username\.nuget\packages\microsoft.netcore.app\3.0.0-preview5-27609-17\ref\netcoreapp3.0\netstandard.dll" />
-        <Reference Include="C:\Users\username\.nuget\packages\microsoft.netcore.app\3.0.0-preview5-27609-17\ref\netcoreapp3.0\System.IO.dll" />
-      </ItemGroup>
-    -->
-    <ItemGroup>
-      <Reference Include="$(PkgMicrosoft_NETCore_App)\ref\$(TargetFramework)\%(NetCoreReference.Identity).dll"
-                 Condition="Exists('$(PkgMicrosoft_NETCore_App)\ref\$(TargetFramework)\%(NetCoreReference.Identity).dll')" >
-        <NuGetPackageId>Microsoft.NetCore.App</NuGetPackageId>
-      </Reference>
-    </ItemGroup>
-  </Target>
-
 
   <Target
     Name="LimitNetCoreAppReferences"
-    AfterTargets="ResolveTargetingPacks"
+    AfterTargets="ResolveTargetingPackAssets;ResolveTargetingPacks"
     Returns="@(Reference)"
-    Condition="'$(PkgMicrosoft_NETCore_App)'!='' And '@(NetCoreReference)' != '' And '@(Reference)' != ''">
+    Condition="'@(NetCoreReference)' != '' And '@(Reference)' != ''">
     <!--
       Example
       <NetCoreReference Include="Microsoft.CSharp" />
@@ -102,28 +75,10 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ResolveMicrosoftWindowsDesktopAppReferences"
-          Returns="@(Reference)"
-          Condition="'$(PkgMicrosoft_WindowsDesktop_App)'!='' And '@(WindowsDesktopAppReference)'!='' and $(TargetFramework.StartsWith('netcoreapp3')) and '$(DoNotLimitWindowsDesktopAppReferences)'!='true'">
-    <!-- 
-    In your project, Add a references to assemblies from Microsoft.NETCore.App like this
-      <ItemGroup>
-        <WindowsDesktopAppeference Include="PresentationCore" />
-        <WindowsDesktopAppeference Include="System.Xaml" />
-      </ItemGroup>
-    -->
-    <ItemGroup>
-      <Reference Include="$(PkgMicrosoft_WindowsDesktop_App)\ref\$(TargetFramework)\%(NetCoreReference.Identity).dll"
-                 Condition="Exists('$(PkgMicrosoft_WindowsDesktop_App)\ref\$(TargetFramework)\%(NetCoreReference.Identity).dll')">
-        <NuGetPackageId>Microsoft.WindowsDesktop.App</NuGetPackageId>
-      </Reference>
-    </ItemGroup>
-  </Target>
-
   <Target Name="LimitWindowsDesktopAppReferences"
-        AfterTargets="ResolveTargetingPacks"
+        AfterTargets="ResolveTargetingPacks;ResolveTargetingPackAsssets"
         Returns="@(Reference)"
-        Condition="'$(PkgMicrosoft_WindowsDesktop_App)'!='' And '@(WindowsDesktopReference)'!='' and '@(Reference)' != ''">
+        Condition="'@(WindowsDesktopReference)'!='' and '@(Reference)' != ''">
     <!--
       Example
       <WindowsDesktopReference Include="PresentationCore" />
@@ -160,7 +115,10 @@
   <Target
     Name="ResolveMicrosoftDotNetWpfGitHubReferences"
     Returns="@(ReferencePath)"
-    Condition="'@(MicrosoftDotNetWpfGitHubReference)'!='' and $(TargetFramework.StartsWith('netcoreapp3')) and '$(DoNotLimitMicrosoftDotNetWpfGitHubReferences)'!='true'">
+    Condition="'@(MicrosoftDotNetWpfGitHubReference)'!='' 
+           And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
+           And '$(TargetFrameworkVersion)' == 'v3.0'
+           and '$(DoNotLimitMicrosoftDotNetWpfGitHubReferences)'!='true'">
     <!-- 
     In your project, Add a references to WPF GitHub transport package like this:
       <ItemGroup>
@@ -198,7 +156,9 @@
       </ItemGroup>
    -->
   <Target Name="ResolveWinFormsReferences"
-          Condition="'@(MicrosoftPrivateWinFormsReference)'!='' And $(TargetFramework.StartsWith('netcoreapp3'))">
+          Condition="'@(MicrosoftPrivateWinFormsReference)'!='' 
+                 And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
+                 And '$(TargetFrameworkVersion)' == 'v3.0'">
     <ItemGroup>
       <Reference Include="$(PkgMicrosoft_Private_Winforms)\ref\$(TargetFramework)\%(MicrosoftPrivateWinFormsReference.Identity).dll"
                  Condition="Exists('$(PkgMicrosoft_Private_Winforms)\ref\$(TargetFramework)\%(MicrosoftPrivateWinFormsReference.Identity).dll')">


### PR DESCRIPTION
Porting changes over from Release/3.1 into the DARC flow for Release/3.0.

Cherry-picked commits:
https://github.com/dotnet/wpf/commit/e1d79c0e7c593ccbf9c700d830fbb5d9f2fcc43b
MarkupCompilationPass1 getting too large a list of references which was causing a conflict between WindowsBase (the facade in NetCoreApp) and WindowsBase (the product assembly).

https://github.com/dotnet/wpf/commit/7f91d7c79eaddf12b5528a39e0f08e6f22967ad4
NuGet changes here are creating errors in our packaging.
