### PR TITLE
Replaced some Dictionaries and Hashtables with Hashsets

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontResourceCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontResourceCache.cs
@@ -28,10 +28,10 @@ namespace MS.Internal.FontCache
         private static void ConstructFontResourceCache(Assembly entryAssembly, Dictionary<string, List<string>> folderResourceMap)
         {
             // For entryAssembly build a set of mapping from paths to entries that describe each resource.
-            Dictionary<string, string> contentFiles = ContentFileHelper.GetContentFiles(entryAssembly);
+            HashSet<string> contentFiles = ContentFileHelper.GetContentFiles(entryAssembly);
             if (contentFiles != null)
             {
-                foreach (string contentFile in contentFiles.Keys)
+                foreach (string contentFile in contentFiles)
                 {
                     AddResourceToFolderMap(folderResourceMap, contentFile);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ContentFileHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ContentFileHelper.cs
@@ -28,7 +28,7 @@ namespace MS.Internal.Resources
 
             if (_contentFiles != null && _contentFiles.Count > 0)
             {                
-                if (_contentFiles.ContainsKey(partName))
+                if (_contentFiles.Contains(partName))
                 {
                     return true;
                 }
@@ -40,9 +40,9 @@ namespace MS.Internal.Resources
         //
         // Get a list of Content Files for a given Assembly.
         //
-        static internal Dictionary<string, string> GetContentFiles(Assembly asm)
+        static internal HashSet<string> GetContentFiles(Assembly asm)
         {
-            Dictionary<string, string> contentFiles = null;
+            HashSet<string> contentFiles = null;
 
             Attribute[] assemblyAttributes;
 
@@ -53,7 +53,7 @@ namespace MS.Internal.Resources
                 {
                     // If we have no entry assembly return an empty list because
                     // we can't have any content files.
-                    return new Dictionary<string, string>();
+                    return new HashSet<string>();
                 }
             }
 
@@ -63,20 +63,20 @@ namespace MS.Internal.Resources
 
             if (assemblyAttributes != null && assemblyAttributes.Length > 0)
             {
-                contentFiles = new Dictionary<string, string>(assemblyAttributes.Length, StringComparer.OrdinalIgnoreCase);
+                contentFiles = new HashSet<string>(assemblyAttributes.Length, StringComparer.OrdinalIgnoreCase);
 
                 for (int i=0; i<assemblyAttributes.Length; i++)
                 {
                     AssemblyAssociatedContentFileAttribute aacf;
 
                     aacf = (AssemblyAssociatedContentFileAttribute) assemblyAttributes[i];
-                    contentFiles.Add(aacf.RelativeContentFilePath, null);
+                    contentFiles.Add(aacf.RelativeContentFilePath);
                 }
             }
 
             return contentFiles;
         }
 
-        private static Dictionary<string, string> _contentFiles;
+        private static HashSet<string> _contentFiles;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
@@ -223,7 +223,7 @@ namespace System.Windows.Media
             _contextGuid = Guid.NewGuid();
 
             // Create a dictionary in which we manage the CompositionTargets.
-            _registeredICompositionTargets = new Dictionary<ICompositionTarget, object>();
+            _registeredICompositionTargets = new HashSet<ICompositionTarget>();
 
             _renderModeMessage = new DispatcherOperationCallback(InvalidateRenderMode);
 
@@ -367,7 +367,7 @@ namespace System.Windows.Media
         {
             Debug.Assert(CheckAccess());
             
-            foreach (ICompositionTarget target in _registeredICompositionTargets.Keys)
+            foreach (ICompositionTarget target in _registeredICompositionTargets)
             {
                 HwndTarget hwndTarget = target as HwndTarget;
 
@@ -1441,7 +1441,7 @@ namespace System.Windows.Media
 
                 // First make a copy of the dictionarys contents, because ICompositionTarget.Dispose modifies this collection.
                 ICompositionTarget[] registeredVTs = new ICompositionTarget[_registeredICompositionTargets.Count];
-                _registeredICompositionTargets.Keys.CopyTo(registeredVTs, 0);
+                _registeredICompositionTargets.CopyTo(registeredVTs, 0);
 
                 // Iterate through the ICompositionTargets and dispose them. Be careful, ICompositionTarget.Dispose
                 // removes the ICompositionTargets from the Dictionary. This is why we don't iterate the Dictionary directly.
@@ -1519,7 +1519,7 @@ namespace System.Windows.Media
                 iv.AddRefOnChannel(channelSet.Channel, channelSet.OutOfBandChannel);
             }
 
-            _registeredICompositionTargets.Add(iv, null); // We use the dictionary just as a set.  
+            _registeredICompositionTargets.Add(iv);
         }
 
         /// <summary>
@@ -2067,7 +2067,7 @@ namespace System.Windows.Media
                 // ----------------------------------------------------------------
                 // 1) Render each registered ICompositionTarget to finish up the batch.
 
-                foreach (ICompositionTarget registeredTarget in _registeredICompositionTargets.Keys)
+                foreach (ICompositionTarget registeredTarget in _registeredICompositionTargets)
                 {
                     DUCE.ChannelSet channelSet;
                     channelSet.Channel = _channelManager.Channel;
@@ -2727,7 +2727,7 @@ namespace System.Windows.Media
         /// <summary>
         /// Set of ICompositionTargets that are currently registered with the MediaSystem;
         /// </summary>
-        private Dictionary<ICompositionTarget, object> _registeredICompositionTargets;
+        private HashSet<ICompositionTarget> _registeredICompositionTargets;
 
         /// <summary>
         /// This are the the permissions the Context has to access Visual APIs.

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonMenuItemsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonMenuItemsPanel.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
             // Divide remainingHeight equally among starLayoutProviders
             remainingHeight = finalSize.Height - totalDesiredHeight;
-            Dictionary<UIElement, object> starLayoutTargets = GetStarLayoutProviderTargets();
+            HashSet<UIElement> starLayoutTargets = GetStarLayoutProviderTargets();
             if (DoubleUtil.GreaterThan(remainingHeight, 0.0) && starLayoutTargets.Count > 0)
             {
                 surplusHeight = remainingHeight / starLayoutTargets.Count;
@@ -230,7 +230,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
             for (int i = 0; i < children.Count; i++)
             {
                 UIElement child = children[i];
-                if (starLayoutTargets.ContainsKey(child))
+                if (starLayoutTargets.Contains(child))
                 {
                     // if the child is a StarLayoutProvider, give it the surplusHeight.
                     double availableHeight = child.DesiredSize.Height + surplusHeight;
@@ -266,16 +266,16 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
             base.BringIndexIntoView(index);
         }
 
-        private Dictionary<UIElement, object> GetStarLayoutProviderTargets()
+        private HashSet<UIElement> GetStarLayoutProviderTargets()
         {
-            Dictionary<UIElement, object> targets = new Dictionary<UIElement, object>();
+            HashSet<UIElement> targets = new HashSet<UIElement>();
 
             foreach (IProvideStarLayoutInfoBase starProvider in _registeredStarLayoutProviders)
             {
                 UIElement starLayoutTarget = starProvider.TargetElement;
                 if (starLayoutTarget != null)
                 {
-                    targets.Add(starLayoutTarget, null);
+                    targets.Add(starLayoutTarget);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -258,7 +258,7 @@ namespace MS.Internal.Xaml.Context
         public override IEnumerable<NamespaceDeclaration> GetNamespacePrefixes()
         {
             ObjectWriterFrame frame = _stack.CurrentFrame;
-            Dictionary<string, string> keys = new Dictionary<string, string>();
+            HashSet<string> keys = new HashSet<string>();
 
             while (frame.Depth > 0)
             {
@@ -266,9 +266,8 @@ namespace MS.Internal.Xaml.Context
                 {
                     foreach (NamespaceDeclaration namespaceDeclaration in frame.GetNamespacePrefixes())
                     {
-                        if (!keys.ContainsKey(namespaceDeclaration.Prefix))
+                        if (keys.Add(namespaceDeclaration.Prefix))
                         {
-                            keys.Add(namespaceDeclaration.Prefix, null);
                             yield return namespaceDeclaration;
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
@@ -78,16 +78,15 @@ namespace MS.Internal.Xaml.Context
         public override IEnumerable<NamespaceDeclaration> GetNamespacePrefixes()
         {
             XamlParserFrame frame = _stack.CurrentFrame;
-            Dictionary<string, string> keys = new Dictionary<string, string>();
+            HashSet<string> keys = new HashSet<string>();
             while (frame.Depth > 0)
             {
                 if (frame._namespaces != null)
                 {
                     foreach (NamespaceDeclaration namespaceDeclaration in frame.GetNamespacePrefixes())
                     {
-                        if (!keys.ContainsKey(namespaceDeclaration.Prefix))
+                        if (keys.Add(namespaceDeclaration.Prefix))
                         {
-                            keys.Add(namespaceDeclaration.Prefix, null);
                             yield return namespaceDeclaration;
                         }
                     }
@@ -99,9 +98,8 @@ namespace MS.Internal.Xaml.Context
             {
                 foreach (KeyValuePair<string, string> kvp in _prescopeNamespaces)
                 {
-                    if (!keys.ContainsKey(kvp.Key))
+                    if (keys.Add(kvp.Key))
                     {
-                        keys.Add(kvp.Key, null);
                         yield return new NamespaceDeclaration(kvp.Value, kvp.Key);
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -436,7 +436,7 @@ namespace System.Xaml.MS.Impl
                 // Calculate the subsume count upfront, since this also serves as our cycle detection
                 _subsumeCount = new Dictionary<string,int>(nsInfo.OldToNewNs.Count);
 
-                Dictionary<string, object> visited = new Dictionary<string, object>();
+                HashSet<string> visited = new HashSet<string>();
 
                 // for every XmlnsCompatAttribute
                 foreach (string newNs in nsInfo.OldToNewNs.Values)
@@ -447,11 +447,10 @@ namespace System.Xaml.MS.Impl
                     string ns = newNs;
                     do
                     {
-                        if (visited.ContainsKey(ns))
+                        if (!visited.Add(ns))
                         {
                             throw new XamlSchemaException(SR.Get(SRID.XmlnsCompatCycle, assembly.FullName, ns));
                         }
-                        visited.Add(ns, null);
                         IncrementSubsumeCount(ns);
                         ns = GetNewNs(ns);
                     }


### PR DESCRIPTION
I replaced some Dictionaries and Hashtables that only use the key as a way to filter out duplicates. I replaced them with HashSet to improve performance.

I used the following code to benchmark it :
https://gist.github.com/ThomasGoulet73/99559a6cd49a04dc70a413e9668eee22

Here are the results (First row is 10 items, second is 1000 and third is 100000) :

Dictionary vs HashSet:
|     Method |           enumerable |           Mean |         Error |        StdDev |    Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 |   Allocated |
|----------- |--------------------- |---------------:|--------------:|--------------:|---------:|--------:|---------:|---------:|---------:|------------:|
| Dictionary | Syste(...)ring] [48] |       742.2 ns |      14.71 ns |      13.76 ns |     1.00 |    0.00 |   0.2270 |   0.0010 |        - |     1.39 KB |
| Dictionary | Syste(...)ring] [48] |    60,340.7 ns |     231.42 ns |     216.47 ns |    81.32 |    1.42 |  18.8599 |   4.6997 |        - |   116.13 KB |
| Dictionary | Syste(...)ring] [48] | 6,990,405.3 ns | 114,642.24 ns | 101,627.36 ns | 9,405.37 |  234.34 | 796.8750 | 750.0000 | 742.1875 | 10303.12 KB |
|    HashSet | Syste(...)ring] [48] |       558.8 ns |       1.55 ns |       1.45 ns |     0.75 |    0.01 |   0.1907 |        - |        - |     1.17 KB |
|    HashSet | Syste(...)ring] [48] |    47,343.1 ns |     173.14 ns |     161.96 ns |    63.81 |    1.22 |  14.2822 |   2.8076 |        - |    87.76 KB |
|    HashSet | Syste(...)ring] [48] | 5,982,708.5 ns |  80,465.49 ns |  75,267.47 ns | 8,062.82 |  161.97 | 703.1250 | 648.4375 | 648.4375 |  7945.69 KB |

Hashtable vs HashSet:
|        Method |           enumerable |            Mean |         Error |        StdDev |     Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|-------------- |--------------------- |----------------:|--------------:|--------------:|----------:|--------:|---------:|---------:|---------:|----------:|
| HashHashtable | Syste(...)ring] [48] |        680.6 ns |       3.88 ns |       3.44 ns |      1.00 |    0.00 |   0.1326 |        - |        - |     832 B |
| HashHashtable | Syste(...)ring] [48] |     94,554.4 ns |     477.01 ns |     372.42 ns |    138.79 |    0.76 |  13.7939 |   3.4180 |        - |   87472 B |
| HashHashtable | Syste(...)ring] [48] | 13,670,183.4 ns | 145,574.93 ns | 129,048.39 ns | 20,086.21 |  188.35 | 640.6250 | 640.6250 | 640.6250 | 7244564 B |
|       HashSet | Syste(...)ring] [48] |        379.2 ns |       2.95 ns |       2.76 ns |      0.56 |    0.00 |   0.1287 |   0.0005 |        - |     808 B |
|       HashSet | Syste(...)ring] [48] |     36,610.4 ns |     152.59 ns |     142.74 ns |     53.79 |    0.40 |  11.5967 |   2.8687 |        - |   73200 B |
|       HashSet | Syste(...)ring] [48] |  4,631,696.9 ns |  63,645.40 ns |  53,146.79 ns |  6,801.30 |   90.29 | 562.5000 | 523.4375 | 523.4375 | 6038279 B |

I think the perf gain is good enough to consider this PR.

Thank you!