### PR TITLE
Update branding from '4.8.1-rtm' to '4.8.1-servicing'

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>4.8.1</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <SystemResourcesExtensionsVersion>4.7.0-preview3.19551.2</SystemResourcesExtensionsVersion>


### PR DESCRIPTION
This matches what's in release/3.0: https://github.com/dotnet/wpf/blob/release/3.0/eng/Versions.props#L6

@vatsan-madhavan @mmitche PTAL