### PR TITLE
Set debug optimization flags early in build

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -57,6 +57,20 @@
       <TargetFrameworkSDKToolsDirectory Condition="'$(Platform)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(Platform)\</TargetFrameworkSDKToolsDirectory>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental Condition="'$(ManagedCxx)'=='true'">false</LinkIncremental>
+    <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+    <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(ManagedCxx)'=='true'">
     <!-- Works around a bug in the C++ compiler where we get the error
          'System::ReadOnlySpan::default': could not import member. -->

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -5,20 +5,6 @@
     <NativeResourceFileWithVersionInformation Condition="'$(NativeResourceFileWithVersionInformation)' == ''">$(IntermediateOutputPath)ExtendedNativeVersion.rc</NativeResourceFileWithVersionInformation>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <LinkIncremental>true</LinkIncremental>
-    <LinkIncremental Condition="'$(ManagedCxx)'=='true'">false</LinkIncremental>
-    <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <LinkIncremental>false</LinkIncremental>
-    <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-  </PropertyGroup>
-
   <Import Project="Wpf.Cpp.PrivateTools.targets" Condition="Exists('Wpf.Cpp.PrivateTools.targets') And '$(UsePrivateCppTools)'=='true'"/>
   
   <ItemDefinitionGroup>


### PR DESCRIPTION
Revert "Set debug and optimization settings in targets so that it supersedes settings set by props files"

This reverts commit c22c04640b325af24b392a13fb8bf3b7f91baf73.