### PR TITLE
Import Microsoft.WinFx.props only when it is present

### DIFF
--- a/eng/WpfArcadeSdk/tools/Pbt.props
+++ b/eng/WpfArcadeSdk/tools/Pbt.props
@@ -58,5 +58,6 @@
   
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop"
         Project="../targets/Microsoft.WinFx.props"
-        Condition="!Exists('$(LocalMicrosoftWinFXProps)')"/>
+        Condition="!Exists('$(LocalMicrosoftWinFXProps)') And 
+                    Exists('../targets/Microsoft.WinFx.props')"/>
 </Project>


### PR DESCRIPTION
Import Microsoft.WinFx.props only when it is present
