### PR TITLE
Try to create application before show SplashScreen

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -3207,15 +3207,17 @@ namespace MS.Internal
 
                 if (cmmMain != null)
                 {
+                    //   MyApplication app = new MyApplication();
+                    //
+                    CodeVariableReferenceExpression cvreApp = GenerateAppInstance(cmmMain);
+
+                    //   SplashScreen splashScreen = new SplashScreen("SplashScreen.png");
+                    //
                     CodeVariableReferenceExpression cvreSplashScreen = null;
                     if (!string.IsNullOrEmpty(_splashImage) && !HostInBrowser)
                     {
                         cvreSplashScreen = GenerateSplashScreenInstance(cmmMain);
                     }
-
-                    //   MyApplication app = new MyApplication();
-                    //
-                    CodeVariableReferenceExpression cvreApp = GenerateAppInstance(cmmMain);
 
                     if (_ccRoot.InitializeComponentFn != null)
                     {


### PR DESCRIPTION

Fixes Issue https://github.com/dotnet/wpf/issues/4316



## Description

Because Activated is fired in the WmActivateApp method of the Application class. The WmActivateApp method is fired by Windows messages. See [WM_ACTIVATEAPP](https://docs.microsoft.com/zh-cn/windows/win32/winmsg/wm-activateapp?WT.mc_id=WD-MVP-5003260 )


```csharp
        private void EnsureHwndSource()
        {
            if (_parkingHwnd == null)
            {
                // _appFilterHook needs to be member variable otherwise
                // it is GC'ed and we don't get messages from HwndWrapper
                // (HwndWrapper keeps a WeakReference to the hook)

                _appFilterHook = new HwndWrapperHook(AppFilterMessage);
                HwndWrapperHook[] wrapperHooks = {_appFilterHook};

                _parkingHwnd = new HwndWrapper(
                                0,
                                0,
                                0,
                                0,
                                0,
                                0,
                                0,
                                "",
                                IntPtr.Zero,
                                wrapperHooks);
            }
        }

        private IntPtr AppFilterMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
        {
            IntPtr retInt = IntPtr.Zero;
            switch ((WindowMessage)msg)
            {
                case WindowMessage.WM_ACTIVATEAPP:
                    handled = WmActivateApp(NativeMethods.IntPtrToInt32(wParam));
                    break;
                case WindowMessage.WM_QUERYENDSESSION :
                    handled = WmQueryEndSession(lParam, ref retInt);
                    break;
                default:
                    handled = false;
                    break;
            }
            return retInt;
        }

        private bool WmActivateApp(Int32 wParam)
        {
            int temp = wParam;
            bool isActivated = (temp == 0? false : true);

            // Event handler exception continuality: if exception occurs in Activate/Deactivate event handlers, our state would not
            // be corrupted because no internal state are affected by Activate/Deactivate. Please check Event handler exception continuality
            // if a state depending on those events is added.
            if (isActivated == true)
            {
                OnActivated(EventArgs.Empty);
            }
            else
            {
                OnDeactivated(EventArgs.Empty);
            }
            return false;
        }
```

But after setting SplashScreen, WPF will create the code in the generated App.g.cs file.

```csharp
        [System.STAThreadAttribute()]
        [System.Diagnostics.DebuggerNonUserCodeAttribute()]
        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "5.0.1.0")]
        public static void Main() 
        {
            SplashScreen splashScreen = new SplashScreen("SplashScreen.png");
            splashScreen.Show(true);
            App app = new App();
            app.InitializeComponent();
            app.Run();
        }
```

As you can see, in the Main function, SplashScreen will be called first and then the App object will be created.

And SplashScreen will create windows very fast. After the SplashScreen creates the window, the system will send the WM_ACTIVATEAPP message to the application. But at this time the App object has not been created yet. 

Therefore, before EnsureHwndSource method in Application is called, the system has already sent the WM_ACTIVATEAPP message to the application.
So AppFilterMessage method in Application will not receive WM_ACTIVATEAPP message, and will not trigger the Activated event 

I fix it by create application before show SplashScreen

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
