### PR TITLE
Added linker hint for DirectWriteForwarder

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ILLinkTrim.xml
@@ -2,6 +2,7 @@
   <!-- Include dependencies of DirectWriteForwarder, which is not
        analyzed by the linker. -->
   <assembly fullname="System.Diagnostics.Debug" />
+  <assembly fullname="System.Runtime.InteropServices" />
   <assembly fullname="mscorlib" />
   <assembly fullname="netstandard" />  
 </linker>


### PR DESCRIPTION
Fixes Issue #3903

## Description
I added a linker hint for a dependency of DirectWriteForwarder. The linker does not currently C++/CLI assembly (See https://github.com/mono/linker/issues/676). This assembly might have been missed by #1387 because the exception does not occur at startup.

## Customer Impact
Adds a 23,5 Kb dll when using the linker.

## Regression
I don't think it ever worked.

## Testing
I tested using a simple repro that failed with `<TrimMode>link</TrimMode>` and it worked with `<TrimmerRootAssembly Include="System.Runtime.InteropServices" />`.

## Risk
I don't think there is a risk, it only sets an assembly as never trimmed when a WPF application is trimmed.
