### PR TITLE
Enable build triggers after default branch rename from master to main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ trigger:
   batch: true 
   branches:
     include: 
+    - main
     - release/3.*
     - release/5.*
     - internal/release/5.*
@@ -48,6 +49,7 @@ pr:
   autoCancel: true
   branches:
     include:
+    - main
     - release/3.* 
     - internal/release/3.*
     - release/5.*


### PR DESCRIPTION
The triggers had to be disabled prior to renaming the branch to prevent 60+ PR builds from kicking off.  This change re-enables the build triggers.