### PR TITLE
Fix ReachFramework's resource string resolution

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/SR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/SR.cs
@@ -8,14 +8,14 @@ namespace System.Windows.Xps
 {
     internal static partial class SR
     {
-        public static string Get(string id)
+        public static string Get(string name)
         {
-             return SR.Format(id);
+            return GetResourceString(name, null);
         }
-        
-        public static string Get(string id, params object[] args)
+
+        public static string Get(string name, params object[] args)
         {
-             return SR.Format(id, args);
+            return Format(GetResourceString(name, null), args);
         }
     }
 }


### PR DESCRIPTION
## Description

System.Windows.Documents.Serialization.SerializerProvider creation always fails while creating System.Uri. 

```cs
SerializerProvider sp = new SerializerProvider();
```   
> at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind)
   at System.Uri..ctor(String uriString)
   at System.Windows.Xps.Serialization.XpsSerializerFactory.get_ManufacturerWebsite()
   at System.Windows.Documents.Serialization.SerializerDescriptor.CreateFromFactoryInstance(ISerializerFactory factoryInstance)
   at System.Windows.Documents.Serialization.SerializerProvider..ctor()
   at TestSerializerProvider.MainWindow..ctor() in D:\PluginSerializer\TestSerializerProvider\MainWindow.xaml.cs:line 30

The issue is that resource lookups for the ReachFramework were not actually resolving the string, and instead were returning the key.  When the key `Xps_ManufacturersWebsite` was passed in to the URI constructor, URI creation failed.  Fixing the resource lookup path fixed `SerializerProvider`.  Fixes https://github.com/dotnet/wpf/issues/4481.  

This bug is blocking testing of the fix for another bug that is preventing WPF from taking the latest WinForms update: https://github.com/dotnet/wpf/issues/4479.  

## Regression

No.  This is a longstanding bug from 3.0.  

## Testing

Repro'd the failure, fixed the resource string lookup, and verified SerializerProvider is working.  


