### PR TITLE
Remove unused local variable 'selfStyle' and related conditionals in System.Windows.StyleHelper.GetThemeStyle

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -168,7 +168,6 @@ namespace System.Windows
             // Fetch the DefaultStyleKey and the self Style for
             // the given Framework[Content]Element
             object themeStyleKey = null;
-            Style selfStyle = null;
             Style oldThemeStyle = null;
             Style newThemeStyle = null;
             bool overridesDefaultStyle;
@@ -180,10 +179,7 @@ namespace System.Windows
 
                 themeStyleKey = fe.DefaultStyleKey;
                 overridesDefaultStyle = fe.OverridesDefaultStyle;
-                if(ShouldGetValueFromStyle ( FrameworkElement.DefaultStyleKeyProperty ) )
-                {
-                    selfStyle = fe.Style;
-                }
+              
                 oldThemeStyle = fe.ThemeStyle;
             }
             else
@@ -194,10 +190,7 @@ namespace System.Windows
 
                 themeStyleKey = fce.DefaultStyleKey;
                 overridesDefaultStyle = fce.OverridesDefaultStyle;
-                if(ShouldGetValueFromStyle ( FrameworkContentElement.DefaultStyleKeyProperty) )
-                {
-                    selfStyle = fce.Style;
-                }
+               
                 oldThemeStyle = fce.ThemeStyle;
             }
 


### PR DESCRIPTION
We define the selfStyle variable, but we do not use it. I remove the codes to improve performance