### PR TITLE
Use params and char overload

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -1477,7 +1477,7 @@ namespace MS.Internal
             StringBuilder sb = new StringBuilder(typeName, 20);
             sb.Append(GENERIC_DELIMITER);
 
-            _typeArgsList = typeArgs.Split(new Char[] { COMMA });
+            _typeArgsList = typeArgs.Split(COMMA);
 
             sb.Append(_typeArgsList.Length);
 
@@ -1537,7 +1537,7 @@ namespace MS.Internal
         {
             if (ns.Length > 0)
             {
-                string[] nsParts = ns.Split(new char[] { DOTCHAR });
+                string[] nsParts = ns.Split(DOTCHAR);
 
                 foreach (string nsPart in nsParts)
                 {
@@ -1629,7 +1629,7 @@ namespace MS.Internal
                     {
                         string relPath = TargetPath.Substring(SourceFileInfo.SourcePath.Length);
                         relPath += SourceFileInfo.RelativeSourceFilePath;
-                        string[] dirs = relPath.Split(new Char[] { Path.DirectorySeparatorChar });
+                        string[] dirs = relPath.Split(Path.DirectorySeparatorChar);
                         for (int i = 1; i < dirs.Length; i++)
                         {
                             parentFolderPrefix += PARENTFOLDER;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehaviorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehaviorConverter.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Media.Animation
     {
         #region Data
 
-        private static char[] _iterationCharacter = new char[] { 'x' };
+        private const char _iterationCharacter = 'x';
 
         #endregion
 
@@ -81,7 +81,7 @@ namespace System.Windows.Media.Animation
                     return RepeatBehavior.Forever;
                 }
                 else if (   stringValue.Length > 0
-                         && stringValue[stringValue.Length - 1] == _iterationCharacter[0])
+                         && stringValue[stringValue.Length - 1] == _iterationCharacter)
                 {
                     string stringDoubleValue = stringValue.TrimEnd(_iterationCharacter);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -105,7 +105,7 @@ namespace MS.Internal
 
             string tokens = trimmedColor.Substring(s_ContextColor.Length);
             tokens = tokens.Trim();
-            string[] preSplit = tokens.Split(new Char[] { ' ' });
+            string[] preSplit = tokens.Split(' ');
             if (preSplit.GetLength(0)< 2)
             {
                 throw new FormatException(SR.Get(SRID.Parsers_IllegalToken));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -285,7 +285,7 @@ namespace System.Windows.Navigation
 
             if (fHasComponent)
             {
-                string[] assemblyInfo = firstSegment.Split(new char[] { COMPONENT_DELIMITER });
+                string[] assemblyInfo = firstSegment.Split(COMPONENT_DELIMITER);
 
                 int count = assemblyInfo.Length;
 
@@ -336,7 +336,7 @@ namespace System.Windows.Navigation
         {
             if (component.EndsWith(COMPONENT, StringComparison.OrdinalIgnoreCase))
             {
-                string[] assemblyInfo = component.Split(new Char[] { COMPONENT_DELIMITER });
+                string[] assemblyInfo = component.Split(COMPONENT_DELIMITER);
                 // Check whether the assembly name is the same as the EntryAssembly.
                 int count = assemblyInfo.Length;
                 if ((count >= 2) && (count <= 4))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
@@ -222,20 +222,20 @@ namespace MS.Internal.Annotations.Anchoring
                     string value = "";
                     if (!double.IsNaN(fp.Segments[i].Start.X))
                     {
-                        value += fp.Segments[i].Start.X.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator[0] + fp.Segments[i].Start.Y.ToString(NumberFormatInfo.InvariantInfo);
+                        value += fp.Segments[i].Start.X.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator + fp.Segments[i].Start.Y.ToString(NumberFormatInfo.InvariantInfo);
                     }
                     else
                     {
-                        value += TextSelectionProcessor.Separator[0];
+                        value += TextSelectionProcessor.Separator;
                     }
-                    value += TextSelectionProcessor.Separator[0];
+                    value += TextSelectionProcessor.Separator;
                     if (!double.IsNaN(fp.Segments[i].End.X))
                     {
-                        value += fp.Segments[i].End.X.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator[0] + fp.Segments[i].End.Y.ToString(NumberFormatInfo.InvariantInfo);
+                        value += fp.Segments[i].End.X.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator + fp.Segments[i].End.Y.ToString(NumberFormatInfo.InvariantInfo);
                     }
                     else
                     {
-                        value += TextSelectionProcessor.Separator[0];
+                        value += TextSelectionProcessor.Separator;
                     }
 
                     part.NameValuePairs.Add(TextSelectionProcessor.SegmentAttribute + i.ToString(NumberFormatInfo.InvariantInfo), value);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
@@ -169,7 +169,7 @@ namespace MS.Internal.Annotations.Anchoring
             {
                 GetTextSegmentValues(textSegments[i], elementStart, elementEnd, out startOffset, out endOffset);
 
-                part.NameValuePairs.Add(SegmentAttribute + i.ToString(NumberFormatInfo.InvariantInfo), startOffset.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator[0] + endOffset.ToString(NumberFormatInfo.InvariantInfo));
+                part.NameValuePairs.Add(SegmentAttribute + i.ToString(NumberFormatInfo.InvariantInfo), startOffset.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator + endOffset.ToString(NumberFormatInfo.InvariantInfo));
             }
 
             part.NameValuePairs.Add(CountAttribute, textSegments.Count.ToString(NumberFormatInfo.InvariantInfo));
@@ -424,7 +424,7 @@ namespace MS.Internal.Annotations.Anchoring
         internal const String IncludeOverlaps = "IncludeOverlaps";
 
         // Potential separators for values in segment name/value pairs
-        internal static readonly Char[] Separator = new Char[] { ',' };
+        internal const Char Separator = ',';
 
         // Name of locator part element
         internal static readonly XmlQualifiedName CharacterRangeElementName = new XmlQualifiedName("CharacterRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
@@ -158,7 +158,7 @@ namespace MS.Internal.Annotations.Anchoring
 
             ContentLocatorPart part = new ContentLocatorPart(TextSelectionProcessor.CharacterRangeElementName);// DocumentPageViewLocatorPart();
             part.NameValuePairs.Add(TextSelectionProcessor.CountAttribute, 1.ToString(NumberFormatInfo.InvariantInfo));
-            part.NameValuePairs.Add(TextSelectionProcessor.SegmentAttribute + 0.ToString(NumberFormatInfo.InvariantInfo), startOffset.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator[0] + endOffset.ToString(NumberFormatInfo.InvariantInfo));
+            part.NameValuePairs.Add(TextSelectionProcessor.SegmentAttribute + 0.ToString(NumberFormatInfo.InvariantInfo), startOffset.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator + endOffset.ToString(NumberFormatInfo.InvariantInfo));
             part.NameValuePairs.Add(TextSelectionProcessor.IncludeOverlaps, Boolean.TrueString);
 
             res.Add(part);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -1612,7 +1612,7 @@ namespace Microsoft.Win32
             if (filter != null)
             {
                 // Filter strings are '|' delimited, so we split on them
-                string[] tokens = filter.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] tokens = filter.Split('|', StringSplitOptions.RemoveEmptyEntries);
 
                 // Calculate the index of the token containing extension(s) selected
                 // by the FilterIndex property.  Remember FilterIndex is one based.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
@@ -966,7 +966,7 @@ namespace System.Windows.Annotations
         /// <summary>
         /// Colon used to split the parts of a qualified name attribute value
         /// </summary>
-        private static readonly char[] _Colon = new char[] { ':' };
+        private const char _Colon = ':';
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ColorConvertedBitmapExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ColorConvertedBitmapExtension.cs
@@ -47,7 +47,7 @@ namespace System.Windows
                 throw new ArgumentNullException("image");
             }
 
-            string[] tokens = ((string)image).Split(new char[] { ' ' });
+            string[] tokens = ((string)image).Split(' ');
 
             foreach (string str in tokens)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecords.cs
@@ -2528,7 +2528,7 @@ namespace System.Windows.Markup
             if (ValueType != null && ValueType.IsEnum)
             {
                 uint uintValue = 0;
-                string [] enumValues = Value.Split(new Char[] { ',' });
+                string [] enumValues = Value.Split(',');
 
                 // if the Enum is a flag, then resolve each flag value in the enum value string.
                 foreach (string enumValue in enumValues)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Compoundfile/ContainerUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Compoundfile/ContainerUtilities.cs
@@ -45,7 +45,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// Used by ConvertBackSlashPathToStringArrayPath and 
         ///     ConvertStringArrayPathToBackSlashPath to separate path elements.
         static readonly internal char PathSeparator = Path.DirectorySeparatorChar;
-        static private readonly char[] _PathSeparatorArray = new char[] { PathSeparator };
         static readonly internal string PathSeparatorAsString = new string(ContainerUtilities.PathSeparator, 1);
 
         static private readonly CaseInsensitiveOrdinalStringComparer _stringCaseInsensitiveComparer = new CaseInsensitiveOrdinalStringComparer();
@@ -347,7 +346,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             // Build the array
             string[] splitArray =
-                backSlashPath.Split(_PathSeparatorArray);
+                backSlashPath.Split(PathSeparator);
 
             // Look for empty strings in the array
             foreach (string arrayElement in splitArray)


### PR DESCRIPTION
## Description
Uses the single char overload instead of the one using char array.

Note: PresentationBuildTasks targets .Net Framework 4.7.2 and .Net Core 2.1. The method `string.Split(char)` was introduced in .Net Core 2.0 so the changes do not apply to .Net Framework. .Net Framework 4.7.2 will call `string.Split(params char[])` and .Net Core 2.1 will call `string.Split(char)`.

Thoses changes should give a small perf gain and reduce memory usage.

Here is the result for the method `string.Split` on my machine:
|    Method |                 str |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |-------------------- |---------:|---------:|---------:|------:|-------:|------:|------:|----------:|
| CharArray | 123456789,123456789 | 55.03 ns | 0.562 ns | 0.469 ns |  1.00 | 0.0242 |     - |     - |     152 B |
|      Char | 123456789,123456789 | 51.92 ns | 0.193 ns | 0.162 ns |  0.94 | 0.0191 |     - |     - |     120 B |
|           |                     |          |          |          |       |        |       |       |           |
| CharArray |  123456789123456789 | 26.66 ns | 0.157 ns | 0.131 ns |  1.00 | 0.0102 |     - |     - |      64 B |
|      Char |  123456789123456789 | 23.84 ns | 0.081 ns | 0.076 ns |  0.89 | 0.0051 |     - |     - |      32 B |

## Customer Impact

## Regression

## Testing

## Risk
There is a risk that the behavior for the method overload using char array is not the same as the one using a single char but since those method are in the BCL, I think the risk is very low.
