### PR TITLE
Change WPF's default branch to 'main':  Update pipeline triggers to include 'main'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ trigger:
   branches:
     include: 
     - master
+    - main 
     - release/3.*
     - release/5.*
     - internal/release/5.*
@@ -50,6 +51,7 @@ pr:
   branches:
     include:
     - master
+    - main 
     - release/3.* 
     - internal/release/3.*
     - release/5.*


### PR DESCRIPTION
Please see https://github.com/dotnet/wpf/issues/4120.  This change updates the triggers to include the 'main' branch.