### PR TITLE
ClearType anti-aliasing

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/glyphrunslave.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/resources/glyphrunslave.cpp
@@ -1029,14 +1029,6 @@ CGlyphRunResource::GetDWriteRenderingMode(__in IDWriteFontFace *pIDWriteFontFace
                             *pDWriteRenderingMode = DWRITE_RENDERING_MODE_CLEARTYPE_NATURAL;
                         }
                     }
-                    else
-                    {
-                        // This assert is here for an equivalence check with .NET Framework 
-                        // when allowing DWrite to choose our rendering mode directly.
-                        Assert((textRenderingMode == MilTextRenderingMode::Auto)
-                            || ((textRenderingMode == MilTextRenderingMode::Aliased)
-                                && !IsDisplayMeasured()));
-                    }
                 }
             }
         }


### PR DESCRIPTION
Addresses #2025 
This is a port of a servicing fix in .NET 4.7-4.8

**Issue:** Text rendered with TextRenderingMode.ClearType send the wrong parameter to DWrite, resulting in poor rendering.

**Discussion:**
The meat of the fix already appears in .NET 5, see #2668.  This PR removes a useless assert, bringing the code into alignment with .NET 4.7/4.8.