### PR TITLE
CommandParameter invalidates CanExecute

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -486,7 +486,9 @@ namespace System.Windows.Controls
         public static readonly DependencyProperty CommandParameterProperty =
                 ButtonBase.CommandParameterProperty.AddOwner(
                         typeof(MenuItem),
-                        new FrameworkPropertyMetadata((object) null));
+                        new FrameworkPropertyMetadata(
+                                (object)null,
+                                new PropertyChangedCallback(OnCommandParameterChanged)));
 
         /// <summary>
         ///     The parameter to pass to MenuItem's Command.
@@ -497,6 +499,12 @@ namespace System.Windows.Controls
         {
             get { return GetValue(CommandParameterProperty); }
             set { SetValue(CommandParameterProperty, value); }
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            MenuItem item = (MenuItem)d;
+            item.UpdateCanExecute();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ButtonBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ButtonBase.cs
@@ -207,7 +207,9 @@ namespace System.Windows.Controls.Primitives
                         "CommandParameter",
                         typeof(object),
                         typeof(ButtonBase),
-                        new FrameworkPropertyMetadata((object) null));
+                        new FrameworkPropertyMetadata(
+                            (object)null,
+                            new PropertyChangedCallback(OnCommandParameterChanged)));
 
         /// <summary>
         ///     The DependencyProperty for Target property
@@ -359,6 +361,12 @@ namespace System.Windows.Controls.Primitives
             {
                 SetValue(CommandParameterProperty, value);
             }
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ButtonBase b = (ButtonBase)d;
+            b.UpdateCanExecute();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Hyperlink.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Hyperlink.cs
@@ -263,7 +263,9 @@ namespace System.Windows.Documents
                         "CommandParameter",
                         typeof(object),
                         typeof(Hyperlink),
-                        new FrameworkPropertyMetadata((object)null));
+                        new FrameworkPropertyMetadata(
+                            (object)null,
+                            new PropertyChangedCallback(OnCommandParameterChanged)));
 
         /// <summary>
         /// Reflects the parameter to pass to the CommandProperty upon execution.
@@ -280,6 +282,12 @@ namespace System.Windows.Documents
             {
                 SetValue(CommandParameterProperty, value);
             }
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            Hyperlink h = (Hyperlink)d;
+            h.UpdateCanExecute();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGallery.cs
@@ -2828,7 +2828,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             "CommandParameter",
                             typeof(object),
                             typeof(RibbonGallery),
-                            new FrameworkPropertyMetadata(null));
+                            new FrameworkPropertyMetadata(new PropertyChangedCallback(OnCommandParameterChanged)));
 
         /// <summary>
         ///   Gets or sets a user defined data value that can be passed to the command when it is previewed.
@@ -2926,6 +2926,12 @@ namespace Microsoft.Windows.Controls.Ribbon
             {
                 CanExecute = true;
             }
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            RibbonGallery gallery = (RibbonGallery)d;
+            gallery.UpdateCanExecute();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTextBox.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                             "CommandParameter",
                             typeof(object),
                             typeof(RibbonTextBox),
-                            new FrameworkPropertyMetadata(null));
+                            new FrameworkPropertyMetadata(new PropertyChangedCallback(OnCommandParameterChanged)));
 
         /// <summary>
         ///   Gets or sets the object that the command is being executed on.
@@ -216,6 +216,12 @@ namespace Microsoft.Windows.Controls.Ribbon
             {
                 CanExecute = true;
             }
+        }
+
+        private static void OnCommandParameterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            RibbonTextBox textBox = (RibbonTextBox)d;
+            textBox.UpdateCanExecute();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes Issue #3452 #4078 (also discussed in #316)

In summary, the issue is that 
```xml
<MenuItem CommandParameter="P" Command="C" />
```
and
```xml
<MenuItem Command="C" CommandParameter="P" />
```
behave differently. In the latter case, `C.CanExecute` is called to determine whether the element should be enabled, but since the parameter has not been parsed yet, `CanExecute` is called with a `null` argument. After the parameter is parsed, the status of the command is not re-evaluated and therefore the element stays disabled when it shouldn't be.

A common workaround is to use the former syntax.



# Description

Adds property changed callback to `CommandParameterProperty` wherever applicable (`MenuItem`, `ButtonBase`, `Hyperlink`, `RibbonGallery`, `RibbonTextBox`) to call `UpdateCanExecute`.

This way, changing command parameter makes it re-evaluate command's `CanExecute` value. Most notably, this will make the order of `Command` and `CommandParameter` properties in XAML irrelevant.

Note that `ThumbButtonInfo` already implements this behaviour.

# Customer Impact

Not taking this fix retains the existing XAML attributes order significance (and the inconsistency with `ThumbButtonInfo` behaivour).

# Testing

*This has not been tested as the branch does not build at the time of submitting this PR*. Happy to test if further instructions provided.

# Risk

No public API changes, 5 private static methods and callback instances in DP properties introduced. All changes in the  _PresentationFramework_ assembly.

The new behaviour will cause the `CanExecute` method of commands to be called more often (with every parameter change), and specifically twice during loading of the element (which could be avoided by deferring `CanExecute` to `EndInit` phase).

If user changes both parameter and command and changes the command parameter first, with the new behaviour the existing command will potentially be called with a command parameter of an unexpected type. Since the API accepts `object` though, the implementations of `CanExecute` should be able to handle both `null` and any object type.
