### PR TITLE
Ensure the WindowsDesktopSdk RepoLocation overrides all others.

### DIFF
--- a/eng/WpfArcadeSdk/tools/ShippingProjects.props
+++ b/eng/WpfArcadeSdk/tools/ShippingProjects.props
@@ -185,7 +185,7 @@
     <RepoLocation Condition="'$(RepoLocation)' == '' And $(ExternalShippingProjects.Contains('$(NormalizedMSBuildProjectName)'))">External</RepoLocation>
  
     <!-- WindowsDesktopSdk overrides Internal, External etc. -->
-    <RepoLocation Condition="'$(RepoLocation)' == '' And $(WindowsDesktopSdkProject.Contains('$(NormalizedMSBuildProjectName)'))">WindowsDesktopSdk</RepoLocation>
+    <RepoLocation Condition="$(WindowsDesktopSdkProject.Contains('$(NormalizedMSBuildProjectName)'))">WindowsDesktopSdk</RepoLocation>
 
     <IncludeLibFilesInPackaging Condition="$(ShippingLibProjects.Contains('$(NormalizedMSBuildProjectName)'))">true</IncludeLibFilesInPackaging>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #2363 

Ensure the WindowsDesktopSdk RepoLocation overrides all others.  This is key to packaging PresentationBuildTasks and associated files.