### PR TITLE
Handle incremental build when XAML files are removed from the Page glob

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
@@ -389,13 +389,22 @@ namespace MS.Internal.Tasks
                 {
                     numLocalTypeXamls = CompilerLocalReference.LocalMarkupPages.Length;
 
+                    // Under incremental builds of SDK projects, we can have a state where the cache contains some XAML files but the Page blob
+                    // no longer contains them.  To avoid attempting to recompile a file that no longer exists, ensure that any cached XAML file
+                    // still exists in the Page blob prior to queuing it up for recompilation.
+                    HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata("FullPath")));
+
                     for (int i = 0; i < CompilerLocalReference.LocalMarkupPages.Length; i++)
                     {
                         LocalReferenceFile localRefFile = CompilerLocalReference.LocalMarkupPages[i];
-                        recompiledXaml.Add(new FileUnit(
-                                                localRefFile.FilePath, 
-                                                localRefFile.LinkAlias, 
-                                                localRefFile.LogicalName));
+
+                        if (localMarkupPages.Contains(localRefFile.FilePath))
+                        {
+                            recompiledXaml.Add(new FileUnit(
+                                                    localRefFile.FilePath,
+                                                    localRefFile.LinkAlias,
+                                                    localRefFile.LogicalName));
+                        }
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
@@ -393,7 +393,7 @@ namespace MS.Internal.Tasks
                     // Under incremental builds of SDK projects, we can have a state where the cache contains some XAML files but the Page blob
                     // no longer contains them.  To avoid attempting to recompile a file that no longer exists, ensure that any cached XAML file
                     // still exists in the Page blob prior to queuing it up for recompilation.
-                    HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata(SharedStrings.FullPath)));
+                    HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata(SharedStrings.FullPath)), StringComparer.OrdinalIgnoreCase);
 
                     for (int i = 0; i < CompilerLocalReference.LocalMarkupPages.Length; i++)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
@@ -395,7 +395,7 @@ namespace MS.Internal.Tasks
                     // still exists in the Page blob prior to queuing it up for recompilation.
                     HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata(SharedStrings.FullPath)), StringComparer.OrdinalIgnoreCase);
 
-                    for (int i = 0; i < CompilerLocalReference.LocalMarkupPages.Length; i++)
+                    for (int i = 0; i < numLocalTypeXamls; i++)
                     {
                         LocalReferenceFile localRefFile = CompilerLocalReference.LocalMarkupPages[i];
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 using Microsoft.Build.Tasks.Windows;
@@ -392,7 +393,7 @@ namespace MS.Internal.Tasks
                     // Under incremental builds of SDK projects, we can have a state where the cache contains some XAML files but the Page blob
                     // no longer contains them.  To avoid attempting to recompile a file that no longer exists, ensure that any cached XAML file
                     // still exists in the Page blob prior to queuing it up for recompilation.
-                    HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata("FullPath")));
+                    HashSet<string> localMarkupPages = new HashSet<string>(_mcPass1.PageMarkup.Select(x => x.GetMetadata(SharedStrings.FullPath)));
 
                     for (int i = 0; i < CompilerLocalReference.LocalMarkupPages.Length; i++)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/shared.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/shared.cs
@@ -44,6 +44,7 @@ namespace MS.Internal.Tasks
         internal const string       Localizable="Localizable";
         internal const string       Link="Link";
         internal const string       LogicalName="LogicalName";
+        internal const string       FullPath = "FullPath";
 
         // 
         // externs for generated files


### PR DESCRIPTION
Ensure that we don't include XAML files that no longer exist on disk as part of the LocalMarkupPages when we load from the compiler cache.

This allows SDK style projects to react to files deleted from the glob between two incremental builds.

Fixes #2287 