### PR TITLE
Add S.W.Forms.Primitives references to accommodate type-moves coming from dotnet/winforms

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -253,6 +253,9 @@
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Thread" />
     <NetCoreReference Include="System.Threading.ThreadPool" />
+
+    <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
+    <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
@@ -70,7 +70,9 @@
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
     <NetCoreReference Include="System.Threading" />
+    
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
+    <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="$(SystemDrawingCommonPackage)" Version="$(SystemDrawingCommonVersion)" />

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/ref/WindowsFormsIntegration-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/ref/WindowsFormsIntegration-ref.csproj
@@ -40,7 +40,9 @@
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
     <NetCoreReference Include="System.Threading" />
+    
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
+    <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="$(SystemDrawingCommonPackage)" Version="$(SystemDrawingCommonVersion)" />


### PR DESCRIPTION
Add S.W.Forms.Primitives references to accommodate type-moves comign from dotnet/winforms

dotnet/winforms has moved some types from S.W.Forms.dll to S.W.Forms.Primitives.dll. Adding references to it to accomodate the type move. 

WinForms still needs to fix a bug on its end (namely, the transport package Microsoft.Winforms.Private has lib\S.W.Forms.Primitives.dll, but ref\S.W.Forms.Primitives.dll is absent) to complete the solution. 

These are needed to unblock https://github.com/dotnet/wpf/pull/2432

/cc @RussKie 