### PR TITLE
Include additional headers in the transported Microsoft.DotNet.Arcade.Wpf.Sdk used by internal dotnet-wpf-int repo

### DIFF
--- a/eng/WpfArcadeSdk/tools/FolderPaths.targets
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.targets
@@ -14,6 +14,10 @@
     <!-- Consume from $(WpfTestArcadeWpfSdkPath) -->
     <WpfTransportedCommonDir Condition="'$(WpfTransportedCommonDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\Common\</WpfTransportedCommonDir>
 
+    <WpfTransportedGraphicsDir Condition="'$(WpfTransportedGraphicsDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\WpfGfx\')">$(WpfArcadeSdkRoot)src\WpfGfx\</WpfTransportedGraphicsDir>
+    <WpfTransportedGraphicsDir Condition="'$(WpfTransportedGraphicsDir)'=='' And Exists('$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\WpfGfx\')">$(WpfArcadeSdkRoot)..\..\src\Microsoft.DotNet.Wpf\src\WpfGfx\</WpfTransportedGraphicsDir>
+
+    <WpfTransportedGraphicsPath>$(WpfTransportedGraphicsDir)</WpfTransportedGraphicsPath>
 
     <WpfTracingDir Condition="'$(WpfTracingDir)' == '' And Exists('$(WpfSharedDir)Tracing\')">$(WpfSharedDir)Tracing\</WpfTracingDir>
     <WpfTracingDir Condition="'$(WpfTracingDir)' == '' And Exists('$(WpfTransportedSharedDir)Tracing\')">$(WpfTransportedSharedDir)Tracing\</WpfTracingDir>

--- a/packaging/Microsoft.DotNet.Arcade.Wpf.Sdk/Microsoft.DotNet.Arcade.Wpf.Sdk.ArchNeutral.csproj
+++ b/packaging/Microsoft.DotNet.Arcade.Wpf.Sdk/Microsoft.DotNet.Arcade.Wpf.Sdk.ArchNeutral.csproj
@@ -38,5 +38,10 @@
   <ItemGroup>
     <PackagingContent Include="$(WpfSharedDir)**\*" SubFolder="root\Src\Shared\%(RecursiveDir)" />
     <PackagingContent Include="$(WpfCommonDir)**\*" SubFolder="root\Src\Common\%(RecursiveDir)" />
+    
+    <PackagingContent Include="$(WpfGraphicsDir)core\**\*.h*" SubFolder="root\Src\WpfGfx\core\%(RecursiveDir)" />
+    <PackagingContent Include="$(WpfGraphicsDir)core\**\*.inl" SubFolder="root\Src\WpfGfx\core\%(RecursiveDir)" />
+    <PackagingContent Include="$(WpfGraphicsDir)common\**\*.h*" SubFolder="root\Src\WpfGfx\common\%(RecursiveDir)" />
+    <PackagingContent Include="$(WpfGraphicsDir)common\**\*.in*" SubFolder="root\Src\WpfGfx\common\%(RecursiveDir)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Include additional headers in the transported Microsoft.DotNet.Arcade.Wpf.Sdk used by internal dotnet-wpf-int repo. 