### PR TITLE
Fix the casing of 'Shared' in WpfSharedDir

### DIFF
--- a/eng/WpfArcadeSdk/tools/FolderPaths.targets
+++ b/eng/WpfArcadeSdk/tools/FolderPaths.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- $(WpfSharedDir) is present in the current repository -->
-    <WpfSharedDir Condition="'$(WpfSharedDir)'=='' And Exists('$(WpfSourceDir)shared\')">$(WpfSourceDir)shared\</WpfSharedDir>
+    <WpfSharedDir Condition="'$(WpfSharedDir)'=='' And Exists('$(WpfSourceDir)Shared\')">$(WpfSourceDir)Shared\</WpfSharedDir>
     <!-- Consume from NuGet cache -->
     <WpfTransportedSharedDir Condition="'$(WpfTransportedSharedDir)'=='' And Exists('$(WpfArcadeSdkRoot)src\shared\')">$(WpfArcadeSdkRoot)src\shared\</WpfTransportedSharedDir>
     <!-- Consume from $(WpfTestArcadeWpfSdkPath) -->


### PR DESCRIPTION
The value was specified with a lower case 's', but the directory in Git is spelt with a capital 'S'. This discrepancy causes failures on source server lookups. For example, stepping into `MS.Utility.FrugalList` tries to load (using .NET 5.0 RC1):

https://raw.githubusercontent.com/dotnet/wpf/be89bbfaded6ad3f0f4143bf1a8dd075a5789715/src/Microsoft.DotNet.Wpf/src/shared/MS/Utility/FrugalList.cs

but the server returns a 404 response. The source is actually at:

https://raw.githubusercontent.com/dotnet/wpf/be89bbfaded6ad3f0f4143bf1a8dd075a5789715/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs