### PR TITLE
avoid boxing

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 using MS.Internal.WindowsBase;  // for FriendAccessAllowed
@@ -51,7 +52,7 @@ namespace System.Windows
                 EntryIndex entryIndex = instance.LookupEntry(_globalIndex);
 
                 // Set the value if it's not the default, otherwise remove the value.
-                if (!object.ReferenceEquals(value, _defaultValue))
+                if (!EqualityComparer<T>.Default.Equals(value, _defaultValue))
                 {
                     instance.SetEffectiveValue(entryIndex, null /* dp */, _globalIndex, null /* metadata */, value, BaseValueSourceInternal.Local);
                     _hasBeenSet = true;


### PR DESCRIPTION
Fixes Issue [4114](https://github.com/dotnet/wpf/issues/4114)

Master PR <!-- Link to PR if any that fixed this in the master branch. -->

## Description
#4114 
Using the EqualityComparer<T>.Default instead the ReferenceEquals method to avoid the boxing for value types.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

No risks
