### PR TITLE
Fix the MimeObjectFactory field capacity

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/MimeObjectFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/MimeObjectFactory.cs
@@ -66,7 +66,7 @@ namespace MS.Internal.AppModel
 
         #region private members
 
-        private static readonly Dictionary<ContentType, StreamToObjectFactoryDelegate> _objectConverters = new Dictionary<ContentType, StreamToObjectFactoryDelegate>(5, new ContentType.WeakComparer());
+        private static readonly Dictionary<ContentType, StreamToObjectFactoryDelegate> _objectConverters = new Dictionary<ContentType, StreamToObjectFactoryDelegate>(capacity: 9, new ContentType.WeakComparer());
 
         #endregion
     }


### PR DESCRIPTION


Fixes Issue  #4492


## Description

The default MS.Internal.AppModel.MimeObjectFactory._objectConverters capacity should be 9

