### PR TITLE
Move DebugInformationFormat setting to Wpf.Cpp.target

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,11 +5,9 @@
     Use the published SDK from NuGet if available, or local files otherwise. 
     -->
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
-          Version="$(MicrosoftDotNetArcadeWpfSdkVersion)"
           Project="..\tools\Publishing.props"
           Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk" 
-          Version="$(MicrosoftDotNetArcadeWpfSdkVersion)"
           Project="..\tools\Publishing.targets"
           Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' != ''"/>
 

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -209,14 +209,6 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       
       <!-- 
-        Workaround for https://github.com/dotnet/arcade/issues/4763
-        Embed PDB's into the .lib files directly using /Z7 when building out of 
-        dotnet-wpf-int repo
-      -->
-      <DebugInformationFormat Condition="'$(ManagedCxx)' != 'true' and 
-                                         '$(RepoLocation)' == 'Internal'">oldStyle</DebugInformationFormat>
-      
-      <!-- 
         Disambiguate the PDB produced by the compiler with a -compile suffix, so that the PDB
         produced by the linker is not accidentally clobbered by this one.
       -->

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -57,20 +57,6 @@
       <TargetFrameworkSDKToolsDirectory Condition="'$(Platform)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(Platform)\</TargetFrameworkSDKToolsDirectory>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
-    <LinkIncremental Condition="'$(ManagedCxx)'=='true'">false</LinkIncremental>
-    <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
-    <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(ManagedCxx)'=='true'">
     <!-- Works around a bug in the C++ compiler where we get the error
          'System::ReadOnlySpan::default': could not import member. -->

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -5,6 +5,20 @@
     <NativeResourceFileWithVersionInformation Condition="'$(NativeResourceFileWithVersionInformation)' == ''">$(IntermediateOutputPath)ExtendedNativeVersion.rc</NativeResourceFileWithVersionInformation>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental Condition="'$(ManagedCxx)'=='true'">false</LinkIncremental>
+    <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+    <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+  </PropertyGroup>
+
   <Import Project="Wpf.Cpp.PrivateTools.targets" Condition="Exists('Wpf.Cpp.PrivateTools.targets') And '$(UsePrivateCppTools)'=='true'"/>
   
   <ItemDefinitionGroup>

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -13,6 +13,14 @@
       <AdditionalIncludeDirectories Condition="Exists('$(WpfCommonDir)inc\')">%(AdditionalIncludeDirectories);$(WpfCommonDir)inc\</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(NativeVersionFileDirectory);$(WpfTracingDir)native\</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(WpfSharedDir)inc\ddbanned.h</ForcedIncludeFiles>
+
+      <!-- 
+        Workaround for https://github.com/dotnet/arcade/issues/4763
+        Embed PDB's into the .lib files directly using /Z7 when building out of 
+        dotnet-wpf-int repo
+      -->
+      <DebugInformationFormat Condition="'$(ManagedCxx)' != 'true' and 
+                                         '$(RepoLocation)' == 'Internal'">oldStyle</DebugInformationFormat>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(NativeVersionFileDirectory)</AdditionalIncludeDirectories>


### PR DESCRIPTION
Move DebugInformationFormat setting to Wpf.Cpp.targets; Remove version from sdk import (it's implicit)