### PR TITLE
Remove method with the same signature created in two different CTP PRs 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -65,14 +65,6 @@ namespace System.Xaml.MS.Impl
         /// <summary>
         /// Standard String Index search operation.
         /// </summary>
-        public static int IndexOf(string src, char value)
-        {
-            return src.IndexOf(value);
-        }
-
-        /// <summary>
-        /// Standard String Index search operation.
-        /// </summary>
         public static int IndexOf(string src, string chars)
         {
             return src.IndexOf(chars, StringComparison.Ordinal);


### PR DESCRIPTION
Merging the community test pass PRs independently caused two methods with the same signature to be added.  This removes one of them.  