### PR TITLE
Fix RuntimeFrameworkReferences for RTM builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -93,6 +93,14 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1dfd9438149f74ae11918a7b0709b8d58c61443f</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.1.20428.3" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1dfd9438149f74ae11918a7b0709b8d58c61443f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20428.3" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1dfd9438149f74ae11918a7b0709b8d58c61443f</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20419.21">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,8 @@
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>
     <MicrosoftNETCoreAppInternalVersion>5.0.0-rc.1.20428.3</MicrosoftNETCoreAppInternalVersion>
+    <MicrosoftNETCoreAppRefVersion>5.0.0-rc.1.20428.3</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>5.0.0-rc.1.20428.3</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftNETCorePlatformsVersion>5.0.0-rc.1.20428.3</MicrosoftNETCorePlatformsVersion>
     <SystemDrawingCommonVersion>5.0.0-rc.1.20428.3</SystemDrawingCommonVersion>
     <SystemDirectoryServicesVersion>5.0.0-rc.1.20428.3</SystemDirectoryServicesVersion>

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppInternalVersion)'!='' And 
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)'!='' And 
                                         '$(NoTargets)'!='true' And 
                                          '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And 
-                                         ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0')">$(MicrosoftNETCoreAppInternalVersion)</RuntimeFrameworkVersion>
+                                         ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0')">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -13,12 +13,12 @@
                                 Condition="'$(ManagedCxx)'=='true'"/>
     
     <FrameworkReference Update="Microsoft.NETCore.App"
-                      Condition="'$(MicrosoftNETCoreAppInternalVersion)'!='' 
+                      Condition="'$(MicrosoftNETCoreAppRefVersion)'!='' 
                              And '$(NoTargets)'!='true' 
                              And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
                              And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v5.0') 
                              And '$(MSBuildProjectExtension)'!='.vcxproj'">
-      <TargetingPackVersion>$(MicrosoftNETCoreAppInternalVersion)</TargetingPackVersion>
+      <TargetingPackVersion>$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
     </FrameworkReference>
 
     <!-- 


### PR DESCRIPTION
In RTM and post-RTM, the ref pack will rev less frequently, and so the ref pack version should be used for the targeting pack version.
In addition, the RuntimeFrameworkVersion should be set to a property that will track the stable version of the runtime, rather than the internal version.