### PR TITLE
Remove dependency on .NET SDK installs for IL Tools

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -16,7 +16,6 @@ WPF requires the following workloads and  components be selected when installing
 * Required Individual Components:
   * C++/CLI support
   * Windows 10 SDK
-  * .NET 4.6.1 SDK or .NET 4.6.2 SDK (see [#2298](https://github.com/dotnet/wpf/issues/2298))
 
 ## Workflow
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,6 +73,7 @@
     <!-- These versions are specified in global.json -->
     <StrawberryPerlVersion>5.28.1.1-1</StrawberryPerlVersion>
     <NetFramework48RefAssembliesVersion>0.0.0.1</NetFramework48RefAssembliesVersion>
+    <NetFramework472IlToolsVersion>0.0.0.1</NetFramework472IlToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -32,6 +32,18 @@
       </PropertyGroup>
 
     </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- 
+        We use blob storage to ensure that all machines we build on have the .NET Framework 4.7.2 IL Tools.
+        This allows us to sidestep a requirement to have the .NET 4.7.2 Dev Pack installed and prevents mismatched IL(D)Asm utilities.
+        Note that we do not use .NET 4.8 tools here due to this round-tripping issue: https://developercommunity.visualstudio.com/content/problem/545431/ildasmexe-regression-with-infinum-floating-point-v.html
+        -->
+        <Net472IlToolsDir>$(RepositoryToolsDir)native\bin\net-framework-472-iltools\$(NetFramework472IlToolsVersion)\</Net472IlToolsDir>
+        <ILDAsm>$(Net472IlToolsDir)ildasm.exe</ILDAsm>
+        <ILAsm>$(Net472IlToolsDir)ilasm.exe</ILAsm>
+      </PropertyGroup>
+    </Otherwise>
   </Choose>
 
   <PropertyGroup>
@@ -43,36 +55,6 @@
     <TaskFactoryReference Include="mscorlib" />
     <TaskFactoryReference Include="netstandard" />
   </ItemGroup>
-
-  <!--
-      Locate the IL tools included with the highest version of .NET Framework and the .NET Framework SDK installed on the machine.
-  -->
-  <UsingTask TaskName="FindDotNetFrameworkILToolsTask"
-             TaskFactory="$(TaskFactory)"
-             AssemblyFile="$(TaskFactoryAssemblyFile)">
-    <ParameterGroup>
-      <ILAsm ParameterType="System.String" Output="true"/>
-      <ILDAsm ParameterType="System.String" Output="true"/>
-      <DotNetBitness ParameterType="System.String" Required="true"/>
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="Microsoft.Build.Utilities" />
-      <Code Type="fragment" Language="cs">
-        <![CDATA[
-          try
-          {
-            var bitness = (DotNetFrameworkArchitecture)Enum.Parse(typeof(DotNetFrameworkArchitecture), DotNetBitness);
-            ILAsm = ToolLocationHelper.GetPathToDotNetFrameworkFile("ILAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
-            ILDAsm = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("ILDAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
-          }
-          catch(Exception e)
-          {
-            Log.LogError("FindDotNetFrameworkILToolsTask: Could not find .NET Framework IL Tools: " + e.ToString());
-          }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 
   <!-- Call into the supplied ILDAsm. -->
   <UsingTask TaskName="ILDasmTask"
@@ -340,20 +322,6 @@
     <Copy SourceFiles="@(ILDAsm_Files)" DestinationFolder="$(ILToolsPath)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(ILAsm_Files)" DestinationFolder="$(ILToolsPath)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(CoreCLR_Files)" DestinationFolder="$(ILToolsPath)" SkipUnchangedFiles="true"/>
-  </Target>
-
-  <!--
-      Locate the IL tools included with the highest version of .NET Framework and the .NET Framework SDK installed on the machine.
-  -->
-  <Target Name="FindNetFrameworkILTools" BeforeTargets="DeconstructDll" Condition="'$(UseNetCoreILTools)'!='true'">
-    <PropertyGroup>
-      <DotNetFrameworkBitness Condition="'$(WpfRuntimeIdentifier)'=='win-x64'">Bitness64</DotNetFrameworkBitness>
-      <DotNetFrameworkBitness Condition="'$(WpfRuntimeIdentifier)'=='win-x86'">Bitness32</DotNetFrameworkBitness>
-    </PropertyGroup>
-    <FindDotNetFrameworkILToolsTask DotNetBitness="$(DotNetFrameworkBitness)">
-      <Output TaskParameter="ILDAsm" PropertyName="ILDAsm" />
-      <Output TaskParameter="ILAsm" PropertyName="ILAsm" />
-    </FindDotNetFrameworkILToolsTask>
   </Target>
 
   <!-- Disassemble the target binary. -->

--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -356,8 +356,8 @@
     </PropertyGroup>
 
     <AddModuleConstructorTask ILFile="$(ILFile)"
-                              MsCorLibAssemblySectionIL="$(ModuleInitializer)"
-                              ModuleConstructorIL="$(MsCorLibAssemblySection)"/>
+                              MsCorLibAssemblySectionIL="$(MsCorLibAssemblySection)"
+                              ModuleConstructorIL="$(ModuleInitializer)"/>
 
   </Target>
 

--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer/AddModuleConstructorTask.cs
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer/AddModuleConstructorTask.cs
@@ -41,31 +41,33 @@ namespace WpfArcadeSdk.Build.Tasks
                 var moduleConstructorIL = File.ReadAllText(ModuleConstructorIL);
                 var msCorLibAssemblySectionIL = File.ReadAllText(MsCorLibAssemblySectionIL);
                 var sourceIL = File.ReadAllText(ILFile);
+                string ilToInject = msCorLibAssemblySectionIL + Environment.NewLine + moduleConstructorIL;
 
                 using (var outputIL = new StreamWriter(File.Open(ILFile, FileMode.Truncate)))
                 {
-                    if (Regex.Match(sourceIL, @"\.assembly extern mscorlib", RegexOptions.Singleline) == Match.Empty)
-                    {
-                        outputIL.WriteLine(msCorLibAssemblySectionIL);
-                    }
-
                     if (Regex.Match(sourceIL, @"\.class.+?ModuleInitializer.+?\.method.+?static.+?Initialize\(\).+?end of class ModuleInitializer", RegexOptions.Singleline) == Match.Empty)
                     {
                         Log.LogError("Inserting a module initializer requires the assembly to implement a class named ModuleInitializer with a static parameterless method named Initialize.");
                         return false;
                     }
 
-                    if (Regex.Match(sourceIL, @"\.class private auto ansi '\<Module\>'.+?\.method private hidebysig specialname rtspecialname static void \.cctor \(\) cil managed ", RegexOptions.Singleline) == Match.Empty)
-                    {
-                        outputIL.WriteLine(moduleConstructorIL);
-                    }
-                    else
+                    if (Regex.Match(sourceIL, @"\.class private auto ansi '\<Module\>'.+?\.method private hidebysig specialname rtspecialname static void \.cctor \(\) cil managed ", RegexOptions.Singleline) != Match.Empty)
                     {
                         Log.LogError("Cannot insert a module initializer into an assembly that already contains one.");
                         return false;
                     }
 
-                    outputIL.WriteLine(sourceIL);
+                    // Attempt to replace an existing mscorlib reference with the reference + module initializer.
+                    string modifiedIL = Regex.Replace(sourceIL, @"\.assembly extern mscorlib.+};", ilToInject, RegexOptions.Singleline);
+
+                    // If we are given the same string back, there was nothing to replace.
+                    // In that case write out the reference and initializer from scratch.
+                    if (object.ReferenceEquals(modifiedIL, sourceIL))
+                    {
+                        outputIL.WriteLine(ilToInject);
+                    }
+
+                    outputIL.WriteLine(modifiedIL);
                 }
 
                 return true;

--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer/AddModuleConstructorTask.cs
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer/AddModuleConstructorTask.cs
@@ -44,15 +44,15 @@ namespace WpfArcadeSdk.Build.Tasks
 
                 using (var outputIL = new StreamWriter(File.Open(ILFile, FileMode.Truncate)))
                 {
+                    if (Regex.Match(sourceIL, @"\.assembly extern mscorlib", RegexOptions.Singleline) == Match.Empty)
+                    {
+                        outputIL.WriteLine(msCorLibAssemblySectionIL);
+                    }
+
                     if (Regex.Match(sourceIL, @"\.class.+?ModuleInitializer.+?\.method.+?static.+?Initialize\(\).+?end of class ModuleInitializer", RegexOptions.Singleline) == Match.Empty)
                     {
                         Log.LogError("Inserting a module initializer requires the assembly to implement a class named ModuleInitializer with a static parameterless method named Initialize.");
                         return false;
-                    }
-
-                    if (Regex.Match(sourceIL, @"\.assembly extern mscorlib", RegexOptions.Singleline) == Match.Empty)
-                    {
-                        outputIL.WriteLine(msCorLibAssemblySectionIL);
                     }
 
                     if (Regex.Match(sourceIL, @"\.class private auto ansi '\<Module\>'.+?\.method private hidebysig specialname rtspecialname static void \.cctor \(\) cil managed ", RegexOptions.Singleline) == Match.Empty)

--- a/global.json
+++ b/global.json
@@ -19,6 +19,7 @@
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.2",
-    "msvcurt-c1xx": "0.0.0.8"
+    "msvcurt-c1xx": "0.0.0.8",
+    "net-framework-472-iltools":  "0.0.0.1"
   }
 }


### PR DESCRIPTION
Fixes #2298

Use a set of matched, private IL tools in order to inject a module constructor into `PresentationCore`.  These are copied binaries from a .NET Framework 4.7.2 installation and SDK.

Also fixing some issues with utilizing `ILAsm` outside of the installed Framework directory and some bugs that went unnoticed in our injection targets.

# Pending
- [x] IL comparison between `PresentationCore` from this change and current .NET 5.0 `PresentationCore`.