### PR TITLE
Fixup Environment.UserInteractive uses to workaround https://github.com/dotnet/runtime/issues/32929

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
@@ -194,8 +194,10 @@ namespace System.Windows.Media
         /// when inside a SCM service. 
         /// </remarks>
         internal static bool ShouldRenderEvenWhenNoDisplayDevicesAreAvailable { get; } =
-            !Environment.UserInteractive ? // IF DisplayDevicesNotAvailable && IsNonInteractiveWindowStation/IsService...  
-                !CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation :      // THEN render by default, allow ShouldNotRender AppContext override 
+            // Temporary workaround for https://github.com/dotnet/runtime/issues/32929
+            // Do not merge into master 
+            // !Environment.UserInteractive ? // IF DisplayDevicesNotAvailable && IsNonInteractiveWindowStation/IsService...  
+            //    !CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation :      // THEN render by default, allow ShouldNotRender AppContext override 
                 CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable;   // ELSE do not render by default, allow ShouldRender AppContext override
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
@@ -72,10 +72,13 @@ namespace Microsoft.Win32
 
             // Don't allow file dialogs to be shown if not in interactive mode
             // (for example, if we're running as a service)
-            if (!Environment.UserInteractive)
-            {
-                throw new InvalidOperationException(SR.Get(SRID.CantShowModalOnNonInteractive));
-            }
+            
+            // Temporary workaround for https://github.com/dotnet/runtime/issues/32929
+            // Do not merge into master 
+            // if (!Environment.UserInteractive)
+            // {
+            //    throw new InvalidOperationException(SR.Get(SRID.CantShowModalOnNonInteractive));
+            // }
 
             // Call GetActiveWindow to retrieve the window handle to the active window
             // attached to the calling thread's message queue.  We'll set the owner of
@@ -149,10 +152,13 @@ namespace Microsoft.Win32
 
             // Don't allow file dialogs to be shown if not in interactive mode
             // (for example, if we're running as a service)
-            if (!Environment.UserInteractive)
-            {
-                throw new InvalidOperationException(SR.Get(SRID.CantShowModalOnNonInteractive));
-            }
+            
+            // Temporary workaround for https://github.com/dotnet/runtime/issues/32929
+            // Do not merge into master
+            // if (!Environment.UserInteractive)
+            // {
+                // throw new InvalidOperationException(SR.Get(SRID.CantShowModalOnNonInteractive));
+            // }
 
             // Get the handle of the owner window using WindowInteropHelper.
             IntPtr hwndOwner = (new WindowInteropHelper(owner)).CriticalHandle;


### PR DESCRIPTION
Fixes #2663 

Temporary workaround for https://github.com/dotnet/runtime/issues/32929; do not merge into master.

Treat `Environment.UserInteractive` as `true`

/cc @rladuca, @danmosemsft, @ericstj, @richaverma1 