### PR TITLE
[release/3.1] Unescape PresentationBuildTasks.dll paths containing special characters

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.props
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFx.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_PresentationBuildTasksTfm>
     <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_PresentationBuildTasksTfm>
-    <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll'))</_PresentationBuildTasksAssembly>
+    <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$([MSBuild]::Unescape($([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll'))))</_PresentationBuildTasksAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Microsoft.Build.Tasks.Windows.MarkupCompilePass1" AssemblyFile="$(_PresentationBuildTasksAssembly)" />


### PR DESCRIPTION
Fixes #2415 

### Description 

.NET Core 3.1 SDK installed in paths containing special characters like `'(` fails to build WPF projects. This affects the default WOW64 installation - i.e., x86 MSI installation on x64 system, that typically installs under `%SystemDrive%\Program Files (x86)\dotnet`

The builds fail with the following error: 

```
c:\Program Files (x86)\dotnet\sdk\3.1.101\Sdks\Microsoft.NET.Sdk.WindowsDesktop\targets\Microsoft.WinFX.targets(225,9): 
error MSB4062: The "Microsoft.Build.Tasks.Windows.MarkupCompilePass1" task could not be loaded from
the assembly c:\Program Files %28x86%29\dotnet\sdk\3.1.101\Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\netcoreapp2.1\PresentationBuildTasks.dll. 
Could not load file or assembly 'c:\Program Files %28x86%29\dotnet\sdk\3.1.101\Sdks\Microsoft.NET.Sdk.WindowsDesktop\tools\netcoreapp2.1\PresentationBuildTasks.dll'.
The system cannot find the path specified. Confirm that the <UsingTask> declaration is correct, that the assembly
and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. 
```

When the SDK is installed in a path containing special characters, for e.g., under `C:\Program Files (x86)\dotnet` (the special characters here being `{'(', ')'}`), calling an MSBuild property function like `$([System.IO.Path]::GetFullPath())` on `$(MSBuildThisFileDirectory)` will result in MSBuild escaping any special characters that are returned.

Now, this is what the [documentation ](https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2019)says about using property functions:

>String values returned from property functions have[ special characters](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-special-characters?view=vs-2019) escaped. If you want the value to be treated as though it was put directly in the project file, use `$([MSBuild]::Unescape())` to unescape the special characters.
>...
>In static property functions, you can use any static method or property of these system classes:
> ```
> System.Byte
>...
> System.IO.Path
>...
> Microsoft.Build.Utilities.ToolLocationHelper
> ```

When such an escaping happens, characters like `(` get translated to`%28` etc. When `UsingTask` encounters a value of `$(_PresentationBuildTasksAssembly)` containing encoded characters, it fails.

We must unescape these characters by calling `$([MSBuild]::Unescape())` to ensure that `UsingTask` will not fail.

### Customer Impact 

Developers who install x86 SDK on x64 OS are not able to build WPF apps using 3.1.x SDK. 

### Regression 

This was a regression introduced by #2075, [[release/3.1] Use correct PresentationBuildTasks.dll for VS and MSBuild builds](#2075). 

We did not catch this during development and testing early on since testing was done using SDK's installed under `%appdata%`, `%temp%` etc., which typically didn't have special characters that are escaped by MSBuild. 

We are still trying to understand how we failed to catch this in end-to-end testing. The current theory is that the x86 SDK was likely tested directly on an x86 OS installation where this problem would not have manifested itself (since the default install location would have been `%SystemDrive%\Program Files`, and would not have involved WOW64). 

We are taking steps to ensure that this scenario is covered in testing. 

### Risk 

Low. 

- The change is being tested by building a corpus of WPF applications on different configurations (x86 SDK on x86 OS, x86 SDK on x64 OS, x64 SDK on x64 OS) x (simple installation path, installation paths with special chars). 
- The fix is simple and easy to review for correctness. 