### PR TITLE
SharedSizeGroup loop

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -1178,11 +1178,11 @@ namespace System.Windows.Controls
             {
                 if (isRows)
                 {
-                    minSizes[PrivateCells[i].RowIndex] = DefinitionsV[PrivateCells[i].RowIndex].MinSize;
+                    minSizes[PrivateCells[i].RowIndex] = DefinitionsV[PrivateCells[i].RowIndex].RawMinSize;
                 }
                 else
                 {
-                    minSizes[PrivateCells[i].ColumnIndex] = DefinitionsU[PrivateCells[i].ColumnIndex].MinSize;
+                    minSizes[PrivateCells[i].ColumnIndex] = DefinitionsU[PrivateCells[i].ColumnIndex].RawMinSize;
                 }
 
                 i = PrivateCells[i].Next;


### PR DESCRIPTION
Ask Mode Template:  

Description 

After every layout pass, a SharedSizeGroup re-evaluates its  shared size and updates the state of its constituent ColumnDefinitions.  The  goal is to mark the "long-pole" definitions (the largest ones in the group), and  to identify Grids that need to be remeasured.  The logic for this is flawed in  several ways;  both goals can fail in either direction (false positive or false  negative).   These flaws usually result in redundant layout work - the Grids get  measured twice, with the mistakes in the second pass cancelling those in in the  first - but correct layout results.  But in some cases they lead to an infinite  cycle of re-layout;  the app hangs.   In the customer's scenario this happens  when  
a. the Grids are within the scope of a ScrollViewer with  VerticalScrollbarVisibility="Auto"  
b. there are more than 157 Grids (the  threshold for coalescing pending measure tasks into one task at the root)   
c. the minimum width of a non-long-pole Grid increases, away from the shared column

Customer Impact 

Hang. 

Regression 

No.   (Port of servicing fix for .NET 4.5.2 - 4.8)

Risk 

Low 

Fixes #2222
Hang during layout when using SharedSizeGroup