### PR TITLE
Don't double import WinFX targets

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.targets
@@ -6,7 +6,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
           created a backup copy.  Incorrect changes to this file will make it
           impossible to load or build your projects from the command-line or the IDE.
 
-Copyright (c) .NET Foundation. All rights reserved. 
+Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project>
@@ -14,4 +14,5 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <!--Post 5.0, Microsoft.NET.Sdk.WindowsDesktop.targets will be imported by SDK conditionally-->
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -1,4 +1,5 @@
 <Project>
+
   <ItemGroup Condition=" '$(_EnableWindowsDesktopGlobbing)' == 'true' ">
     <ApplicationDefinition Include="App.xaml"
                            Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
@@ -19,9 +20,9 @@
     </Page>
 
 
-    <!-- 
+    <!--
       See https://github.com/dotnet/wpf/issues/685
-      Visual Studio would prefer that we remove **/*.xaml instead of 
+      Visual Studio would prefer that we remove **/*.xaml instead of
       being more precise.
 
       <None Remove="@(Page)"
@@ -33,7 +34,7 @@
           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And '$(EnableDefaultPageItems)' != 'false'" />
   </ItemGroup>
 
-  
+
   <ItemGroup Condition=" '$(_EnableWindowsDesktopNetCoreFrameworkReferences)' == 'true' ">
 
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" IsImplicitlyDefined="true"
@@ -45,39 +46,37 @@
     <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" IsImplicitlyDefined="true"
                         Condition="('$(UseWPF)' != 'true') And ('$(UseWindowsForms)' == 'true')"/>
   </ItemGroup>
-  
+
 
   <!--
     Traditionally, Visual Studio has supplied these references for .NET Framework based
-    WPF Projects: 
-    
-    .NET 3.x:   PresentationCore, PresentationFramework, WindowsBase 
-    .NET 4.x:   PresentationCore, PresentationFramework, WindowsBase, System.Xaml 
+    WPF Projects:
+
+    .NET 3.x:   PresentationCore, PresentationFramework, WindowsBase
+    .NET 4.x:   PresentationCore, PresentationFramework, WindowsBase, System.Xaml
 
 
-    Microsoft.NET.WindowsDesktop.SDK will supply the following references to .NET Framework based 
-    WPF Projects: 
-    
-    .NET 3.x:   PresentationCore, PresentationFramework, WindowsBase 
-    
-    .NET 4.0:   PresentationCore, PresentationFramework, WindowsBase, System.Xaml, 
+    Microsoft.NET.WindowsDesktop.SDK will supply the following references to .NET Framework based
+    WPF Projects:
+
+    .NET 3.x:   PresentationCore, PresentationFramework, WindowsBase
+
+    .NET 4.0:   PresentationCore, PresentationFramework, WindowsBase, System.Xaml,
                 UIAutomationClient, UIAutomationClientSideProviders, UIAutomationProvider, UIAutomationTypes
-                
-    .NET 4.5+:  PresentationCore, PresentationFramework, WindowsBase, System.Xaml, 
+
+    .NET 4.5+:  PresentationCore, PresentationFramework, WindowsBase, System.Xaml,
                 UIAutomationClient, UIAutomationClientSideProviders, UIAutomationProvider, UIAutomationTypes
                 System.Windows.Controls.Ribbon
-
   -->
   <ItemGroup Condition=" '$(_EnableWindowsDesktopNETFrameworkImplicitReference)' == 'true' ">
-
     <!--
       The following 3 _WpfCommonNetFxReference items normally require Condition="'$(_TargetFrameworkVersionValue)' >= '3.0'", since
-      they are supported on .NET Framework 3.0 and above. 
-      
-      This condition is implicitly satisfied by '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)' 
+      they are supported on .NET Framework 3.0 and above.
+
+      This condition is implicitly satisfied by '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'
       in the outer ItemGroup
     -->
-    <_WpfCommonNetFxReference Include="WindowsBase" /> 
+    <_WpfCommonNetFxReference Include="WindowsBase" />
     <_WpfCommonNetFxReference Include="PresentationCore" />
     <_WpfCommonNetFxReference Include="PresentationFramework" />
 
@@ -93,39 +92,38 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(_EnableWindowsDesktopNETFrameworkImplicitReference)' == 'true' ">
-    
+
     <_SDKImplicitReference Include="@(_WpfCommonNetFxReference)"
                        Condition="'$(UseWPF)' == 'true'"/>
-    
+
     <_SDKImplicitReference Include="System.Windows.Forms"
                         Condition="('$(UseWindowsForms)' == 'true') " />
-    
+
     <_SDKImplicitReference Include="WindowsFormsIntegration"
                        Condition=" ('$(UseWindowsForms)' == 'true') And ('$(UseWPF)' == 'true') "/>
   </ItemGroup>
-  
-  
-  <!-- 
-        Supported (and unsupported) TargetFrameworks 
-        
-        Visual Studio Project System determines the list of valid TargetFrameworks to show 
-        in the Project properties by querying SupportedTargetFramework values. 
-        
+
+
+  <!--
+        Supported (and unsupported) TargetFrameworks
+
+        Visual Studio Project System determines the list of valid TargetFrameworks to show
+        in the Project properties by querying SupportedTargetFramework values.
+
         The Project System does not refer to this list at this time for .NET Framework TFM's.
   -->
 
-  <!-- 
+  <!--
     When WindowsDesktop SDK is used without setting UseWPF or UseWindowsForms, it shows a (suppressible) warning and functions much
     like Microsoft.NET.Sdk
-    
-    Likewise, when WindowsDesktop SDK is used with a netcore TFM that is less than 3.0, it will simply act as if it were an
-    Microsoft.NET.Sdk project (and show a suppressible build-time warning). 
-    
-    Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
-  --> 
-  <ItemGroup Condition=" '$(_RemoveUnsupportedTargetFrameworksForWindowsDesktop)' == 'true' ">
 
-    <!-- 
+    Likewise, when WindowsDesktop SDK is used with a netcore TFM that is less than 3.0, it will simply act as if it were an
+    Microsoft.NET.Sdk project (and show a suppressible build-time warning).
+
+    Detect these situations and skip updates to @(SupportedTargetFramework) etc.
+  -->
+  <ItemGroup Condition=" '$(_RemoveUnsupportedTargetFrameworksForWindowsDesktop)' == 'true' ">
+    <!--
         Windows Forms and WPF are supported only on .NET Core 3.0+
     -->
     <_UnsupportedNETCoreAppTargetFramework Include=".NETCoreApp,Version=v1.0" />
@@ -140,17 +138,17 @@
     <_UnsupportedNETStandardTargetFramework Include="@(SupportedNETStandardTargetFramework)" />
 
     <!--
-        Windows Forms was supported since .NET Framework 1.0, and is currently supported on 
-        .NET Framework 2.0+. 
-        
+        Windows Forms was supported since .NET Framework 1.0, and is currently supported on
+        .NET Framework 2.0+.
+
         WPF is supported on .NET Framework and WPF are supported on .NET Framework 3.0+
-        
+
         In practice, the WindowsDesktop SDK is only supported on .NET Framework 3.0+ - this is controlled
         by $(_WindowsDesktopSdkTargetFrameworkVersionFloor), defined as 3.0, which applies to both .NETFramework
         and .NETCore.
-        
-        Here, we will encode .NET Framework 3.0 as the lowest supported version for both Windows Forms and WPF. 
-        
+
+        Here, we will encode .NET Framework 3.0 as the lowest supported version for both Windows Forms and WPF.
+
         The SDK does not define versions < 2.0 in @(SupportedNETFrameworkTargetFramework) list, so none of those
         need to be excluded here - removing 2.0 would suffice.
     -->
@@ -159,7 +157,8 @@
     <SupportedNETCoreAppTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework)" />
     <SupportedNETStandardTargetFramework Remove="@(_UnsupportedNETStandardTargetFramework)" />
     <SupportedNETFrameworkTargetFramework Remove="@(_UnsupportedNETFrameworkTargetFramework)" />
-    
+
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -161,4 +161,13 @@
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
 
+  <!--
+    Workaround: https://github.com/microsoft/msbuild/issues/4948
+    Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
+    and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
+  -->
+  <PropertyGroup>
+    <ImportFrameworkWinFXTargets>false</ImportFrameworkWinFXTargets>
+  </PropertyGroup>
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -165,9 +165,10 @@
     Workaround: https://github.com/microsoft/msbuild/issues/4948
     Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
     and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
+    Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK's version.
   -->
   <PropertyGroup>
-    <ImportFrameworkWinFXTargets>false</ImportFrameworkWinFXTargets>
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
   </PropertyGroup>
 
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -8,21 +8,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- 
-    WindowsDesktop SDK supports WPF and WinForms on 
+    <!--
+    WindowsDesktop SDK supports WPF and WinForms on
       - .NET Core 3.0 and greater
       - .NET Framework 3.0 and greater
-   
-    Note that on .NET Framework versions < 4.0, additional workarounds may be required to build applications 
+
+    Note that on .NET Framework versions < 4.0, additional workarounds may be required to build applications
     using the SDK style projects. For e.g., see https://github.com/microsoft/msbuild/issues/1333
-    
-    Irrespective of whether '$(TargetFrameworkIdentifier)' is '.NETCoreApp' or '.NETFramework', 
+
+    Irrespective of whether '$(TargetFrameworkIdentifier)' is '.NETCoreApp' or '.NETFramework',
     the minimum value of $(_TargetFrameworkVersionValue) we will be testing for is '3.0'
-    
   -->
     <_WindowsDesktopSdkTargetFrameworkVersionFloor>3.0</_WindowsDesktopSdkTargetFrameworkVersionFloor>
-
-    <!-- 
+    <!--
       Represents an undefined TFV value. This will be used in comparisons of _TargetFrameworkVersionValue (defined in Microsoft.NET.WindowsDesktop.targets)
       to identify when a TFV is undefined
     -->
@@ -30,24 +28,24 @@
   </PropertyGroup>
 
 
-  <!-- 
-    $(TargetFrameworkVersion), $(_TargetFrameworkVersionWithoutV) etc. are defined in 
-    Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets. 
-    
+  <!--
+    $(TargetFrameworkVersion), $(_TargetFrameworkVersionWithoutV) etc. are defined in
+    Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets.
+
     Microsoft.NET.Sdk.targets is included prior to this file by Sdk.targets, so it is safe to define _TargetFrameworkValue
-    here. 
-    
-    _TargetFrameworkValue will be used in WindowsDesktop SDK as reliable proxy for _TargetFrameworkVersionWithoutV. 
+    here.
+
+    _TargetFrameworkValue will be used in WindowsDesktop SDK as reliable proxy for _TargetFrameworkVersionWithoutV.
     _TargetFrameworkVersionWithoutV can be empty ('') or it can be a numeric value (e.g., '3.0') - which makes it hard to work with
-    esp. in outer builds.  _TargetFrameworkValue will always be guaranteed to have a numeric value ('0.0' or a valid TFM). 
-    
+    esp. in outer builds.  _TargetFrameworkValue will always be guaranteed to have a numeric value ('0.0' or a valid TFM).
+
     _TargetFrameworkVersionValue will be used in Microsoft.NET.Sdk.WindowsDesktop.props in Item conditions. This will be valid
-    because Items are evaluated after Properties (see https://docs.microsoft.com/en-us/visualstudio/msbuild/comparing-properties-and-items?view=vs-2019). 
-    
+    because Items are evaluated after Properties (see https://docs.microsoft.com/en-us/visualstudio/msbuild/comparing-properties-and-items?view=vs-2019).
+
     Note:
-      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of 
+      Please see https://github.com/microsoft/msbuild/issues/3212 for a discussion about the use of
       the private $(_TargetFrameworkVersionWithoutV) property - which will likely remain supported and
-      is safe to use here. 
+      is safe to use here.
   -->
   <PropertyGroup>
     <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault('$(_TargetFrameworkVersionWithoutV)', '$(_UndefinedTargetFrameworkVersion)'))</_TargetFrameworkVersionValue>
@@ -71,33 +69,30 @@
                         '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">true</_RemoveUnsupportedTargetFrameworksForWindowsDesktop>
   </PropertyGroup>
 
-  
+
   <Import Project="Microsoft.WinFX.targets" />
 
-  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And 
+  <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And
                          ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-
     <!--
          In the WindowsDesktop .props, we globbed all .xaml files as Page items.  If any of those files are included
          as Resource, Content then remove them from the Page items.
     -->
     <Page Remove="@(Resource);@(Content)"
           Condition="'$(EnableDefaultPageItems)' != 'false'" />
-
     <!--
         ApplicationDefinition must also be removed from Page.  Otherwise, PresentationBuildTasks will include the
         generated code for the ApplicationDefinition twice.  We cannot do this in all cases in the props file as
         ApplicationDefinition isn't available at that point in the evaluation when EnableDefaultApplicationDefinition
-        is false.  We unconditionally remove it here as ApplicationDefinition is considered a special singleton Item 
+        is false.  We unconditionally remove it here as ApplicationDefinition is considered a special singleton Item
         in WPF.
     -->
     <Page Remove="@(ApplicationDefinition)" />
-    
     <!--
-         The WindowsDesktop props file removes "**/*.xaml" from None if both EnableDefaultApplicationDefinition and 
+         The WindowsDesktop props file removes "**/*.xaml" from None if both EnableDefaultApplicationDefinition and
          EnableDefaultPageItems are true.  This is done so that we remove any implicitly globbed XAML files from None
-         in support of Visual Studio.  
-         
+         in support of Visual Studio.
+
          In the case where one or both of these properties are not true, the WindowsDesktop props file does not remove
          any XAML files from None.  Under those conditions, removing None from Page here will remove explicitly specified
          pages causing compilation errors.  We match the condition from the WindowsDesktop props file here so that we only
@@ -110,7 +105,7 @@
   <!-- Generate error if there are duplicate page items.  The task comes from the .NET SDK, and this target follows
        the pattern in the CheckForDuplicateItems task, where the .NET SDK checks for duplicate items for the item
        types it knows about. -->
-  <Target Name="CheckForDuplicatePageItems" 
+  <Target Name="CheckForDuplicatePageItems"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile"
           DependsOnTargets="CheckForDuplicateItems"
           Condition="('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
@@ -133,29 +128,30 @@
 
   </Target>
 
-  <!-- 
+  <!--
     This warning can be suppressed by setting $(MSBuildWarningsAsMessages) property, like this:
     <PropertyGroup>
       <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1106</MSBuildWarningsAsMessages>
     </PropertyGroup>
-  --> 
+  -->
   <Target Name="_WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
           Condition="('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
-    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms" 
+    <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresUseWpfOrUseWindowsForms"
                    Condition="'$(UseWpf)' != 'true' And '$(UseWindowsForms)' != 'true'"/>
   </Target>
 
-    <!-- 
+    <!--
     This warning can be suppressed by setting $(MSBuildWarningsAsMessages) property, like this:
     <PropertyGroup>
       <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);NETSDK1105</MSBuildWarningsAsMessages>
     </PropertyGroup>
-  --> 
+  -->
   <Target Name="_WindowsDesktopFrameworkRequiresVersion30"
         BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-        Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And 
+        Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp') And
                   ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <_MicrosoftNetSdkWindowsDesktop>true</_MicrosoftNetSdkWindowsDesktop>
+    <_MicrosoftNETSdkWindowsDesktop>true</_MicrosoftNETSdkWindowsDesktop>
     <EnableDefaultPageItems Condition="'$(EnableDefaultPageItems)' == ''">true</EnableDefaultPageItems>
     <EnableDefaultApplicationDefinition Condition="'$(EnableDefaultApplicationDefinition)' == ''">true</EnableDefaultApplicationDefinition>
     <DefaultXamlRuntime Condition="'$(DefaultXamlRuntime)'==''">Wpf</DefaultXamlRuntime>
@@ -152,7 +152,7 @@
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
 
-  <!-- Import WPF Build logic -->
-  <Import Project="Microsoft.WinFX.targets" />
+  <!-- Import WPF Build logic only when we don't import NETFX's WinFX targets -->
+  <Import Project="Microsoft.WinFX.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'true'"/>
 
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -70,8 +70,6 @@
   </PropertyGroup>
 
 
-  <Import Project="Microsoft.WinFX.targets" />
-
   <ItemGroup Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And
                          ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <!--
@@ -153,5 +151,8 @@
                   ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And ('$(_TargetFrameworkVersionValue)' &lt; '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
+
+  <!-- Import WPF Build logic -->
+  <Import Project="Microsoft.WinFX.targets" />
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -19,10 +19,9 @@
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(AlwaysCompileMarkupFilesInSeparateDomain)' == '' ">true</AlwaysCompileMarkupFilesInSeparateDomain>
     <LocalizationDirectivesToLocFile Condition="'$(LocalizationDirectivesToLocFile)' == ''">None</LocalizationDirectivesToLocFile>
   </PropertyGroup>
-  
+
   <!-- Some Default Settings -->
   <PropertyGroup>
-
       <!--
           XamlDebuggingInformation property controls whether or not to put line number information in the
           generated binary file for a Xaml markup file.
@@ -32,10 +31,8 @@
       If XamlDebuggingInformation property is not explicitly set, and the current build is for debug,
           Set true to XamlDebuggingInformation, if the build is not for Debug, keep the empty setting for
           XamlDebuggingInformation, it means not to put line number information in the generated binary file.
-
       -->
       <XamlDebuggingInformation Condition="'$(XamlDebuggingInformation)' == '' and '$(ConfigurationName)' == 'Debug'">true</XamlDebuggingInformation>
-
 
       <HostInBrowser Condition="'$(HostInBrowser)'==''">false</HostInBrowser>
       <Version Condition="'$(Version)'==''">1.0.0.0</Version>
@@ -51,32 +48,26 @@
   </PropertyGroup>
 
   <PropertyGroup>
-
       <IsApplication Condition="'$(OutputType)'=='exe'">true</IsApplication>
       <IsApplication Condition="'$(OutputType)'=='winexe'">true</IsApplication>
       <IsLibrary Condition="'$(OutputType)'=='library'">true</IsLibrary>
       <IsLibrary Condition="'$(OutputType)'=='module'">true</IsLibrary>
-
   </PropertyGroup>
 
 
   <PropertyGroup>
-
       <!--
           Inject AssignWinFXEmbeddedResource target at right stage.
       -->
-
       <PrepareResourceNamesDependsOn>
                     AssignWinFXEmbeddedResource;
                     $(PrepareResourceNamesDependsOn)
       </PrepareResourceNamesDependsOn>
-
   </PropertyGroup>
 
 
   <!-- Common Application and Library Property settings -->
   <PropertyGroup>
-
       <PrepareResourcesDependsOn>
                 MarkupCompilePass1;
                 AfterMarkupCompilePass1;
@@ -85,23 +76,19 @@
                 MainResourcesGeneration;
                 $(PrepareResourcesDependsOn)
       </PrepareResourcesDependsOn>
-
   </PropertyGroup>
 
 
   <PropertyGroup>
         <!-- Add Markup compilation to the CoreCompileDependsOn so that the IDE inproc compilers (particularly VB)
              can "see" the generated source files. -->
-
       <CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
           DesignTimeMarkupCompilation;
           $(CoreCompileDependsOn)
       </CoreCompileDependsOn>
-
   </PropertyGroup>
 
   <Target Name="DesignTimeMarkupCompilation">
-
         <!-- Only if we are not actually performing a compile i.e. we are in design mode -->
         <CallTarget Condition="'$(BuildingProject)' != 'true' Or $(DesignTimeBuild) == 'true'"
                 Targets="MarkupCompilePass1" />
@@ -111,12 +98,10 @@
 
 
     <ItemGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
-
          <!--
             Add WinFX specific Item names to AvailableItemName item, so that they can show up
             in a drop-down menu for Build Action field of the properties window in VisualStudio.
          -->
-
          <AvailableItemName Include="ApplicationDefinition" />
          <AvailableItemName Include="Page" />
          <AvailableItemName Include="Resource" />
@@ -147,12 +132,10 @@
 
 
   <PropertyGroup>
-
     <!--
          Hook up AfterCompileWinFX to that it runs
          where AfterCompile would have run
     -->
-
     <CompileDependsOn>
         $(CompileDependsOn);
         _AfterCompileWinFXInternal
@@ -174,13 +157,11 @@
          Target PrepareResourcesForSatelliteAssemblies is for this.
 
     -->
-
     <_AfterCompileWinFXInternalDependsOn>
         PrepareResourcesForSatelliteAssemblies;
         MergeLocalizationDirectives;
         AfterCompileWinFX
     </_AfterCompileWinFXInternalDependsOn>
-
   </PropertyGroup>
 
 
@@ -237,6 +218,7 @@
             <_IntellisenseOnlyCompile>false</_IntellisenseOnlyCompile>
             <_IntellisenseOnlyCompile Condition="'$(BuildingProject)' != 'true'">true</_IntellisenseOnlyCompile>
         </PropertyGroup>
+
         <MarkupCompilePass1
                Language="$(Language)"
                UICulture="$(UICulture)"
@@ -264,7 +246,6 @@
                IsRunningInVisualStudio="$(BuildingInsideVisualStudio)"
                OutputPath="$(IntermediateOutputPath)">
 
-
               <Output ItemName="GeneratedBaml" TaskParameter="GeneratedBamlFiles"/>
               <Output ItemName="GeneratedLocalizationFiles" TaskParameter="GeneratedLocalizationFiles" />
               <Output PropertyName="_RequireMCPass2ForMainAssembly" TaskParameter="RequirePass2ForMainAssembly" />
@@ -277,9 +258,7 @@
               <Output ItemName="_GeneratedCodeFiles"
                       TaskParameter="GeneratedCodeFiles" />
 
-
         </MarkupCompilePass1>
-
 
         <Message Text="(out) GeneratedBamlFiles: '@(GeneratedBaml)'" Condition="'$(MSBuildTargetsVerbose)'=='true'"/>
         <Message Text="(out) SourceCodeFiles: '@(Compile)'" Condition="'$(MSBuildTargetsVerbose)'=='true'"/>
@@ -334,7 +313,6 @@
                If MarupCompilePass2 is for Main Assembly as well, output the Baml files into GeneratedBaml, FileClassifier task will be invoked later.
           -->
 
-
             <Output ItemName="GeneratedBamlWithLocalType"
                     TaskParameter="GeneratedBaml"
                     Condition="'$(MSBuildTargetsVerbose)'=='true'"/>
@@ -347,9 +325,7 @@
                     TaskParameter="GeneratedBaml"
                     Condition="'$(_RequireMCPass2ForSatelliteAssemblyOnly)' == 'true'" />
 
-
             <!-- Put the generated files in item FileWrites so that they can be cleaned up appropriately in a next Rebuild -->
-
             <Output ItemName="FileWrites" TaskParameter="GeneratedBaml" />
 
         </MarkupCompilePass2>
@@ -375,7 +351,6 @@
   -->
 
   <PropertyGroup>
-
        <MarkupCompilePass2ForMainAssemblyDependsOn>
                      GenerateTemporaryTargetAssembly;
                      MarkupCompilePass2;
@@ -385,7 +360,7 @@
 
         <_CompileTargetNameForLocalType Condition="'$(_CompileTargetNameForLocalType)' == ''">_CompileTemporaryAssembly</_CompileTargetNameForLocalType>
 
-        <!-- The updated .NET 5.0.2 GenerateTemporaryTargetAssembly behavior that supports source generators is off by default. --> 
+        <!-- The updated .NET 5.0.2 GenerateTemporaryTargetAssembly behavior that supports source generators is off by default. -->
         <IncludePackageReferencesDuringMarkupCompilation Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' == ''">false</IncludePackageReferencesDuringMarkupCompilation>
         <_ResolveProjectReferencesTargetName Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'">ResolveProjectReferences</_ResolveProjectReferencesTargetName>
         <_CompileTemporaryAssemblyDependsOn>BuildOnlySettings;ResolveKeySource;$(_ResolveProjectReferencesTargetName);CoreCompile</_CompileTemporaryAssemblyDependsOn>
@@ -410,10 +385,10 @@
                 Name : GenerateTemporaryTargetAssembly
 
   -->
-  <Target Name="GenerateTemporaryTargetAssembly" Condition="'$(_RequireMCPass2ForMainAssembly)' == 'true'"> 
+  <Target Name="GenerateTemporaryTargetAssembly" Condition="'$(_RequireMCPass2ForMainAssembly)' == 'true'">
 
      <Message Text="MSBuildProjectFile is $(MSBuildProjectFile)" Condition="'$(MSBuildTargetsVerbose)' == 'true'" />
-         
+
        <!-- Create a temporary target assembly project name with a random component. -->
        <PropertyGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'">
             <_ParentProjectName>$([System.IO.Path]::GetFileNameWithoutExtension('$(MSBuildProjectFullPath)'))</_ParentProjectName>
@@ -431,22 +406,21 @@
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.props"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.targets"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.dgspec.json"/>
-
       </ItemGroup>
 
       <!-- Copy the renamed outer project NuGet props/targets files to the MSBuildProjectExtensionsPath used by NuGet. -->
       <Copy Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'"
             SourceFiles="@(_SourceGeneratedNuGetPropsAndTargets)"
-            DestinationFiles="@(_DestGeneratedNuGetPropsAndTargets)" 
+            DestinationFiles="@(_DestGeneratedNuGetPropsAndTargets)"
        />
 
        <!--
         Undo TargetFramework and RID append set in Microsoft.NET.RuntimeIdentifierInference.targets to prevent
-        a duplicate target framework and runtime identifier in the IntermediateOutputPath when the new BuildEngine 
-        instance runs. 
+        a duplicate target framework and runtime identifier in the IntermediateOutputPath when the new BuildEngine
+        instance runs.
 
         'Append $(RuntimeIdentifier) to directory to output and intermediate paths to prevent bin clashes between
-        targets. But do not append the implicit default runtime identifier for .NET Framework apps as that would 
+        targets. But do not append the implicit default runtime identifier for .NET Framework apps as that would
         append a RID the user never mentioned in the path and do so even in the AnyCPU case.'
        -->
 
@@ -455,18 +429,18 @@
       </PropertyGroup>
 
       <PropertyGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false' and
-          '$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and 
+          '$(AppendRuntimeIdentifierToOutputPath)' == 'true' and '$(RuntimeIdentifier)' != '' and
           '$(_UsingDefaultRuntimeIdentifier)' != 'true'">
         <_IntermediateOutputPathNoTargetFrameworkOrRID>$([System.Text.RegularExpressions.Regex]::Replace($(_IntermediateOutputPathNoTargetFrameworkOrRID), "$(RuntimeIdentifier)\\$",, System.Text.RegularExpressions.RegexOptions.IgnoreCase))</_IntermediateOutputPathNoTargetFrameworkOrRID>
       </PropertyGroup>
-      
-      <PropertyGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false' and 
-          '$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and 
+
+      <PropertyGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false' and
+          '$(AppendTargetFrameworkToOutputPath)' == 'true' and '$(TargetFramework)' != '' and
           '$(_UnsupportedTargetFrameworkError)' != 'true'">
           <_IntermediateOutputPathNoTargetFrameworkOrRID>$([System.Text.RegularExpressions.Regex]::Replace($(_IntermediateOutputPathNoTargetFrameworkOrRID), "$(TargetFramework)\\$",, System.Text.RegularExpressions.RegexOptions.IgnoreCase))</_IntermediateOutputPathNoTargetFrameworkOrRID>
       </PropertyGroup>
 
-       <!--  Use the legacy .NET Framework/.NET Core 3.0 GenerateTemporaryTargetAssembly path if 'IncludePackageReferencesDuringMarkupCompilation' is 'false',. --> 
+       <!--  Use the legacy .NET Framework/.NET Core 3.0 GenerateTemporaryTargetAssembly path if 'IncludePackageReferencesDuringMarkupCompilation' is 'false',. -->
        <GenerateTemporaryTargetAssembly
                 CurrentProject="$(MSBuildProjectFullPath)"
                 MSBuildBinPath="$(MSBuildBinPath)"
@@ -480,7 +454,7 @@
                 CompileTargetName="$(_CompileTargetNameForLocalType)"
                 GenerateTemporaryTargetAssemblyDebuggingInformation="$(GenerateTemporaryTargetAssemblyDebuggingInformation)"
                 IncludePackageReferencesDuringMarkupCompilation="$(IncludePackageReferencesDuringMarkupCompilation)"
-                Analyzers="$(Analyzers)" 
+                Analyzers="$(Analyzers)"
                 TemporaryTargetAssemblyProjectName="$(_TemporaryTargetAssemblyProjectName)"
                  >
 
@@ -492,10 +466,10 @@
 
        <!-- Remove generated NuGet props/targets files. -->
        <Delete
-           Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false' 
+           Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'
             and '$(GenerateTemporaryTargetAssemblyDebuggingInformation)' != 'true'"
             Files="@(_DestGeneratedNuGetPropsAndTargets)" />
-        
+
    </Target>
 
   <!--
@@ -567,7 +541,6 @@
              SignDeploymentManifest
      </GenerateManifestsDependsOn>
 
-
      <GenerateManifests Condition="'$(GenerateManifests)' == ''" >true</GenerateManifests>
      <GenerateClickOnceManifests Condition="'$(GenerateClickOnceManifests)' == ''">$(GenerateManifests)</GenerateClickOnceManifests>
 
@@ -576,7 +549,6 @@
          But if 'install' is set in project, don't change it now. Later
          the PropertyValidation target will check if it is correct or not.
      -->
-
      <Install Condition="'$(Install)'==''">false</Install>
 
      <!--
@@ -588,14 +560,12 @@
          If this property is not set in project, for HostInBrowser,
          we set default value 'Internet' here.
      -->
-
      <TargetZone Condition="'$(TargetZone)' == ''">Internet</TargetZone>
 
 
      <!--
         Overwrite below properties which have been set in Microsoft.Common.targets.
      -->
-
      <TargetUrl Condition="'$(TargetUrl)' != ''">$(TargetUrl)/$(TargetDeployManifestFileName)</TargetUrl>
      <StartURL Condition="'$(StartURL)'==''">$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetDeployManifestFileName)</StartURL>
      <StartArguments Condition="'$(StartArguments)' == ''">-debug  "$(StartURL)"</StartArguments>
@@ -629,13 +599,12 @@
       <Error Condition=" '$(PlatformTarget)' != '' and '$(PlatformTarget)' != 'AnyCpu' "
              Text="Cannot build a platform-specific XAML Browser Application. If HostInBrowser property is set to 'True', either do not set the PlatformTarget property or set it to 'AnyCpu'." />
 
-
   </Target>
 
   <Target Name="SplashScreenValidation" Condition="'@(SplashScreen)' != ''" >
-    <Error Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And 
-                      '$(_TargetFrameworkVersionWithoutV)' != ''        And 
-                      '$(_TargetFrameworkVersionWithoutV)' == '3.0'" 
+    <Error Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And
+                      '$(_TargetFrameworkVersionWithoutV)' != ''        And
+                      '$(_TargetFrameworkVersionWithoutV)' == '3.0'"
            Text="The SplashScreen Build Action is not supported on $(TargetFrameworkIdentifier) $(TargetFrameworkVersion)." />
   </Target>
 
@@ -716,7 +685,6 @@
   -->
 
   <PropertyGroup>
-
      <!--
           If the UICulture is not set, resources will be embedded into main assembly.
           keep $(AssemblyName).g.resources as resource name for this scenario.
@@ -728,13 +696,8 @@
               $(AssemblyName).g for localizable resources,
               $(AssemblyName).unlocalizable.g for unlocalizable resources
       -->
-
-
      <_ResourceNameInMainAssembly Condition="'$(UICulture)' == ''">$(AssemblyName).g.resources</_ResourceNameInMainAssembly>
-
      <_ResourceNameInMainAssembly Condition="'$(UICulture)' != ''">$(AssemblyName).unlocalizable.g.resources</_ResourceNameInMainAssembly>
-
-
   </PropertyGroup>
 
 
@@ -807,7 +770,6 @@
 
             <!-- Put the generated files in item FileWrites so that they can be cleaned up appropriately in a next Rebuild -->
             <Output ItemName="FileWrites" TaskParameter="OutputResourcesFile" />
-
 
       </ResourcesGenerator>
 
@@ -978,7 +940,6 @@
                    AdditionalMetadata="CopyToOutputDirectory=PreserveNewest; TargetPath=$(AssemblyName).loc" >
            <Output ItemName="_NoneWithTargetPath" TaskParameter="Include"/>
            <Output ItemName="FileWrites" TaskParameter="Include"/>
-
        </CreateItem>
 
   </Target>
@@ -1010,8 +971,7 @@
     </ItemGroup>
 
   </Target>
+
   <!-- End of the project file, Do not add any more propeties, items, targets etc. -->
 
-
 </Project>
-


### PR DESCRIPTION
Don't import .NET Framework's WinFX targets, When the SDK's implementation is being used and vice versa

**Reference**: microsoft/msbuild#4948