### PR TITLE
Make ArtifactsTmpDir platform-specific

### DIFF
--- a/eng/WpfArcadeSdk/tools/FolderPaths.props
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <!--
+      Append Platform to $(ArtifactsTmpDir)
+    -->
+    <ArtifactsTmpDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTmpDir)', '$(Architecture)'))</ArtifactsTmpDir>
+  </PropertyGroup>
+  <PropertyGroup>
     <WpfCycleBreakersDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\cycle-breakers\</WpfCycleBreakersDir>
     <WpfApiCompatBaselineDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\ApiCompat\Baselines\</WpfApiCompatBaselineDir>
     <WpfSourceDir>$(RepoRoot)src\Microsoft.DotNet.Wpf\src\</WpfSourceDir>

--- a/eng/WpfArcadeSdk/tools/Publishing.props
+++ b/eng/WpfArcadeSdk/tools/Publishing.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <PublishDependsOnTargets>
       ReconfigureAssetManifestFileName;
-      $(PublishPackagesToBlobFeedDependsOn);
+      $(PublishDependsOnTargets);
     </PublishDependsOnTargets>
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/Publishing.props
+++ b/eng/WpfArcadeSdk/tools/Publishing.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <PublishPackagesToBlobFeedDependsOn>
+    <PublishDependsOnTargets>
       ReconfigureAssetManifestFileName;
       $(PublishPackagesToBlobFeedDependsOn);
-    </PublishPackagesToBlobFeedDependsOn>
+    </PublishDependsOnTargets>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Make ArtifactsTmpDir platform-specific - this should help ensure Asset-manifests are not clobbered. 