### PR TITLE
Update dotnet/CoreCLR repo link to dotnet/Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Visual Studio WPF designer is now available as part of Visual Studio 2019.
 
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
-* This repo defines [contributing guidelines](Documentation/contributing.md) and also follows the more general [.NET Core contributing guide](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md).
+* This repo defines [contributing guidelines](Documentation/contributing.md) and also follows the more general [.NET Core contributing guide](https://github.com/dotnet/runtime/blob/master/CONTRIBUTING.md).
 * If you have a question or have found a bug, [file an issue](https://github.com/dotnet/wpf/issues/new).
 * Use [daily builds](Documentation/getting-started.md#installation) if you want to contribute and stay up to date with the team.
 


### PR DESCRIPTION
The link points to old repo (dotnet/coreclr) which migrated to dotnet/runtime. The old one is used only for servicing .NET Core 2.1 and 3.1.