### PR TITLE
Revert "Merge internal/release/3.1 and update branding in release/3.1 to 3.1.13"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-servicing.21064.4">
+    <Dependency Name="Microsoft.Private.Winforms" Version="4.8.1-servicing.20561.1">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>77b8f5e591e4e29951113504738ee1298d180367</Sha>
+      <Sha>af517511ca77d0aed7408e2ca712aa2b984d6ecb</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
       Version prefix used by a few projects like Project Templates
       Revision portion of Major.Minor.Revision usually updated every release
     -->
-    <TraditionalVersionPrefix>3.1.13</TraditionalVersionPrefix>
+    <TraditionalVersionPrefix>3.1.12</TraditionalVersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <!-- NuGet Package Versions -->
   <PropertyGroup>
-    <MicrosoftPrivateWinformsVersion>4.8.1-servicing.21064.4</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>4.8.1-servicing.20561.1</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/coreclr -->
   <PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/wpf#4165.  This should not have been a squash commit. 