### PR TITLE
Update WPF binary names with _cor3 suffix to _net6

### DIFF
--- a/Documentation/projects-and-assemblies.md
+++ b/Documentation/projects-and-assemblies.md
@@ -357,24 +357,24 @@ The following assemblies are being produced today:
             WindowsFormsIntegration.resources.dll
 \---win-x86
     \---native
-            D3DCompiler_47_cor3.dll
-            PenImc_cor3.dll
-            PenImc_cor3.pdb
-            PresentationNative_cor3.dll
-            PresentationNative_cor3.pdb
+            D3DCompiler_47_net6.dll
+            PenImc_net6.dll
+            PenImc_net6.pdb
+            PresentationNative_net6.dll
+            PresentationNative_net6.pdb
             vcruntime140d.dll
-            wpfgfx_cor3.dll
-            wpfgfx_cor3.pdb
+            wpfgfx_net6.dll
+            wpfgfx_net6.pdb
 \---win-x64
     \---native
-            D3DCompiler_47_cor3.dll
-            PenImc_cor3.dll
-            PenImc_cor3.pdb
-            PresentationNative_cor3.dll
-            PresentationNative_cor3.pdb
+            D3DCompiler_47_net6.dll
+            PenImc_net6.dll
+            PenImc_net6.pdb
+            PresentationNative_net6.dll
+            PresentationNative_net6.pdb
             vcruntime140d.dll
-            wpfgfx_cor3.dll
-            wpfgfx_cor3.pdb			
+            wpfgfx_net6.dll
+            wpfgfx_net6.pdb			
 ```        
 
 The following projects exist in the repo. Those corresponding to the assemblies listed above are currently building. 

--- a/Documentation/projects-and-assemblies.md
+++ b/Documentation/projects-and-assemblies.md
@@ -92,7 +92,7 @@ The following assemblies are being produced today:
     |       
     \---zh-Hant
             PresentationBuildTasks.resources.dll
-\---net5.0
+\---net6.0
     |   DirectWriteForwarder.dll
     |   DirectWriteForwarder.pdb
     |   PresentationCore.dll

--- a/Documentation/redistributables.md
+++ b/Documentation/redistributables.md
@@ -15,7 +15,7 @@ WPF has two C++/CLI `/clr:pure` assemblies - `DirectWriteForwarder.dll` and `Sys
 
 This requires that end-users deploying WPF applications to install VC runtime redistributables. **We would like to avoid this.**
 
-`wpfgfx_cor3.dll` - WPF's renderer - depends on `d3dcompiler_47.dll` - which is not available on all platforms (Operating Systems) universally. Some platforms have shipped `d3dcompiler_47.dll` via WU or Download Center and requires customers/consumers to download and install it manually. 
+`wpfgfx_net6.dll` - WPF's renderer - depends on `d3dcompiler_47.dll` - which is not available on all platforms (Operating Systems) universally. Some platforms have shipped `d3dcompiler_47.dll` via WU or Download Center and requires customers/consumers to download and install it manually. 
 
 We would like to assure that `d3dcompiler_47.dll` to be available at runtime along with WPF on .NET Core.
 
@@ -26,8 +26,8 @@ Since applications are free to redistribute these assemblies as well, and someti
 In other words, 
 
 ```
- - vcruntime140.dll -> renamed to vcruntime140_cor3.dll 
- - d3dcompiler_47.dll -> renamed to d3dcompiler_47_cor3.dll 
+ - vcruntime140.dll -> renamed to vcruntime140_net6.dll 
+ - d3dcompiler_47.dll -> renamed to d3dcompiler_47_net6.dll 
 ```
 
 

--- a/eng/WpfArcadeSdk/tools/VersionSuffix.props
+++ b/eng/WpfArcadeSdk/tools/VersionSuffix.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <WpfVersionSuffix>_cor3</WpfVersionSuffix>
+    <WpfVersionSuffix>_net6</WpfVersionSuffix>
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -153,10 +153,10 @@
     <DisallowLibClause Condition="'$(DynamicStandardCppLibrary)'!=''">$(DisallowLibClause) /disallowlib:libcpmt$(LibSuffix).lib</DisallowLibClause>
 
     <!-- 
-      When linking to vcruntime140.dll, rename and link to vcruntime140_cor3.dll 
+      When linking to vcruntime140.dll, rename and link to vcruntime140_net6.dll 
         Caveats:
           - Supported only on Release builds 
-          - WPF will carry a privatized copy of vcruntime with it - renamed with suffix _cor3
+          - WPF will carry a privatized copy of vcruntime with it - renamed with suffix _net6
           - Debug builds normally link to Static VCRT by default, and linking to a privatized vcruntime is not required
           - Managed C++ assemblies that utilize /clr:pure always link to vcruntime implicitly, and should employ this 
             DLL renaming at link time and reference the privatized copy of vcruntime.

--- a/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
+++ b/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
@@ -54,19 +54,19 @@
     <WpfProjectPath Include="UIAutomationClientSideProviders" ProjectPath="$(WpfSourceDir)UIAutomation\UIAutomationClientSideProviders\UIAutomationClientSideProviders.csproj" />
 
 
-    <WpfProjectPath Include="PresentationNative_cor3" ProjectPath="$(WpfSourceDir)PresentationNative\dll\PresentationNative.vcxproj">
+    <WpfProjectPath Include="PresentationNative_net6" ProjectPath="$(WpfSourceDir)PresentationNative\dll\PresentationNative.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
     </WpfProjectPath>
-    <WpfProjectPath Include="WpfGfx_cor3" ProjectPath="$(WpfSourceDir)WpfGfx\core\dll\WpfGfx.vcxproj">
+    <WpfProjectPath Include="WpfGfx_net6" ProjectPath="$(WpfSourceDir)WpfGfx\core\dll\WpfGfx.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>    
     </WpfProjectPath>
-    <WpfProjectPath Include="PenImc_cor3" ProjectPath="$(WpfSourceDir)PenImc\dll\PenImc.vcxproj">
+    <WpfProjectPath Include="PenImc_net6" ProjectPath="$(WpfSourceDir)PenImc\dll\PenImc.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
+++ b/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
@@ -54,19 +54,19 @@
     <WpfProjectPath Include="UIAutomationClientSideProviders" ProjectPath="$(WpfSourceDir)UIAutomation\UIAutomationClientSideProviders\UIAutomationClientSideProviders.csproj" />
 
 
-    <WpfProjectPath Include="PresentationNative_net6" ProjectPath="$(WpfSourceDir)PresentationNative\dll\PresentationNative.vcxproj">
+    <WpfProjectPath Include="PresentationNative$(WpfVersionSuffix)" ProjectPath="$(WpfSourceDir)PresentationNative\dll\PresentationNative.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
     </WpfProjectPath>
-    <WpfProjectPath Include="WpfGfx_net6" ProjectPath="$(WpfSourceDir)WpfGfx\core\dll\WpfGfx.vcxproj">
+    <WpfProjectPath Include="WpfGfx$(WpfVersionSuffix)" ProjectPath="$(WpfSourceDir)WpfGfx\core\dll\WpfGfx.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>    
     </WpfProjectPath>
-    <WpfProjectPath Include="PenImc_net6" ProjectPath="$(WpfSourceDir)PenImc\dll\PenImc.vcxproj">
+    <WpfProjectPath Include="PenImc$(WpfVersionSuffix)" ProjectPath="$(WpfSourceDir)PenImc\dll\PenImc.vcxproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.DotNet.Wpf/redist/D3DCompiler/D3DCompiler.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/redist/D3DCompiler/D3DCompiler.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Architecture)'!='arm64'">
     <!-- 
       Target assembly will be a privatized copy of D3DCompiler, like  
-      d3dcompiler_47_cor3.dll
+      d3dcompiler_47_net6.dll
     -->
     <TargetName>$(D3DCompilerDllBaseName)$(D3DCompilerVersion)$(WpfVersionSuffix)</TargetName>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/redist/VCRuntime/VCRuntime.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/redist/VCRuntime/VCRuntime.vcxproj
@@ -41,7 +41,7 @@
     <VCRedistFallbackCrtFolderName Condition="'$(Configuration)'=='Release'">Microsoft.VC141.CRT</VCRedistFallbackCrtFolderName>
     <VCRedistFallbackCrtFolderName Condition="'$(Configuration)'=='Debug'">Microsoft.VC141.DebugCRT</VCRedistFallbackCrtFolderName>
     <!-- 
-      In Release builds,  the Target assembly will be a privatized copy of VC runtime with a name like vcruntime140_cor3.dll
+      In Release builds,  the Target assembly will be a privatized copy of VC runtime with a name like vcruntime140_net6.dll
       In Debug builds, the Target assembly will be a privatize copy of the VC runtime with no name changes - like vcruntime140d.dll
     -->
     <TargetName Condition="'$(Configuration)'=='Release'">$(VCRuntimeDllBaseName)$(VCRuntimeVersion)$(LibSuffix)$(WpfVersionSuffix)</TargetName>

--- a/src/Microsoft.DotNet.Wpf/src/PenImc/dll/PenIMC.manifest
+++ b/src/Microsoft.DotNet.Wpf/src/PenImc/dll/PenIMC.manifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
     
- <file name="PenImc_cor3.dll" hashalg="SHA1">
+ <file name="PenImc_net6.dll" hashalg="SHA1">
     <comClass 
         clsid="{F269D7C4-EF22-48A1-A503-4E0A620FC746}" 
         tlbid="{33363EEE-828A-4DFC-BB3C-AB9628E6DD62}" 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ExternDll.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ExternDll.cs
@@ -30,11 +30,11 @@ namespace MS.Win32
         public const string Oleacc = "oleacc.dll";
         public const string Oleaut32 = "oleaut32.dll";
         public const string Olepro32 = "olepro32.dll";
-        public const string Penimc ="PenIMC_cor3.dll";
+        public const string Penimc ="PenIMC_net6.dll";
         public const string PresentationCore = "PresentationCore.dll";
         public const string PresentationFramework = "PresentationFramework.dll";
-        public const string PresentationHostDll = "PresentationHost_cor3.dll";
-        public const string PresentationNativeDll = "PresentationNative_cor3.dll";
+        public const string PresentationHostDll = "PresentationHost_net6.dll";
+        public const string PresentationNativeDll = "PresentationNative_net6.dll";
         public const string Psapi = "psapi.dll";
         public const string Shcore = "shcore.dll";
         public const string Shell32 = "shell32.dll";
@@ -49,7 +49,7 @@ namespace MS.Win32
         public const string Winmm = "winmm.dll";
         public const string Winspool = "winspool.drv";
         public const string Wldp = "wldp.dll";
-        public const string WpfGfx = "WpfGfx_cor3.dll";
+        public const string WpfGfx = "WpfGfx_net6.dll";
         public const string WtsApi32 = "wtsapi32.dll";
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
@@ -33,7 +33,7 @@ namespace MS.Internal.Drt
 
     internal static class NativeMethodsSetLastError
     {
-        private const string PresentationNativeDll = "PresentationNative_cor3.dll";
+        private const string PresentationNativeDll = "PresentationNative_net6.dll";
 
 #if WINDOWSFORMSINTEGRATION     // WinFormsIntegration
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/RefAssemblyAttrs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/RefAssemblyAttrs.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Internal
     internal static class BuildInfo
     {
         internal const string WCP_VERSION = "4.0.0.0";
-        internal const string WCP_VERSION_SUFFIX = "_cor3";
+        internal const string WCP_VERSION_SUFFIX = "_net6";
         internal const string MIL_VERSION_SUFFIX = "";
 
         // MicrosoftShared PublicKeyToken

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/InteropWin32ApiThunk.hpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/inc/InteropWin32ApiThunk.hpp
@@ -366,7 +366,7 @@ namespace Win32ApiThunk
                 xpsPackageTarget);
         }
     private:
-        [DllImportAttribute("PresentationNative_cor3.dll" ,EntryPoint="IsStartXpsPrintJobSupported",
+        [DllImportAttribute("PresentationNative_net6.dll" ,EntryPoint="IsStartXpsPrintJobSupported",
                              CharSet=CharSet::Unicode,
                              SetLastError=true, 
                              CallingConvention = CallingConvention::Winapi)]
@@ -374,7 +374,7 @@ namespace Win32ApiThunk
         BOOL
         IsStartXpsPrintJobSupportedImpl(VOID);
         
-        [DllImportAttribute("PresentationNative_cor3.dll" ,EntryPoint="LateBoundStartXpsPrintJob",
+        [DllImportAttribute("PresentationNative_net6.dll" ,EntryPoint="LateBoundStartXpsPrintJob",
                              CharSet=CharSet::Unicode,
                              SetLastError=true, 
                              CallingConvention = CallingConvention::Winapi)]
@@ -393,7 +393,7 @@ namespace Win32ApiThunk
             VOID **printTicketStream
         );
         
-        [DllImportAttribute("PresentationNative_cor3.dll", EntryPoint = "IsPrintPackageTargetSupported",
+        [DllImportAttribute("PresentationNative_net6.dll", EntryPoint = "IsPrintPackageTargetSupported",
             CharSet = CharSet::Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention::Winapi)]
@@ -401,7 +401,7 @@ namespace Win32ApiThunk
         BOOL
         IsPrintPackageTargetSupportedImpl(VOID);
 
-        [DllImportAttribute("PresentationNative_cor3.dll", EntryPoint = "PrintToPackageTarget",
+        [DllImportAttribute("PresentationNative_net6.dll", EntryPoint = "PrintToPackageTarget",
             CharSet = CharSet::Unicode,
             SetLastError = true,
             CallingConvention = CallingConvention::Winapi)]

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/ExternDll.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/ExternDll.cs
@@ -11,7 +11,7 @@ namespace MS.Win32
 #if NET4X 
             "_v0400";
 #else
-            "_cor3";
+            "_net6";
 #endif
 
         const string PENIMC_SUFFIX =


### PR DESCRIPTION
PenImc_cor3.dll, wpfgfx_cor3.dll, and PresentationNative_cor3.dll were named during the port from .NET Framework to .NET Core and need to be updated.

These have been updated to _net6 from _cor3.  Fixes https://github.com/dotnet/wpf/issues/4062.  

/cc @SamBent 