### PR TITLE
Community.testpass.1.25.2021

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -65,9 +65,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2f1def8c556403ca85d1de50609492fef664b638</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="6.0.0-alpha.1.21076.2">
+    <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="6.0.0-preview.2.21076.4">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
-      <Sha>58eb956f3df6277f02b26db7ec2249f6e2585292</Sha>
+      <Sha>20cd392bb0d21d827970598527a61d49b464813e</Sha>
     </Dependency>
     <Dependency Name="System.IO.Packaging" Version="6.0.0-preview.1.21074.3" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <SystemIOPackagingVersion>6.0.0-preview.1.21074.3</SystemIOPackagingVersion>
     <SystemResourcesExtensionsVersion>6.0.0-preview.1.21074.3</SystemResourcesExtensionsVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -89,6 +89,6 @@
     <SystemReflectionMetadataLoadContextPackage>System.Reflection.MetadataLoadContext</SystemReflectionMetadataLoadContextPackage>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetWpfDncEngVersion>6.0.0-alpha.1.21076.2</MicrosoftDotNetWpfDncEngVersion>
+    <MicrosoftDotNetWpfDncEngVersion>6.0.0-preview.2.21076.4</MicrosoftDotNetWpfDncEngVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -492,7 +492,7 @@ namespace MS.Internal
                     }
                 }
 
-                int pathEndIndex = SourceFileInfo.RelativeSourceFilePath.LastIndexOf(string.Empty + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+                int pathEndIndex = SourceFileInfo.RelativeSourceFilePath.LastIndexOf(Path.DirectorySeparatorChar);
                 string targetPath = TargetPath + SourceFileInfo.RelativeSourceFilePath.Substring(0, pathEndIndex + 1);
 
                 // Create if not already exists
@@ -716,7 +716,7 @@ namespace MS.Internal
 
                 if (sourceFileInfo.IsXamlFile)
                 {
-                    int fileExtIndex = file.Path.LastIndexOf(DOT, StringComparison.Ordinal);
+                    int fileExtIndex = file.Path.LastIndexOf(DOTCHAR);
                     
                     sourceFileInfo.RelativeSourceFilePath = file.Path.Substring(0, fileExtIndex);
                 }
@@ -1420,7 +1420,7 @@ namespace MS.Internal
         internal void ValidateFullSubClassName(ref string subClassFullName)
         {
             bool isValid = false;
-            int index = subClassFullName.LastIndexOf(DOT, StringComparison.Ordinal);
+            int index = subClassFullName.LastIndexOf(DOTCHAR);
 
             if (index > 0)
             {
@@ -1449,7 +1449,7 @@ namespace MS.Internal
             if (className.Length > 0)
             {
                 // Split the Namespace
-                int index = className.LastIndexOf(DOT, StringComparison.Ordinal);
+                int index = className.LastIndexOf(DOTCHAR);
 
                 if (index > 0)
                 {
@@ -2323,7 +2323,7 @@ namespace MS.Internal
 
                     // NOTE: Remove when CodeDom is fixed to understand mangled generic names.
                     genericName = t.FullName;
-                    int bang = genericName.IndexOf(GENERIC_DELIMITER, StringComparison.Ordinal);
+                    int bang = genericName.IndexOf(GENERIC_DELIMITER);
                     if (bang > 0)
                     {
                         genericName = genericName.Substring(0, bang);
@@ -2366,7 +2366,7 @@ namespace MS.Internal
 
                 // NOTE: Remove when CodeDom is fixed to understand mangled generic names.
                 string genericName = t.Namespace + DOT + t.Name;
-                int bang = genericName.IndexOf(GENERIC_DELIMITER, StringComparison.Ordinal);
+                int bang = genericName.IndexOf(GENERIC_DELIMITER);
                 if (bang > 0)
                 {
                     genericName = genericName.Substring(0, bang);
@@ -3542,7 +3542,7 @@ namespace MS.Internal
         private const string            ANONYMOUS_ENTRYCLASS_PREFIX = "Generated";
         private const string            DEFINITION_PREFIX = "x";
         private const char              COMMA = ',';
-        private const string            GENERIC_DELIMITER = "`";
+        private const char              GENERIC_DELIMITER = '`';
         internal const char             DOTCHAR = '.';
         internal const string           DOT = ".";
         internal const string           CODETAG = "Code";

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
@@ -839,7 +839,7 @@ namespace MS.Internal
                 {
                     if (_class == MarkupCompiler.DOT)
                     {
-                        int index = xamlDefAttributeNode.Value.LastIndexOf(MarkupCompiler.DOT, StringComparison.Ordinal);
+                        int index = xamlDefAttributeNode.Value.LastIndexOf(MarkupCompiler.DOTCHAR);
                         ThrowException(SRID.InvalidClassName,
                                        MarkupCompiler.DefinitionNSPrefix,
                                        CLASS,
@@ -869,7 +869,7 @@ namespace MS.Internal
                 {
                     if (_subClass == MarkupCompiler.DOT)
                     {
-                        int index = xamlDefAttributeNode.Value.LastIndexOf(MarkupCompiler.DOT, StringComparison.Ordinal);
+                        int index = xamlDefAttributeNode.Value.LastIndexOf(MarkupCompiler.DOTCHAR);
                         ThrowException(SRID.InvalidClassName,
                                        MarkupCompiler.DefinitionNSPrefix,
                                        SUBCLASS,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
@@ -363,7 +363,7 @@ namespace MS.Internal
                 //
                 // For Xaml Source file, we need to remove the .xaml extension part.
                 //
-                int fileExtIndex = newRelativeFilePath.LastIndexOf(MarkupCompiler.DOT, StringComparison.Ordinal);
+                int fileExtIndex = newRelativeFilePath.LastIndexOf(MarkupCompiler.DOTCHAR);
                 newRelativeFilePath = newRelativeFilePath.Substring(0, fileExtIndex);
             }
 
@@ -413,7 +413,7 @@ namespace MS.Internal
                 // and put the deepest directory that file is in as the new
                 // SourceDir.
                 //
-                int pathEndIndex = fullFilePath.LastIndexOf(string.Empty + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+                int pathEndIndex = fullFilePath.LastIndexOf(Path.DirectorySeparatorChar);
 
                 newSourceDir = fullFilePath.Substring(0, pathEndIndex + 1);
                 newRelativeFilePath = fullFilePath.Substring(pathEndIndex + 1);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -1085,7 +1085,7 @@ namespace Microsoft.Build.Tasks.Windows
                 // and put the deepest directory that file is in as the new
                 // SourceDir.
                 //
-                int pathEndIndex = fullFilePath.LastIndexOf(string.Empty + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+                int pathEndIndex = fullFilePath.LastIndexOf(Path.DirectorySeparatorChar);
                 
                 newSourceDir = fullFilePath.Substring(0, pathEndIndex + 1);
                 newRelativeFilePath = TaskHelper.GetRootRelativePath(newSourceDir, fullFilePath);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass2.cs
@@ -550,7 +550,7 @@ namespace Microsoft.Build.Tasks.Windows
                 // and put the deepest directory that file is in as the new
                 // SourceDir.
                 //
-                int pathEndIndex = fullFilePath.LastIndexOf(string.Empty + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+                int pathEndIndex = fullFilePath.LastIndexOf(Path.DirectorySeparatorChar);
 
                 newSourceDir = fullFilePath.Substring(0, pathEndIndex + 1);
                 newRelativeFilePath = TaskHelper.GetRootRelativePath(newSourceDir, fullFilePath);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGesture.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/KeyGesture.cs
@@ -253,7 +253,7 @@ namespace System.Windows.Input
                 string keyDisplayString;
 
                 // break apart first gesture from the rest
-                int index = keyGestures.IndexOf(MULTIPLEGESTURE_DELIMITER, StringComparison.Ordinal);
+                int index = keyGestures.IndexOf(MULTIPLEGESTURE_DELIMITER);
                 if (index >= 0)
                 {   // multiple gestures exist
                     keyGestureToken  = keyGestures.Substring(0, index);
@@ -266,7 +266,7 @@ namespace System.Windows.Input
                 }
 
                 // similarly, break apart first display string from the rest
-                index = displayStrings.IndexOf(MULTIPLEGESTURE_DELIMITER, StringComparison.Ordinal);
+                index = displayStrings.IndexOf(MULTIPLEGESTURE_DELIMITER);
                 if (index >= 0)
                 {   // multiple display strings exist
                     keyDisplayString  = displayStrings.Substring(0, index);
@@ -310,7 +310,7 @@ namespace System.Windows.Input
         private ModifierKeys   _modifiers = ModifierKeys.None;
         private Key            _key = Key.None;
         private string         _displayString;
-        private const string MULTIPLEGESTURE_DELIMITER = ";";
+        private const char MULTIPLEGESTURE_DELIMITER = ';';
         private static TypeConverter _keyGestureConverter = new KeyGestureConverter();
         //private static bool    _classRegistered = false;
 #endregion Private Fields

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Input
 
                 if (text != String.Empty)
                 {
-                    if (text.LastIndexOf(".", StringComparison.Ordinal) == -1)
+                    if (text.LastIndexOf('.') == -1)
                     {
                         CursorType ct = (CursorType)Enum.Parse(typeof(CursorType), text);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
@@ -256,7 +256,7 @@ namespace WinRT
                 }
                 catch (Exception) { }
 
-                var lastSegment = moduleName.LastIndexOf(".");
+                var lastSegment = moduleName.LastIndexOf('.');
                 if (lastSegment <= 0)
                 {
                     Marshal.ThrowExceptionForHR(hr);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -12498,7 +12498,7 @@ namespace System.Windows.Controls
                     }
                     if (filename != "none" && s_seqno > 1)
                     {
-                        int dotIndex = filename.LastIndexOf(".", StringComparison.Ordinal);
+                        int dotIndex = filename.LastIndexOf('.');
                         if (dotIndex < 0) dotIndex = filename.Length;
                         filename = filename.Substring(0, dotIndex) +
                             s_seqno.ToString() +

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -8238,7 +8238,7 @@ namespace System.Windows.Documents
                     // is very low. Now we replace image with the included picture uri to get
                     // the image directly from the specified Uri.
                     int uriSourceIndex = dnImage.Xaml.IndexOf("UriSource=", StringComparison.Ordinal);
-                    int uriSourceEndIndex = dnImage.Xaml.IndexOf("\"", uriSourceIndex + 11,  StringComparison.Ordinal);
+                    int uriSourceEndIndex = dnImage.Xaml.IndexOf('\"', uriSourceIndex + 11);
 
                     string imageXaml = dnImage.Xaml.Substring(0, uriSourceIndex);
                     imageXaml += "UriSource=\"" + pictureUri + "\"";
@@ -8410,7 +8410,7 @@ namespace System.Windows.Documents
             {
                 pictureUri = instructionName.Substring(uriIndex, instructionName.Length - uriIndex - 1);
 
-                int pictureUriEndIndex = pictureUri.IndexOf("\"", StringComparison.OrdinalIgnoreCase);
+                int pictureUriEndIndex = pictureUri.IndexOf('\"');
                 if (pictureUriEndIndex != -1)
                 {
                     pictureUri = pictureUri.Substring(0, pictureUriEndIndex);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -2231,7 +2231,7 @@ namespace System.Windows.Documents
         {
             RtfImageFormat imageFormat = RtfImageFormat.Unknown;
 
-            int extensionIndex = imageName.LastIndexOf(".", StringComparison.OrdinalIgnoreCase);
+            int extensionIndex = imageName.LastIndexOf('.');
 
             if (extensionIndex >= 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/Command/CommandConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/Command/CommandConverter.cs
@@ -235,7 +235,7 @@ namespace System.Windows.Input
             localName = ((string)source).Trim();
 
             // split CommandName from its TypeName (e.g. ScrollViewer.PageDownCommand to Scrollviewerand PageDownCommand)
-            int Offset = localName.LastIndexOf(".", StringComparison.Ordinal);
+            int Offset = localName.LastIndexOf('.');
             if (Offset >= 0)
             {
                 typeName = localName.Substring(0, Offset);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -1170,7 +1170,7 @@ namespace System.Windows.Markup
                              string       typeFullName,
                          out short        typeId)
         {
-            int dotIndex = typeFullName.LastIndexOf(".", StringComparison.Ordinal);
+            int dotIndex = typeFullName.LastIndexOf('.');
             string typeShortName;
             string typeClrNamespace;
             if (dotIndex >= 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlReader.cs
@@ -392,7 +392,7 @@ namespace System.Windows.Markup
                 {
                     _name = info.Name;
                     _localName = info.LocalName;
-                    int index = info.Name.LastIndexOf(".", StringComparison.Ordinal);
+                    int index = info.Name.LastIndexOf('.');
                     if (index > 0)
                     {
                         _ownerTypeName = info.Name.Substring(0, index);
@@ -439,7 +439,7 @@ namespace System.Windows.Markup
                     _connectionId = 0;
                     _prefix = string.Empty;
                     _name = cpInfo.Name;
-                    int index = cpInfo.Name.LastIndexOf(".", StringComparison.Ordinal);
+                    int index = cpInfo.Name.LastIndexOf('.');
                     if (index > 0)
                     {
                         _ownerTypeName = cpInfo.Name.Substring(0, index);
@@ -1305,7 +1305,7 @@ namespace System.Windows.Markup
                         }
                         BamlTypeInfoRecord typeInfo = MapTable.GetTypeInfoFromId(typeKeyRecord.TypeId);
                         string typeName = typeInfo.TypeFullName;
-                        typeName = typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1);
+                        typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
                         string assemblyName;
                         string prefix;
                         string xmlNamespace;
@@ -1425,7 +1425,7 @@ namespace System.Windows.Markup
             // a x:Key attribute.
             BamlTypeInfoRecord typeInfo = MapTable.GetTypeInfoFromId(keyStartRecord.TypeId);
             string markupString = typeInfo.TypeFullName;
-            markupString = markupString.Substring(markupString.LastIndexOf(".", StringComparison.Ordinal) + 1);
+            markupString = markupString.Substring(markupString.LastIndexOf('.') + 1);
             string assemblyName;
             string prefix;
             string xmlNamespace;
@@ -1552,7 +1552,7 @@ namespace System.Windows.Markup
                         BamlElementStartRecord elementStartRecord = _currentBamlRecord as BamlElementStartRecord;
                         BamlTypeInfoRecord elementTypeInfo = MapTable.GetTypeInfoFromId(elementStartRecord.TypeId);
                         string typename = elementTypeInfo.TypeFullName;
-                        typename = typename.Substring(typename.LastIndexOf(".", StringComparison.Ordinal) + 1);
+                        typename = typename.Substring(typename.LastIndexOf('.') + 1);
                         GetAssemblyAndPrefixAndXmlns(elementTypeInfo, out assemblyName, out prefix, out xmlNamespace);
                         if (prefix != string.Empty)
                         {
@@ -1964,7 +1964,7 @@ namespace System.Windows.Markup
 
             NodeTypeInternal = BamlNodeType.StartElement;
             _name = typeInfo.TypeFullName;
-            _localName = _name.Substring(_name.LastIndexOf(".", StringComparison.Ordinal) + 1);
+            _localName = _name.Substring(_name.LastIndexOf('.') + 1);
             _ownerTypeName = string.Empty;
             _clrNamespace = typeInfo.ClrNamespace;
             GetAssemblyAndPrefixAndXmlns(typeInfo, out _assemblyName, out _prefix, out _xmlNamespace);
@@ -2081,7 +2081,7 @@ namespace System.Windows.Markup
             // Set instance variables to node info extracted from record.
             NodeTypeInternal = BamlNodeType.StartComplexProperty;
             _localName = nodeInfo.LocalName;
-            int index = nodeInfo.Name.LastIndexOf(".", StringComparison.Ordinal);
+            int index = nodeInfo.Name.LastIndexOf('.');
             if (index > 0)
             {
                 _ownerTypeName = nodeInfo.Name.Substring(0, index);
@@ -2152,7 +2152,7 @@ namespace System.Windows.Markup
             NodeTypeInternal = BamlNodeType.EndComplexProperty;
             _name = nodeInfo.Name;
             _localName = nodeInfo.LocalName;
-            int index = nodeInfo.Name.LastIndexOf(".", StringComparison.Ordinal);
+            int index = nodeInfo.Name.LastIndexOf('.');
             if (index > 0)
             {
                 _ownerTypeName = nodeInfo.Name.Substring(0, index);
@@ -2409,7 +2409,7 @@ namespace System.Windows.Markup
                 string valueAssemblyName;
                 GetAssemblyAndPrefixAndXmlns(valueTypeInfo, out valueAssemblyName, out valuePrefix, out valueXmlNamespace);
                 typeName = valueTypeInfo.TypeFullName;
-                typeName = typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1);
+                typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
                 propName = attrInfo.Name;
             }
 
@@ -2484,7 +2484,7 @@ namespace System.Windows.Markup
                 string valueAssemblyName;
                 GetAssemblyAndPrefixAndXmlns(valueTypeInfo, out valueAssemblyName, out valuePrefix, out valueXmlNamespace);
                 typeName = valueTypeInfo.TypeFullName;
-                typeName = typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1);
+                typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
                 propName = attrInfo.Name;
             }
 
@@ -2598,7 +2598,7 @@ namespace System.Windows.Markup
             string valueAssemblyName;
             GetAssemblyAndPrefixAndXmlns(valueTypeInfo, out valueAssemblyName, out valuePrefix, out valueXmlNamespace);
             string typeName = valueTypeInfo.TypeFullName;
-            typeName = typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1);
+            typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
             if (valuePrefix == string.Empty)
             {
                 valueString += typeName;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
@@ -841,7 +841,7 @@ namespace System.Windows.Markup.Primitives
                         writtenAttributes[property.Name] = property.Name;
                         _writer.WriteStartElement(prefix, item.ObjectType.Name + "." + property.PropertyDescriptor.Name, uri);
 
-                        if (property.IsComposite || property.StringValue.IndexOf("{", StringComparison.Ordinal) == 0)
+                        if (property.IsComposite || property.StringValue.IndexOf('{') == 0)
                         {
                             foreach (MarkupObject subItem in property.Items)
                             {
@@ -1649,7 +1649,7 @@ namespace System.Windows.Markup.Primitives
                         result = "assembly";
                         if (uri.StartsWith(clrUriPrefix, StringComparison.Ordinal))
                         {
-                            string ns = uri.Substring(clrUriPrefix.Length, uri.IndexOf(";", StringComparison.Ordinal) - clrUriPrefix.Length);
+                            string ns = uri.Substring(clrUriPrefix.Length, uri.IndexOf(';') - clrUriPrefix.Length);
                             StringBuilder r = new StringBuilder();
                             for (int i = 0; i < ns.Length; i++)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationSequence.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationSequence.cs
@@ -999,7 +999,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="expansion">the new expansion</param>
         /// <param name="orientation">the new orientation</param>
         /// <param name="timestamp">the time of the new values</param>
-        private void OverwriteManipulationState(PointF position, float scale, float expansion, float orientation, Int64 timestamp)
+        private void OverwriteManipulationState(in PointF position, float scale, float expansion, float orientation, Int64 timestamp)
         {
             this.currentManipulationState = new ManipulationState(position, scale, expansion, orientation, timestamp);
 #if DEBUG
@@ -1033,7 +1033,7 @@ namespace System.Windows.Input.Manipulations
         /// </summary>
         /// <param name="referenceOrigin">the common point of reference</param>
         /// <param name="settings">manipulation settings</param>
-        private void SetVectorsFromPoint(PointF referenceOrigin, ISettings settings)
+        private void SetVectorsFromPoint(in PointF referenceOrigin, ISettings settings)
         {
             Debug.Assert(this.manipulatorStates != null && this.manipulatorStates.Count > 0);
 
@@ -1549,7 +1549,7 @@ namespace System.Windows.Input.Manipulations
             public readonly float Orientation;
             public Int64 Timestamp;
 
-            public ManipulationState(PointF position, float scale, float expansion, float orientation, Int64 timestamp)
+            public ManipulationState(in PointF position, float scale, float expansion, float orientation, Int64 timestamp)
             {
                 Debug.Assert(!float.IsNaN(position.X) && !float.IsNaN(position.Y));
                 Debug.Assert(!float.IsInfinity(position.Y) && !float.IsInfinity(position.Y));

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/PointF.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/PointF.cs
@@ -13,10 +13,10 @@ namespace System.Windows.Input.Manipulations
     /// two floats everywhere, but I just couldn't take it any more. A point class is just
     /// too nice a thing.
     /// </summary>
-    internal struct PointF
+    internal readonly struct PointF
     {
-        private float x;
-        private float y;
+        private readonly float x;
+        private readonly float y;
 
         /// <summary>
         /// Create a basic point structure
@@ -36,7 +36,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="point">The point to convert.</param>
         /// <returns>A VectorF structure with an X value equal to this point's X value
         /// and a Y value equal to this point's Y value.</returns>
-        public static explicit operator VectorF(PointF point)
+        public static explicit operator VectorF(in PointF point)
         {
             return new VectorF(point.x, point.y);
         }
@@ -47,7 +47,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator !=(PointF left, PointF right)
+        public static bool operator !=(in PointF left, in PointF right)
         {
             return left.X != right.X || left.Y != right.Y;
         }
@@ -61,7 +61,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="left"></param>
         /// <param name="right"></param>
         /// <returns></returns>
-        public static bool operator ==(PointF left, PointF right)
+        public static bool operator ==(in PointF left, in PointF right)
         {
             return left.X == right.X && left.Y == right.Y;
         }
@@ -73,7 +73,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="pt">The point to translate.</param>
         /// <param name="offset">The amount by which to translate the point.</param>
         /// <returns>The result of translating the specified point by the specified vector.</returns>
-        public static PointF operator +(PointF pt, VectorF offset)
+        public static PointF operator +(in PointF pt, VectorF offset)
         {
             return new PointF(pt.X + offset.X, pt.Y + offset.Y);
         }
@@ -85,7 +85,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="point1">The point from which point2 is subtracted.</param>
         /// <param name="point2">The point to subtract from point1.</param>
         /// <returns>The difference between point1 and point2.</returns>
-        public static VectorF operator -(PointF point1, PointF point2)
+        public static VectorF operator -(in PointF point1, in PointF point2)
         {
             return new VectorF(point1.x - point2.x, point1.y - point2.y);
         }
@@ -97,7 +97,7 @@ namespace System.Windows.Input.Manipulations
         /// <param name="point">The point from which vector is subtracted.</param>
         /// <param name="vector">The vector to subtract from point</param>
         /// <returns>The difference between point and vector.</returns>
-        public static PointF operator -(PointF point, VectorF vector)
+        public static PointF operator -(in PointF point, VectorF vector)
         {
             return new PointF(point.x - vector.X, point.y - vector.Y);
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Markup
             // included in the output formulation -- UTC gets written out with a "Z",
             // and Local gets written out with e.g. "-08:00" for Pacific Standard Time.
             
-            formatString.Append("K");
+            formatString.Append('K');
 
             // We've finally got our format string built, we can create the string.
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -1996,7 +1996,7 @@ namespace System.Xaml
                 if (value is NameFixupToken && parentProperty != XamlLanguage.Items)
                 {
                     NameFixupToken token = value as NameFixupToken;
-                    string names = String.Join(",", token.NeededNames.ToArray());
+                    string names = String.Join(',', token.NeededNames.ToArray());
                     string msg = SR.Get(SRID.ForwardRefDirectives, names);
                     throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                 }
@@ -2033,7 +2033,7 @@ namespace System.Xaml
                             // Only the key directive may be assigned a reference.
                             if (parentProperty != XamlLanguage.Key)
                             {
-                                string names = String.Join(",", token.NeededNames.ToArray());
+                                string names = String.Join(',', token.NeededNames.ToArray());
                                 string msg = SR.Get(SRID.ForwardRefDirectives, names);
                                 throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                             }
@@ -2086,7 +2086,7 @@ namespace System.Xaml
                                 if (parentProperty != XamlLanguage.Key)
                                 {
                                     NameFixupToken token = (NameFixupToken)value;
-                                    string names = String.Join(",", token.NeededNames.ToArray());
+                                    string names = String.Join(',', token.NeededNames.ToArray());
                                     string msg = SR.Get(SRID.ForwardRefDirectives, names);
                                     throw ctx.WithLineInfo(new XamlObjectWriterException(msg));
                                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -78,6 +78,14 @@ namespace System.Xaml.MS.Impl
             return src.IndexOf(chars, StringComparison.Ordinal);
         }
 
+        /// <summary>
+        /// Standard String Index search operation.
+        /// </summary>
+        public static int IndexOf(string src, char ch)
+        {
+            return src.IndexOf(ch, StringComparison.Ordinal);
+        }
+
         public static bool EndsWith(string src, string target)
         {
             return src.EndsWith(target, StringComparison.Ordinal);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -65,6 +65,14 @@ namespace System.Xaml.MS.Impl
         /// <summary>
         /// Standard String Index search operation.
         /// </summary>
+        public static int IndexOf(string src, char value)
+        {
+            return src.IndexOf(value);
+        }
+
+        /// <summary>
+        /// Standard String Index search operation.
+        /// </summary>
         public static int IndexOf(string src, string chars)
         {
             return src.IndexOf(chars, StringComparison.Ordinal);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -65,14 +65,6 @@ namespace System.Xaml.MS.Impl
         /// <summary>
         /// Standard String Index search operation.
         /// </summary>
-        public static int IndexOf(string src, char value)
-        {
-            return src.IndexOf(value);
-        }
-
-        /// <summary>
-        /// Standard String Index search operation.
-        /// </summary>
         public static int IndexOf(string src, string chars)
         {
             return src.IndexOf(chars, StringComparison.Ordinal);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -243,7 +243,7 @@ namespace MS.Internal.Xaml.Parser
                 value = value.Substring(2);
             } 
             
-            if (!value.Contains("\\"))
+            if (!value.Contains(Backslash))
             {
                 return value;
             }
@@ -352,7 +352,7 @@ namespace MS.Internal.Xaml.Parser
                 // handle escaping and quoting first.
                 if(escaped)
                 {
-                    sb.Append('\\');
+                    sb.Append(Backslash);
                     sb.Append(ch);
                     escaped = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
@@ -37,7 +37,7 @@ namespace MS.Internal.Xaml.Parser
 
         public static bool ContainsDot(string name)
         {
-            return name.Contains(".");
+            return name.Contains(Dot);
         }
 
         public static bool IsValidXamlName(string name)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
@@ -23,7 +23,7 @@ namespace System.Xaml.Schema
             // xmlns:bar="clr-namespace:MyAppsNs"
             // xmlns:spam="clr-namespace:MyAppsNs;assembly="  
 
-            int colonIdx = KS.IndexOf(uriInput, ":");
+            int colonIdx = KS.IndexOf(uriInput, ':');
             if (colonIdx == -1)
             {
                 return false;
@@ -36,7 +36,7 @@ namespace System.Xaml.Schema
             }
 
             int clrNsStartIdx = colonIdx + 1;
-            int semicolonIdx = KS.IndexOf(uriInput, ";");
+            int semicolonIdx = KS.IndexOf(uriInput, ';');
             if (semicolonIdx == -1)
             {
                 clrNs = uriInput.Substring(clrNsStartIdx);
@@ -50,7 +50,7 @@ namespace System.Xaml.Schema
             }
 
             int assemblyKeywordStartIdx = semicolonIdx+1;
-            int equalIdx = KS.IndexOf(uriInput, "=");
+            int equalIdx = KS.IndexOf(uriInput, '=');
             if (equalIdx == -1)
             {
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -260,12 +260,12 @@ namespace System.Xaml
 
                     if (s[i] == '\\' || s[i] == '"')
                     {
-                        sb.Append("\\");
+                        sb.Append('\\');
                     }
                     sb.Append(s[i]);
                 }
 
-                sb.Append("\"");
+                sb.Append('\"');
                 return sb.ToString();
             }
 
@@ -274,7 +274,7 @@ namespace System.Xaml
                 if (!string.IsNullOrEmpty(prefix))
                 {
                     writer.sb.Append(prefix);
-                    writer.sb.Append(":");
+                    writer.sb.Append(':');
                 }
             }
 
@@ -308,7 +308,7 @@ namespace System.Xaml
 
                 string prefix = writer.LookupPrefix(type);
 
-                writer.sb.Append("{");
+                writer.sb.Append('{');
                 WritePrefix(writer, prefix);
                 writer.sb.Append(XamlXmlWriter.GetTypeName(type));
 
@@ -342,7 +342,7 @@ namespace System.Xaml
                     throw new InvalidOperationException(SR.Get(SRID.XamlMarkupExtensionWriterInputInvalid));
                 }
 
-                writer.sb.Append("}");
+                writer.sb.Append('}');
 
                 if (writer.nodes.Count == 0)
                 {
@@ -419,7 +419,7 @@ namespace System.Xaml
                     writer.sb.Append(property.Name);
                 }
 
-                writer.sb.Append("=");
+                writer.sb.Append('=');
 
                 writer.currentState = InMember.State;
             }
@@ -576,7 +576,7 @@ namespace System.Xaml
                 }
                 string prefix = writer.LookupPrefix(type);
 
-                writer.sb.Append("{");
+                writer.sb.Append('{');
                 WritePrefix(writer, prefix);
                 writer.sb.Append(XamlXmlWriter.GetTypeName(type));
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -1361,19 +1361,19 @@ namespace System.Xaml
             }
             if (!string.IsNullOrEmpty(ns))
             {
-                sb.Append("{");
+                sb.Append('{');
                 sb.Append(PreferredXamlNamespace);
-                sb.Append("}");
+                sb.Append('}');
             }
             else if (UnderlyingTypeInternal.Value != null)
             {
                 sb.Append(UnderlyingTypeInternal.Value.Namespace);
-                sb.Append(".");
+                sb.Append('.');
             }
             sb.Append(Name);
             if (IsGeneric)
             {
-                sb.Append("(");
+                sb.Append('(');
                 for (int i = 0; i < TypeArguments.Count; i++)
                 {
                     TypeArguments[i].AppendTypeName(sb, forceNsInitialization);
@@ -1382,7 +1382,7 @@ namespace System.Xaml
                         sb.Append(", ");
                     }
                 }
-                sb.Append(")");
+                sb.Append(')');
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -242,9 +242,9 @@ namespace System.Xaml.Schema
             }
             if (prefixGenerator == null)
             {
-                result.Append("{");
+                result.Append('{');
                 result.Append(Namespace);
-                result.Append("}");
+                result.Append('}');
             }
             else
             {
@@ -256,7 +256,7 @@ namespace System.Xaml.Schema
                 if (prefix.Length != 0)
                 {
                     result.Append(prefix);
-                    result.Append(":");
+                    result.Append(':');
                 }
             }
             if (HasTypeArgs)
@@ -266,9 +266,9 @@ namespace System.Xaml.Schema
                 string name = GenericTypeNameScanner.StripSubscript(Name, out subscript);
                 result.Append(name);
 
-                result.Append("(");
+                result.Append('(');
                 ConvertListToStringInternal(result, TypeArguments, prefixGenerator);
-                result.Append(")");
+                result.Append(')');
 
                 result.Append(subscript);
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -655,7 +655,7 @@ namespace System.Xaml
             if (type.TypeArguments != null)
             {
                 bool added = false;
-                builder.Append("(");
+                builder.Append('(');
                 foreach (XamlType arg in type.TypeArguments)
                 {
                     if (added)
@@ -665,7 +665,7 @@ namespace System.Xaml
                     ConvertXamlTypeToStringHelper(arg, builder);
                     added = true;
                 }
-                builder.Append(")");
+                builder.Append(')');
             }
 
             // re-attach the subscript


### PR DESCRIPTION
**Community PR Test Pass 1/25/2021**

These PRs will be merged if no regressions are found.

**Community PRs included in this test branch:**

@lindexi: 

Using array empty to replace create an empty array #2843

@GrabYourPitchforks: 

Remove custom copy of PtrToStringChars #3117

@benaadams: 

Use char.{Last}IndexOf #3285

@ThomasGoulet73: 

Use char overload in System.Xaml #3998

@lindex:  

Use readonly struct in System.Windows.Input.Manipulations.PointF #4017 

**Test Matrix**

| OS | Architecture |
| --- | --- |
| Windows 7 SP1	Enterprise	| x86 |	
| Windows 7 SP1	Enterprise	| x64 |	
| Windows Blue	Enterprise	| x86 |	
| Windows Server 2012 R2 SP1	| x64 |
| Win10 RS1                	Enterprise	| x86 |
| Win10 RS3	Enterprise	| x64 |
| Win10 RS4	Enterprise	| x86 |
| Windows Server 2019		| x64  |
| Win10 RS6	Enterprise	| X86 |
| Windows Server 2016	 | x64 |