### PR TITLE
Enable post-build signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ variables:
     value: WINDOWSDESKTOP
   - name: _DotNetValidationArtifactsCategory
     value: WINDOWSDESKTOP
+  - name: PostBuildSign
+    value: true
   
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: DotNet-Wpf-SDLValidation-Params


### PR DESCRIPTION
Enables post build signing. This repo will discontinue signing in-build and instead the entire product will sign all at once in the staging pipelines.