### PR TITLE
Fix RuntimeFrameworkVersion logic

### DIFF
--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppVersion)'!='' And 
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppInternalVersion)'!='' And 
                                         '$(NoTargets)'!='true' And 
                                          '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And 
-                                         ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0')">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+                                         ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0')">$(MicrosoftNETCoreAppInternalVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -13,12 +13,12 @@
                                 Condition="'$(ManagedCxx)'=='true'"/>
     
     <FrameworkReference Update="Microsoft.NETCore.App"
-                      Condition="'$(MicrosoftNETCoreAppVersion)'!='' 
+                      Condition="'$(MicrosoftNETCoreAppInternalVersion)'!='' 
                              And '$(NoTargets)'!='true' 
                              And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
                              And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0') 
                              And '$(MSBuildProjectExtension)'!='.vcxproj'">
-      <TargetingPackVersion>$(MicrosoftNETCoreAppVersion)</TargetingPackVersion>
+      <TargetingPackVersion>$(MicrosoftNETCoreAppInternalVersion)</TargetingPackVersion>
     </FrameworkReference>
 
     <!-- 


### PR DESCRIPTION
https://github.com/dotnet/wpf/commit/60422e32024e035a42ae036f876669abcded3cda regressed `RuntimeFrameworkVersion` references. Update to use `MicrosoftNETCoreAppInternalVersion `for `RuntimeFrameworkVersion`