### PR TITLE
[release/3.0] Centralize VersionPrefix information in Version.props

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,15 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Branding information -->
   <PropertyGroup>
+    <!-- 
+      Primary version prefix for this repo - usually changes only once per major release
+    -->
     <VersionPrefix>4.8.0</VersionPrefix>
+    <!-- 
+      Version prefix used by a few projects like Project Templates
+      Revision portion of Major.Minor.Revision usually updated every release
+    -->
+    <TraditionalVersionPrefix>3.0.3</TraditionalVersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <!--

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{BFF6C118-3369-43B5-ACA6-D65ED00EEBE0}</ProjectGuid>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <VersionPrefix>3.0.3</VersionPrefix>
+    <VersionPrefix>$(TraditionalVersionPrefix)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <VersionPrefix>3.0.3</VersionPrefix>
+    <VersionPrefix>$(TraditionalVersionPrefix)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Centralize VersionPrefix information in Version.props

Verified using local build using shipping-versions that this works as intended. 
```
build -pack /p:DotNetUseShippingVersions=true

C:\src\repos\wpf (refactor-versionprefix-rel30 -> origin)
λ dir /s artifacts\packages\Debug\NonShipping\ /b
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Arcade.Wpf.Sdk.4.8.0-dev.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Wpf.GitHub.4.8.0-dev.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.DotNet.Wpf.ProjectTemplates.3.0.3-dev.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\Microsoft.NET.Sdk.WindowsDesktop.3.0.3-dev.20065.1.nupkg
C:\src\repos\wpf\artifacts\packages\Debug\NonShipping\runtime.win-x86.Microsoft.DotNet.Wpf.GitHub.4.8.0-dev.20065.1.nupkg

```

/cc @mmitche 