### PR TITLE
#include <tuple> to matrix_t.hpp

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/common/DirectXLayer/interfaces/matrix_t.hpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/common/DirectXLayer/interfaces/matrix_t.hpp
@@ -11,6 +11,7 @@
 #include "quaternion_t.hpp"
 
 #include <vector>
+#include <tuple>
 
 namespace dxlayer
 {


### PR DESCRIPTION
The builds will start failing soon when building using Dev16.7 previews (I'm on Version 16.7.0 Preview 3.0 [30126.5.master]) with the following errors: 

```
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\control\util\util.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\effects\effects.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\api\api.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\av\av.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\scanop\scanop.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\common\common.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\shared\shared.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\glyph\glyph.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\sw\swlib\sw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\geometry\Geometry.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\targets\targets.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\hw\hw.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\meta\meta.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\fxjit\Platform\Platform.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\resources\resources.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(135,1): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(134,17): error C2027: use of undefined type 'std::tuple<dxlayer::vector3_t<dxlayer::dxapi::xmath>,dxlayer::quaternion_t<dxlayer::dxapi::xmath>,dxlayer::vector3_t<dxlayer::dxapi::xmath>>' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,25): error C2039: 'make_tuple': is not a member of 'std' [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,1): error C2065: 'make_tuple': undeclared identifier [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,36): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\common\DirectXLayer\xmath\matrix_xm.hpp(142,17): error C2275: 'dxlayer::vector3_t<dxlayer::dxapi::xmath>': illegal use of this type as an expression [\wpf\src\Microsoft.DotNet.Wpf\src\WpfGfx\core\uce\uce.vcxproj]
```

The fix is rather simple, and corrects an oversight I must've introduced a long time ago 😞 

/cc @SamBent 