### PR TITLE
In WispLogic.cs, improve performance by reducing memory copy of arrays

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -208,8 +208,8 @@ namespace System.Windows.Input.StylusWisp
                     else
                     {
                         // GetRawPacketData creates copies, so only call them once
-                        int[] oldData = coalescedMove.GetRawPacketData();
-                        int[] newData = inputReport.GetRawPacketData();
+                        int[] oldData = coalescedMove.Data;
+                        int[] newData = inputReport.Data;
                         int[] mergedData = new int[oldData.Length + newData.Length];
 
                         oldData.CopyTo(mergedData, 0);


### PR DESCRIPTION
We haven't modified the contents of the array, so we don't need to call the RawStylusInputReport.GetRawPacketData method to create a copy of the array. We can use RawStylusInputReport.Data to return the original array