### PR TITLE
Use char overload in System.Xaml

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Markup
             // included in the output formulation -- UTC gets written out with a "Z",
             // and Local gets written out with e.g. "-08:00" for Pacific Standard Time.
             
-            formatString.Append("K");
+            formatString.Append('K');
 
             // We've finally got our format string built, we can create the string.
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1996,7 +1996,7 @@ namespace System.Xaml
                 if (value is NameFixupToken && parentProperty != XamlLanguage.Items)
                 {
                     NameFixupToken token = value as NameFixupToken;
-                    string names = String.Join(",", token.NeededNames.ToArray());
+                    string names = String.Join(',', token.NeededNames.ToArray());
                     string msg = SR.Get(SRID.ForwardRefDirectives, names);
                     throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                 }
@@ -2033,7 +2033,7 @@ namespace System.Xaml
                             // Only the key directive may be assigned a reference.
                             if (parentProperty != XamlLanguage.Key)
                             {
-                                string names = String.Join(",", token.NeededNames.ToArray());
+                                string names = String.Join(',', token.NeededNames.ToArray());
                                 string msg = SR.Get(SRID.ForwardRefDirectives, names);
                                 throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                             }
@@ -2086,7 +2086,7 @@ namespace System.Xaml
                                 if (parentProperty != XamlLanguage.Key)
                                 {
                                     NameFixupToken token = (NameFixupToken)value;
-                                    string names = String.Join(",", token.NeededNames.ToArray());
+                                    string names = String.Join(',', token.NeededNames.ToArray());
                                     string msg = SR.Get(SRID.ForwardRefDirectives, names);
                                     throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -70,6 +70,14 @@ namespace System.Xaml.MS.Impl
             return src.IndexOf(chars, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Standard String Index search operation.
+        /// </summary>
+        public static int IndexOf(string src, char ch)
+        {
+            return src.IndexOf(ch, StringComparison.Ordinal);
+        }
+
         public static bool EndsWith(string src, string target)
         {
             return src.EndsWith(target, StringComparison.Ordinal);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -243,7 +243,7 @@ namespace MS.Internal.Xaml.Parser
                 value = value.Substring(2);
             } 
             
-            if (!value.Contains("\\"))
+            if (!value.Contains(Backslash))
             {
                 return value;
             }
@@ -352,7 +352,7 @@ namespace MS.Internal.Xaml.Parser
                 // handle escaping and quoting first.
                 if(escaped)
                 {
-                    sb.Append('\\');
+                    sb.Append(Backslash);
                     sb.Append(ch);
                     escaped = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
@@ -37,7 +37,7 @@ namespace MS.Internal.Xaml.Parser
 
         public static bool ContainsDot(string name)
         {
-            return name.Contains(".");
+            return name.Contains(Dot);
         }
 
         public static bool IsValidXamlName(string name)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
@@ -23,7 +23,7 @@ namespace System.Xaml.Schema
             // xmlns:bar="clr-namespace:MyAppsNs"
             // xmlns:spam="clr-namespace:MyAppsNs;assembly="  
 
-            int colonIdx = KS.IndexOf(uriInput, ":");
+            int colonIdx = KS.IndexOf(uriInput, ':');
             if (colonIdx == -1)
             {
                 return false;
@@ -36,7 +36,7 @@ namespace System.Xaml.Schema
             }
 
             int clrNsStartIdx = colonIdx + 1;
-            int semicolonIdx = KS.IndexOf(uriInput, ";");
+            int semicolonIdx = KS.IndexOf(uriInput, ';');
             if (semicolonIdx == -1)
             {
                 clrNs = uriInput.Substring(clrNsStartIdx);
@@ -50,7 +50,7 @@ namespace System.Xaml.Schema
             }
 
             int assemblyKeywordStartIdx = semicolonIdx+1;
-            int equalIdx = KS.IndexOf(uriInput, "=");
+            int equalIdx = KS.IndexOf(uriInput, '=');
             if (equalIdx == -1)
             {
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -260,12 +260,12 @@ namespace System.Xaml
 
                     if (s[i] == '\\' || s[i] == '"')
                     {
-                        sb.Append("\\");
+                        sb.Append('\\');
                     }
                     sb.Append(s[i]);
                 }
 
-                sb.Append("\"");
+                sb.Append('\"');
                 return sb.ToString();
             }
 
@@ -274,7 +274,7 @@ namespace System.Xaml
                 if (!string.IsNullOrEmpty(prefix))
                 {
                     writer.sb.Append(prefix);
-                    writer.sb.Append(":");
+                    writer.sb.Append(':');
                 }
             }
 
@@ -308,7 +308,7 @@ namespace System.Xaml
 
                 string prefix = writer.LookupPrefix(type);
 
-                writer.sb.Append("{");
+                writer.sb.Append('{');
                 WritePrefix(writer, prefix);
                 writer.sb.Append(XamlXmlWriter.GetTypeName(type));
 
@@ -342,7 +342,7 @@ namespace System.Xaml
                     throw new InvalidOperationException(SR.Get(SRID.XamlMarkupExtensionWriterInputInvalid));
                 }
 
-                writer.sb.Append("}");
+                writer.sb.Append('}');
 
                 if (writer.nodes.Count == 0)
                 {
@@ -419,7 +419,7 @@ namespace System.Xaml
                     writer.sb.Append(property.Name);
                 }
 
-                writer.sb.Append("=");
+                writer.sb.Append('=');
 
                 writer.currentState = InMember.State;
             }
@@ -576,7 +576,7 @@ namespace System.Xaml
                 }
                 string prefix = writer.LookupPrefix(type);
 
-                writer.sb.Append("{");
+                writer.sb.Append('{');
                 WritePrefix(writer, prefix);
                 writer.sb.Append(XamlXmlWriter.GetTypeName(type));
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1361,19 +1361,19 @@ namespace System.Xaml
             }
             if (!string.IsNullOrEmpty(ns))
             {
-                sb.Append("{");
+                sb.Append('{');
                 sb.Append(PreferredXamlNamespace);
-                sb.Append("}");
+                sb.Append('}');
             }
             else if (UnderlyingTypeInternal.Value != null)
             {
                 sb.Append(UnderlyingTypeInternal.Value.Namespace);
-                sb.Append(".");
+                sb.Append('.');
             }
             sb.Append(Name);
             if (IsGeneric)
             {
-                sb.Append("(");
+                sb.Append('(');
                 for (int i = 0; i < TypeArguments.Count; i++)
                 {
                     TypeArguments[i].AppendTypeName(sb, forceNsInitialization);
@@ -1382,7 +1382,7 @@ namespace System.Xaml
                         sb.Append(", ");
                     }
                 }
-                sb.Append(")");
+                sb.Append(')');
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -242,9 +242,9 @@ namespace System.Xaml.Schema
             }
             if (prefixGenerator == null)
             {
-                result.Append("{");
+                result.Append('{');
                 result.Append(Namespace);
-                result.Append("}");
+                result.Append('}');
             }
             else
             {
@@ -256,7 +256,7 @@ namespace System.Xaml.Schema
                 if (prefix.Length != 0)
                 {
                     result.Append(prefix);
-                    result.Append(":");
+                    result.Append(':');
                 }
             }
             if (HasTypeArgs)
@@ -266,9 +266,9 @@ namespace System.Xaml.Schema
                 string name = GenericTypeNameScanner.StripSubscript(Name, out subscript);
                 result.Append(name);
 
-                result.Append("(");
+                result.Append('(');
                 ConvertListToStringInternal(result, TypeArguments, prefixGenerator);
-                result.Append(")");
+                result.Append(')');
 
                 result.Append(subscript);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -655,7 +655,7 @@ namespace System.Xaml
             if (type.TypeArguments != null)
             {
                 bool added = false;
-                builder.Append("(");
+                builder.Append('(');
                 foreach (XamlType arg in type.TypeArguments)
                 {
                     if (added)
@@ -665,7 +665,7 @@ namespace System.Xaml
                     ConvertXamlTypeToStringHelper(arg, builder);
                     added = true;
                 }
-                builder.Append(")");
+                builder.Append(')');
             }
 
             // re-attach the subscript


### PR DESCRIPTION
Replace all method call that uses a single char string while there is another method that accepts a char.

Should yield tiny performance benefit on hot paths.