### PR TITLE
Using readonly struct in WPF Ink module

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ContourSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/ContourSegment.cs
@@ -16,7 +16,7 @@ namespace MS.Internal.Ink
     /// inner area being on the right side.
     /// Used in hit-testing a contour vs another contour.
     /// </summary> 
-    internal struct ContourSegment
+    internal readonly struct ContourSegment
     {
         /// <summary>
         /// Constructor for linear segments
@@ -61,9 +61,9 @@ namespace MS.Internal.Ink
 
         #region Fields
 
-        private Point   _begin;
-        private Vector  _vector;
-        private Vector  _radius;
+        private readonly Point   _begin;
+        private readonly Vector  _vector;
+        private readonly Vector  _radius;
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/EllipticalNodeOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/EllipticalNodeOperations.cs
@@ -86,7 +86,7 @@ namespace MS.Internal.Ink
         /// <param name="beginNode">a node to connect</param>
         /// <param name="endNode">another node, next to beginNode</param>
         /// <returns>connecting quadrangle</returns>
-        internal override Quad GetConnectingQuad(StrokeNodeData beginNode, StrokeNodeData endNode)
+        internal override Quad GetConnectingQuad(in StrokeNodeData beginNode,in StrokeNodeData endNode)
         {
             if (beginNode.IsEmpty || endNode.IsEmpty || DoubleUtil.AreClose(beginNode.Position, endNode.Position))
             {
@@ -213,7 +213,7 @@ namespace MS.Internal.Ink
         /// <param name="hitEndPoint">an end point of the hitting linear segment</param>
         /// <returns>true if the hitting segment intersect the contour comprised of the two stroke nodes</returns>
         internal override bool HitTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
+           in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
         {
             StrokeNodeData bigNode, smallNode;
             if (beginNode.IsEmpty || (quad.IsEmpty && (endNode.PressureFactor > beginNode.PressureFactor)))
@@ -278,7 +278,7 @@ namespace MS.Internal.Ink
         /// <param name="hitContour">a collection of basic segments outlining the hitting contour</param>
         /// <returns>true if the contours intersect or overlap</returns>
         internal override bool HitTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
+            in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
         {
             StrokeNodeData bigNode, smallNode;
             double bigRadiusSquared, smallRadiusSquared = 0;
@@ -384,7 +384,7 @@ namespace MS.Internal.Ink
         /// <param name="hitEndPoint">End point of the hitting segment</param>
         /// <returns>Exact location to cut at represented by StrokeFIndices</returns>
         internal override StrokeFIndices CutTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
+            in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
         {
             // Compute the positions of the involved points relative to the endNode.
             Vector spineVector = beginNode.IsEmpty ? new Vector(0, 0) : (beginNode.Position - endNode.Position);
@@ -462,7 +462,7 @@ namespace MS.Internal.Ink
         /// <param name="hitContour">The hitting ContourSegments</param>
         /// <returns>StrokeFIndices representing the location for cutting</returns>
         internal override StrokeFIndices CutTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
+            in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
         {
             // Compute the positions of the beginNode relative to the endNode.
             Vector spineVector = beginNode.IsEmpty ? new Vector(0, 0) : (beginNode.Position - endNode.Position);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Quad.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/Quad.cs
@@ -26,7 +26,7 @@ namespace MS.Internal.Ink
     {
         #region Statics
 
-        private static Quad s_empty = new Quad(new Point(0, 0), new Point(0, 0), new Point(0, 0), new Point(0, 0));
+        private static readonly Quad s_empty = new Quad(new Point(0, 0), new Point(0, 0), new Point(0, 0), new Point(0, 0));
 
         #endregion 
         

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeFIndices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeFIndices.cs
@@ -23,8 +23,8 @@ namespace MS.Internal.Ink
     internal struct StrokeFIndices : IEquatable<StrokeFIndices>
     {
         #region Private statics
-        private static StrokeFIndices s_empty = new StrokeFIndices(AfterLast, BeforeFirst);
-        private static StrokeFIndices s_full = new StrokeFIndices(BeforeFirst, AfterLast);
+        private static readonly StrokeFIndices s_empty = new StrokeFIndices(AfterLast, BeforeFirst);
+        private static readonly StrokeFIndices s_full = new StrokeFIndices(BeforeFirst, AfterLast);
         #endregion
 
         #region Internal API

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNode.cs
@@ -35,8 +35,8 @@ namespace MS.Internal.Ink
         internal StrokeNode(
             StrokeNodeOperations operations,
             int index,
-            StrokeNodeData nodeData,
-            StrokeNodeData lastNodeData,
+            in StrokeNodeData nodeData,
+            in StrokeNodeData lastNodeData,
             bool isLastNode)
         {
             System.Diagnostics.Debug.Assert(operations != null);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
@@ -17,11 +17,11 @@ namespace MS.Internal.Ink
     /// <summary>
     /// This structure represents a node on a stroke spine. 
     /// </summary>
-    internal struct StrokeNodeData
+    internal readonly struct StrokeNodeData
     {
         #region Statics
 
-        private static StrokeNodeData s_empty = new StrokeNodeData();
+        private static readonly StrokeNodeData s_empty = new StrokeNodeData();
 
         #endregion
 
@@ -76,8 +76,8 @@ namespace MS.Internal.Ink
 
         #region Privates
 
-        private Point   _position;
-        private float _pressure;
+        private readonly Point   _position;
+        private readonly float _pressure;
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
@@ -28,7 +28,7 @@ namespace MS.Internal.Ink
         #region API (internal)
 
         /// <summary> Returns static object representing an unitialized node </summary>
-        internal static StrokeNodeData Empty { get { return s_empty; } }
+        internal static ref readonly StrokeNodeData Empty { get { return ref s_empty; } }
 
         /// <summary>
         /// Constructor for nodes of a pressure insensitive stroke

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
@@ -64,7 +64,7 @@ namespace MS.Internal.Ink
         /// </summary>
         /// <param name="node">node to compute bounds of</param>
         /// <returns>bounds of the node</returns>
-        internal Rect GetNodeBounds(StrokeNodeData node)
+        internal Rect GetNodeBounds(in StrokeNodeData node)
         {
             if (_shapeBounds.IsEmpty)
             {
@@ -97,7 +97,7 @@ namespace MS.Internal.Ink
             return boundingBox;
         }
 
-        internal void GetNodeContourPoints(StrokeNodeData node, List<Point> pointBuffer)
+        internal void GetNodeContourPoints(in StrokeNodeData node, List<Point> pointBuffer)
         {
             double pressureFactor = node.PressureFactor;
             if (DoubleUtil.AreClose(pressureFactor, 1d))
@@ -182,7 +182,7 @@ namespace MS.Internal.Ink
         /// <param name="beginNode">a node to connect</param>
         /// <param name="endNode">another node, next to beginNode</param>
         /// <returns>connecting quadrangle, that can be empty if one node is inside the other</returns>
-        internal virtual Quad GetConnectingQuad(StrokeNodeData beginNode, StrokeNodeData endNode)
+        internal virtual Quad GetConnectingQuad(in StrokeNodeData beginNode, in StrokeNodeData endNode)
         {            
             // Return an empty quad if either of the nodes is empty (not a node) 
             // or if both nodes are at the same position.
@@ -296,7 +296,7 @@ namespace MS.Internal.Ink
         /// <param name="hitEndPoint">End point of the hitting segment</param>
         /// <returns>true if there's intersection, false otherwise</returns>
         internal virtual bool HitTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
+           in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
         {
             // Check for special cases when the endNode is the very first one (beginNode.IsEmpty) 
             // or one node is completely inside the other. In either case the connecting quad 
@@ -441,7 +441,7 @@ namespace MS.Internal.Ink
         /// <param name="hitContour">a collection of basic segments outlining the hitting contour</param>
         /// <returns>true if the contours intersect or overlap</returns>
         internal virtual bool HitTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
+           in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
         {           
             // Check for special cases when the endNode is the very first one (beginNode.IsEmpty) 
             // or one node is completely inside the other. In either case the connecting quad 
@@ -469,7 +469,7 @@ namespace MS.Internal.Ink
         /// <param name="hitEndPoint">End point of the hitting segment</param>
         /// <returns>Exact location to cut at represented by StrokeFIndices</returns>
         internal virtual StrokeFIndices CutTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
+            in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, Point hitBeginPoint, Point hitEndPoint)
         {
             StrokeFIndices result = StrokeFIndices.Empty;
 
@@ -561,7 +561,7 @@ namespace MS.Internal.Ink
         /// <param name="hitContour">a collection of basic segments outlining the hitting contour</param>
         /// <returns></returns>
         internal virtual StrokeFIndices CutTest(
-            StrokeNodeData beginNode, StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
+            in StrokeNodeData beginNode, in StrokeNodeData endNode, Quad quad, IEnumerable<ContourSegment> hitContour)
         {
             if (beginNode.IsEmpty)
             {
@@ -930,7 +930,7 @@ namespace MS.Internal.Ink
         /// <param name="endNode">End node of the stroke segment</param>
         /// <returns>true if hit; false otherwise</returns>
         private bool HitTestPolygonContourSegments(
-            IEnumerable<ContourSegment> hitContour, StrokeNodeData beginNode, StrokeNodeData endNode)
+            IEnumerable<ContourSegment> hitContour, in StrokeNodeData beginNode, in StrokeNodeData endNode)
         {
             bool isHit = false;
 
@@ -1019,7 +1019,7 @@ namespace MS.Internal.Ink
         /// <param name="endNode">End node of the stroke segment</param>
         /// <returns>true if hit; false otherwise</returns>
         private bool HitTestInkContour(
-            IEnumerable<ContourSegment> hitContour, Quad quad, StrokeNodeData beginNode, StrokeNodeData endNode)
+            IEnumerable<ContourSegment> hitContour, Quad quad, in StrokeNodeData beginNode, in StrokeNodeData endNode)
         {
             System.Diagnostics.Debug.Assert(!quad.IsEmpty);
             bool isHit = false;
@@ -1183,7 +1183,7 @@ namespace MS.Internal.Ink
         /// <param name="result"></param>
         /// <returns></returns>
         private bool HitTestStrokeNodes(
-            ContourSegment hitSegment, StrokeNodeData beginNode, StrokeNodeData endNode, ref StrokeFIndices result)
+            in ContourSegment hitSegment, in StrokeNodeData beginNode, in StrokeNodeData endNode, ref StrokeFIndices result)
         {
             // First, find out if hitSegment intersects with either of the ink nodes
             bool isHit = false;
@@ -1271,7 +1271,7 @@ namespace MS.Internal.Ink
         /// <param name="pressureDelta"></param>
         /// <returns>the clip location. not-clip if return StrokeFIndices.BeforeFirst</returns>
         private double CalculateClipLocation(
-            ContourSegment hitSegment, StrokeNodeData beginNode, Vector spineVector, double pressureDelta)
+           in ContourSegment hitSegment, in StrokeNodeData beginNode, Vector spineVector, double pressureDelta)
         {
             double findex = StrokeFIndices.BeforeFirst;
             bool clipIt = hitSegment.IsArc ? true


### PR DESCRIPTION
See: https://github.com/dotnet/wpf/issues/812

Benchmark:

|          Method |           context |     Mean |     Error |    StdDev | Ratio | RatioSD |
|---------------- |------------------ |---------:|----------:|----------:|------:|--------:|
|    CalcGeometry |    WpfInk.Context | 1.595 ms | 0.0031 ms | 0.0029 ms |     ? |       ? |
|                 |                   |          |           |           |       |         |
| CalcGeometryOld | WpfInkOld.Context | 1.628 ms | 0.0069 ms | 0.0064 ms |  1.00 |    0.00 |

Benchmark code:  https://github.com/lindexi/lindexi_gd/tree/376e4404/WpfInk

Update https://github.com/dotnet/wpf/pull/2839/