### PR TITLE
Port release/5.0 5.0.3 servicing fix to master: markup compiler updates

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -154,6 +154,11 @@ namespace MS.Internal
             set { _taskLogger = value; }
         }
 
+        /// <summary>
+        /// Support custom IntermediateOutputPath and BaseIntermediateOutputPath outside the project path
+        /// </summary>
+        internal bool SupportCustomOutputPaths { get; set; } = false;
+
         // If the xaml has local references, then it could have internal element & properties
         // but there is no way to determine this until MCPass2. Yet, GeneratedInternalTypeHelper,
         // which is the class that allows access to legitimate internals, needs to be generated
@@ -1575,11 +1580,30 @@ namespace MS.Internal
         {
             get
             {
-#if NETFX 
-                return PathInternal.GetRelativePath(TargetPath, SourceFileInfo.SourcePath, StringComparison.OrdinalIgnoreCase) + Path.DirectorySeparatorChar;
+                if (SupportCustomOutputPaths)
+                {
+                    #if NETFX 
+                    return PathInternal.GetRelativePath(TargetPath, SourceFileInfo.SourcePath, StringComparison.OrdinalIgnoreCase) + Path.DirectorySeparatorChar;
 #else
-                return Path.GetRelativePath(TargetPath, SourceFileInfo.SourcePath) + Path.DirectorySeparatorChar;
+                    return Path.GetRelativePath(TargetPath, SourceFileInfo.SourcePath) + Path.DirectorySeparatorChar;
 #endif
+                }
+                else
+                {
+                    string parentFolderPrefix = string.Empty;
+                    if (TargetPath.StartsWith(SourceFileInfo.SourcePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string relPath = TargetPath.Substring(SourceFileInfo.SourcePath.Length);
+                        relPath += SourceFileInfo.RelativeSourceFilePath;
+                        string[] dirs = relPath.Split(new Char[] { Path.DirectorySeparatorChar });
+                        for (int i = 1; i < dirs.Length; i++)
+                        {
+                            parentFolderPrefix += PARENTFOLDER;
+                        }
+                    }
+
+                    return parentFolderPrefix;
+                } 
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
@@ -201,6 +201,11 @@ namespace MS.Internal
             get { return _nErrors; }
         }
 
+        internal bool SupportCustomOutputPaths 
+        {
+            set { _mc.SupportCustomOutputPaths = value; }
+        }
+
         // <summary>
         // Start the compilation.
         // </summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -223,7 +223,7 @@ namespace MS.Internal.Tasks
         //
         // Helper to create CompilerWrapper.
         //
-        internal static CompilerWrapper CreateCompilerWrapper(bool fInSeparateDomain, ref AppDomain  appDomain)
+        internal static CompilerWrapper CreateCompilerWrapper()
         {
             return new CompilerWrapper();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -411,15 +411,9 @@
         <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_ParentProjectName)$(_ParentProjectExtension).nuget.g.targets"/>
         <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_ParentProjectName)$(_ParentProjectExtension).nuget.dgspec.json"/>
 
-<<<<<<< HEAD
-        <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.props"/>
-        <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.targets"/>
-        <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.dgspec.json"/>
-=======
         <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.props"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.targets"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.dgspec.json"/>
->>>>>>> 860cb373 (Always copy project.assets.json and project.nuget.cache when BaseIntermediateOutputPath is set)
       </ItemGroup>
 
       <!-- Project assets and nuget.cache files must also be copied if a custom BaseIntermediateOutputPath is set. -->

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -400,16 +400,37 @@
        </PropertyGroup>
 
       <!-- Collect the generated NuGet files from the parent project required to support PackageReferences. -->
+      <!--  
+          Note that MSBuildProjectExtensionsPath defaults to BaseIntermediateOutputPath (Microsoft.Common.props) 
+          unless it it set prior to importing the .NET SDK. In the WPF temp project, MSBuildProjectExtensionsPath 
+          cannot be defined before the .NET SDK is imported, and always defaults to BaseIntermediateOutputPath.
+      -->
+
       <ItemGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'">
         <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_ParentProjectName)$(_ParentProjectExtension).nuget.g.props"/>
         <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_ParentProjectName)$(_ParentProjectExtension).nuget.g.targets"/>
         <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_ParentProjectName)$(_ParentProjectExtension).nuget.dgspec.json"/>
 
+<<<<<<< HEAD
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.props"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.targets"/>
         <_DestGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)$(_TemporaryTargetAssemblyProjectName).nuget.dgspec.json"/>
+=======
+        <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.props"/>
+        <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.g.targets"/>
+        <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)$(_TemporaryTargetAssemblyProjectName).nuget.dgspec.json"/>
+>>>>>>> 860cb373 (Always copy project.assets.json and project.nuget.cache when BaseIntermediateOutputPath is set)
       </ItemGroup>
 
+      <!-- Project assets and nuget.cache files must also be copied if a custom BaseIntermediateOutputPath is set. -->
+      <ItemGroup Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false' and '$(_InitialBaseIntermediateOutputPath)' != '$(BaseIntermediateOutputPath)'">
+        <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)project.assets.json"/>
+        <_SourceGeneratedNuGetPropsAndTargets Include="$(MSBuildProjectExtensionsPath)project.nuget.cache"/>
+
+        <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)project.assets.json"/>
+        <_DestGeneratedNuGetPropsAndTargets Include="$(BaseIntermediateOutputPath)project.nuget.cache"/>
+      </ItemGroup>
+         
       <!-- Copy the renamed outer project NuGet props/targets files to the MSBuildProjectExtensionsPath used by NuGet. -->
       <Copy Condition="'$(IncludePackageReferencesDuringMarkupCompilation)' != 'false'"
             SourceFiles="@(_SourceGeneratedNuGetPropsAndTargets)"

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -244,7 +244,8 @@
                ExtraBuildControlFiles="@(ExtraBuildControlFiles)"
                XamlDebuggingInformation="$(XamlDebuggingInformation)"
                IsRunningInVisualStudio="$(BuildingInsideVisualStudio)"
-               OutputPath="$(IntermediateOutputPath)">
+               OutputPath="$(IntermediateOutputPath)"
+               SupportCustomOutputPaths="$(IncludePackageReferencesDuringMarkupCompilation)">
 
               <Output ItemName="GeneratedBaml" TaskParameter="GeneratedBamlFiles"/>
               <Output ItemName="GeneratedLocalizationFiles" TaskParameter="GeneratedLocalizationFiles" />
@@ -304,7 +305,8 @@
                XamlDebuggingInformation="$(XamlDebuggingInformation)"
                GeneratedBaml=""
                OutputPath="$(IntermediateOutputPath)"
-               ContinueOnError="false" >
+               ContinueOnError="false" 
+               SupportCustomOutputPaths="$(IncludePackageReferencesDuringMarkupCompilation)">
 
           <!--
                Output Items for MarkupCompilePass2

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -588,6 +588,11 @@ namespace Microsoft.Build.Tasks.Windows
         }
 
         ///<summary>
+        /// Support custom IntermediateOutputPath and BaseIntermediateOutputPath outside the project path
+        ///</summary>
+        public bool SupportCustomOutputPaths { get; set; } = false;
+
+        ///<summary>
         /// Generated source code files for the given programing language.
         ///</summary>
         [Output]
@@ -1215,7 +1220,7 @@ namespace Microsoft.Build.Tasks.Windows
 
             try
             {
-                compilerWrapper = TaskHelper.CreateCompilerWrapper(AlwaysCompileMarkupFilesInSeparateDomain, ref appDomain);
+                compilerWrapper = TaskHelper.CreateCompilerWrapper();
 
                 if (compilerWrapper != null)
                 {
@@ -1238,6 +1243,8 @@ namespace Microsoft.Build.Tasks.Windows
                     }
 
                     compilerWrapper.ContentFiles = CompilerAnalyzer.ContentFiles;
+
+                    compilerWrapper.SupportCustomOutputPaths = SupportCustomOutputPaths;
 
                     // Process Reference list here.
                     ArrayList referenceList = ProcessReferenceList();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -322,6 +322,11 @@ namespace Microsoft.Build.Tasks.Windows
             set { _xamlDebuggingInformation = value; }
         }
 
+        ///<summary>
+        /// Support custom IntermediateOutputPath and BaseIntermediateOutputPath outside the project path
+        ///</summary>
+        public bool SupportCustomOutputPaths { get; set; } = false;
+
         /// <summary>
         /// Known reference paths hold referenced assemblies which are never changed during the build procedure.
         /// such as references in GAC, in framework directory or framework SDK directory etc.
@@ -634,7 +639,7 @@ namespace Microsoft.Build.Tasks.Windows
 
             try
             {
-                compilerWrapper = TaskHelper.CreateCompilerWrapper(AlwaysCompileMarkupFilesInSeparateDomain, ref appDomain);
+                compilerWrapper = TaskHelper.CreateCompilerWrapper();
 
                 if (compilerWrapper != null)
                 {
@@ -644,6 +649,8 @@ namespace Microsoft.Build.Tasks.Windows
                     compilerWrapper.TaskLogger = Log;
                     compilerWrapper.UnknownErrorID = UnknownErrorID;
                     compilerWrapper.XamlDebuggingInformation = XamlDebuggingInformation;
+
+                    compilerWrapper.SupportCustomOutputPaths = SupportCustomOutputPaths;
 
                     compilerWrapper.TaskFileService = _taskFileService;
 


### PR DESCRIPTION
### [release/5.0] Improve handling of custom paths in markup compiler [ask-mode for 5.0 servicing]

*This feature requires applications to **opt-in** by explicitly setting a property in their project file.  Otherwise, the existing path handling code is executed.*

> * Relative path fixes from previous commit: https://github.com/dotnet/wpf/pull/3120

This PR brings the changes from master to release/5.0: 

A single property turns on the feature `(IncludePackageReferencesDuringMarkupCompilation = true)` and enables the new behavior.  By default, the unmodified markup compiler code is called, the *old* path.

