### PR TITLE
Improve `HWND` validity testing in `HwndHost` 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -308,7 +308,7 @@ namespace System.Windows.Interop
         protected virtual bool HasFocusWithinCore()
         {
             HandleRef hwndFocus = new HandleRef(this, UnsafeNativeMethods.GetFocus());
-            if (_hwnd.Handle != IntPtr.Zero && (hwndFocus.Handle == _hwnd.Handle || UnsafeNativeMethods.IsChild(_hwnd, hwndFocus)))
+            if (Handle != IntPtr.Zero && (hwndFocus.Handle == _hwnd.Handle || UnsafeNativeMethods.IsChild(_hwnd, hwndFocus)))
             {
                 return true;
             }
@@ -423,7 +423,7 @@ namespace System.Windows.Interop
             get
             {
                 if (!_hasDpiAwarenessContextTransition) return 1;
-                DpiScale2 dpi = DpiUtil.GetWindowDpi(_hwnd.Handle, fallbackToNearestMonitorHeuristic: false);
+                DpiScale2 dpi = DpiUtil.GetWindowDpi(Handle, fallbackToNearestMonitorHeuristic: false);
                 DpiScale2 dpiParent = DpiUtil.GetWindowDpi(UnsafeNativeMethods.GetParent(_hwnd), fallbackToNearestMonitorHeuristic: false);
 
                 if (dpi == null || dpiParent == null)
@@ -734,7 +734,7 @@ namespace System.Windows.Interop
         {
             DrawingGroup drawingGroup = null;
 
-            if(_hwnd.Handle != IntPtr.Zero && UnsafeNativeMethods.IsWindow(_hwnd))
+            if(Handle != IntPtr.Zero)
             {
                 NativeMethods.RECT rc = new NativeMethods.RECT();
                 SafeNativeMethods.GetWindowRect(_hwnd, ref rc);
@@ -976,7 +976,7 @@ namespace System.Windows.Interop
                         UnsafeNativeMethods.SetParent(_hwnd, new HandleRef(null,hwndParent));
                     }
                 }
-                else if (_hwnd.Handle != IntPtr.Zero)
+                else if (Handle != IntPtr.Zero)
                 {
                     // Reparent the window to notification-only window provided by SystemResources
                     // This keeps the child window around, but it is not visible.  We can reparent the 


### PR DESCRIPTION
Fixes #2239 

`s/_hwnd.Handle/Handle` in a few places, notably in in a check in `BuildOrReparentWindow`

--

The key change is in `BuildOrReparentWindow `where an additional check for  `IsWindow()` is desirable; without this check, non-`NULL` yet invalid `HWND`'s are able to make their way into the "reparent under a `SystemResources` managed message-only `HWND`" logic, which in turn tries to query other characteristics of the (invalid) `HWND`. 

One of these steps eventually fails, and WPF decides that the failure is sufficiently bad and crashes (this happens in `MS.Internal.DpiUtil.HwndDpiInfo.NearestMonitorInfoFromWindow(IntPtr hwnd)`).

Also changing `_hwnd.Handle` to `Handle` in a few other places where additional check for `HWND` validity seems valuable.

/cc @teh173 

[NearestMonitorDpiCrash.zip](https://github.com/dotnet/wpf/files/3899149/NearestMonitorDpiCrash.zip)