### PR TITLE
Add sdk.version entry to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -11,6 +11,9 @@
       "version": "16.1"
     }
   },
+  "sdk": {
+    "version": "5.0.100-alpha1-015515"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20154.1",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20154.1"


### PR DESCRIPTION
Adds `sdk.version` entry to `global.json` which tells msbuild SDK resolver which SDK version to look for when looking for `Microsoft.NET.Sdk`

Detailed explanation at https://github.com/dotnet/wpf/issues/2714#issuecomment-595419219

Fixes #2714 