### PR TITLE
Use reflection-only context for InternalsVisibleToAttribute type comparison

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -505,7 +505,7 @@ namespace System.Xaml
 
             for (int j = 0; j < list.Count; j++)
             {
-                friendAssemblyName = GetCustomAttributeData(list[j], typeof(InternalsVisibleToAttribute), out typeValue, false, false, false);
+                friendAssemblyName = GetCustomAttributeData(list[j], GetMscorlibType(typeof(InternalsVisibleToAttribute)), out typeValue, false, false, false);
                 if (friendAssemblyName != null && friendAssemblyName == LocalAssemblyName)
                 {
                     isFriend = true;


### PR DESCRIPTION
## Description

Use reflection-only context for InternalsVisibleToAttribute type comparison.

Fixes Issue #2492: Compilation error MC3064 when importing internal user control from signed class library.  The wrong load context was used for a type comparison that always failed.  

## Customer Impact

Internal types contained in assemblies with InternalsVisibleTo attributes that are referenced in markup cause a markup compiler error:  *error MC3064: Only public or internal classes can be used within markup. 'InternalClass' type is not public or internal.*

## Regression

This is a regression from .NET Framework.  

## Testing

Repro'd the issue and tested the fix against .NET Core targeting .NET Framework 4.72/4.8 + .NET Core 3.1/6.0 and .NET Framework targeting .NET Framework 4.72/4.8 + .NET Core 3.1/6.0.  Referencing internal types in markup that are contained in an assembly with InternalsVisibleTo (which grants access to the target assembly) now works as expected.
