### PR TITLE
Adding DependencyProperty for ShouldShowOnKeyboardFocus

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/tooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/tooltip.cs
@@ -87,11 +87,30 @@ namespace System.Windows.Controls
             }
         }
 
-        internal virtual bool ShouldShowOnKeyboardFocus
+        /// <summary>
+        /// The DependencyProperty for the ShouldShowOnKeyboardFocus property.
+        /// Default: true
+        /// </summary>
+        public static readonly DependencyProperty ShouldShowOnKeyboardFocusProperty =
+            DependencyProperty.Register(
+                                nameof(ShouldShowOnKeyboardFocus),
+                                typeof(bool),
+                                typeof(ToolTip),
+                                new FrameworkPropertyMetadata(BooleanBoxes.TrueBox));
+
+        /// <summary>
+        /// Whether or not the tooltip should show on Keyboard focus.
+        /// </summary>
+        [Bindable(true), Category("Behavior")]
+        public bool ShouldShowOnKeyboardFocus
         {
             get
             {
-                return true;
+                return (bool)GetValue(ShouldShowOnKeyboardFocusProperty);
+            }
+            set
+            {
+                SetValue(ShouldShowOnKeyboardFocusProperty, BooleanBoxes.Box(value));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToolTip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonToolTip.cs
@@ -42,6 +42,13 @@ namespace Microsoft.Windows.Controls.Ribbon
             DefaultStyleKeyProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(ownerType));
             IsOpenProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(new PropertyChangedCallback(OnIsOpenChanged), new CoerceValueCallback(CoerceIsOpen)));
             PlacementTargetProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(OnPlacementTargetPropertyChanged));
+
+            // DDVSO 614397: Tooltips should show on Keyboard focus.
+            // Override from tooltip, we don't want RibbonToolTips to show on Keyboard
+            // focus to keep this consistent with other Microsoft products.
+            // If a user needs to bring up a RibbonToolTip this change also
+            // introduces Ctrl+Shift+F10 as a shortcut for tooltips.
+            ShouldShowOnKeyboardFocusProperty.OverrideMetadata(ownerType, new FrameworkPropertyMetadata(false));
         }
 
         /// <summary>
@@ -127,16 +134,6 @@ namespace Microsoft.Windows.Controls.Ribbon
         #endregion VisualStates
 
         #region Public Properties
-
-        // DDVSO 614397: Tooltips should show on Keyboard focus.
-        // Override from tooltip, we don't want RibbonToolTips to show on Keyboard
-        // focus to keep this consistent with other Microsoft products.
-        // If a user needs to bring up a RibbonToolTip this change also
-        // introduces Ctrl+Shift+F10 as a shortcut for tooltips.
-        internal override bool ShouldShowOnKeyboardFocus
-        {
-            get { return false; }
-        }
 
         /// <summary>
         ///   Gets or sets the Title property.


### PR DESCRIPTION
Fixes Issue #4172

# Description

Converts the virtual internal property for ShouldShowOnKeyboardFocus to a public property and also adds a DependencyProperty for it.

# Customer Impact

Tooltips always show on keyboard focus which is not the desired behavior in all customer applications.