### PR TITLE
Publishing fixup for .Debug builds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="Version.props"/>
+  <Import Project="Versions.props"/>
   
   <!-- 
     Publishing.props from WPF's build props will be imported here directly during publishing

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,4 @@
 <Project>
-  <Import Project="Versions.props"/>
-  
   <!-- 
     Publishing.props from WPF's build props will be imported here directly during publishing
     

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk">
+  <!-- Publishing.props from WPF's build props will be imported here directly during publishing -->
+</Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -10,7 +10,7 @@
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
           Project="Sdk.props"
           Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
-=  <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
+  <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
           Project="Sdk.targets"
           Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -7,16 +7,16 @@
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
           Project="..\tools\Publishing.props"
-          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
+          Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
           Project="..\tools\Publishing.targets"
-          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
+          Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
 
   <Import Project="WpfArcadeSdk\tools\Publishing.props"
-          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
+          Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' == '' And 
                       Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
   <Import Project="WpfArcadeSdk\tools\Publishing.targets"
-        Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
+        Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' == '' And 
                       Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,3 +1,24 @@
-<Project Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk">
-  <!-- Publishing.props from WPF's build props will be imported here directly during publishing -->
+<Project>
+  <Import Project="Version.props"/>
+  
+  <!-- 
+    Publishing.props from WPF's build props will be imported here directly during publishing
+    
+    Use the published SDK from NuGet if available, or local files otherwise. 
+    -->
+  <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
+          Version="$(MicrosoftDotNetArcadeWpfSdk)"
+          Project="Sdk.props"
+          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
+=  <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
+          Version="$(MicrosoftDotNetArcadeWpfSdk)"
+          Project="Sdk.targets"
+          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
+
+  <Import Project="WpfArcadeSdk\Sdk\Sdk.props"
+          Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
+                      Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
+  <Import Project="WpfArcadeSdk\Sdk\Sdk.targets"
+        Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
+                      Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,11 +5,11 @@
     Use the published SDK from NuGet if available, or local files otherwise. 
     -->
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
-          Version="$(MicrosoftDotNetArcadeWpfSdk)"
+          Version="$(MicrosoftDotNetArcadeWpfSdkVersion)"
           Project="..\tools\Publishing.props"
           Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
-          Version="$(MicrosoftDotNetArcadeWpfSdk)"
+          Version="$(MicrosoftDotNetArcadeWpfSdkVersion)"
           Project="..\tools\Publishing.targets"
           Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -6,17 +6,17 @@
     -->
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
-          Project="Sdk.props"
+          Project="..\tools\Publishing.props"
           Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
           Version="$(MicrosoftDotNetArcadeWpfSdk)"
-          Project="Sdk.targets"
+          Project="..\tools\Publishing.targets"
           Condition="'$(MicrosoftDotNetArcadeWpfSdk)' != ''"/>
 
-  <Import Project="WpfArcadeSdk\Sdk\Sdk.props"
+  <Import Project="WpfArcadeSdk\tools\Publishing.props"
           Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
                       Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
-  <Import Project="WpfArcadeSdk\Sdk\Sdk.targets"
+  <Import Project="WpfArcadeSdk\tools\Publishing.targets"
         Condition="'$(MicrosoftDotNetArcadeWpfSdk)' == '' And 
                       Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
 </Project>

--- a/eng/WpfArcadeSdk/tools/FolderPaths.props
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(ArtifactsTmpDir)' != '' And '$(Architecture)' != ''">
     <!--
       Append Platform to $(ArtifactsTmpDir)
     -->


### PR DESCRIPTION
`Publish.pro`j comes from within the Arcade.SDK, which is outside the cone of the repo - this normally doesn't import WPF's build props, the Repo's D.B.props etc. 

It makes one exception - it will import `eng\Publishing.prop`s. 

We add `eng\Publishing.props` and use that to hook up our own `publishing.props/publishing.targets`, where we will in-turn override` $(AssetManifestFilePath)` to be distinct for` {$Platform} x {$Configuration}`. This will in turn ensure that all transport-packages produced by CI builds are published without loss. The current default-scheme in Arcade is lossy (it only uses` $(Platform)` in `$(AssetManifestFilePath)`, which means that `$(Configuration)` sensitive packages clobber one another). 

