### PR TITLE
Add BindingFailed event for diagnostics of binding failures

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Diagnostics/XamlSourceInfoHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Diagnostics/XamlSourceInfoHelper.cs
@@ -31,6 +31,8 @@ namespace System.Windows.Diagnostics
 {
     internal static class XamlSourceInfoHelper
     {
+        public const string XamlSourceInfoEnvironmentVariable = "ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO";
+
         // Weak reference storage to map objects to their markup location. It is fast enough, e.g. it takes
         // about 50ms to add 100K entries (small test app, Debug build, under debugger, dev laptop).
         private static ConditionalWeakTable<object, XamlSourceInfo> s_sourceInfoTable; // no storage by default
@@ -56,7 +58,7 @@ namespace System.Windows.Diagnostics
         private static void InitializeEnableXamlSourceInfo(string value)
         {
             if (VisualDiagnostics.IsEnabled &&
-                VisualDiagnostics.IsEnvironmentVariableSet(value, "ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO") &&
+                VisualDiagnostics.IsEnvironmentVariableSet(value, XamlSourceInfoHelper.XamlSourceInfoEnvironmentVariable) &&
                 InitializeXamlObjectEventArgs())
             {
                 s_sourceInfoTable = new ConditionalWeakTable<object, XamlSourceInfo>();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CLRBindingWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CLRBindingWorker.cs
@@ -488,7 +488,7 @@ namespace MS.Internal.Data
                 SourceValueInfo svi = PW.GetSourceValueInfo(k);
                 Type type = PW.GetType(k);
                 string parentName = (k > 0) ? PW.GetSourceValueInfo(k - 1).name : String.Empty;
-                TraceData.Trace(ParentBindingExpression.TraceLevel,
+                TraceData.TraceAndNotify(ParentBindingExpression.TraceLevel,
                         TraceData.CannotGetClrRawValue(
                             svi.propertyName, type.Name,
                             parentName, AvTrace.TypeName(item)),
@@ -502,7 +502,7 @@ namespace MS.Internal.Data
             {
                 SourceValueInfo svi = PW.GetSourceValueInfo(k);
                 Type type = PW.GetType(k);
-                TraceData.Trace(TraceEventType.Error,
+                TraceData.TraceAndNotify(TraceEventType.Error,
                         TraceData.CannotSetClrRawValue(
                             svi.propertyName, type.Name,
                             AvTrace.TypeName(item),
@@ -521,7 +521,7 @@ namespace MS.Internal.Data
                     // There is probably no data item; e.g. we've moved currency off of a list.
                     // the type of the missing item is supposed to be _arySVS[k].info.DeclaringType
                     // the property we're looking for is named _arySVS[k].name
-                    TraceData.Trace(TraceEventType.Information, TraceData.MissingDataItem, ParentBindingExpression);
+                    TraceData.TraceAndNotify(TraceEventType.Information, TraceData.MissingDataItem, ParentBindingExpression);
                 }
 
                 if (info == null)
@@ -531,7 +531,7 @@ namespace MS.Internal.Data
                     // this can happen when parent is Nullable with no value
                     // check _arySVS[k-1].info.ComponentType
                     //if (!IsNullableType(_arySVS[k-1].info.ComponentType))
-                    TraceData.Trace(TraceEventType.Information, TraceData.MissingInfo, ParentBindingExpression);
+                    TraceData.TraceAndNotify(TraceEventType.Information, TraceData.MissingInfo, ParentBindingExpression);
                 }
 
                 if (item == BindingExpression.NullDataItem)
@@ -539,7 +539,7 @@ namespace MS.Internal.Data
                     // this is OK, not an error.
                     // this can happen when detaching bindings.
                     // this can happen when binding has a Nullable data item with no value
-                    TraceData.Trace(TraceEventType.Information, TraceData.NullDataItem, ParentBindingExpression);
+                    TraceData.TraceAndNotify(TraceEventType.Information, TraceData.NullDataItem, ParentBindingExpression);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/DefaultValueConverter.cs
@@ -335,7 +335,7 @@ namespace MS.Internal.Data
             {
                 if ((culture != null) && (savedEx != null))
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                         TraceData.DefaultValueConverterFailedForCulture(
                             AvTrace.ToStringHelper(o),
                             AvTrace.TypeName(o),
@@ -345,7 +345,7 @@ namespace MS.Internal.Data
                 }
                 else if (needAssignment)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                         TraceData.DefaultValueConverterFailed(
                             AvTrace.ToStringHelper(o),
                             AvTrace.TypeName(o),

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/EnumerableCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/EnumerableCollectionView.cs
@@ -586,7 +586,7 @@ namespace MS.Internal.Data
                     if (TraceData.IsEnabled && !_warningHasBeenRaised)
                     {
                         _warningHasBeenRaised = true;
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotify(TraceEventType.Warning,
                             TraceData.CollectionChangedWithoutNotification(SourceCollection.GetType().FullName));
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ObjectRef.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ObjectRef.cs
@@ -157,7 +157,7 @@ namespace MS.Internal.Data
 
                     if (args.IsTracing)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotify(TraceEventType.Warning,
                                             TraceData.ElementNameQueryTemplate(
                                                 _name,
                                                 TraceData.Identify(d)));
@@ -203,7 +203,7 @@ namespace MS.Internal.Data
 
                 if (args.IsTracing)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.ElementNameQuery(
                                             _name,
                                             TraceData.Identify(fo.DO)));
@@ -417,7 +417,7 @@ namespace MS.Internal.Data
 
             if (args.IsTracing)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.RelativeSource(
                                         _relativeSource.Mode,
                                         TraceData.Identify(d)));
@@ -528,7 +528,7 @@ namespace MS.Internal.Data
             if (ic == null)
             {
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.RefPreviousNotInContext);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.RefPreviousNotInContext);
                 return null;
             }
 
@@ -550,7 +550,7 @@ namespace MS.Internal.Data
             {
                 d = null;
                 if ((j < 0) && TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.RefNoWrapperInChildren);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.RefNoWrapperInChildren);
             }
             return d;
         }
@@ -560,13 +560,13 @@ namespace MS.Internal.Data
             if (type == null)
             {
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.RefAncestorTypeNotSpecified);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.RefAncestorTypeNotSpecified);
                 return null;
             }
             if (level < 1)
             {
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.RefAncestorLevelInvalid);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.RefAncestorLevelInvalid);
                 return null;
             }
 
@@ -578,7 +578,7 @@ namespace MS.Internal.Data
             {
                 if (isTracing)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.AncestorLookup(
                                             type.Name,
                                             TraceData.Identify(fo.DO)));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PropertyPathWorker.cs
@@ -320,13 +320,14 @@ namespace MS.Internal.Data
                 if (accessor == DependencyProperty.UnsetValue)
                     accessor = null;
 
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GetValue(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         level,
                                         TraceData.Identify(item),
                                         TraceData.IdentifyAccessor(accessor),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    _host.ParentBindingExpression);
             }
 
             return value;
@@ -344,13 +345,14 @@ namespace MS.Internal.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.SetValue(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         level,
                                         TraceData.Identify(item),
                                         TraceData.IdentifyAccessor(_arySVS[level].info),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    _host.ParentBindingExpression);
             }
 
             switch (SVI[level].type)
@@ -756,11 +758,12 @@ namespace MS.Internal.Data
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.ReplaceItemShort(
                                             TraceData.Identify(_host.ParentBindingExpression),
                                             k,
-                                            TraceData.Identify(newO)));
+                                            TraceData.Identify(newO)),
+                                        _host.ParentBindingExpression);
                 }
 
                 return;
@@ -849,12 +852,13 @@ namespace MS.Internal.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.ReplaceItemLong(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         k,
                                         TraceData.Identify(newO),
-                                        TraceData.IdentifyAccessor(svs.info)));
+                                        TraceData.IdentifyAccessor(svs.info)),
+                                    _host.ParentBindingExpression);
             }
 
             // start listening to new item
@@ -933,9 +937,10 @@ namespace MS.Internal.Data
                     if (!SystemXmlHelper.IsEmptyXmlDataCollection(parent))
                     {
                         SourceValueInfo svi = SVI[k];
+                        bool inCollection = (svi.drillIn == DrillIn.Always);
                         string cs = (svi.type != SourceValueType.Indexer) ? svi.name : "[" + svi.name + "]";
                         string ps = TraceData.DescribeSourceObject(parent);
-                        string os = (svi.drillIn == DrillIn.Always) ? "current item of collection" : "object";
+                        string os = inCollection ? "current item of collection" : "object";
 
                         // if the parent is null, the path error probably only means the
                         // data provider hasn't produced any data yet.  When it does,
@@ -943,18 +948,20 @@ namespace MS.Internal.Data
                         // feedback for this special case, so as not to alarm users unduly.
                         if (parent == null)
                         {
-                            TraceData.Trace(TraceEventType.Information, TraceData.NullItem(cs, os), bindingExpression);
+                            TraceData.TraceAndNotify(TraceEventType.Information, TraceData.NullItem(cs, os), bindingExpression);
                         }
                         // Similarly, if the parent is the NewItemPlaceholder.
                         else if (parent == CollectionView.NewItemPlaceholder ||
                                 parent == DataGrid.NewItemPlaceholder)
                         {
-                            TraceData.Trace(TraceEventType.Information, TraceData.PlaceholderItem(cs, os), bindingExpression);
+                            TraceData.TraceAndNotify(TraceEventType.Information, TraceData.PlaceholderItem(cs, os), bindingExpression);
                         }
                         else
                         {
                             TraceEventType traceType = (bindingExpression != null) ? bindingExpression.TraceLevel : TraceEventType.Error;
-                            TraceData.Trace(traceType, TraceData.ClrReplaceItem(cs, ps, os), bindingExpression);
+                            TraceData.TraceAndNotify(traceType, TraceData.ClrReplaceItem(cs, ps, os), bindingExpression,
+                                traceParameters: new object[] { bindingExpression },
+                                eventParameters: new object[] { cs, parent, inCollection });
                         }
                     }
                     else
@@ -1042,11 +1049,12 @@ namespace MS.Internal.Data
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.GetInfo_Reuse(
                                             TraceData.Identify(_host.ParentBindingExpression),
                                             k,
-                                            TraceData.IdentifyAccessor(svs.info)));
+                                            TraceData.IdentifyAccessor(svs.info)),
+                                        _host.ParentBindingExpression);
                 }
                 return;
             }
@@ -1061,10 +1069,11 @@ namespace MS.Internal.Data
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.GetInfo_Null(
                                             TraceData.Identify(_host.ParentBindingExpression),
-                                            k));
+                                            k),
+                                        _host.ParentBindingExpression);
                 }
                 return;
             }
@@ -1093,13 +1102,14 @@ namespace MS.Internal.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.GetInfo_Cache(
                                                 TraceData.Identify(_host.ParentBindingExpression),
                                                 k,
                                                 newType.Name,
                                                 SVI[k].name,
-                                                TraceData.IdentifyAccessor(svs.info)));
+                                                TraceData.IdentifyAccessor(svs.info)),
+                                            _host.ParentBindingExpression);
                     }
 
 #if DEBUG   // compute the answer the old-fashioned way, and compare
@@ -1120,13 +1130,14 @@ namespace MS.Internal.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.GetInfo_Property(
                                                 TraceData.Identify(_host.ParentBindingExpression),
                                                 k,
                                                 newType.Name,
                                                 SVI[k].name,
-                                                TraceData.IdentifyAccessor(info)));
+                                                TraceData.IdentifyAccessor(info)),
+                                            _host.ParentBindingExpression);
                     }
 
                     DependencyProperty dp;
@@ -1224,13 +1235,14 @@ namespace MS.Internal.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.GetInfo_Indexer(
                                                 TraceData.Identify(_host.ParentBindingExpression),
                                                 k,
                                                 newType.Name,
                                                 SVI[k].name,
-                                                TraceData.IdentifyAccessor(info)));
+                                                TraceData.IdentifyAccessor(info)),
+                                            _host.ParentBindingExpression);
                     }
 
                     break;
@@ -1733,11 +1745,12 @@ namespace MS.Internal.Data
         {
             if (IsExtendedTraceEnabled(TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         "PropertyChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    _host.ParentBindingExpression);
             }
 
             _host.OnSourcePropertyChanged(sender, e.PropertyName);
@@ -1747,11 +1760,12 @@ namespace MS.Internal.Data
         {
             if (IsExtendedTraceEnabled(TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         "ValueChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    _host.ParentBindingExpression);
             }
 
             _host.OnSourcePropertyChanged(sender, e.PropertyDescriptor.Name);
@@ -1769,11 +1783,12 @@ namespace MS.Internal.Data
         {
             if (IsExtendedTraceEnabled(TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(_host.ParentBindingExpression),
                                         "PropertyChanged",
-                                        "(static)"));
+                                        "(static)"),
+                                    _host.ParentBindingExpression);
             }
 
             _host.OnSourcePropertyChanged(sender, e.PropertyName);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/XmlBindingWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/XmlBindingWorker.cs
@@ -155,10 +155,11 @@ namespace MS.Internal.Data
         {
             if (TraceData.IsEnabled)
             {
-                TraceData.Trace(traceType,
+                TraceData.TraceAndNotifyWithNoParameters(traceType,
                                     TraceData.BadXPath(
                                         XPath,
-                                        IdentifyNode(ContextNode)));
+                                        IdentifyNode(ContextNode)),
+                                    ParentBindingExpression);
             }
         }
 
@@ -187,10 +188,11 @@ namespace MS.Internal.Data
             {
                 if (_contextNode != value && TraceData.IsExtendedTraceEnabled(ParentBindingExpression, TraceDataLevel.ReplaceItem))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.XmlContextNode(
                                             TraceData.Identify(ParentBindingExpression),
-                                            IdentifyNode(value)));
+                                            IdentifyNode(value)),
+                                        ParentBindingExpression);
                 }
 
                 _contextNode = value;
@@ -312,8 +314,8 @@ namespace MS.Internal.Data
 
                 if (ContextNode != CollectionView.CurrentItem && TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.XmlBindingToNonXmlCollection, XPath,
-                            ParentBindingExpression, DataItem);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlBindingToNonXmlCollection, ParentBindingExpression,
+                        traceParameters: new object[] { XPath, ParentBindingExpression, DataItem });
                 }
             }
             else
@@ -322,8 +324,8 @@ namespace MS.Internal.Data
 
                 if (ContextNode != DataItem && TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.XmlBindingToNonXml, XPath,
-                            ParentBindingExpression, DataItem);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlBindingToNonXml, ParentBindingExpression,
+                        traceParameters: new object[] { XPath, ParentBindingExpression, DataItem });
                 }
             }
 
@@ -391,10 +393,11 @@ namespace MS.Internal.Data
         {
             if (TraceData.IsExtendedTraceEnabled(ParentBindingExpression, TraceDataLevel.GetValue))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.XmlNewCollection(
                                         TraceData.Identify(ParentBindingExpression),
-                                        IdentifyNodeList(nodes)));
+                                        IdentifyNodeList(nodes)),
+                                    ParentBindingExpression);
             }
 
             QueriedCollection = new XmlDataCollection(XmlDataProvider);
@@ -412,11 +415,12 @@ namespace MS.Internal.Data
         {
             if (TraceData.IsExtendedTraceEnabled(ParentBindingExpression, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(ParentBindingExpression),
                                         "XmlNodeChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    ParentBindingExpression);
             }
 
             ProcessXmlNodeChanged(e);
@@ -472,10 +476,11 @@ namespace MS.Internal.Data
                 {
                     if (TraceData.IsExtendedTraceEnabled(ParentBindingExpression, TraceDataLevel.GetValue))
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.XmlSynchronizeCollection(
                                                 TraceData.Identify(ParentBindingExpression),
-                                                IdentifyNodeList(nodes)));
+                                                IdentifyNodeList(nodes)),
+                                            ParentBindingExpression);
                     }
 
                     // Any xml change action, doesn't matter if it's an insert,
@@ -521,20 +526,21 @@ namespace MS.Internal.Data
                 Status = BindingStatusInternal.PathError;
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.CannotGetXmlNodeCollection,
-                            (ContextNode != null) ? ContextNode.Name : null, XPath,
-                            ParentBindingExpression, xe);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.CannotGetXmlNodeCollection, ParentBindingExpression,
+                        traceParameters: new object[] { (ContextNode != null) ? ContextNode.Name : null, XPath, ParentBindingExpression, xe },
+                        eventParameters: new object[] { xe });
                 }
             }
 
             if (TraceData.IsExtendedTraceEnabled(ParentBindingExpression, TraceDataLevel.GetValue))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.SelectNodes(
                                         TraceData.Identify(ParentBindingExpression),
                                         IdentifyNode(ContextNode),
                                         TraceData.Identify(XPath),
-                                        IdentifyNodeList(nodes)));
+                                        IdentifyNodeList(nodes)),
+                                    ParentBindingExpression);
             }
 
             return nodes;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -334,7 +334,8 @@ namespace MS.Internal
                     if (style != DependencyProperty.UnsetValue &&
                         (style is Style || style is ResourceReferenceExpression))
                     {
-                        TraceData.Trace(TraceEventType.Error, TraceData.StyleAndStyleSelectorDefined(name), d);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.StyleAndStyleSelectorDefined(name), null,
+                            traceParameters: new object[] { d });
                     }
                 }
             }
@@ -360,7 +361,8 @@ namespace MS.Internal
                 {
                     if (IsTemplateDefined(templateProperty, d))
                     {
-                        TraceData.Trace(TraceEventType.Error, TraceData.TemplateAndTemplateSelectorDefined(name), d);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.TemplateAndTemplateSelectorDefined(name), null,
+                            traceParameters: new object[] { d });
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -844,6 +844,8 @@
     <Compile Include="System\Windows\DependencyPropertyHelper.cs" />
     <Compile Include="System\Windows\DescendentsWalker.cs" />
     <Compile Include="System\Windows\DescendentsWalkerBase.cs" />
+    <Compile Include="System\Windows\Diagnostics\BindingDiagnostics.cs" />
+    <Compile Include="System\Windows\Diagnostics\BindingFailedEventArgs.cs" />
     <Compile Include="System\Windows\Diagnostics\ResourceDictionaryDiagnostics.cs" />
     <Compile Include="System\Windows\Diagnostics\ResourceDictionaryEventArgs.cs" />
     <Compile Include="System\Windows\Diagnostics\ResourceDictionaryInfo.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataErrorValidationRule.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataErrorValidationRule.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Controls
 
                         if (TraceData.IsEnabled)
                         {
-                            TraceData.Trace(TraceEventType.Error,
+                            TraceData.TraceAndNotify(TraceEventType.Error,
                                             TraceData.DataErrorInfoFailed(
                                                 name,
                                                 idei.GetType().FullName,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -7249,7 +7249,7 @@ namespace System.Windows.Controls
                 }
                 catch (InvalidOperationException invalidOperationException)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                                     TraceData.CannotSort(sortPropertyName),
                                     invalidOperationException);
                     Items.SortDescriptions.Clear();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -1397,7 +1397,8 @@ namespace System.Windows.Controls
                 // The ItemTemplate isn't used, which may confuse the user (bug 991101).
                 if (ItemTemplate != null || ItemTemplateSelector != null)
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.ItemTemplateForDirectItem, AvTrace.TypeName(item));
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.ItemTemplateForDirectItem, null,
+                        traceParameters: new object[] { AvTrace.TypeName(item) });
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -73,16 +73,18 @@ namespace System.Windows.Data
 
                 if (String.IsNullOrEmpty(binding.XPath))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.BindingPath(
-                                            TraceData.Identify(path)));
+                                            TraceData.Identify(path)),
+                                        this);
                 }
                 else
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.BindingXPathAndPath(
                                             TraceData.Identify(binding.XPath),
-                                            TraceData.Identify(path)));
+                                            TraceData.Identify(path)),
+                                        this);
                 }
             }
         }
@@ -443,7 +445,7 @@ namespace System.Windows.Data
                 // null converter means failure to create one
                 if (converter == null && TraceData.IsEnabled)
                 {
-                     TraceData.Trace(TraceEventType.Error,
+                     TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Error,
                                     TraceData.CannotCreateDefaultValueConverter(
                                         type,
                                         TargetProperty.PropertyType,
@@ -530,10 +532,11 @@ namespace System.Windows.Data
 
                     if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Attach))
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.UseMentor(
                                                 TraceData.Identify(this),
-                                                TraceData.Identify(mentor)));
+                                                TraceData.Identify(mentor)),
+                                            this);
                     }
                 }
             }
@@ -555,9 +558,10 @@ namespace System.Windows.Data
 
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.AttachToContext))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.DeferAttachToContext(
-                                            TraceData.Identify(this)));
+                                            TraceData.Identify(this)),
+                                        this);
                 }
             }
 
@@ -625,10 +629,11 @@ namespace System.Windows.Data
                 {
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.SourceRequiresTreeContext(
                                                 TraceData.Identify(this),
-                                                or.Identify()));
+                                                or.Identify()),
+                                            this);
                     }
 
                     return;
@@ -639,10 +644,11 @@ namespace System.Windows.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.AttachToContext(
                                         TraceData.Identify(this),
-                                        lastChance ? " (last chance)" : String.Empty));
+                                        lastChance ? " (last chance)" : String.Empty),
+                                    this);
             }
 
             // if the path has unresolved type names, the parser needs namesapce
@@ -656,10 +662,11 @@ namespace System.Windows.Data
                 {
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.PathRequiresTreeContext(
                                                 TraceData.Identify(this),
-                                                ParentBinding.Path.Path));
+                                                ParentBinding.Path.Path),
+                                            this);
                     }
 
                     return;
@@ -672,9 +679,10 @@ namespace System.Windows.Data
             {
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
-                                        TraceData.NoMentorExtended(
-                                            TraceData.Identify(this)));
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                        TraceData.NoMentorExtended(
+                            TraceData.Identify(this)),
+                        this);
                 }
 
                 if (lastChance)
@@ -682,7 +690,7 @@ namespace System.Windows.Data
                     SetStatus(BindingStatusInternal.PathError);
                     if (TraceData.IsEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Error, TraceData.NoMentor, this);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.NoMentor, this);
                     }
                 }
                 return;
@@ -730,11 +738,12 @@ namespace System.Windows.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.ContextElement(
                                         TraceData.Identify(this),
                                         TraceData.Identify(contextElement),
-                                        contextElementFound ? "OK" : "error"));
+                                        contextElementFound ? "OK" : "error"),
+                                    this);
             }
 
             // if we need a context element, check that we found it
@@ -745,7 +754,7 @@ namespace System.Windows.Data
                     SetStatus(BindingStatusInternal.PathError);
                     if (TraceData.IsEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Error, TraceData.NoDataContext, this);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.NoDataContext, this);
                     }
                 }
 
@@ -768,9 +777,10 @@ namespace System.Windows.Data
                 {
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
-                                            TraceData.NullDataContext(
-                                                TraceData.Identify(this)));
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                            TraceData.NullDataContext(
+                                TraceData.Identify(this)),
+                            this);
                     }
 
                     return;
@@ -792,7 +802,7 @@ namespace System.Windows.Data
                         SetStatus(BindingStatusInternal.PathError);
                         if (TraceData.IsEnabled)
                         {
-                            TraceData.Trace(TraceLevel, TraceData.NoSource(sourceRef), this);
+                            TraceData.TraceAndNotify(TraceLevel, TraceData.NoSource(sourceRef), this);
                         }
                     }
 
@@ -900,7 +910,7 @@ namespace System.Windows.Data
                                 SetStatus(BindingStatusInternal.PathError);
                                 if (TraceData.IsEnabled)
                                 {
-                                    TraceData.Trace(TraceEventType.Error, TraceData.NoMentor, this);
+                                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.NoMentor, this);
                                 }
                                 return;
                             }
@@ -919,7 +929,7 @@ namespace System.Windows.Data
                     SetStatus(BindingStatusInternal.PathError);
                     if (TraceData.IsEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Error, TraceData.NoDataContext, this);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.NoDataContext, this);
                     }
                     return;
                 }
@@ -965,10 +975,11 @@ namespace System.Windows.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.UseCVS(
                                                 TraceData.Identify(this),
-                                                TraceData.Identify(cvs)));
+                                                TraceData.Identify(cvs)),
+                                            this);
                     }
                 }
                 else
@@ -982,10 +993,11 @@ namespace System.Windows.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.ActivateItem(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(item)));
+                                        TraceData.Identify(item)),
+                                    this);
             }
 
             if (Worker == null)
@@ -1102,9 +1114,10 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Activate))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.Deactivate(
-                                        TraceData.Identify(this)));
+                                        TraceData.Identify(this)),
+                                    this);
             }
 
             // stop transfers
@@ -1158,10 +1171,11 @@ namespace System.Windows.Data
 
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Activate))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.UseDataProvider(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(newDataProvider)));
+                                            TraceData.Identify(newDataProvider)),
+                                        this);
                 }
 
                 if (newDataProvider != null)
@@ -1280,10 +1294,11 @@ namespace System.Windows.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GetRawValue(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
 
             // apply any necessary conversions
@@ -1308,10 +1323,11 @@ namespace System.Windows.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.UserConverter(
                                                 TraceData.Identify(this),
-                                                TraceData.Identify(value)));
+                                                TraceData.Identify(value)),
+                                            this);
                     }
 
                     // chain in a default value converter if the returned value's type is not compatible with the targetType
@@ -1352,10 +1368,11 @@ namespace System.Windows.Data
 
                         if (isExtendedTraceEnabled)
                         {
-                            TraceData.Trace(TraceEventType.Warning,
+                            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                                 TraceData.NullConverter(
                                                     TraceData.Identify(this),
-                                                    TraceData.Identify(value)));
+                                                    TraceData.Identify(value)),
+                                                this);
                         }
                     }
                 #if !TargetNullValueBC   //BreakingChange
@@ -1377,10 +1394,11 @@ namespace System.Windows.Data
 
                         if (isExtendedTraceEnabled)
                         {
-                            TraceData.Trace(TraceEventType.Warning,
+                            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                                 TraceData.ConvertDBNull(
                                                     TraceData.Identify(this),
-                                                    TraceData.Identify(value)));
+                                                    TraceData.Identify(value)),
+                                                this);
                         }
                     }
                 #endif
@@ -1398,10 +1416,11 @@ namespace System.Windows.Data
 
                         if (isExtendedTraceEnabled)
                         {
-                            TraceData.Trace(TraceEventType.Warning,
+                            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                                 TraceData.DefaultConverter(
                                                     TraceData.Identify(this),
-                                                    TraceData.Identify(value)));
+                                                    TraceData.Identify(value)),
+                                                this);
                         }
                     }
                 }
@@ -1428,15 +1447,17 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled && !IsInBindingExpressionCollection)
                 {
-                    TraceData.Trace(TraceLevel, TraceData.BadValueAtTransfer, value, this);
+                    TraceData.TraceAndNotify(TraceLevel, TraceData.BadValueAtTransfer, this,
+                        traceParameters: new object[] { value, this });
                 }
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.BadValueAtTransferExtended(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(value)));
+                                            TraceData.Identify(value)),
+                                        this);
                 }
 
                 value = DependencyProperty.UnsetValue;
@@ -1454,10 +1475,11 @@ namespace System.Windows.Data
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.UseFallback(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(value)));
+                                            TraceData.Identify(value)),
+                                        this);
                 }
             }
 
@@ -1470,10 +1492,11 @@ namespace System.Windows.Data
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.TransferValue(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
 
             // if this is a re-transfer after a source update and the value
@@ -1597,10 +1620,11 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Update))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.ValidationRuleFailed(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(validationRule)));
+                                            TraceData.Identify(validationRule)),
+                                        this);
                 }
 
                 error = new ValidationError(validationRule, this, validationResult.ErrorContent, null);
@@ -1649,7 +1673,7 @@ namespace System.Windows.Data
                 if (TraceData.IsEnabled)
                 {
                     string name = String.IsNullOrEmpty(stringFormat) ? converter.GetType().Name : "StringFormat";
-                    TraceData.Trace(TraceLevel,
+                    TraceData.TraceAndNotify(TraceLevel,
                             TraceData.BadConverterForTransfer(
                                 name,
                                 AvTrace.ToStringHelper(value),
@@ -1662,7 +1686,7 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceLevel,
+                    TraceData.TraceAndNotify(TraceLevel,
                             TraceData.BadConverterForTransfer(
                                 converter.GetType().Name,
                                 AvTrace.ToStringHelper(value),
@@ -1713,7 +1737,7 @@ namespace System.Windows.Data
 
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                         TraceData.BadConverterForUpdate(
                             AvTrace.ToStringHelper(Value),
                             AvTrace.TypeName(value)),
@@ -1727,7 +1751,7 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                         TraceData.BadConverterForUpdate(
                             AvTrace.ToStringHelper(Value),
                             AvTrace.TypeName(value)),
@@ -1830,10 +1854,11 @@ namespace System.Windows.Data
             bool isExtendedTraceEnabled = TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Update);
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.UpdateRawValue(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
 
             Type sourceType = Worker.SourcePropertyType;
@@ -1858,10 +1883,11 @@ namespace System.Windows.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.UserConvertBack(
                                                 TraceData.Identify(this),
-                                                TraceData.Identify(value)));
+                                                TraceData.Identify(value)),
+                                            this);
                     }
 
                     // chain in a default value converter if the returned value's type is not compatible with the sourceType
@@ -1906,20 +1932,22 @@ namespace System.Windows.Data
 
                     if (isExtendedTraceEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                             TraceData.DefaultConvertBack(
                                                 TraceData.Identify(this),
-                                                TraceData.Identify(value)));
+                                                TraceData.Identify(value)),
+                                            this);
                     }
                 }
             }
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.Update(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
 
             // if the conversion failed, signal a validation error
@@ -2003,7 +2031,7 @@ namespace System.Windows.Data
                     throw;
 
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.WorkerUpdateFailed, this, ex);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.WorkerUpdateFailed, this, ex);
 
                 ProcessException(ex, (ValidatesOnExceptions || BindingGroup != null));
                 SetStatus(BindingStatusInternal.UpdateSourceError);
@@ -2012,7 +2040,7 @@ namespace System.Windows.Data
             catch // non CLS compliant exception
             {
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.WorkerUpdateFailed, this);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.WorkerUpdateFailed, this);
 
                 SetStatus(BindingStatusInternal.UpdateSourceError);
                 value = DependencyProperty.UnsetValue;
@@ -2424,11 +2452,12 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(this),
                                         "CurrentChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    this);
             }
 
             Worker.OnCurrentChanged(sender as ICollectionView, e);
@@ -2438,11 +2467,12 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(this),
                                         "CurrentChanging",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    this);
             }
 
             Update();
@@ -2453,11 +2483,12 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(this),
                                         "DataChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    this);
             }
             Activate(sender);
         }
@@ -2466,11 +2497,12 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(this),
                                         "InheritanceContextChanged",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    this);
             }
 
             if (StatusInternal == BindingStatusInternal.Unattached)
@@ -2498,11 +2530,12 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotEvent(
                                         TraceData.Identify(this),
                                         "LostFocus",
-                                        TraceData.Identify(sender)));
+                                        TraceData.Identify(sender)),
+                                    this);
             }
 
             Update();
@@ -2628,11 +2661,12 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GotPropertyChanged(
                                         TraceData.Identify(this),
                                         TraceData.Identify(d),
-                                        dp.Name));
+                                        dp.Name),
+                                    this);
             }
 
             if (dp == FrameworkElement.DataContextProperty)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -161,18 +161,20 @@ namespace System.Windows.Data
             {
                 if (parent == null)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.CreatedExpression(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(binding)));
+                                            TraceData.Identify(binding)),
+                                        this);
                 }
                 else
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.CreatedExpressionInParent(
                                             TraceData.Identify(this),
                                             TraceData.Identify(binding),
-                                            TraceData.Identify(parent)));
+                                            TraceData.Identify(parent)),
+                                        this);
                 }
             }
 
@@ -940,10 +942,11 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Attach))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.AttachExpression(
                                         TraceData.Identify(this),
-                                        target.GetType().FullName, dp.Name, AvTrace.GetHashCodeHelper(target)));
+                                        target.GetType().FullName, dp.Name, AvTrace.GetHashCodeHelper(target)),
+                                    this);
             }
 
             return true;
@@ -975,9 +978,10 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Attach))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.DetachExpression(
-                                        TraceData.Identify(this)));
+                                        TraceData.Identify(this)),
+                                    this);
             }
         }
 
@@ -1193,10 +1197,11 @@ namespace System.Windows.Data
                         {
                             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Update))
                             {
-                                TraceData.Trace(TraceEventType.Warning,
+                                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                                     TraceData.ValidationRuleFailed(
                                                         TraceData.Identify(this),
-                                                        TraceData.Identify(validationRule)));
+                                                        TraceData.Identify(validationRule)),
+                                                    this);
                             }
 
                             UpdateValidationError( new ValidationError(validationRule, this, validationResult.ErrorContent, null));
@@ -1277,7 +1282,8 @@ namespace System.Windows.Data
                             // supported (bug 1274874).
                             if (TraceData.IsEnabled)
                             {
-                                TraceData.Trace(TraceEventType.Critical, TraceData.RequiresExplicitCulture, TargetProperty.Name, this);
+                                TraceData.TraceAndNotify(TraceEventType.Critical, TraceData.RequiresExplicitCulture, this,
+                                    traceParameters: new object[] { TargetProperty.Name, this });
                             }
 
                             throw new InvalidOperationException(SR.Get(SRID.RequiresExplicitCulture, TargetProperty.Name));
@@ -1572,7 +1578,7 @@ namespace System.Windows.Data
 
                     if (TraceData.IsEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Information, TraceData.NoValueToTransfer, this);
+                        TraceData.TraceAndNotify(TraceEventType.Information, TraceData.NoValueToTransfer, this);
                     }
                 }
             }
@@ -1756,11 +1762,12 @@ namespace System.Windows.Data
                     {
                         if (bgCandidate.SharesProposedValues && TraceData.IsEnabled)
                         {
-                            TraceData.Trace(TraceEventType.Warning,
+                            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.SharesProposedValuesRequriesImplicitBindingGroup(
                                             TraceData.Identify(this),
                                             groupName,
-                                            TraceData.Identify(bgCandidate)));
+                                            TraceData.Identify(bgCandidate)),
+                                    this);
                         }
 
                         // return the matching group
@@ -1773,7 +1780,7 @@ namespace System.Windows.Data
                 // no match - report an error
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                             TraceData.BindingGroupNameMatchFailed(groupName),
                             this);
                 }
@@ -1824,11 +1831,12 @@ namespace System.Windows.Data
 
                     if (bg.SharesProposedValues && TraceData.IsEnabled)
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                 TraceData.SharesProposedValuesRequriesImplicitBindingGroup(
                                         TraceData.Identify(root),
                                         root.ParentBindingBase.BindingGroupName,
-                                        TraceData.Identify(bg)));
+                                        TraceData.Identify(bg)),
+                                this);
                     }
                 }
             }
@@ -2127,13 +2135,13 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                             TraceData.FallbackConversionFailed(
                                 AvTrace.ToStringHelper(value),
                                 AvTrace.TypeName(value),
                                 dp.Name,
                                 dp.PropertyType.Name),
-                            sender, e);
+                            sender as BindingExpressionBase, e);
                 }
             }
 
@@ -2153,13 +2161,13 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error,
+                    TraceData.TraceAndNotify(TraceEventType.Error,
                             TraceData.TargetNullValueConversionFailed(
                                 AvTrace.ToStringHelper(value),
                                 AvTrace.TypeName(value),
                                 dp.Name,
                                 dp.PropertyType.Name),
-                            sender, e);
+                            sender as BindingExpressionBase, e);
                 }
             }
 
@@ -2516,10 +2524,11 @@ namespace System.Windows.Data
 
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ResolveDefaults))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.ResolveDefaultMode(
                                             TraceData.Identify(this),
-                                            (f == BindingFlags.OneWay) ? BindingMode.OneWay : BindingMode.TwoWay));
+                                            (f == BindingFlags.OneWay) ? BindingMode.OneWay : BindingMode.TwoWay),
+                                        this);
                 }
             }
 
@@ -2535,10 +2544,11 @@ namespace System.Windows.Data
 
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ResolveDefaults))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.ResolveDefaultUpdate(
                                             TraceData.Identify(this),
-                                            ust));
+                                            ust),
+                                        this);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingGroup.cs
@@ -581,7 +581,7 @@ namespace System.Windows.Data
                 TraceData.IsEnabled)
             {
                 string name = (property != null) ? property.Name : "(null)";
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                         TraceData.BindingGroupWrongProperty(name, context.GetType().FullName));
             }
 
@@ -615,7 +615,7 @@ namespace System.Windows.Data
             // is amiss.
             if (_hasMultipleInheritanceContexts && property != ItemsControl.ItemBindingGroupProperty && TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                         TraceData.BindingGroupMultipleInheritance);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -74,7 +74,7 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                         TraceData.CollectionViewIsUnsupported);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/MultiBindingExpression.cs
@@ -191,17 +191,19 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         bool isExtendedTraceEnabled = TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.AttachToContext);
 
         _converter = ParentMultiBinding.Converter;
-        if (_converter == null && String.IsNullOrEmpty(EffectiveStringFormat))
+        if (_converter == null && String.IsNullOrEmpty(EffectiveStringFormat) && TraceData.IsEnabled)
         {
-            TraceData.Trace(TraceEventType.Error, TraceData.MultiBindingHasNoConverter, ParentMultiBinding);
+            TraceData.TraceAndNotify(TraceEventType.Error, TraceData.MultiBindingHasNoConverter, this,
+                traceParameters: new object[] { ParentMultiBinding });
         }
 
         if (isExtendedTraceEnabled)
         {
-            TraceData.Trace(TraceEventType.Warning,
-                                TraceData.AttachToContext(
-                                    TraceData.Identify(this),
-                                    lastChance ? " (last chance)" : String.Empty));
+            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                TraceData.AttachToContext(
+                    TraceData.Identify(this),
+                    lastChance ? " (last chance)" : String.Empty),
+                this);
         }
 
         TransferIsDeferred = true;
@@ -219,9 +221,10 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
-                                    TraceData.ChildNotAttached(
-                                        TraceData.Identify(this)));
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                    TraceData.ChildNotAttached(
+                        TraceData.Identify(this)),
+                    this);
             }
 
             return;
@@ -382,9 +385,10 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.AttachToContext))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.DeferAttachToContext(
-                                        TraceData.Identify(this)));
+                                        TraceData.Identify(this)),
+                                    this);
             }
         }
 
@@ -529,7 +533,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             if (TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceEventType.Error,
+                TraceData.TraceAndNotify(TraceEventType.Error,
                     TraceData.BadMultiConverterForUpdate(
                         Converter.GetType().Name,
                         AvTrace.ToStringHelper(value),
@@ -545,11 +549,12 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             for (int i=0; i<values.Length; ++i)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.UserConvertBackMulti(
                                         TraceData.Identify(this),
                                         i,
-                                        TraceData.Identify(values[i])));
+                                        TraceData.Identify(values[i])),
+                                    this);
             }
         }
 
@@ -557,9 +562,8 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         int count = MutableBindingExpressions.Count;
         if (values.Length != count && TraceData.IsEnabled)
         {
-            TraceData.Trace(TraceEventType.Information, TraceData.MultiValueConverterMismatch,
-                    Converter.GetType().Name, count, values.Length,
-                    TraceData.DescribeTarget(target, TargetProperty));
+            TraceData.TraceAndNotify(TraceEventType.Information, TraceData.MultiValueConverterMismatch, this,
+                traceParameters: new object[] { Converter.GetType().Name, count, values.Length, TraceData.DescribeTarget(target, TargetProperty) });
         }
 
         // use the smaller count
@@ -587,7 +591,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
             }
             else if (value == DependencyProperty.UnsetValue && TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceEventType.Information,
+                TraceData.TraceAndNotify(TraceEventType.Information,
                     TraceData.UnsetValueInMultiBindingExpressionUpdate(
                         Converter.GetType().Name,
                         AvTrace.ToStringHelper(value),
@@ -616,7 +620,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             if (TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceEventType.Error, TraceData.MultiValueConverterMissingForUpdate, this);
+                TraceData.TraceAndNotify(TraceEventType.Error, TraceData.MultiValueConverterMissingForUpdate, this);
             }
 
             return DependencyProperty.UnsetValue;
@@ -1020,7 +1024,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
         if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
         {
-            TraceData.Trace(TraceEventType.Warning,
+            TraceData.TraceAndNotify(TraceEventType.Warning,
                                 TraceData.GotPropertyChanged(
                                     TraceData.Identify(this),
                                     TraceData.Identify(d),
@@ -1093,7 +1097,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
     {
         if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
         {
-            TraceData.Trace(TraceEventType.Warning,
+            TraceData.TraceAndNotify(TraceEventType.Warning,
                                 TraceData.GotEvent(
                                     TraceData.Identify(this),
                                     "LostFocus",
@@ -1165,11 +1169,12 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.GetRawValueMulti(
                                         TraceData.Identify(this),
                                         i,
-                                        TraceData.Identify(_tempValues[i])));
+                                        TraceData.Identify(_tempValues[i])),
+                                    this);
             }
         }
 
@@ -1187,10 +1192,11 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.UserConverter(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(preFormattedValue)));
+                                        TraceData.Identify(preFormattedValue)),
+                                    this);
             }
         }
         else if (EffectiveStringFormat != null)
@@ -1210,7 +1216,7 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             if (TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceEventType.Error, TraceData.MultiValueConverterMissingForTransfer, this);
+                TraceData.TraceAndNotify(TraceEventType.Error, TraceData.MultiValueConverterMissingForTransfer, this);
             }
 
             goto Done;
@@ -1239,10 +1245,11 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                         TraceData.FormattedValue(
                                             TraceData.Identify(this),
-                                            TraceData.Identify(value)));
+                                            TraceData.Identify(value)),
+                                        this);
                 }
             }
             catch (FormatException)
@@ -1252,10 +1259,11 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
-                                        TraceData.FormattingFailed(
-                                            TraceData.Identify(this),
-                                            EffectiveStringFormat));
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                                    TraceData.FormattingFailed(
+                                        TraceData.Identify(this),
+                                        EffectiveStringFormat),
+                                    this);
                 }
             }
         }
@@ -1281,10 +1289,11 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.NullConverter(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
         }
 
@@ -1293,15 +1302,17 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
         {
             if (TraceData.IsEnabled)
             {
-                TraceData.Trace(TraceLevel, TraceData.BadValueAtTransfer, value, this);
+                TraceData.TraceAndNotify(TraceLevel, TraceData.BadValueAtTransfer, this,
+                    traceParameters: new object[] { value, this });
             }
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.BadValueAtTransferExtended(
                                         TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                                        TraceData.Identify(value)),
+                                    this);
             }
 
             value = DependencyProperty.UnsetValue;
@@ -1314,19 +1325,21 @@ public sealed class MultiBindingExpression: BindingExpressionBase, IDataBindEngi
 
             if (isExtendedTraceEnabled)
             {
-                TraceData.Trace(TraceEventType.Warning,
-                                    TraceData.UseFallback(
-                                        TraceData.Identify(this),
-                                        TraceData.Identify(value)));
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                                TraceData.UseFallback(
+                                    TraceData.Identify(this),
+                                    TraceData.Identify(value)),
+                                this);
             }
         }
 
         if (isExtendedTraceEnabled)
         {
-            TraceData.Trace(TraceEventType.Warning,
-                                TraceData.TransferValue(
-                                    TraceData.Identify(this),
-                                    TraceData.Identify(value)));
+            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
+                            TraceData.TransferValue(
+                                TraceData.Identify(this),
+                                TraceData.Identify(value)),
+                            this);
         }
 
         // if this is a re-transfer after a source update and the value

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ObjectDataProvider.cs
@@ -293,7 +293,7 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.BeginQuery(
                                         TraceData.Identify(this),
                                         IsAsynchronous ? "asynchronous" : "synchronous"));
@@ -385,7 +385,7 @@ namespace System.Windows.Data
             if (_mode == SourceMode.NoSource || _objectType == null)
             {
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.ObjectDataProviderHasNoSource);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.ObjectDataProviderHasNoSource);
                 e = new InvalidOperationException(SR.Get(SRID.ObjectDataProviderHasNoSource));
             }
             else
@@ -425,7 +425,7 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.QueryFinished(
                                         TraceData.Identify(this),
                                         Dispatcher.CheckAccess() ? "synchronous" : "asynchronous",
@@ -501,7 +501,11 @@ namespace System.Windows.Data
             {
                 // report known errors through TraceData (instead of throwing exceptions)
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.ObjDPCreateFailed, _objectType.Name, error, e);
+                {
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.ObjDPCreateFailed, null,
+                        traceParameters: new object[] { _objectType.Name, error, e },
+                        eventParameters: new object[] { e });
+                }
 
                 // in async mode we pass all exceptions to main thread;
                 // in sync mode we don't handle unknown exceptions.
@@ -587,7 +591,11 @@ namespace System.Windows.Data
             {
                 // report known errors through TraceData (instead of throwing exceptions)
                 if (TraceData.IsEnabled)
-                    TraceData.Trace(TraceEventType.Error, TraceData.ObjDPInvokeFailed, MethodName, _objectType.Name, error, e);
+                {
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.ObjDPInvokeFailed, null,
+                        traceParameters: new object[] { MethodName, _objectType.Name, error, e },
+                        eventParameters: new object[] { e });
+                }
 
                 // in async mode we pass all exceptions to main thread;
                 // in sync mode we don't handle unknown exceptions.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/PriorityBindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/PriorityBindingExpression.cs
@@ -257,12 +257,13 @@ public sealed class PriorityBindingExpression : BindingExpressionBase
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Transfer))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                     TraceData.PriorityTransfer(
                                         TraceData.Identify(this),
                                         TraceData.Identify(newValue),
                                         _activeIndex,
-                                        TraceData.Identify(bindExpr)));
+                                        TraceData.Identify(bindExpr)),
+                                    this);
             }
 
             // don't invalidate during Attach.  The property engine does it
@@ -576,11 +577,12 @@ public sealed class PriorityBindingExpression : BindingExpressionBase
 
         if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.Events))
         {
-            TraceData.Trace(TraceEventType.Warning,
+            TraceData.TraceAndNotifyWithNoParameters(TraceEventType.Warning,
                                 TraceData.GotPropertyChanged(
                                     TraceData.Identify(this),
                                     TraceData.Identify(d),
-                                    dp.Name));
+                                    dp.Name),
+                                this);
         }
 
         for (int i=0; i<AttentiveBindingExpressions; ++i)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/XmlDataProvider.cs
@@ -274,7 +274,7 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.BeginQuery(
                                         TraceData.Identify(this),
                                         IsAsynchronous ? "asynchronous" : "synchronous"));
@@ -480,7 +480,7 @@ namespace System.Windows.Data
                 {
                     if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.XmlProvider))
                     {
-                        TraceData.Trace(TraceEventType.Warning,
+                        TraceData.TraceAndNotify(TraceEventType.Warning,
                                             TraceData.XmlLoadInline(
                                                 TraceData.Identify(this),
                                                 Dispatcher.CheckAccess() ? "synchronous" : "asynchronous"));
@@ -492,7 +492,7 @@ namespace System.Windows.Data
                 catch (XmlException xmle)
                 {
                     if (TraceData.IsEnabled)
-                        TraceData.Trace(TraceEventType.Error, TraceData.XmlDPInlineDocError, xmle);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlDPInlineDocError, xmle);
                     ex = xmle;
                 }
 
@@ -520,7 +520,7 @@ namespace System.Windows.Data
                 XmlNode root = doc.DocumentElement;
                 if (root != null && root.NamespaceURI == xmlReader.LookupNamespace(String.Empty))
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.XmlNamespaceNotSet);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlNamespaceNotSet);
                 }
             }
 
@@ -534,12 +534,13 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.QueryFinished(
                                             TraceData.Identify(this),
                                             Dispatcher.CheckAccess() ? "synchronous" : "asynchronous",
                                             TraceData.Identify(null),
-                                            TraceData.IdentifyException(ex)));
+                                            TraceData.IdentifyException(ex)),
+                                        ex);
                 }
 
                 // Load failed.  Report the error, and reset
@@ -567,7 +568,7 @@ namespace System.Windows.Data
             {
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.XmlLoadSource(
                                             TraceData.Identify(this),
                                             Dispatcher.CheckAccess() ? "synchronous" : "asynchronous",
@@ -585,7 +586,7 @@ namespace System.Windows.Data
 
                 if (isExtendedTraceEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.XmlLoadDoc(
                                             TraceData.Identify(this)));
                 }
@@ -603,7 +604,9 @@ namespace System.Windows.Data
                 ex = e;
                 if (TraceData.IsEnabled)
                 {
-                    TraceData.Trace(TraceEventType.Error, TraceData.XmlDPAsyncDocError, Source, ex);
+                    TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlDPAsyncDocError, null,
+                        traceParameters: new object[] { Source, ex },
+                        eventParameters: new object[] { ex });
                 }
             }
             //FXCop Fix: CatchNonClsCompliantExceptionsInGeneralHandlers
@@ -616,12 +619,13 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.QueryFinished(
                                             TraceData.Identify(this),
                                             Dispatcher.CheckAccess() ? "synchronous" : "asynchronous",
                                             TraceData.Identify(null),
-                                            TraceData.IdentifyException(ex)));
+                                            TraceData.IdentifyException(ex)),
+                                        ex);
                 }
 
                 // we're done if we got an error up to this point
@@ -651,7 +655,7 @@ namespace System.Windows.Data
             {
                 if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.XmlBuildCollection))
                 {
-                    TraceData.Trace(TraceEventType.Warning,
+                    TraceData.TraceAndNotify(TraceEventType.Warning,
                                         TraceData.XmlBuildCollection(
                                             TraceData.Identify(this)));
                 }
@@ -669,7 +673,7 @@ namespace System.Windows.Data
 
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.QueryFinished(
                                         TraceData.Identify(this),
                                         Dispatcher.CheckAccess() ? "synchronous" : "asynchronous",
@@ -686,7 +690,7 @@ namespace System.Windows.Data
         {
             if (TraceData.IsExtendedTraceEnabled(this, TraceDataLevel.ProviderQuery))
             {
-                TraceData.Trace(TraceEventType.Warning,
+                TraceData.TraceAndNotify(TraceEventType.Warning,
                                     TraceData.QueryResult(
                                         TraceData.Identify(this),
                                         TraceData.Identify(Data)));
@@ -787,7 +791,9 @@ namespace System.Windows.Data
                 catch (XPathException xe)
                 {
                     if (TraceData.IsEnabled)
-                        TraceData.Trace(TraceEventType.Error, TraceData.XmlDPSelectNodesFailed, xpath, xe);
+                        TraceData.TraceAndNotify(TraceEventType.Error, TraceData.XmlDPSelectNodesFailed, null,
+                            traceParameters: new object[] { xpath, xe },
+                            eventParameters: new object[] { xe });
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingDiagnostics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingDiagnostics.cs
@@ -7,7 +7,6 @@
 //  Binding diagnostics API
 //
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace System.Windows.Diagnostics
@@ -21,7 +20,7 @@ namespace System.Windows.Diagnostics
     /// </remarks>
     public static class BindingDiagnostics
     {
-        internal static bool IsEnabled { get; }
+        internal static bool IsEnabled { get; private set; }
 
         private static event EventHandler<BindingFailedEventArgs> bindingFailed;
         private static List<BindingFailedEventArgs> pendingEvents;
@@ -43,6 +42,9 @@ namespace System.Windows.Diagnostics
             }
         }
 
+        /// <summary>
+        /// Handlers of this event should return control to WPF quickly, and not cache BindingFailedEventArgs for future use.
+        /// </summary>
         public static event EventHandler<BindingFailedEventArgs> BindingFailed
         {
             add

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingDiagnostics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingDiagnostics.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Description:
+//  Binding diagnostics API
+//
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace System.Windows.Diagnostics
+{
+    /// <summary>
+    /// Provides a notification infrastructure for listening to binding failure events.
+    /// </summary>
+    /// <remarks>
+    /// This type supports the .NET Framework infrastructure and is not intended to be used directly
+    /// from application code.
+    /// </remarks>
+    public static class BindingDiagnostics
+    {
+        internal static bool IsEnabled { get; }
+
+        private static event EventHandler<BindingFailedEventArgs> bindingFailed;
+        private static List<BindingFailedEventArgs> pendingEvents;
+        private static object pendingEventsLock;
+        private const int maxPendingEvents = 2000;
+
+        static BindingDiagnostics()
+        {
+            BindingDiagnostics.IsEnabled = VisualDiagnostics.IsEnabled && VisualDiagnostics.IsEnvironmentVariableSet(null, XamlSourceInfoHelper.XamlSourceInfoEnvironmentVariable);
+
+            if (BindingDiagnostics.IsEnabled)
+            {
+                // Listeners may miss the initial set of binding failures, so cache events until the first listener attaches.
+                // Normally there will only be one listener added soon after the process starts,
+                // and it will want to know about any binding failures that already happened.
+
+                BindingDiagnostics.pendingEvents = new List<BindingFailedEventArgs>();
+                BindingDiagnostics.pendingEventsLock = new object();
+            }
+        }
+
+        public static event EventHandler<BindingFailedEventArgs> BindingFailed
+        {
+            add
+            {
+                if (BindingDiagnostics.IsEnabled)
+                {
+                    BindingDiagnostics.bindingFailed += value;
+                    BindingDiagnostics.FlushPendingBindingFailedEvents();
+                }
+            }
+
+            remove
+            {
+                BindingDiagnostics.bindingFailed -= value;
+            }
+        }
+
+        /// <summary>
+        /// Flushes all cached binding failure events and stops any further events from being cached.
+        /// </summary>
+        private static void FlushPendingBindingFailedEvents()
+        {
+            if (BindingDiagnostics.pendingEvents != null)
+            {
+                BindingFailedEventArgs[] pendingEventsCopy = null;
+
+                lock (BindingDiagnostics.pendingEventsLock)
+                {
+                    pendingEventsCopy = BindingDiagnostics.pendingEvents?.ToArray();
+
+                    // Don't allow any more event caching
+                    BindingDiagnostics.pendingEvents = null;
+                }
+
+                if (pendingEventsCopy != null)
+                {
+                    foreach (BindingFailedEventArgs args in pendingEventsCopy)
+                    {
+                        BindingDiagnostics.bindingFailed?.Invoke(null, args);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Either triggers the BindingFailed event or caches the event for when the first listener attaches.
+        /// </summary>
+        internal static void NotifyBindingFailed(BindingFailedEventArgs args)
+        {
+            if (!BindingDiagnostics.IsEnabled)
+            {
+                return;
+            }
+
+            if (BindingDiagnostics.pendingEvents != null)
+            {
+                lock (BindingDiagnostics.pendingEventsLock)
+                {
+                    if (BindingDiagnostics.pendingEvents != null)
+                    {
+                        // Limit the pending event count so that memory doesn't grow unbounded if no event handler is ever added
+                        if (BindingDiagnostics.pendingEvents.Count < BindingDiagnostics.maxPendingEvents)
+                        {
+                            BindingDiagnostics.pendingEvents.Add(args);
+                        }
+
+                        return;
+                    }
+                }
+            }
+
+            BindingDiagnostics.bindingFailed?.Invoke(null, args);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingFailedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingFailedEventArgs.cs
@@ -33,6 +33,8 @@ namespace System.Windows.Diagnostics
 
         /// <summary>
         /// Can be null for some failure codes that don't have a BindingExpressionBase context.
+        /// This reference should be used while handling the BindingFailed event and not cached for future use, it
+        /// could be holding onto a lot of objects that could be garbage collected.
         /// </summary>
         public BindingExpressionBase Binding { get; }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingFailedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/BindingFailedEventArgs.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+// Description:
+//      Contains EventArg types raised to communicate BindingFailed events.
+
+using System.Diagnostics;
+using System.Windows.Data;
+
+namespace System.Windows.Diagnostics
+{
+    /// <summary>
+    /// Provides data for <see cref="BindingDiagnostics.BindingFailed"/> 
+    /// </summary>
+    public class BindingFailedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// For filtering failures (warnings, errors, etc).
+        /// </summary>
+        public TraceEventType EventType { get; }
+
+        /// <summary>
+        /// Failure code.
+        /// </summary>
+        public int Code { get; }
+
+        /// <summary>
+        /// This is the full message that is also written to debug output.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Can be null for some failure codes that don't have a BindingExpressionBase context.
+        /// </summary>
+        public BindingExpressionBase Binding { get; }
+
+        /// <summary>
+        /// Extra parameters that are unique to certain failure codes, such as an Exception instance.
+        /// </summary>
+        public object[] Parameters { get; }
+
+        internal BindingFailedEventArgs(TraceEventType eventType, int code, string message, BindingExpressionBase binding, params object[] parameters)
+        {
+            this.EventType = eventType;
+            this.Code = code;
+            this.Message = message ?? string.Empty;
+            this.Binding = binding;
+            this.Parameters = parameters ?? Array.Empty<object>();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Diagnostics/ResourceDictionaryDiagnostics.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Diagnostics
         static ResourceDictionaryDiagnostics()
         {
             IsEnabled = VisualDiagnostics.IsEnabled &&
-                VisualDiagnostics.IsEnvironmentVariableSet(null, "ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO");
+                VisualDiagnostics.IsEnvironmentVariableSet(null, XamlSourceInfoHelper.XamlSourceInfoEnvironmentVariable);
 
             // internal property, not visible to user
             IgnorableProperties.Add(typeof(ResourceDictionary).GetProperty("DeferrableContent"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -9517,6 +9517,18 @@ namespace System.Windows.Data
 }
 namespace System.Windows.Diagnostics
 {
+    public static partial class BindingDiagnostics
+    {
+        public static event System.EventHandler<BindingFailedEventArgs> BindingFailed { add { } remove { } }
+    }
+    public partial class BindingFailedEventArgs
+    {
+        public System.Diagnostics.TraceEventType EventType { get { throw null; } }
+        public int Code { get { throw null; } }
+        public string Message { get { throw null; } }
+        public System.Windows.Data.BindingExpressionBase Binding { get { throw null; } }
+        public object[] Parameters { get { throw null; } }
+    }
     public static partial class ResourceDictionaryDiagnostics
     {
         public static System.Collections.Generic.IEnumerable<System.Windows.Diagnostics.ResourceDictionaryInfo> GenericResourceDictionaries { get { throw null; } }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -205,17 +205,17 @@ namespace MS.Internal
             }
 
             return false;
-}
+        }
 
 
 
-       ///
-       ///  Read the registry to see if WPF tracing is allowed
-       ///
+        ///
+        ///  Read the registry to see if WPF tracing is allowed
+        ///
 
-       [FriendAccessAllowed]
-       static internal bool IsWpfTracingEnabledInRegistry()
-       {
+        [FriendAccessAllowed]
+        static internal bool IsWpfTracingEnabledInRegistry()
+        {
             // First time this is called, initialize from the registry
 
             if( _enabledInRegistry == null )
@@ -235,10 +235,10 @@ namespace MS.Internal
                 // Update the static.  Doing this last protects us from threading problems; worse case, multiple
                 // threads will set the same value into it.
                 _enabledInRegistry = enabled;
-}
+            }
 
             return (bool) _enabledInRegistry;
-}
+        }
 
 
 
@@ -258,14 +258,14 @@ namespace MS.Internal
         //  note: labels start at index 1, parameters start at index 0
         //
 
-        public void Trace( TraceEventType type, int eventId, string message, string[] labels, object[] parameters )
+        public string Trace( TraceEventType type, int eventId, string message, string[] labels, object[] parameters )
         {
             // Don't bother building the string if this trace is going to be ignored.
 
             if( _traceSource == null
                 || !_traceSource.Switch.ShouldTrace( type ))
             {
-                return;
+                return null;
             }
 
 
@@ -317,7 +317,7 @@ namespace MS.Internal
 
                     arrayList.Add( labels[i] );
                     arrayList.Add( parameters[j] );
-}
+                }
 
                 // It's OK if we terminate because we have more lables than parameters;
                 // this is used by traces to have out-values in the Stop message.
@@ -326,14 +326,16 @@ namespace MS.Internal
                 {
                     TraceExtraMessages( traceBuilder, parameters, j );
                 }
-}
+            }
 
             // Send the trace
+
+            string traceMessage = traceBuilder.ToString();
 
             _traceSource.TraceEvent(
                 type,
                 eventId,
-                traceBuilder.ToString(),
+                traceMessage,
                 arrayList.ToArray() );
 
             // When in the debugger, always flush the output, to guarantee that the
@@ -343,7 +345,9 @@ namespace MS.Internal
             {
                 _traceSource.Flush();
             }
-}
+
+            return traceMessage;
+        }
 
 
         //
@@ -465,7 +469,7 @@ namespace MS.Internal
 
                 return 0;
             }
-}
+        }
 
 
         //
@@ -513,7 +517,7 @@ namespace MS.Internal
         static Nullable<bool> _enabledInRegistry = null;
 
         static char[] FormatChars = new char[]{ '{', '}' };
-}
+    }
 
     internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, object[] parameters, int start );
 
@@ -571,7 +575,7 @@ namespace MS.Internal
         {
             return _sb.ToString();
         }
-}
+    }
 
     internal delegate TraceSource GetTraceSourceDelegate();
     internal delegate void ClearTraceSourceDelegate();


### PR DESCRIPTION
Visual Studio 16.8 will include a new set of XAML Binding Failures diagnostic improvements. The challenge with a binding failure is locating the source of the binding in XAML. We determined that to locate a binding failure in XAML, the source location must be provided by the platform. This will allow the user to quickly navigate to the binding failure.

The design is that WPF will trigger a new event any time debug traces are written for a binding failure. Debug traces alone aren’t enough to find the source of the failure. The new event will contain more information about the binding failure, such as the BindingExpression object, which helps locate the binding in the XAML source.

**Risk**

The risk for the runtime is very low because this feature doesn’t get activated for any application running. It only gets executed when the application is run under the debugger.

The new event has no effect on memory or performance unless certain conditions are met (these condition are the same as the existing ResourceDictionaryDiagnostics feature): 

1. VisualDiagnostics must be enabled 
2. The environment variable ENABLE_XAML_DIAGNOSTICS_SOURCE_INFO must be set so that source information is cached for XAML elements 
3. Trace output must be enabled for binding failures, if there’s no trace there’s no event 

**Event cache**

When Visual Studio injects a DLL into the user’s WPF app, it will attach to the new event BindingDiagnostics.BindingFailed. This happens well after the app starts running so it will miss initial failure events. To solve that, all BindingFailed events are cached until VS can add an event handler. There is a limit to the cache, but it will use memory until VS can add the handler. Then the cache is flushed. Again, this cache is only created if the diagnostics conditions are met (environment variable, etc).

Look in the new file BindingDiagnostics.cs for the cache (and most of the new code).

**Testing**

Tests are currently being written in the Visual Studio repository, which will fully test the new BindingFailed event. Tests will also be added to the internal dotnet-wpf-test repository, they have not been added yet but work is starting on that ASAP.