### PR TITLE
Do not build debug in official builds

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -112,17 +112,19 @@ jobs:
 
       strategy:
         matrix:
-          Build_Debug_x86:
-            _BuildConfig: Debug
-            # override some variables for debug
-            # _SignType has to be real for package publishing to succeed - do not override to test.
+          ${{ if eq(parameters.runAsPublic, 'true') }}:
+            Build_Debug_x86:
+              _BuildConfig: Debug
+              # override some variables for debug
+              # _SignType has to be real for package publishing to succeed - do not override to test.
           Build_Release_x86:
             _BuildConfig: Release
-          Build_Debug_x64:
-            _BuildConfig: Debug
-            # override some variables for debug
-            # _SignType has to be real for package publishing to succeed - do not override to test.
-            _Platform: x64
+          ${{ if eq(parameters.runAsPublic, 'true') }}:
+            Build_Debug_x64:
+              _BuildConfig: Debug
+              # override some variables for debug
+              # _SignType has to be real for package publishing to succeed - do not override to test.
+              _Platform: x64
           Build_Release_x64:
             _BuildConfig: Release
             _Platform: x64


### PR DESCRIPTION
There is no need to build debug in official builds as it's covered in CI as well as PRs