### PR TITLE
Call SHA1.HashData static helper instead of instantiating SHA1CSP

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/GuidGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/GuidGenerator.cs
@@ -136,11 +136,7 @@ namespace WinRT
                 return new Guid(sig);
             }
             var data = wrt_pinterface_namespace.ToByteArray().Concat(UTF8Encoding.UTF8.GetBytes(sig)).ToArray();
-            using (SHA1 sha = new SHA1CryptoServiceProvider())
-            {
-                var hash = sha.ComputeHash(data);
-                return encode_guid(hash);
-            }
+            return encode_guid(SHA1.HashData(data));
         }
     }
 }


### PR DESCRIPTION
We're trying to minimize usage of the `*CryptoServiceProvider` and `*Managed` types through our code bases so that we can eventually write analyzers to recommend moving off of them. See https://github.com/dotnet/runtime/issues/40169 for some related discussion w.r.t. `RNGCryptoServiceProvider`.

This PR changes the call site to use the static one-shot helper method so that you don't need to instantiate a hasher object. The `HashData` static method uses the best available implementation for the current OS.