### PR TITLE
[release/3.1] Centralize VersionPrefix information in Version.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <!-- 
+      Primary version prefix for this repo - usually changes only once per major release
+    -->
     <VersionPrefix>4.8.1</VersionPrefix>
+    <!-- 
+      Version prefix used by a few projects like Project Templates
+      Revision portion of Major.Minor.Revision usually updated every release
+    -->
+    <TraditionalVersionPrefix>3.1.2</TraditionalVersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{BFF6C118-3369-43B5-ACA6-D65ED00EEBE0}</ProjectGuid>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>$(TraditionalVersionPrefix)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>$(TraditionalVersionPrefix)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Centralize VersionPrefix information in Version.props

Verified using local build using shipping-versions that this works as intended.

```
build -ci -pack /p:DotNetUseShippingVersions=true

> dir /s artifacts\packages\Debug\NonShipping\ /b 

C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Arcade.Wpf.Sdk.4.8.1-ci.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Wpf.GitHub.4.8.1-ci.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Wpf.ProjectTemplates.3.1.2-ci.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.NET.Sdk.WindowsDesktop.3.1.2-ci.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\runtime.win-x86.Microsoft.DotNet.Wpf.GitHub.4.8.1-ci.20065.1.nupkg
```

/cc @mmitche, thoughts about taking this in ? 