### PR TITLE
Avoid null item AutomationPeers

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridColumnHeadersPresenterAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridColumnHeadersPresenterAutomationPeer.cs
@@ -131,7 +131,7 @@ namespace System.Windows.Automation.Peers
 
                     // protection from indistinguishable items - for example, 2 strings with same value
                     // this scenario does not work in ItemsControl however is not checked for.
-                    if (ItemPeers[dataItem] == null)
+                    if (peer != null && ItemPeers[dataItem] == null)
                     {
                         children.Add(peer);
                         ItemPeers[dataItem] = peer;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GroupItemAutomationPeer.cs
@@ -274,8 +274,8 @@ namespace System.Windows.Automation.Peers
                             // but only if we haven't added a peer for this item during this GetChildrenCore call.
                             bool itemMissingPeerInGlobalStorage = itemsControlAP.ItemPeers[item] == null;
 
-                            if (itemMissingPeerInGlobalStorage
-                                || (peer?.GetParent() == this && addedChildren[item] == null))
+                            if (peer != null && (itemMissingPeerInGlobalStorage
+                                || (peer.GetParent() == this && addedChildren[item] == null)))
                             {
                                 children.Add(peer);
                                 addedChildren[item] = peer;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -199,7 +199,7 @@ namespace System.Windows.Automation.Peers
 
                     // protection from indistinguishable items - for example, 2 strings with same value
                     // this scenario does not work in ItemsControl however is not checked for.
-                    if (_dataChildren[dataItem] == null)
+                    if (peer != null && _dataChildren[dataItem] == null)
                     {
                         children.Add(peer);
                         _dataChildren[dataItem] = peer;


### PR DESCRIPTION
Addresses #3116 
This is a port of a servicing fix in .NET 4.7-4.8

**Issue:** Crash involving automation of ItemsControls

**Discussion:**
This bug arises because some AutomationPeers can add 'null' to their list of children, which leads to NRE in the common method EnsureChildren.  The peer in the repro is a DataGridColumnHeadersPresenterAutomationPeer, but I've identified two other peers with the same flaw.

The flawed peers add null only when 'null' appears as a child in the corresponding visual tree.  This normally doesn't happen, but it can if the visual tree is in a torn state at the time GetChildrenCore is called, specifically if the first few entries of the corresponding visual collection have been set to null but the collection itself has not yet been cleared.  This situation doesn't usually happen either, but it can if the removal of a visual element causes an automation event, COM pumps messages while delivering the event, and the pump finds a message that leads to a (re-entrant) layout pass.
