### PR TITLE
Add @dotnet/wpf-developers to CODEOWNERS 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo,
+# and will automatically be added as reviewers to all pull requests.
+*       @dotnet/wpf-developers


### PR DESCRIPTION
Add @dotnet/wpf-developers to CODEOWNERS to get automatic inclusion into all PR's

The msftbot system in use today for PR assignments doesn't work with GitHub teams, and requires individual GitHub ID's to be used. CODEOWNERS is more flexible and can automatically include a team in CR's. I believe i can also work side-by-side with msftbot. 

[dotnet/winforms](https://github.com/dotnet/winforms) uses a similar scheme today and this is borrowed from there.  