### PR TITLE
HostVisual threading

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
@@ -404,8 +404,7 @@ namespace System.Windows.Media
                 // Adding commands to a channel is not thread-safe,
                 // we must do the actual work on the same dispatcher thread
                 // where the connection happened.
-                if (CoreAppContextSwitches.HostVisualDisconnectsOnWrongThread ||
-                    (channelDispatcher != null && channelDispatcher.CheckAccess()))
+                if (channelDispatcher != null && channelDispatcher.CheckAccess())
                 {
                     Disconnect(channel,
                                channelDispatcher,
@@ -519,10 +518,7 @@ namespace System.Windows.Media
                                 DUCE.ResourceHandle targetHandle,
                                 DUCE.MultiChannelResource contentRoot)
         {
-            if (!CoreAppContextSwitches.HostVisualDisconnectsOnWrongThread)
-            {
-                channelDispatcher.VerifyAccess();
-            }
+            channelDispatcher.VerifyAccess();
 
             DUCE.CompositionNode.RemoveChild(
                 hostHandle,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
@@ -440,12 +440,6 @@ namespace System.Windows.Media
                     _connectedChannels.Remove(channel);
                 }
             }
-
-            if (removeChannelFromCollection)
-                {
-                    _connectedChannels.Remove(channel);
-                }
-            }
         }
 
         /// <summary>
@@ -576,57 +570,57 @@ namespace System.Windows.Media
         /// </remarks>
         private VisualTarget _target;
 
-    /// <summary>
-    /// The channels we have marshalled the visual target composition root.
-    /// </summary>
-    /// <remarks>
-    /// This field is free-threaded and should be accessed from under a lock.
-    /// </remarks>
-    private Dictionary<DUCE.Channel, Dispatcher> _connectedChannels = new Dictionary<DUCE.Channel, Dispatcher>();
+        /// <summary>
+        /// The channels we have marshalled the visual target composition root.
+        /// </summary>
+        /// <remarks>
+        /// This field is free-threaded and should be accessed from under a lock.
+        /// </remarks>
+        private Dictionary<DUCE.Channel, Dispatcher> _connectedChannels = new Dictionary<DUCE.Channel, Dispatcher>();
 
-    /// <summary>
-    /// Data needed to disconnect the visual target.
-    /// </summary>
-    /// <remarks>
-    /// This field is free-threaded and should be accessed from under a lock.
-    /// It's the head of a singly-linked list of pending disconnect requests,
-    /// each identified by the channel.  In practice, the list is either empty
-    /// or has only one entry.
-    /// </remarks>
-    private static DisconnectData _disconnectData;
+        /// <summary>
+        /// Data needed to disconnect the visual target.
+        /// </summary>
+        /// <remarks>
+        /// This field is free-threaded and should be accessed from under a lock.
+        /// It's the head of a singly-linked list of pending disconnect requests,
+        /// each identified by the channel and HostVisual.  In practice, the list
+        /// is either empty or has only one entry.
+        /// </remarks>
+        private static DisconnectData _disconnectData;
 
-    private class DisconnectData
-    {
-        public DispatcherOperation DispatcherOperation { get; private set; }
-        public DUCE.Channel Channel { get; private set; }
-        public Dispatcher ChannelDispatcher { get; private set; }
-        public HostVisual HostVisual { get; private set; }
-        public DUCE.ResourceHandle HostHandle { get; private set; }
-        public DUCE.ResourceHandle TargetHandle { get; private set; }
-        public DUCE.MultiChannelResource ContentRoot { get; private set; }
-        public DisconnectData Next { get; set; }
-
-        public DisconnectData(DispatcherOperation op,
-                              DUCE.Channel channel,
-                              Dispatcher dispatcher,
-                              HostVisual hostVisual,
-                              DUCE.ResourceHandle hostHandle,
-                              DUCE.ResourceHandle targetHandle,
-                              DUCE.MultiChannelResource contentRoot,
-                              DisconnectData next)
+        private class DisconnectData
         {
-            DispatcherOperation = op;
-            Channel = channel;
-            ChannelDispatcher = dispatcher;
-            HostVisual = hostVisual;
-            HostHandle = hostHandle;
-            TargetHandle = targetHandle;
-            ContentRoot = contentRoot;
-            Next = next;
-        }
-    }
+            public DispatcherOperation DispatcherOperation { get; private set; }
+            public DUCE.Channel Channel { get; private set; }
+            public Dispatcher ChannelDispatcher { get; private set; }
+            public HostVisual HostVisual { get; private set; }
+            public DUCE.ResourceHandle HostHandle { get; private set; }
+            public DUCE.ResourceHandle TargetHandle { get; private set; }
+            public DUCE.MultiChannelResource ContentRoot { get; private set; }
+            public DisconnectData Next { get; set; }
 
-    #endregion Private Fields
-}
+            public DisconnectData(DispatcherOperation op,
+                                  DUCE.Channel channel,
+                                  Dispatcher dispatcher,
+                                  HostVisual hostVisual,
+                                  DUCE.ResourceHandle hostHandle,
+                                  DUCE.ResourceHandle targetHandle,
+                                  DUCE.MultiChannelResource contentRoot,
+                                  DisconnectData next)
+            {
+                DispatcherOperation = op;
+                Channel = channel;
+                ChannelDispatcher = dispatcher;
+                HostVisual = hostVisual;
+                HostHandle = hostHandle;
+                TargetHandle = targetHandle;
+                ContentRoot = contentRoot;
+                Next = next;
+            }
+        }
+
+        #endregion Private Fields
+    }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/exports.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/exports.cs
@@ -365,6 +365,15 @@ namespace System.Windows.Media.Composition
         /// channel.
         /// </summary>
         internal sealed partial class Channel
+        #if ENFORCE_CHANNEL_THREAD_ACCESS
+            : System.Windows.Threading.DispatcherObject
+            // "Producer" operations - adding commands et al. - should only be done
+            // on the thread that created the channel.  These operations are on the
+            // hot path, so we don't add the cost of enforcement.  To detect
+            // violations (which can lead to render-thread failures that
+            // are very difficult to diagnose), build
+            // PresentationCore with ENFORCE_CHANNEL_THREAD_ACCESS defined.
+        #endif
         {
             /// <summary>
             /// Primary channel.
@@ -768,6 +777,10 @@ namespace System.Windows.Media.Composition
                 int cSize,
                 bool sendInSeparateBatch)
             {
+                #if ENFORCE_CHANNEL_THREAD_ACCESS
+                VerifyAccess();
+                #endif
+
                 checked
                 {
                     Invariant.Assert(pCommandData != (byte*)0 && cSize > 0);
@@ -808,6 +821,10 @@ namespace System.Windows.Media.Composition
                 int cbSize,
                 int cbExtra)
             {
+                #if ENFORCE_CHANNEL_THREAD_ACCESS
+                VerifyAccess();
+                #endif
+
                 checked
                 {
                     Invariant.Assert(cbSize > 0);


### PR DESCRIPTION
Addresses #3100
This is a port of a servicing fix in .NET 4.7-4.8

**Issue:** HostVisual can disconnect from its rendering channel on the wrong thread.  This can result in corruption that can crash the render thread, usually in some unrelated activity many minutes (or hours) later.

**Discussion:**
HostVisual sometimes adds commands to the graphics channel on the wrong thread.  And sometimes this leaves the channel in a corrupt state, where the primary handle table releases a slot but the secondary handle table doesn't release the corresponding slot.  This is a time-bomb - the next time the primary table allocates the slot, the secondary table allocation will fail, which will crash the app at the next SyncFlush.  (It could take minutes or hours for this to happen.)

The fix is for HostVisual to marshal the offending work back to the right thread.  I'm also adding checks to detect wrong-thread channel activity, available in private builds.