### PR TITLE
Small performance improvement of PathParser

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PathParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PathParser.cs
@@ -189,7 +189,7 @@ namespace MS.Internal.Data
             while (_index < _n && _path[_index] == '.')
                 ++_index;
 
-            while (_index < _n && (level > 0 || SpecialChars.IndexOf(_path[_index]) < 0))
+            while (_index < _n && (level > 0 || !IsSpecialChar(_path[_index])))
             {
                 if (_path[_index] == '(')
                     ++level;
@@ -386,6 +386,11 @@ namespace MS.Internal.Data
             _drillIn = DrillIn.Never;
         }
 
+        private static bool IsSpecialChar(char ch)
+        {
+            return ch == '.' || ch == '/' || ch == '[' || ch == ']';
+        }
+
         State _state;
         string _path;
         int _index;
@@ -395,7 +400,6 @@ namespace MS.Internal.Data
         const char NullChar = Char.MinValue;
         const char EscapeChar = '^';
         static SourceValueInfo[] EmptyInfo = Array.Empty<SourceValueInfo>();
-        static string SpecialChars = @"./[]";
     }
 }
 


### PR DESCRIPTION
I replaced the `IndexOf` call on a private static string with a custom method that returns whether or not a char is a special char. I think this method is on a hot path because it is called on almost every char of the path passed to the method `Parse` and one of the usage of this method is in the constructor of `Binding` when you pass a path, which I think is a very common usage.

Check here to follow the usage in `Binding` ctor:
https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/Binding.cs#L230
https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs#L93
https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PropertyPath.cs#L369
https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/PathParser.cs#L82

I used the following code to benchmark it:
https://gist.github.com/ThomasGoulet73/9220a9e448f86f0c181fe9771fe174d7

Here are the results:
| Method | ch |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |--- |---------:|----------:|----------:|---------:|------:|--------:|------:|------:|------:|----------:|
|    Old |  . | 3.899 ns | 0.0435 ns | 0.0385 ns | 3.900 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    New |  . | 1.900 ns | 0.0212 ns | 0.0198 ns | 1.893 ns |  0.49 |    0.01 |     - |     - |     - |         - |
|        |    |          |           |           |          |       |         |       |       |       |           |
|    Old |  / | 4.155 ns | 0.0183 ns | 0.0171 ns | 4.154 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    New |  / | 1.715 ns | 0.0768 ns | 0.0718 ns | 1.739 ns |  0.41 |    0.02 |     - |     - |     - |         - |
|        |    |          |           |           |          |       |         |       |       |       |           |
|    Old |  [ | 3.979 ns | 0.2053 ns | 0.5653 ns | 4.306 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    New |  [ | 1.837 ns | 0.1387 ns | 0.4069 ns | 1.569 ns |  0.49 |    0.19 |     - |     - |     - |         - |
|        |    |          |           |           |          |       |         |       |       |       |           |
|    Old |  ] | 3.909 ns | 0.2167 ns | 0.6389 ns | 4.288 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    New |  ] | 1.178 ns | 0.0518 ns | 0.0509 ns | 1.182 ns |  0.29 |    0.05 |     - |     - |     - |         - |
|        |    |          |           |           |          |       |         |       |       |       |           |
|    Old |  a | 4.864 ns | 0.1259 ns | 0.1399 ns | 4.803 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    New |  a | 1.215 ns | 0.0374 ns | 0.0350 ns | 1.225 ns |  0.25 |    0.01 |     - |     - |     - |         - |

The perf gain is small but since it's called on almost every char of the path, I think it is worth it.

Thank you!