### PR TITLE
Update branding for 3.1.6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
       Version prefix used by a few projects like Project Templates
       Revision portion of Major.Minor.Revision usually updated every release
     -->
-    <TraditionalVersionPrefix>3.1.5</TraditionalVersionPrefix>
+    <TraditionalVersionPrefix>3.1.6</TraditionalVersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>


### PR DESCRIPTION
Update branding for 3.1.6

Includes the merge from internal/release/3.1 (847da8feefa286affd3f458fc3fdcedcd0d93869) which resulted in no changes after resolving merge conflicts.  No MSRCs were taken for this release, so that is expected. 