### PR TITLE
App resource threading issue

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -700,7 +700,8 @@ namespace System.Windows
             SiteOfOriginContainer sooContainer = (SiteOfOriginContainer)GetResourcePackage(packageUri);
 
             // the SiteOfOriginContainer is shared across threads;  synchronize access to it
-            lock (_packageLock)
+            // using the same lock object as other uses (PackWebResponse+CachedResponse.GetResponseStream)
+            lock (sooContainer)
             {
                 sooPart = sooContainer.GetPart(partUri) as SiteOfOriginPart;
             }
@@ -2017,8 +2018,9 @@ namespace System.Windows
             ResourceContainer resContainer = (ResourceContainer)GetResourcePackage(packageUri);
 
             // the ResourceContainer is shared across threads;  synchronize access to it
+            // using the same lock object as other uses (PackWebResponse+CachedResponse.GetResponseStream)
             PackagePart part = null;
-            lock (_packageLock)
+            lock (resContainer)
             {
                 part = resContainer.GetPart(partUri);
             }
@@ -2417,7 +2419,6 @@ namespace System.Windows
         static private bool                             _appCreatedInThisAppDomain;
         static private Application                      _appInstance;
         static private Assembly                         _resourceAssembly;
-        static private object                           _packageLock = new Object();
 
         // Keep LoadBamlSyncInfo stack so that the Outer LoadBaml and Inner LoadBaml( ) for the same
         // Uri share the related information.


### PR DESCRIPTION
Addresses #3563 
This is a port of a servicing fix in .NET 4.7-4.8

**Issue:** Crash when multi-threaded app loads app resources

**Discussion:**
There is a race condition when two threads try to add parts to one of the app's predefined packages (ResourceContainer or SiteOfOriginContainer), one from Application.GetResourceOrContentPart or Application.GetResourceStream, and the other from PackWebResponse+CachedResponse.GetResponseStream.  These two codepaths use different lock objects to synchronize access to the package, so they can interleave.  An unfavorable interleaving during the time they are actually adding to the package's underlying SortedList can corrupt the list (it's not thread-safe), leaving it with entries in the wrong order and/or spurious 'null' entries.  This breaks the binary search lookup algorithm, and leads to the FailFast crashes.

Fixed by using the same lock object on all codepaths that call GetPart.
