### PR TITLE
Remove windowsdesktop blob feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,6 @@
     <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
-    <add key="dotnet-wd" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>


### PR DESCRIPTION
This should allow the feed check to verify no upstreams across all input feeds.