### PR TITLE
Ensure C/C++ .lib builds in dotnet-wpf-int will set DebugInformationFormat=oldStyle

### DIFF
--- a/eng/WpfArcadeSdk/tools/FolderPaths.targets
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.targets
@@ -1,20 +1,21 @@
 <Project>
   <PropertyGroup>
     <!-- $(WpfSharedDir) is present in the current repository -->
-    <WpfSharedDir Condition="Exists('$(WpfSourceDir)shared\') And '$(RepositoryName)'!='dotnet-wpf-int'">$(WpfSourceDir)shared\</WpfSharedDir>
+    <WpfSharedDir Condition="'$(WpfSharedDir)'=='' And Exists('$(WpfSourceDir)shared\')">$(WpfSourceDir)shared\</WpfSharedDir>
     <!-- Consume from NuGet cache -->
-    <WpfSharedDir Condition="'$(WpfSharedDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\shared\')">$(WpfArcadeSdkRoot)src\shared\</WpfSharedDir>
+    <WpfTransportedSharedDir Condition="'$(WpfTransportedSharedDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\shared\')">$(WpfArcadeSdkRoot)src\shared\</WpfTransportedSharedDir>
     <!-- Consume from $(WpfTestArcadeWpfSdkPath) -->
-    <WpfSharedDir Condition="'$(WpfSharedDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Shared\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Shared\</WpfSharedDir>
+    <WpfTransportedSharedDir Condition="'$(WpfTransportedSharedDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Shared\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Shared\</WpfTransportedSharedDir>
 
     <!-- $(WpfCommonDir) is present in the current repository -->
-    <WpfCommonDir Condition="Exists('$(WpfSourceDir)Common\') And '$(RepositoryName)'!='dotnet-wpf-int'">$(WpfSourceDir)Common\</WpfCommonDir>
+    <WpfCommonDir Condition="'$(WpfCommonDir)'=='' And Exists('$(WpfSourceDir)Common\') And '$(RepositoryName)'!='dotnet-wpf-int'">$(WpfSourceDir)Common\</WpfCommonDir>
     <!-- Consume from NuGet cache -->
-    <WpfCommonDir Condition="'$(WpfCommonDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\Common\')">$(WpfArcadeSdkRoot)src\Common\</WpfCommonDir>
+    <WpfTransportedCommonDir Condition="'$(WpfTransportedCommonDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\Common\')">$(WpfArcadeSdkRoot)src\Common\</WpfTransportedCommonDir>
     <!-- Consume from $(WpfTestArcadeWpfSdkPath) -->
-    <WpfCommonDir Condition="'$(WpfCommonDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\</WpfCommonDir>
+    <WpfTransportedCommonDir Condition="'$(WpfTransportedCommonDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\</WpfTransportedCommonDir>
 
 
-    <WpfTracingDir>$(WpfSharedDir)Tracing\</WpfTracingDir>
+    <WpfTracingDir Condition="'$(WpfTracingDir)' == '' And Exists('$(WpfSharedDir)Tracing\')">$(WpfSharedDir)Tracing\</WpfTracingDir>
+    <WpfTracingDir Condition="'$(WpfTracingDir)' == '' And Exists('$(WpfTransportedSharedDir)Tracing\')">$(WpfTransportedSharedDir)Tracing\</WpfTracingDir>
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -11,6 +11,10 @@
     <ClCompile>
       <AdditionalIncludeDirectories Condition="Exists('$(WpfSharedDir)inc\')">%(AdditionalIncludeDirectories);$(WpfSharedDir)inc\</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="Exists('$(WpfCommonDir)inc\')">%(AdditionalIncludeDirectories);$(WpfCommonDir)inc\</AdditionalIncludeDirectories>
+
+      <AdditionalIncludeDirectories Condition="Exists('$(WpfTransportedSharedDir)inc\')">%(AdditionalIncludeDirectories);$(WpfTransportedSharedDir)inc\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="Exists('$(WpfTransportedCommonDir)inc\')">%(AdditionalIncludeDirectories);$(WpfTransportedCommonDir)inc\</AdditionalIncludeDirectories>
+
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(NativeVersionFileDirectory);$(WpfTracingDir)native\</AdditionalIncludeDirectories>
       <ForcedIncludeFiles>$(WpfSharedDir)inc\ddbanned.h</ForcedIncludeFiles>
 
@@ -20,12 +24,15 @@
         dotnet-wpf-int repo
       -->
       <DebugInformationFormat Condition="'$(ManagedCxx)' != 'true' and 
-                                         '$(RepoLocation)' == 'Internal'">oldStyle</DebugInformationFormat>
+                                         '$(ConfigurationType)' == '$(StaticLibrary)' and
+                                         '$(RepositoryName)' == 'dotnet-wpf-int'">oldStyle</DebugInformationFormat>
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(NativeVersionFileDirectory)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
+  
+  
 
   <!-- 
     Support for /linkrepro
@@ -605,6 +612,24 @@ using namespace System::Runtime::Versioning;
   <Target Name="EnsureLinkReproFolder">
     <RemoveDir Condition="Exists('$(IntermediateOutputPath)LinkRepro\')" Directories="$(IntermediateOutputPath)LinkRepro\" />
     <MakeDir Directories="$(IntermediateOutputPath)LinkRepro\" />
+  </Target>
+
+  <PropertyGroup>
+    <BeforeClCompileTargets>
+      UseOldStyleDebugInformationFormat;
+      $(BeforeClCompileTargets)
+    </BeforeClCompileTargets>
+  </PropertyGroup>
+  
+  <Target Name="UseOldStyleDebugInformationFormat"
+          Condition="'$(RepositoryName)'=='dotnet-wpf-int'    And
+                     '$(ConfigurationType)' =='StaticLibrary' And
+                     '$(ManagedCxx)' != 'true'">
+    <ItemGroup>
+      <ClCompile Update="@(ClCompile)">
+        <DebugInformationFormat>oldStyle</DebugInformationFormat>
+      </ClCompile>
+    </ItemGroup>
   </Target>
 
   <!-- Disable the portions of MSBuild that insist on a targeting pack directory to represent a target framework -->


### PR DESCRIPTION
Ensure C/C++ .lib builds in dotnet-wpf-int will set DebugInformationFormat=oldStyle. 

https://github.com/dotnet/arcade/issues/4763