### PR TITLE
Add .NET SDK to developer guide

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -16,6 +16,7 @@ WPF requires the following workloads and  components be selected when installing
 * Required Individual Components:
   * C++/CLI support
   * Windows 10 SDK
+  * .NET 4.6.1 SDK or .NET 4.6.2 SDK (see [#2298](https://github.com/dotnet/wpf/issues/2298))
 
 ## Workflow
 


### PR DESCRIPTION
Document dependency on .NET SDK.  

The build of PresentationCore uses IL tools.  ILdasm.exe is obtained from a .NET SDK, either 4.6.1 or 4.6.2 (but not higher).

This is a mitigation for #2298.