### PR TITLE
Temporarily disable PR builds in main to prevent PR builds for all open PRs from running

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,6 @@ trigger:
   batch: true 
   branches:
     include: 
-    - master
-    - main 
     - release/3.*
     - release/5.*
     - internal/release/5.*
@@ -50,7 +48,6 @@ pr:
   autoCancel: true
   branches:
     include:
-    - master
     - release/3.* 
     - internal/release/3.*
     - release/5.*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,6 @@ pr:
   branches:
     include:
     - master
-    - main 
     - release/3.* 
     - internal/release/3.*
     - release/5.*


### PR DESCRIPTION
Temporarily disable PR builds in main to prevent PR builds for all open PRs from running after default branch change.