### PR TITLE
Inline VerifyAccess

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -17,6 +17,8 @@ using MS.Internal.Interop;                   // WM
 using MS.Internal.WindowsBase;               // SecurityHelper
 using System.Threading;
 using System.ComponentModel;                 // EditorBrowsableAttribute, BrowsableAttribute
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 // Disabling 1634 and 1691:
 // In order to avoid generating warnings about unknown message numbers and
@@ -222,8 +224,16 @@ namespace System.Windows.Threading
         {
             if(!CheckAccess())
             {
-                throw new InvalidOperationException(SR.VerifyAccess);
+                ThrowVerifyAccess();
             }
+        }
+
+        // Used to inline VerifyAccess.
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowVerifyAccess()
+        {
+            throw new InvalidOperationException(SR.VerifyAccess);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -224,16 +224,14 @@ namespace System.Windows.Threading
         {
             if(!CheckAccess())
             {
+                // Used to inline VerifyAccess.
+                [DoesNotReturn]
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                static void ThrowVerifyAccess()
+                    => throw new InvalidOperationException(SR.VerifyAccess);
+
                 ThrowVerifyAccess();
             }
-        }
-
-        // Used to inline VerifyAccess.
-        [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void ThrowVerifyAccess()
-        {
-            throw new InvalidOperationException(SR.VerifyAccess);
         }
 
         /// <summary>


### PR DESCRIPTION
The method `VerifyAccess` is not being inlined because of the Exception. Not inlining the throw is enough to inline `VerifyAccess` because the method `CheckAccess` already qualifies to be inlined.

I used the following code to benchmark it :
https://gist.github.com/ThomasGoulet73/3dbc0cf5d24ca06b639ba6888c27fe02

Here are the results :
|               Method | count |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |------ |----------:|---------:|---------:|-------:|------:|------:|----------:|
|          CheckAccess |    10 |  95.25 ns | 1.469 ns | 1.374 ns | 0.0764 |     - |     - |     480 B |
|         VerifyAccess |    10 | 143.90 ns | 1.693 ns | 1.501 ns | 0.0763 |     - |     - |     480 B |
|  CheckAccess_Inlined |    10 |  94.92 ns | 1.222 ns | 1.020 ns | 0.0764 |     - |     - |     480 B |
| VerifyAccess_Inlined |    10 |  97.63 ns | 0.627 ns | 0.556 ns | 0.0764 |     - |     - |     480 B |

The perf gain is small but since `VerifyAccess` is used in a lot of place, any perf gain is good.

In the future, we could create a ThrowHelper like in the runtime repo. To prevent inlining throws which may prevent methods to otherwise be inlined.