### PR TITLE
added label "ResourceKey" to trace details when resource is not found

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
@@ -1656,7 +1656,7 @@ namespace MS.Internal
             {
                 if ( _ResourceNotFound == null )
                 {
-                    _ResourceNotFound = new AvTraceDetails(9, new string[] { "Resource not found" } );
+                    _ResourceNotFound = new AvTraceDetails(9, new string[] { "Resource not found", "ResourceKey" } );
                 }
 
                 return _ResourceNotFound;


### PR DESCRIPTION
Fixes #2956

# Summary of issue

When targeting .NET Framework, not finding a `ResourceDictionary` key named `someKey` causes
> System.Windows.ResourceDictionary Warning: 9 : Resource not found; ResourceKey='someKey'

to be written to `PresentationTraceSources.ResourceDictionarySource`, but when targeting .NET Core, that message is only
> System.Windows.ResourceDictionary Warning: 9 : Resource not found

# Contribution

This branch contributes a fix.  I want to explain both why it is a fix and why (I think) it is the correct fix.

## A fix

The change adds `"ResourceKey"` to a string array.  That array is later passed into 
https://github.com/dotnet/wpf/blob/b15227213778b882c11f788bb8679fd52bf88ddb/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs#L256-L261

as the `labels` argument.  With the code currently in `master`, the relevant arguments for the cases in question are
- `labels = new string[] { "Resource not found" }` and
- `parameters = new object[] { "someKey" }`.

Confusingly, the first argument in that array is the same as the `message` argument, so the first entry in `labels` is ignored in this function.  As the comment points out, `note: labels start at index 1, parameters start at index 0`.  Then the body of this for-loop is never executed.

https://github.com/dotnet/wpf/blob/b15227213778b882c11f788bb8679fd52bf88ddb/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs#L281-L287

With my change, the relevant arguments are
- `labels = new string[] { "Resource not found", "ResourceKey" }` and
- `parameters = new object[] { "someKey" }`.

The body of the for-loop executes once to append `; ResourceKey='someKey'` to `traceBuilder`.

## Correct fix

### No unintended consequences

A concern with any bug fix is that it doesn't only fix the bug in question but also has some unintended consequence.  I don't think my change has any unintended consequences.  The line I changed alters the definition of `TraceResourceDictionary.ResourceNotFound`.  According to my searches, the only two references to that property are these two, which both lead to the code to which I linked in the previous section and the behavior I described there.

https://github.com/dotnet/wpf/blob/b15227213778b882c11f788bb8679fd52bf88ddb/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs#L1147-L1158

### Comparison with .NET Framework source

I tried to analyze the same code in .NET Framework and statically verify what I know to be true via testing, which is that .NET Framework does not contain the bug in question.  I didn't quite succeed though.  Considering the reference source, I tracked down the same [two](https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/windows/FrameworkElement.cs,1147) [calls](https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/windows/FrameworkElement.cs,1153) to `TraceResourceDictionary.ResourceNotFound`, but I wasn't able to find `TraceResourceDictionary` in the reference source.

### Generated?

I am concerned that the change I made is in a file that is in a folder called `Generated`.  Did I edit generated code?