### PR TITLE
Remove or replace Policheck violations in code comments

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Common.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/Common.h
@@ -84,8 +84,8 @@ private:
 
     /// <summary>
     /// Exceptions known to have security sensitive data are sanitized in this method,
-    /// by creating copy of original exception without sensitive data and re-thrown.
-    /// Or, to put another way - this funciton acts only on a known whitelist of HRESULT/IErrorInfo combinations, throwing for matches.
+    /// by throwing a copy of the original exception without security sensitive data. 
+    /// Or, to put another way - this function acts only on a list of security sensitive HRESULT/IErrorInfo combinations, throwing for matches.
     /// The IErrorInfo is taken into account in a call to GetExceptionForHR(HRESULT), see MSDN for more details.
     /// </summary>
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonHelper.cs
@@ -2326,8 +2326,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             markupProp.PropertyDescriptor.ComponentType == typeof(ItemsControl))
                         {
                             // Skip the ItemsControl.Items property
-                            // since this will be copied as part of
-                            // the whitelist properties.
+                            // since this will be copied automatically.
 
                             continue;
                         }


### PR DESCRIPTION
This change removes or replaces the word 'whitelist' from code comments in two files.  