### PR TITLE
DataGrid.Copy: fail silently if clipboard is locked

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 using System.Windows.Automation;
@@ -8336,8 +8337,15 @@ namespace System.Windows.Controls
                 dataObject.SetData(format, dataGridStringBuilders[format].ToString(), false /*autoConvert*/);
             }
 
-            Clipboard.CriticalSetDataObject(dataObject, true /* Copy */);
-
+            try
+            {
+                Clipboard.CriticalSetDataObject(dataObject, true /* Copy */);
+            }
+            catch (ExternalException)
+            {
+                // Clipboard failed to set the data object - fail silently.
+                return;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Addresses #3113 
This is a port of a servicing fix in .NET 4.5-4.8

**Issue:**  DataGrid's Copy command crashes the app if the clipboard is locked. 

**Discussion:**
DataGrid's Copy command throws an exception if the clipboard is locked (after the usual round of retries).  There is usually no app code on the stack, so this exception crashes the app.  Other controls that implement Copy (TextBox et al.) simply fail silently - no exception, but nothing gets put on the clipboard.  This is also the way other apps behave (Notepad, Word, browsers, etc.).  This change gives DataGrid that same behavior.