### PR TITLE
Remove workarounds

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -121,10 +121,7 @@
     
     Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
   --> 
-  <ItemGroup Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And 
-                        '$(_TargetFrameworkVersionValue)' != '' And
-                        '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And 
-                        '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
+  <ItemGroup Condition=" '$(_EnableWindowsDesktopSupportUnsupportedTargetFramework)' == 'true' ">
 
     <!-- 
         Windows Forms and WPF are supported only on .NET Core 3.0+

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -121,7 +121,7 @@
     
     Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
   --> 
-  <ItemGroup Condition=" '$(_EnableWindowsDesktopSupportUnsupportedTargetFramework)' == 'true' ">
+  <ItemGroup Condition=" '$(_RemoveUnsupportedTargetFrameworksForWindowsDesktop)' == 'true' ">
 
     <!-- 
         Windows Forms and WPF are supported only on .NET Core 3.0+

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -79,15 +79,15 @@
     <_WpfCommonNetFxReference Include="PresentationCore" />
     <_WpfCommonNetFxReference Include="PresentationFramework" />
 
-    <_WpfCommonNetFxReference Include="System.Xaml" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'">
+    <_WpfCommonNetFxReference Include="System.Xaml" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.0'">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </_WpfCommonNetFxReference>
-    <_WpfCommonNetFxReference Include="UIAutomationClient" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationClientSideProviders" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationProvider" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
-    <_WpfCommonNetFxReference Include="UIAutomationTypes" Condition="'$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationClient" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationClientSideProviders" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationProvider" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.0'" />
+    <_WpfCommonNetFxReference Include="UIAutomationTypes" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.0'" />
 
-    <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionValue)' >= '4.5'" />
+    <_WpfCommonNetFxReference Include="System.Windows.Controls.Ribbon" Condition="'$(_TargetFrameworkVersionValue)' != '' And '$(_TargetFrameworkVersionValue)' >= '4.5'" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(_EnableWindowsDesktopNETFrameworkImplicitReference)' == 'true' ">
@@ -122,6 +122,7 @@
     Detect these situations and skip updates to @(SupportedTargetFramework) etc. 
   --> 
   <ItemGroup Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And 
+                        '$(_TargetFrameworkVersionValue)' != '' And
                         '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And 
                         '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">
 

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -52,11 +52,6 @@
     <_TargetFrameworkVersionValue>$([MSBuild]::ValueOrDefault('$(_TargetFrameworkVersionWithoutV)', '$(_UndefinedTargetFrameworkVersion)'))</_TargetFrameworkVersionValue>
   </PropertyGroup>
 
-  <!-- Set 7.0 as the TargetPlatformVersion for windows. -->
-  <PropertyGroup Condition="'$(TargetPlatformIdentifier)' == 'windows' and '$(TargetPlatformVersion)' == ''" >
-    <TargetPlatformVersion>7.0</TargetPlatformVersion>
-  </PropertyGroup>
-
     <!-- PropertyGroup flags control if Itemgroups in Microsoft.NET.Sdk.WindowsDesktop.props file is being imported -->
   <PropertyGroup>
       <_EnableWindowsDesktopGlobbing Condition=" ('$(EnableDefaultItems)' == 'true') And ('$(UseWPF)' == 'true') And

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -65,9 +65,9 @@
                         ('$(TargetFrameworkIdentifier)' == '.NETFramework') And
                         ('$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)') And
                         ('$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)')">true</_EnableWindowsDesktopNETFrameworkImplicitReference>
-      <_EnableWindowsDesktopSupportUnsupportedTargetFramework Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And
+      <_RemoveUnsupportedTargetFrameworksForWindowsDesktop Condition="('$(UseWPF)' == 'true' Or '$(UseWindowsForms)' == 'true') And
                         '$(_TargetFrameworkVersionValue)' != '$(_UndefinedTargetFrameworkVersion)' And
-                        '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">true</_EnableWindowsDesktopSupportUnsupportedTargetFramework>
+                        '$(_TargetFrameworkVersionValue)' >= '$(_WindowsDesktopSdkTargetFrameworkVersionFloor)'">true</_RemoveUnsupportedTargetFrameworksForWindowsDesktop>
   </PropertyGroup>
 
   


### PR DESCRIPTION
Please review by commit. These are 3 additional changes related to WindowsDesktop SDK.

8ecabfc is to solve https://github.com/dotnet/sdk/issues/12403 (currently has a workaround in SDK)
7baee74 is solve a simple mistake
f309b4b is moved due to dotnet/sdk@d21aaa5

Tested against _WPF-Samples\Graphics\Point_. And all SDK unit tests

SDK side change https://github.com/dotnet/sdk/pull/12459