### PR TITLE
Remove usage of Microsoft.NETCore.App.Internal package.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -89,10 +89,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Internal" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -73,10 +73,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="5.0.0-alpha1.19562.1">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>d5bb8bf2437d447750cf0203dd55bb5160ff36b8</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.ILDAsm" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
@@ -94,6 +90,10 @@
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
+    </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-alpha.1.20557.2" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6cfef20c1524b8d4c1495a652dfe9e898c5a486b</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-alpha.1.20557.2</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <MicrosoftNETCoreAppRefVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftNETCorePlatformsVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCorePlatformsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,6 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppInternalVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppInternalVersion>
     <MicrosoftNETCoreAppRefVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-alpha.1.20557.2</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftNETCorePlatformsVersion>6.0.0-alpha.1.20557.2</MicrosoftNETCorePlatformsVersion>

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "runtimes": {
       "dotnet": [
         "2.1.7",
-        "$(MicrosoftNetCoreAppInternalVersion)"
+        "$(MicrosoftNETCoreAppRuntimewinx64Version)"
       ]
     },
     "vs": {

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "runtimes": {
       "dotnet": [
         "2.1.7",
-        "$(MicrosoftNETCoreAppRuntimewinx64Version)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"
       ]
     },
     "vs": {


### PR DESCRIPTION
The Microsoft.NETCore.App.Internal package is being removed in https://github.com/dotnet/runtime/pull/38457/. The usage in WPF can be replaced with the .NET Core Shared Framework VS insertion package, which is a supported package to reference a runtime version.