### PR TITLE
Update global.json SDK and tools version to include fix for _BlockWinMDsOnSupportedTFMs causing build failures

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.6.20310.4",
+    "dotnet": "5.0.100-preview.6.20323.1",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20316.1"
   },
   "sdk": {
-    "version": "5.0.100-preview.6.20310.4"
+    "version": "5.0.100-preview.6.20323.1"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",


### PR DESCRIPTION
This update (darc-master-89e15d90-235e-4313-959a-f0283bd51d70) caused APICompat to start failing. APICompat expects PresentationUI.dll to exist in wpf.tools\native\bin\net-framework-48-ref-assemblies\0.0.0.1.

The is due to the initial version of the _BlockWinMDsOnUnsupportedTFMs target: 

`.dotnet\sdk\5.0.100-preview.6.20310.4\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.targets`

<Target Name="_BlockWinMDsOnUnsupportedTFMs"
BeforeTargets="CoreCompile"
DependsOnTargets="ResolveReferences"

The version of the SDK must include the fix for _BlockWinMDsOnUnsupportedTFMs (Preview6.20310.4 does not include the fix).  Update global.json SDK and tools version to include fix for _BlockWinMDsOnSupportedTFMs.
