### PR TITLE
[PresentationCore] [Performance] [System.Windows.Media]

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
@@ -435,11 +435,11 @@ namespace MS.Internal.Markup
             }
             else
             {
-                string subString = _pathString.Substring(start, _curIndex - start);
+                ReadOnlySpan<char> slice = _pathString.AsSpan().Slice(start, _curIndex - start);
 
                 try
                 {
-                    return System.Convert.ToDouble(subString, _formatProvider);
+                    return double.Parse(slice, provider: _formatProvider);
                 }
                 catch (FormatException except)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
@@ -435,7 +435,7 @@ namespace MS.Internal.Markup
             }
             else
             {
-                ReadOnlySpan<char> slice = _pathString.AsSpan().Slice(start, _curIndex - start);
+                ReadOnlySpan<char> slice = _pathString.AsSpan(start, _curIndex - start);
 
                 try
                 {


### PR DESCRIPTION
Optimize memory allocations on Geometry parsing.
We are using a lot of geometries in our app that are located in the resource dictionary. I've found some unnecessary string allocations on parsing and fixed them. 

[Profiler Screenshot]
![Screenshot 2020-10-02 at 12 31 50](https://user-images.githubusercontent.com/4997065/94909076-4ba5ae00-04ab-11eb-988b-1ae0b38d2ab9.png)
