### PR TITLE
Remove private Cpp tools in favor of using production tools

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,4 +9,5 @@
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources />
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -61,9 +61,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="5.0.0-preview.8.20412.2">
+    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="5.0.0-rc.1.20414.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
-      <Sha>ae770e8f2bf4dffba628c0175bacb036e27987db</Sha>
+      <Sha>ce881edd67d5f2a607c0b20848aad2f67cb94b31</Sha>
     </Dependency>
     <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,93 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-rc.1.20370.3">
+    <Dependency Name="Microsoft.Private.Winforms" Version="5.0.0-rc.1.20413.3">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>5854f1b352559b04cc4969b0ea2241af517fcdfa</Sha>
+      <Sha>0ef3c13d76f1b2496ae1810d38a676e2e72adaf1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.Win32.Registry" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.CodeDom" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.EventLog" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Drawing.Common" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.Emit" Version="5.0.0-alpha.1.19563.6">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>5cee7c97d602f294e27c582d4dab81ec388f1d7b</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.AccessControl" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Permissions" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Principal.Windows" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Windows.Extensions" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="5.0.0-rc.1.20414.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>ce881edd67d5f2a607c0b20848aad2f67cb94b31</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.Packaging" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19562.1">
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>d5bb8bf2437d447750cf0203dd55bb5160ff36b8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-preview.8.20363.2" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App.Internal" Version="5.0.0-rc.1.20412.8" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2d9dbbb538322a7cc05397f5e2e15d445c7d3ff0</Sha>
+      <Sha>0db8ecbea291c09cfd84d7f33ea049f5c0cec94f</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -91,25 +91,25 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20407.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20411.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ea8f37e8982dc22022b33c5e151081ad04d923a6</Sha>
+      <Sha>ecec08a0eebbd92bb9538e351d475582551d9092</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.20407.3">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.20411.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ea8f37e8982dc22022b33c5e151081ad04d923a6</Sha>
+      <Sha>ecec08a0eebbd92bb9538e351d475582551d9092</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20407.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20411.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ea8f37e8982dc22022b33c5e151081ad04d923a6</Sha>
+      <Sha>ecec08a0eebbd92bb9538e351d475582551d9092</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20407.3">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20411.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ea8f37e8982dc22022b33c5e151081ad04d923a6</Sha>
+      <Sha>ecec08a0eebbd92bb9538e351d475582551d9092</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20407.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20411.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ea8f37e8982dc22022b33c5e151081ad04d923a6</Sha>
+      <Sha>ecec08a0eebbd92bb9538e351d475582551d9092</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -96,6 +96,6 @@
     <SystemReflectionMetadataLoadContextPackage>System.Reflection.MetadataLoadContext</SystemReflectionMetadataLoadContextPackage>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetWpfDncEngVersion>5.0.0-preview.8.20412.2</MicrosoftDotNetWpfDncEngVersion>
+    <MicrosoftDotNetWpfDncEngVersion>5.0.0-rc.1.20414.3</MicrosoftDotNetWpfDncEngVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,40 +4,40 @@
     <VersionPrefix>5.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <SystemIOPackagingVersion>5.0.0-preview.8.20363.2</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsVersion>5.0.0-preview.8.20363.2</SystemResourcesExtensionsVersion>
+    <SystemIOPackagingVersion>5.0.0-rc.1.20412.8</SystemIOPackagingVersion>
+    <SystemResourcesExtensionsVersion>5.0.0-rc.1.20412.8</SystemResourcesExtensionsVersion>
   </PropertyGroup>
   <!-- NuGet Package Versions -->
   <PropertyGroup>
-    <MicrosoftPrivateWinformsVersion>5.0.0-rc.1.20370.3</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>5.0.0-rc.1.20413.3</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/coreclr -->
   <PropertyGroup>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19562.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
-    <MicrosoftNETCoreILDAsmVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreILDAsmVersion>
-    <MicrosoftNETCoreILAsmVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreILDAsmVersion>5.0.0-rc.1.20412.8</MicrosoftNETCoreILDAsmVersion>
+    <MicrosoftNETCoreILAsmVersion>5.0.0-rc.1.20412.8</MicrosoftNETCoreILAsmVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppInternalVersion>5.0.0-preview.8.20363.2</MicrosoftNETCoreAppInternalVersion>
-    <MicrosoftNETCorePlatformsVersion>5.0.0-preview.8.20363.2</MicrosoftNETCorePlatformsVersion>
-    <SystemDrawingCommonVersion>5.0.0-preview.8.20363.2</SystemDrawingCommonVersion>
-    <SystemDirectoryServicesVersion>5.0.0-preview.8.20363.2</SystemDirectoryServicesVersion>
-    <SystemReflectionMetadataLoadContextVersion>5.0.0-preview.8.20363.2</SystemReflectionMetadataLoadContextVersion>
+    <MicrosoftNETCoreAppInternalVersion>5.0.0-rc.1.20412.8</MicrosoftNETCoreAppInternalVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-rc.1.20412.8</MicrosoftNETCorePlatformsVersion>
+    <SystemDrawingCommonVersion>5.0.0-rc.1.20412.8</SystemDrawingCommonVersion>
+    <SystemDirectoryServicesVersion>5.0.0-rc.1.20412.8</SystemDirectoryServicesVersion>
+    <SystemReflectionMetadataLoadContextVersion>5.0.0-rc.1.20412.8</SystemReflectionMetadataLoadContextVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/corefx via core-setup coherency parent dependency -->
   <PropertyGroup>
-    <MicrosoftWin32RegistryPackageVersion>5.0.0-preview.8.20363.2</MicrosoftWin32RegistryPackageVersion>
-    <SystemCodeDomPackageVersion>5.0.0-preview.8.20363.2</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-preview.8.20363.2</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>5.0.0-preview.8.20363.2</SystemDiagnosticsEventLogPackageVersion>
+    <MicrosoftWin32RegistryPackageVersion>5.0.0-rc.1.20412.8</MicrosoftWin32RegistryPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-rc.1.20412.8</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>5.0.0-rc.1.20412.8</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>5.0.0-rc.1.20412.8</SystemDiagnosticsEventLogPackageVersion>
     <SystemReflectionEmitPackageVersion>5.0.0-alpha.1.19563.6</SystemReflectionEmitPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview4.19176.11</SystemReflectionTypeExtensionsPackageVersion>
-    <SystemSecurityAccessControlPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityAccessControlPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityPermissionsPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0-preview.8.20363.2</SystemSecurityPrincipalWindowsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>5.0.0-preview.8.20363.2</SystemWindowsExtensionsPackageVersion>
+    <SystemSecurityAccessControlPackageVersion>5.0.0-rc.1.20412.8</SystemSecurityAccessControlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>5.0.0-rc.1.20412.8</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>5.0.0-rc.1.20412.8</SystemSecurityPermissionsPackageVersion>
+    <SystemSecurityPrincipalWindowsPackageVersion>5.0.0-rc.1.20412.8</SystemSecurityPrincipalWindowsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>5.0.0-rc.1.20412.8</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/arcade -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,9 +41,9 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/arcade -->
   <PropertyGroup>
-    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20407.3</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>5.0.0-beta.20407.3</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20407.3</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20411.8</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>5.0.0-beta.20411.8</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20411.8</MicrosoftDotNetGenAPIVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/corefxlab -->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,8 +64,8 @@
     <!-- 
         Also in global.json 
         Used in Wpf.Cpp.PrivateTools.props/targets 
-    -->
     <MsvcurtC1xxVersion>0.0.1.2</MsvcurtC1xxVersion>
+    -->
     <!--
     This is the version of the test infrastructure package is compiled against. This should be
     removed as part of https://github.com/dotnet/wpf/issues/816 

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -122,10 +122,6 @@
     <!-- Always use Static VC Runtime -->
     <UseStaticVCRT Condition="'$(UseStaticVCRT)'==''">true</UseStaticVCRT>
 
-    <!-- Set up Directories -->
-    <VcrtLibDir>$(VCToolsInstallDir)lib\$(Architecture)\</VcrtLibDir>
-    <UcrtLibDir>$(UniversalCRTSdkDir)Lib\$(WindowsTargetPlatformVersion)\UCRT\$(Architecture)\</UcrtLibDir>
-
     <LibSuffix Condition="'$(Configuration)'=='Debug'">d</LibSuffix>
 
     <!-- Always link to oldnames.lib and legacy_stdio_wide_specifiers.lib   -->
@@ -266,8 +262,6 @@
       <AdditionalOptions Condition="'$(ManagedCxx)'=='false'">%(AdditionalOptions) /MACHINE:$(Architecture)</AdditionalOptions>
       <TargetMachine>Machine$(Architecture)</TargetMachine>
 
-
-      <AdditionalLibraryDirectories Condition="('$(ManagedCxx)'=='false') and ('$(ExplicitCrts)'=='true')">$(VcrtLibDir);$(UcrtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="('$(ManagedCxx)'=='false') and ('$(ExplicitCrts)'=='true')">%(AdditionalDependencies);$(StandardLibrariesForNativeCpp)</AdditionalDependencies>
       <AdditionalOptions Condition="('$(ManagedCxx)'=='false') and ('$(ExplicitCrts)'=='true')">%(AdditionalOptions) $(NoDefaultLibClauseForRuntimeLibs) $(DisallowLibClause)</AdditionalOptions>
       <AdditionalOptions Condition="'$(DllRenameClause)'!=''">%(AdditionalOptions) $(DllRenameClause)</AdditionalOptions>

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -105,7 +105,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <UsePrivateCppTools Condition="'$(UsePrivateCppTools)' == ''">true</UsePrivateCppTools>
+    <UsePrivateCppTools Condition="'$(UsePrivateCppTools)' == ''">false</UsePrivateCppTools>
   </PropertyGroup>
   <Import Project="Wpf.Cpp.PrivateTools.props" Condition="Exists('Wpf.Cpp.PrivateTools.props') And '$(UsePrivateCppTools)'=='true'"/>
   

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -4,6 +4,15 @@
     <NativeVersionFileDirectory>$([System.IO.Path]::GetDirectoryName($(NativeVersionFile)))</NativeVersionFileDirectory>
     <NativeResourceFileWithVersionInformation Condition="'$(NativeResourceFileWithVersionInformation)' == ''">$(IntermediateOutputPath)ExtendedNativeVersion.rc</NativeResourceFileWithVersionInformation>
   </PropertyGroup>
+  
+  <PropertyGroup>
+      <!-- 
+           Set up Directories 
+           Must be done after importing Microsoft.Cpp.VCTools.props
+      -->
+    <VcrtLibDir>$(VCToolsInstallDir)lib\$(Architecture)\</VcrtLibDir>
+    <UcrtLibDir>$(UniversalCRTSdkDir)Lib\$(WindowsTargetPlatformVersion)\UCRT\$(Architecture)\</UcrtLibDir>
+  </PropertyGroup>
 
   <Import Project="Wpf.Cpp.PrivateTools.targets" Condition="Exists('Wpf.Cpp.PrivateTools.targets') And '$(UsePrivateCppTools)'=='true'"/>
   
@@ -27,6 +36,9 @@
                                          '$(ConfigurationType)' == '$(StaticLibrary)' and
                                          '$(RepositoryName)' == 'dotnet-wpf-int'">oldStyle</DebugInformationFormat>
     </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories Condition="('$(ExplicitCrts)'=='true')">$(VcrtLibDir);$(UcrtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(NativeVersionFileDirectory)</AdditionalIncludeDirectories>
     </ResourceCompile>

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -42,6 +42,7 @@ function Build([string]$target) {
     /p:Configuration=$configuration `
     /p:RepoRoot=$RepoRoot `
     /p:BaseIntermediateOutputPath=$outputPath `
+    /v:$verbosity `
     @properties
 }
 

--- a/global.json
+++ b/global.json
@@ -12,8 +12,8 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20407.3",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20407.3"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20411.8",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20411.8"
   },
   "sdk": {
     "version": "5.0.100-preview.6.20323.1"

--- a/global.json
+++ b/global.json
@@ -22,7 +22,6 @@
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
     "dotnet-api-docs_netcoreapp3.0": "0.0.0.2",
-    "msvcurt-c1xx": "0.0.1.2",
     "net-framework-472-iltools": "0.0.0.1"
   }
 }

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.cpp
@@ -92,7 +92,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
         _pFactory = (IDWriteFactory*)factoryTemp;
     }
 
+    #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
     [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+    #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
     __declspec(noinline) bool Factory::ReleaseHandle()
     {
         if (_wpfFontCollectionLoader != nullptr)

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Factory.h
@@ -79,7 +79,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
         protected:
 
+            #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+            #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             virtual bool ReleaseHandle() override;
 
         internal:
@@ -221,7 +223,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
 
             virtual property bool IsInvalid
             {
+                #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
                 [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+                #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
                 bool get() override;
             }
     };

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/NativePointerWrapper.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/NativePointerWrapper.h
@@ -20,7 +20,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface { n
 
             virtual property bool IsInvalid
             {
+                #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
                 [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+                #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
                 bool get() override;
             }
 
@@ -35,7 +37,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface { n
     {
         protected:
 
+            #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+            #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             virtual bool ReleaseHandle() override;
 
         public:
@@ -47,7 +51,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface { n
     {
         protected:
 
+            #pragma warning (disable : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             [ReliabilityContract(Consistency::WillNotCorruptState, Cer::Success)]
+            #pragma warning (default : 4950) // The Constrained Execution Region (CER) feature is not supported.  
             virtual bool ReleaseHandle() override;
 
         public:

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsTablet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/Win32/UnsafeNativeMethodsTablet.cs
@@ -85,14 +85,18 @@ namespace MS.Win32.Recognizer
         // call ReleaseHandle for you.
         public override bool IsInvalid
         {
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             get
             {
                 return IsClosed || handle == IntPtr.Zero;
             }
         }
 
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         override protected bool ReleaseHandle()
         {
             Debug.Assert(handle != IntPtr.Zero);
@@ -122,7 +126,9 @@ namespace MS.Win32.Recognizer
         // call ReleaseHandle for you.
         public override bool IsInvalid
         {
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             get
             {
                 return IsClosed || handle == IntPtr.Zero;
@@ -130,7 +136,9 @@ namespace MS.Win32.Recognizer
         }
 
 
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         override protected bool ReleaseHandle()
         {
             //Note: It is not an error to have already called DestroyRecognizer

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
@@ -524,7 +524,10 @@ namespace MS.Win32.PresentationCore
             [DllImport(DllImport.MilCore, EntryPoint = "MILAddRef")]
             internal static extern UInt32 AddRef(SafeReversePInvokeWrapper pIUnknown);
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             [DllImport(DllImport.MilCore, EntryPoint = "MILRelease"), ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
+
             internal static extern int Release(IntPtr pIUnkown);
 
             internal static void ReleaseInterface(ref IntPtr ptr)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1768,7 +1768,9 @@ namespace System.Windows
 
                     formatter = new BinaryFormatter();
 
+                    #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
                     formatter.Serialize(stream, data);
+                    #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete
                     return SaveStreamToHandle(handle, stream, doNotReallocate);
                 }
             }
@@ -3122,7 +3124,9 @@ namespace System.Windows
                     }
                     try
                     {
+                        #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
                         value = formatter.Deserialize(stream);
+                        #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                     }
                     catch (RestrictedTypeDeserializationException)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AssemblyFilter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AssemblyFilter.cs
@@ -48,7 +48,9 @@ namespace MS.Internal
                 if (!a.ReflectionOnly)
                 {
                     // check if it is in the Gac , this ensures that we eliminate any non GAC assembly which are of no risk
+                    #pragma warning disable SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete.
                     if (a.GlobalAssemblyCache)
+                    #pragma warning restore SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete.
                     {
                         string assemblyName = AssemblyNameWithFileVersion(a);
                         // If we are on the disallowed list kill the application domain

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -109,7 +109,9 @@ namespace MS.Internal.AppModel
 
             try
             {
+                #pragma warning disable // Type or member is obsolete
                 entryLocation = new Uri(Application.ResourceAssembly.CodeBase);
+                #pragma warning restore // Type or member is obsolete
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -252,7 +252,9 @@ namespace MS.Internal.AppModel
             // We do not care about assemblies loaded into the reflection-only context or the Gaced assemblies.
             // For example, in Sparkle whenever a project is built all dependent assemblies will be loaded reflection only.
             // We do no care about those. Only when a assembly is loaded into the execution context, we will need to update the cache. 
+            #pragma warning disable SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete.
             if ((!assembly.ReflectionOnly) && (!assembly.GlobalAssemblyCache))
+            #pragma warning restore SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete.
             {
                 AssemblyName assemblyInfo = new AssemblyName(assembly.FullName);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
@@ -126,7 +126,9 @@ namespace MS.Internal.AppModel
                         {
                             // Convert the value of the DP into a byte array
                             MemoryStream byteStream = new MemoryStream();
+                            #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
                             this.Formatter.Serialize(byteStream, currentValue);
+                            #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                             
                             bytes = byteStream.ToArray();
                             // Dispose the stream
@@ -236,7 +238,9 @@ namespace MS.Internal.AppModel
                     object newValue = null;
                     if (subStream._data != null)
                     {
+                        #pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete 
                         newValue = this.Formatter.Deserialize(new MemoryStream(subStream._data));
+                        #pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete 
                     }
                     element.SetValue(dp, newValue);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Navigation/BindStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Navigation/BindStream.cs
@@ -291,6 +291,7 @@ namespace MS.Internal.Navigation
         /// Overridden InitializeLifetimeService method
         /// </summary>
         /// <returns></returns>
+        [ObsoleteAttribute("InitializeLifetimeService is obsolete.", false)]
         public override object InitializeLifetimeService()
         {
             return _stream.InitializeLifetimeService();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -229,7 +229,9 @@ namespace System.Windows.Markup
             // so they can be loaded again.   The is the Dev build/load/build/load
             // Designer scenario.  (Don't mess with GACed assemblies)
             Assembly assem = ReflectionHelper.GetAlreadyLoadedAssembly(asmName);
+            #pragma warning disable SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete. 
             if (assem != null && !assem.GlobalAssemblyCache)
+            #pragma warning restore SYSLIB0005 // 'Assembly.GlobalAssemblyCache' is obsolete. 
             {
                 ReflectionHelper.ResetCacheForAssembly(asmName);
                 // No way to reset SchemaContext at assembly granularity, so just reset the whole context

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -1389,7 +1389,9 @@ namespace Standard
 
         private SafeDC() : base(true) { }
 
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         protected override bool ReleaseHandle()
         {
             if (_created)
@@ -1512,7 +1514,9 @@ namespace Standard
     {
         private SafeHBITMAP() : base(true) { }
 
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         protected override bool ReleaseHandle()
         {
             return NativeMethods.DeleteObject(handle);
@@ -1523,7 +1527,9 @@ namespace Standard
     {
         private SafeGdiplusStartupToken() : base(true) { }
 
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         protected override bool ReleaseHandle()
         {
             Status s = NativeMethods.GdiplusShutdown(this.handle);
@@ -1592,7 +1598,9 @@ namespace Standard
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         protected override bool ReleaseHandle()
         {
             try
@@ -2657,7 +2665,9 @@ namespace Standard
 
         [SuppressMessage("Mricrosoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("kernel32.dll")]
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool FindClose(IntPtr handle);
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/MS/Internal/Printing/Configuration/UnsafeNativeMethods.cs
@@ -76,7 +76,9 @@ namespace MS.Internal.Printing.Configuration
         /// <param name="handle">device handle proxy has been bound to</param>
         /// <returns>HRESULT code</returns>
         [DllImport(DllImport.PrntvPt, EntryPoint = "PTCloseProvider", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         public static extern uint PTCloseProviderImpl(IntPtr handle);
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockWrapper.cs
@@ -299,7 +299,9 @@ namespace MS.Internal
             /// <summary>
             ///     Wait for a set of handles.
             /// </summary>
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             [PrePrepareMethod]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
             {
                 return MS.Win32.UnsafeNativeMethods.WaitForMultipleObjectsEx(waitHandles.Length, waitHandles, waitAll, millisecondsTimeout, false);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsOther.cs
@@ -258,7 +258,9 @@ namespace MS.Win32
             private BitmapHandle(bool ownsHandle) : base(ownsHandle, NativeMethods.CommonHandles.GDI)
             {
             }
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             protected override bool ReleaseHandle()
             {
                 return UnsafeNativeMethods.DeleteObject(handle);
@@ -284,7 +286,9 @@ namespace MS.Win32
             {
             }
             
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             protected override bool ReleaseHandle()
             {
                 return UnsafeNativeMethods.DestroyIcon(handle);
@@ -310,7 +314,9 @@ namespace MS.Win32
             {
             }
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             protected override bool ReleaseHandle()
             {
                 return UnsafeNativeMethods.DestroyCursor( handle );
@@ -588,7 +594,9 @@ namespace MS.Win32
 		        return (LocalFree(base.handle) == IntPtr.Zero);
 		    }
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
 		    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             [DllImport("kernel32.dll")]
 		    private static extern IntPtr LocalFree(IntPtr hMem);
 		}

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
@@ -170,7 +170,9 @@ namespace MS.Win32
         /// </summary>
         /// <param name="hMem"></param>
         /// <returns></returns>
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
         [DllImport(ExternDll.Kernel32, SetLastError = true), ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
         internal static extern IntPtr LocalFree(IntPtr hMem);
 
 #if BASE_NATIVEMETHODS
@@ -636,7 +638,9 @@ namespace MS.Win32
             }
         }
         [DllImport(ExternDll.User32, EntryPoint = "GetIconInfo", CharSet = CharSet.Auto, SetLastError = true)]
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
         private static extern bool GetIconInfoImpl(HandleRef hIcon, [Out] ICONINFO_IMPL piconinfo);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -660,7 +664,9 @@ namespace MS.Win32
             piconinfo = new NativeMethods.ICONINFO();
             ICONINFO_IMPL iconInfoImpl = new ICONINFO_IMPL();
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             SRCS.RuntimeHelpers.PrepareConstrainedRegions(); // Mark the following as special
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
             try
             {
                 // Intentionally empty

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/GDIExporter/precomp.hpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/GDIExporter/precomp.hpp
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+// Turn off CER warnings: The Constrained Execution Region (CER) feature is not supported.  
+#pragma warning (disable : 4950)
         
 #ifndef GDIEXPORTER
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/InteropPrinterHandler.hpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/InteropPrinterHandler.hpp
@@ -6,6 +6,10 @@
 
 #ifndef __INTEROPPRINTERHANDLER_HPP__
 #define __INTEROPPRINTERHANDLER_HPP__
+
+// Turn off CER warnings: The Constrained Execution Region (CER) feature is not supported.  
+#pragma warning (disable : 4950) 
+
 /*++
     Abstract:
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/otherassemblyattrs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/otherassemblyattrs.cs
@@ -14,7 +14,9 @@ using System.Windows.Markup;
 [assembly:Dependency("System.Xml,", LoadHint.Sometimes)]
 
 [assembly: TypeForwardedTo(typeof(System.Xaml.Permissions.XamlAccessLevel))]
+#pragma warning disable SYSLIB0003 // Type or member is obsolete
 [assembly: TypeForwardedTo(typeof(System.Xaml.Permissions.XamlLoadPermission))]
+#pragma warning restore SYSLIB0003 // Type or member is obsolete
 [assembly: TypeForwardedTo(typeof(System.Windows.Markup.ValueSerializerAttribute))]
 
 [assembly:XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System.Windows.Markup")]

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -503,7 +503,9 @@ namespace MS.Internal.Automation
             }
             else
             {
+                #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
                 RuntimeHelpers.PrepareConstrainedRegions();
+                #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
                 bool fRelease = false;
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
@@ -44,7 +44,9 @@ namespace System.Windows.Automation
             SafeConditionMemoryHandle sh = new SafeConditionMemoryHandle();
             int size = Marshal.SizeOf(uiaCondition);
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             RuntimeHelpers.PrepareConstrainedRegions(); // ensures that the following finally block is atomic
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             try { }
             finally
             {
@@ -64,7 +66,9 @@ namespace System.Windows.Automation
 
             int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
 
+            #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             RuntimeHelpers.PrepareConstrainedRegions(); // ensures that the following finally block is atomic
+            #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
             try { }
             finally
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -995,7 +995,9 @@ namespace MS.Internal.AutomationProxies
             }
             else
             {
+                #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
                 RuntimeHelpers.PrepareConstrainedRegions();
+                #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
                 bool fRelease = false;
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/OtherAssemblyAttrs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/OtherAssemblyAttrs.cs
@@ -85,6 +85,7 @@ using System.Windows.Markup;
 [assembly:TypeForwardedTo(typeof(System.IO.Packaging.PackageRelationshipSelector))] 
 [assembly:TypeForwardedTo(typeof(System.IO.Packaging.PackageRelationshipSelectorType))]
 
+#pragma warning disable SYSLIB0003 // Type or member is obsolete
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.MediaPermissionAudio))]
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.MediaPermissionVideo))]
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.MediaPermissionImage))]
@@ -93,6 +94,7 @@ using System.Windows.Markup;
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.WebBrowserPermissionLevel))]
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.WebBrowserPermission))]
 [assembly: TypeForwardedTo(typeof(System.Security.Permissions.WebBrowserPermissionAttribute))]
+#pragma warning restore SYSLIB0003 // Type or member is obsolete
 
 [assembly: TypeForwardedTo(typeof(System.Collections.ObjectModel.ReadOnlyObservableCollection<>))]
 [assembly: TypeForwardedTo(typeof(System.Collections.ObjectModel.ObservableCollection<>))]

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
@@ -89,7 +89,9 @@ namespace System.Windows.Threading
         /// <summary>
         ///     Wait for a set of handles.
         /// </summary>
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.
         [PrePrepareMethod]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.
         public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
         {
             if(_dispatcher._disableProcessingCount > 0)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
@@ -1881,7 +1881,9 @@ namespace System.Windows.Threading
         public override System.Threading.SynchronizationContext CreateCopy() { throw null; }
         public override void Post(System.Threading.SendOrPostCallback d, object state) { }
         public override void Send(System.Threading.SendOrPostCallback d, object state) { }
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported. 
         public override int Wait(System.IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout) { throw null; }
     }
     public partial class DispatcherTimer

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/MS/Win32/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/MS/Win32/UnsafeNativeMethods.cs
@@ -52,7 +52,9 @@ namespace MS.Win32
         }
 
         [DllImport(ExternDll.Gdi32, ExactSpelling = true, CharSet = CharSet.Auto)]
+        #pragma warning disable SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #pragma warning restore SYSLIB0004 // The Constrained Execution Region (CER) feature is not supported.  
         [ResourceExposure(ResourceScope.None)]
         public static extern bool DeleteDC(IntPtr hDC);
     }

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/BaseMatrix.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/BaseMatrix.cpp
@@ -1031,7 +1031,12 @@ ComputePrefilteredSize(
 #undef pow
 #define RESTORE_POW
 #endif 
-            uPrefiltered = CFloatFPU::Ceiling(uOriginal * std::pow(rScaleThreshold, nExp));
+            // The result of std::pow should be safe to static_cast to REAL since 
+            // rScaleThreshold <= 1 (this is assert'ed early in the method).
+            //
+            //   Assert(rScaleThreshold <= 1.0f);    // Failure is handled with log check
+
+            uPrefiltered = CFloatFPU::Ceiling(uOriginal * TOREAL(std::pow(rScaleThreshold, nExp)));
 #if defined(RESTORE_POW)
 #pragma pop_macro("pow")
 #endif 


### PR DESCRIPTION
Unpin privatized C++ toolsets and ship using real-signed shipping tools
> #2857 introduced use of privatized C++/CLI toolsets. This is a temporary fix and should be rolled back in favor of production tools.

Tracked by issue #2870. 

> //build and RC/RTM products should not ship using these tools - they should be changed to production tools obtained from ambient tools coming from build pipeline machines.

> This would become possible as soon as Dev16.6p3 ships.

> **This should be treated as a release blocker for broad releases like //build, RC etc **

/cc @dotnet/wpf-developers

Requires part 2 (see @vatsan-madhavan's comment): 

> You'll need to make 2 additional changes when fixing this one.

> wpfcontrib@11c24e3
> Disable LTCG for bilinearspan.lib. This causes error C1047 when compilers change. Though this is only a transient problem, it can be a bother in dev-builds.
> Here is a preview of an upcoming build failure:

> C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.28.29115\include\yvals_core.h(503,1): fatal error C1189: #error: STL1001: Unexpected compiler version, expected MSVC 19.27 or newer.


