### PR TITLE
Replace null comparisons on non-nullable types that now cause compilation errors, due to the .NET SDK update.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/EllipseGeometry.cs
@@ -160,9 +160,6 @@ namespace System.Windows.Media
         {
             Rect rect;
 
-            Debug.Assert(worldMatrix != null);
-            Debug.Assert(geometryMatrix != null);
-
             if ( (pen == null || pen.DoesNotContainGaps) &&
                 worldMatrix.IsIdentity && geometryMatrix.IsIdentity)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSourceSafeMILHandle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSourceSafeMILHandle.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Media.Imaging
         {
             long estimatedSize = 0;
 
-            if (bitmapObject != null && bitmapObject != IntPtr.Zero)
+            if (bitmapObject != IntPtr.Zero)
             {
                 IntPtr wicBitmap;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -85,15 +85,6 @@ namespace System.Windows.Media.Imaging
             // Sanitize inputs
             //
 
-            if (pixelFormat == null)
-            {
-                // Backwards Compat:
-                //
-                // The original code would null-ref, but we choose to raise a
-                // better exception.
-                throw new ArgumentNullException("pixelFormat");
-            }
-
             if (pixelFormat.Palettized && palette == null)
             {
                 throw new InvalidOperationException(SR.Get(SRID.Image_IndexedPixelFormatRequiresPalette));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/LineGeometry.cs
@@ -107,9 +107,6 @@ namespace System.Windows.Media
         internal static Rect GetBoundsHelper(Pen pen, Matrix worldMatrix, Point pt1, Point pt2,
                                              Matrix geometryMatrix, double tolerance, ToleranceType type)
         {
-            Debug.Assert(worldMatrix != null);
-            Debug.Assert(geometryMatrix != null);
-
             if (pen == null  &&  worldMatrix.IsIdentity && geometryMatrix.IsIdentity)
             {
                 return new Rect(pt1, pt2);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -190,9 +190,6 @@ namespace System.Windows.Media
         {
             Rect boundingRect;
 
-            Debug.Assert(worldMatrix != null);
-            Debug.Assert(geometryMatrix != null);
-
             if (rect.IsEmpty)
             {
                 boundingRect = Rect.Empty;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/GeneralTransform3DTo2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/GeneralTransform3DTo2D.cs
@@ -43,15 +43,13 @@ namespace System.Windows.Media.Media3D
             result = new Point();
             
             // project the point
-            if (_projectionTransform != null)
-            {                Point3D projectedPoint = _projectionTransform.Transform(inPoint);
+            Point3D projectedPoint = _projectionTransform.Transform(inPoint);
 
-                if (_transformBetween2D != null)
-                {
-                    result = _transformBetween2D.Transform(new Point(projectedPoint.X, projectedPoint.Y));
-                    success = true;
-                }
-            }            
+            if (_transformBetween2D != null)
+            {
+                result = _transformBetween2D.Transform(new Point(projectedPoint.X, projectedPoint.Y));
+                success = true;
+            }
 
             return success;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
@@ -215,8 +215,6 @@ namespace MS.Internal.IO.Packaging
 
                 // allocate an unmanaged PROPVARIANT to return
                 pNative = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(PROPVARIANT)));
-                // Per MSDN, AllocCoTaskMem never returns null. One can't be too careful, though.
-                Invariant.Assert(pNative != null);
 
                 // marshal the managed PROPVARIANT into the unmanaged block and return it
                 Marshal.StructureToPtr(v, pNative, false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
@@ -216,6 +216,9 @@ namespace MS.Internal.IO.Packaging
                 // allocate an unmanaged PROPVARIANT to return
                 pNative = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(PROPVARIANT)));
 
+                // Per MSDN, AllocCoTaskMem never returns null.  Check for IntPtr.Zero instead. 
+                Invariant.Assert(pNative != IntPtr.Zero);
+
                 // marshal the managed PROPVARIANT into the unmanaged block and return it
                 Marshal.StructureToPtr(v, pNative, false);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/indexingfiltermarshaler.cs
@@ -216,7 +216,7 @@ namespace MS.Internal.IO.Packaging
                 // allocate an unmanaged PROPVARIANT to return
                 pNative = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(PROPVARIANT)));
 
-                // Per MSDN, AllocCoTaskMem never returns null.  Check for IntPtr.Zero instead. 
+                // Per MSDN, AllocCoTaskMem never returns null: check for IntPtr.Zero instead.
                 Invariant.Assert(pNative != IntPtr.Zero);
 
                 // marshal the managed PROPVARIANT into the unmanaged block and return it

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/printdlgexmarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/printdlgexmarshaler.cs
@@ -628,7 +628,7 @@ namespace MS.Internal.Printing
                 }
                 catch (Exception)
                 {
-                    if (unmanagedBuffer != null)
+                    if (unmanagedBuffer != IntPtr.Zero)
                     {
                         FreeUnmanagedPrintDlgExStruct(unmanagedBuffer);
                         unmanagedBuffer = IntPtr.Zero;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/CellParaClient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/CellParaClient.cs
@@ -157,7 +157,7 @@ namespace MS.Internal.PtsHost
             int dvrTopSpace;
             PTS.FSPAP fspap;
 
-            if(CellParagraph.StructuralCache.DtrList != null && breakRecordIn != null)
+            if(CellParagraph.StructuralCache.DtrList != null && breakRecordIn != IntPtr.Zero)
             {
                 CellParagraph.InvalidateStructure(TextContainerHelper.GetCPFromElement(CellParagraph.StructuralCache.TextContainer, CellParagraph.Element, ElementEdge.BeforeStart));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
@@ -127,7 +127,7 @@ namespace WinRT
                         marshaler?.Dispose();
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }
@@ -445,7 +445,7 @@ namespace WinRT
                         Marshaler<T>.DisposeMarshaler(marshaler);
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }
@@ -627,7 +627,7 @@ namespace WinRT
                         DisposeMarshaler(marshaler);
                     }
                 }
-                if (_array != null)
+                if (_array != IntPtr.Zero)
                 {
                     Marshal.FreeCoTaskMem(_array);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DateTimeAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DateTimeAutomationPeer.cs
@@ -30,10 +30,7 @@ namespace System.Windows.Automation.Peers
         internal DateTimeAutomationPeer(DateTime date, Calendar owningCalendar, CalendarMode buttonMode)
             : base()
         {
-            if (date == null)
-            {
-                throw new ArgumentNullException("date");
-            }
+            // DateTime is a non-nullable value (a struct) type and cannot be null
             if (owningCalendar == null)
             {
                 throw new ArgumentNullException("owningCalendar");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DateTimeAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DateTimeAutomationPeer.cs
@@ -30,7 +30,6 @@ namespace System.Windows.Automation.Peers
         internal DateTimeAutomationPeer(DateTime date, Calendar owningCalendar, CalendarMode buttonMode)
             : base()
         {
-            // DateTime is a non-nullable value (a struct) type and cannot be null
             if (owningCalendar == null)
             {
                 throw new ArgumentNullException("owningCalendar");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
@@ -1380,7 +1380,6 @@ namespace System.Windows.Controls
             {
                 case CalendarMode.Month:
                 {
-                    // 'this.DisplayDate' is a non-nullable value type (a struct) and can never be null.
                     DateTime? selectedDate = new DateTime(this.DisplayDateInternal.Year, this.DisplayDateInternal.Month, 1);
 
                     if (DateTimeHelper.CompareYearMonth(DateTime.MaxValue, selectedDate.Value) > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Calendar.cs
@@ -1380,23 +1380,21 @@ namespace System.Windows.Controls
             {
                 case CalendarMode.Month:
                 {
-                    if (this.DisplayDate != null)
+                    // 'this.DisplayDate' is a non-nullable value type (a struct) and can never be null.
+                    DateTime? selectedDate = new DateTime(this.DisplayDateInternal.Year, this.DisplayDateInternal.Month, 1);
+
+                    if (DateTimeHelper.CompareYearMonth(DateTime.MaxValue, selectedDate.Value) > 0)
                     {
-                        DateTime? selectedDate = new DateTime(this.DisplayDateInternal.Year, this.DisplayDateInternal.Month, 1);
-
-                        if (DateTimeHelper.CompareYearMonth(DateTime.MaxValue, selectedDate.Value) > 0)
-                        {
-                            // since DisplayDate is not equal to DateTime.MaxValue we are sure selectedDate is not null
-                            selectedDate = DateTimeHelper.AddMonths(selectedDate.Value, 1).Value;
-                            selectedDate = DateTimeHelper.AddDays(selectedDate.Value, -1).Value;
-                        }
-                        else
-                        {
-                            selectedDate = DateTime.MaxValue;
-                        }
-
-                        ProcessSelection(shift, selectedDate);
+                        // since DisplayDate is not equal to DateTime.MaxValue we are sure selectedDate is not null
+                        selectedDate = DateTimeHelper.AddMonths(selectedDate.Value, 1).Value;
+                        selectedDate = DateTimeHelper.AddDays(selectedDate.Value, -1).Value;
                     }
+                    else
+                    {
+                        selectedDate = DateTime.MaxValue;
+                    }
+
+                    ProcessSelection(shift, selectedDate);
 
                     break;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CalendarBlackoutDatesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CalendarBlackoutDatesCollection.cs
@@ -349,7 +349,6 @@ namespace System.Windows.Controls
         /// <returns></returns>
         private CalendarDateRange GetContainingDateRange(DateTime date)
         {
-            // DateTime is a non-nullable value type (a structure) and cannot be null.
             for (int i = 0; i < Count; i++)
             {
                 if (DateTimeHelper.InRange(date, this[i]))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CalendarBlackoutDatesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/CalendarBlackoutDatesCollection.cs
@@ -349,9 +349,7 @@ namespace System.Windows.Controls
         /// <returns></returns>
         private CalendarDateRange GetContainingDateRange(DateTime date)
         {
-            if (date == null)
-                return null;
-
+            // DateTime is a non-nullable value type (a structure) and cannot be null.
             for (int i = 0; i < Count; i++)
             {
                 if (DateTimeHelper.InRange(date, this[i]))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -278,7 +278,9 @@ namespace System.Windows.Controls
                     {
                         column.RefreshCellContent(this, propertyName);
                     }
-                    else if (e != null && e.Property != null)
+                    // DependencyPropertyChangedEventArgs is a non-nullable value type (a struct)
+                    // and can never be null.
+                    else if (e.Property != null)
                     {
                         column.RefreshCellContent(this, e.Property.Name);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -278,8 +278,6 @@ namespace System.Windows.Controls
                     {
                         column.RefreshCellContent(this, propertyName);
                     }
-                    // DependencyPropertyChangedEventArgs is a non-nullable value type (a struct)
-                    // and can never be null.
                     else if (e.Property != null)
                     {
                         column.RefreshCellContent(this, e.Property.Name);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/CalendarItem.cs
@@ -681,7 +681,6 @@ namespace System.Windows.Controls.Primitives
                 CalendarKeyboardHelper.GetMetaKeyState(out ctrl, out shift);
 
                 DateTime selectedDate = (DateTime)b.DataContext;
-                Debug.Assert(selectedDate != null);
 
                 switch (this.Owner.SelectionMode)
                 {
@@ -1303,7 +1302,6 @@ namespace System.Windows.Controls.Primitives
 
                 if (this.Owner != null)
                 {
-                    Debug.Assert(this.Owner.DisplayDateInternal != null);
                     childButton.HasSelectedDays = (DateTimeHelper.CompareYearMonth(day, this.Owner.DisplayDateInternal) == 0);
 
                     if (DateTimeHelper.CompareYearMonth(day, this.Owner.DisplayDateStartInternal) < 0 || DateTimeHelper.CompareYearMonth(day, this.Owner.DisplayDateEndInternal) > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/SelectedDatesCollection.cs
@@ -278,7 +278,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    if (item != null && DateTime.Compare(this[index], item) != 0 && Calendar.IsValidDateSelection(this._owner, item))
+                    if (DateTime.Compare(this[index], item) != 0 && Calendar.IsValidDateSelection(this._owner, item))
                     {
                         removedItems.Add(this[index]);
                         base.SetItem(index, item);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -221,9 +221,6 @@ namespace System.Windows.Data
             if (d == null)
                 throw new ArgumentNullException("d");
 
-            // DependencyPropertyChangedEventArgs is a struct and never equal to null. 
-            // There is no need for a null check here. 
-
             DependencyProperty dp = args.Property;
             if (dp == null)
                 throw new InvalidOperationException(SR.Get(SRID.ArgumentPropertyMustNotBeNull, "Property", "args"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpression.cs
@@ -220,8 +220,9 @@ namespace System.Windows.Data
         {
             if (d == null)
                 throw new ArgumentNullException("d");
-            if (args == null)
-                throw new ArgumentNullException("args");
+
+            // DependencyPropertyChangedEventArgs is a struct and never equal to null. 
+            // There is no need for a null check here. 
 
             DependencyProperty dp = args.Property;
             if (dp == null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -4589,7 +4589,8 @@ namespace System.Windows
                 // First, get clipped, transformed, unrounded size.
                 if (useLayoutRounding)
                 {
-                    if (ltd != null && ltd.TransformedUnroundedDS != null)
+                    // 'transformUnroundedDS' is a non-nullable value type and can never be null.
+                    if (ltd != null)
                     {
                         transformedUnroundedDS = ltd.TransformedUnroundedDS;
                         transformedUnroundedDS.Width = Math.Max(0, transformedUnroundedDS.Width - marginWidth);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -2797,7 +2797,7 @@ namespace Standard
         public static IntPtr GetStockObject(StockObject fnObject)
         {
             IntPtr retPtr = _GetStockObject(fnObject);
-            if (retPtr == null)
+            if (retPtr == IntPtr.Zero)
             {
                 HRESULT.ThrowLastError();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateManager.cs
@@ -408,7 +408,7 @@ namespace System.Windows
             
             if (transition != null)
             {
-                if (transition.GeneratedDuration != null)
+                if (transition.GeneratedDuration != DurationZero)
                 {
                     dynamic.Duration = transition.GeneratedDuration;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -6147,8 +6147,9 @@ namespace System.Windows
         {
             Transform renderTransformValue = (Transform)value;
 
+            // 'renderTransformValue.Value' is of type 'Matrix' and can never be null.
             if ((value == null) ||
-                (renderTransformValue != null && renderTransformValue.Value != null && renderTransformValue.Value.IsIdentity == true))
+                (renderTransformValue != null && renderTransformValue.Value.IsIdentity == true))
             {
                 // setting this value is allowed.
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -6147,7 +6147,6 @@ namespace System.Windows
         {
             Transform renderTransformValue = (Transform)value;
 
-            // 'renderTransformValue.Value' is of type 'Matrix' and can never be null.
             if ((value == null) ||
                 (renderTransformValue != null && renderTransformValue.Value.IsIdentity == true))
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -553,7 +553,8 @@ namespace MS.Win32
 
             //AvDebug.Assert(_gcHandle.IsAllocated, "External GC handle has not been allocated.");
 
-            if(null != _gcHandle)
+            // GCHandle is a non-nullable type.  Check GCHandle.IsAllocated before calling Free().
+            if(_gcHandle.IsAllocated)
                 _gcHandle.Free();
 
             return true;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
@@ -181,7 +181,8 @@ namespace MS.Internal.Security.RightsManagement
             }
 
             // set metafata as required 
-            if (contentId != null)
+            // Guid is a non-nullable value type and gets a value on creation. Check Guid.Empty instead.
+            if (contentId != Guid.Empty)
             {
                 hr = SafeNativeMethods.DRMSetMetaData(
                     _issuanceLicenseHandle,

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
@@ -180,8 +180,7 @@ namespace MS.Internal.Security.RightsManagement
                 }
             }
 
-            // set metafata as required 
-            // Guid is a non-nullable value type and gets a value on creation. Check Guid.Empty instead.
+            // set metadata as required 
             if (contentId != Guid.Empty)
             {
                 hr = SafeNativeMethods.DRMSetMetaData(

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -238,7 +238,7 @@ namespace System.Windows
             // In the case where the developer has specified AutoClose=True and then calls
             // Close(non_zero_timespan) before the auto close operation is dispatched we begin
             // the fadeout immidiately and ignore the later call to close.
-            if (_dt != null || _hwnd == null)
+            if (_dt != null || _hwnd == IntPtr.Zero)
             {
                 return BooleanBoxes.TrueBox;
             }


### PR DESCRIPTION
Replace null comparisons on non-nullable types that now cause compilation errors, due to the .NET SDK update.  This is preventing WPF from updating from the RC1 version of the .NET SDK to RC2.  

These redundant null checks against IntPtr and DateTime are now errors.  This primarily replaces null comparisons on IntPtr and DateTime, but there are a few others.  Where possible, checks were replaced with an alternative (e.g., IntPtr.Zero).  

/cc @SamBent @dotnet/wpf-developers 
