### PR TITLE
Fix STATUS_ILLEGAL_INSTRUCTION crash in win-x86 on some Xeon CPU's

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,8 +64,8 @@
     <!-- 
         Also in global.json 
         Used in Wpf.Cpp.PrivateTools.props/targets 
-    -->
     <MsvcurtC1xxVersion>0.0.0.9</MsvcurtC1xxVersion>
+    -->
     <!--
     This is the version of the test infrastructure package is compiled against. This should be
     removed as part of https://github.com/dotnet/wpf/issues/816 

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -89,7 +89,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <UsePrivateCppTools Condition="'$(UsePrivateCppTools)' == ''">true</UsePrivateCppTools>
+    <UsePrivateCppTools Condition="'$(UsePrivateCppTools)' == ''">false</UsePrivateCppTools>
   </PropertyGroup>
   <Import Project="Wpf.Cpp.PrivateTools.props" Condition="Exists('Wpf.Cpp.PrivateTools.props') And '$(UsePrivateCppTools)'=='true'"/>
   

--- a/global.json
+++ b/global.json
@@ -18,7 +18,6 @@
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
-    "dotnet-api-docs_netcoreapp3.0": "0.0.0.2",
-    "msvcurt-c1xx": "0.0.0.9"
+    "dotnet-api-docs_netcoreapp3.0": "0.0.0.2"
   }
 }


### PR DESCRIPTION
Fixes #2259, #2296

Matching internal PR at https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int/pullrequest/4692?_a=overview

### Description 

#### Part A
- The C++ Tools prior VS 2019 16.4 has a bug in detecting AVX-512 support (512-bit extensions to 256-bit Advanced Vector Extensions SIMD instructions for x86 ISA). It reports support to be present incorrectly on some Xeon processors when the support is not available. 
- It results in a `STATUS_ILLEGAL_INSTRUCTION` crash when running x86 WPF apps on certain Xeon processors. 
- The fix is to simply recompile WPF using a newer 16.4 compiler tools. 

#### Part B

- Switch to use production C++ tools that are ambient to the build machine, instead of privatized C++ tools 
  - Dev/local builds would rely on tools from Dev16.4+ 
- Update tools.dotnet in global.json to 3.1.100

This change is being proposed based on a plan to migrate to production tools that was agreed with @tgani-msft and @jamshedd to move the LTS branch away from using private tools. 

This was the plan: 

- Starts out with privatized tools (same as 3.0) 
- Switches to Dev 16.4 P1 when it becomes available (timing wise, this lines up with 3.0 RTM, roughly). 
- (not-critical) At 3.1 RTM, it will likely switch to using 16.4 RTM (3.1 and 16.4 schedules are lined up). 
- Steady State: 3.1 will use shipping tools, not private tools. 

### Customer Impact 

#### Part A
- Fixes a bad crash that prevents WPF from being used on a class of machines. 

#### Part B 
- Ship product built using production tools
- libraries etc. could have fixes/updates (incl. security updates) that are delivered seamlessly when using ambient tools supplied by the build machines. 

### Regression 

Yes - #2259 is a regression relative to .NET Framework. 

### Risk
Low

- All available WPF tests have been run on bits compiled with the new toolset, and no regressions have been found. 
- No functional changes are being made. 
- The customer who reported #2259 has verified that the new compiler correctly detects AVX-512 support
  - This was verified using a test application, rather than verifying a private build of WPF directly. 