### PR TITLE
WPF fails to pass on embedinteroptypes metadata to items in its temp project

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -650,10 +650,11 @@ namespace Microsoft.Build.Tasks.Windows
                 // Add the attribute to current item node.
                 nodeItem.SetAttributeNode(attrInclude);
 
-                if (TRUE == pItem.GetMetadata(EMBEDINTEROPTYPES))
+                string embedInteropTypesMetadata = pItem.GetMetadata(EMBEDINTEROPTYPES);
+                if (!String.IsNullOrEmpty(embedInteropTypesMetadata))
                 {
                     embedItem = xmlProjectDoc.CreateElement(EMBEDINTEROPTYPES, root.NamespaceURI);
-                    embedItem.InnerText = TRUE;
+                    embedItem.InnerText = embedInteropTypesMetadata; 
                     nodeItem.AppendChild(embedItem);
                 }
 
@@ -799,7 +800,6 @@ namespace Microsoft.Build.Tasks.Windows
         private const string ITEMGROUP_NAME = "ItemGroup";
         private const string INCLUDE_ATTR_NAME = "Include";
 
-        private const string TRUE = "True";
         private const string WPFTMP = "wpftmp";
 
         #endregion Private Fields


### PR DESCRIPTION
Fixes Issue #4203.

## Description

A case-sensitive string comparison was failing: "true" != "True".  This has been removed and now any embedinteroptypes value, including explicit 'false', will be added as item metadata.  

Note that this appears to have been in WPF since 2005.  (The bigger related issue is that only select item metadata is being passed through to the temporary project, which is not fixed here.)

This project will not get embedinteroptypes metadata passed to the temporary project due to the uncapitalized 'T' in 'True'. 

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>WinExe</OutputType>
    <TargetFramework>net5.0-windows</TargetFramework>
    <UseWPF>true</UseWPF>
    <UseWindowsForms>true</UseWindowsForms>
  </PropertyGroup>  

  <ItemGroup>
    <COMReference Include="Microsoft.Office.Excel">
      <EmbedInteropTypes>true</EmbedInteropTypes>
    </COMReference>
  </ItemGroup>

</Project>
```

https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs#L802

```cs
private const string TRUE = "True";
```

https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs#L653

```cs
                if (TRUE == pItem.GetMetadata(EMBEDINTEROPTYPES))
                {
                    embedItem = xmlProjectDoc.CreateElement(EMBEDINTEROPTYPES, root.NamespaceURI);
                    embedItem.InnerText = TRUE;
                    nodeItem.AppendChild(embedItem);
                }
```

Here is the .NET Framework code: 

https://referencesource.microsoft.com/#PresentationBuildTasks/BuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs,488

## Customer Impact

EmbedInteropTypes is sometimes ignored based on casing of 'true', preventing some projects from compiling.

## Regression

No.  This is present in .NET Framework.  

## Testing

Verified with @terrajobst's project here:  https://github.com/terrajobst/ComAutomationRepro.

## Risk

Very low. 
