### PR TITLE
Add IntPtr overloads to MessageBox

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -943,12 +943,18 @@ namespace System.Windows
         public static System.Windows.MessageBoxResult Show(string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) { throw null; }
         public static System.Windows.MessageBoxResult Show(string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult) { throw null; }
         public static System.Windows.MessageBoxResult Show(string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult, System.Windows.MessageBoxOptions options) { throw null; }
+        public static System.Windows.MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button) { throw null; }
+        public static System.Windows.MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) { throw null; }
+        public static System.Windows.MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult) { throw null; }
+        public static System.Windows.MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult, System.Windows.MessageBoxOptions options) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult) { throw null; }
         public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption, System.Windows.MessageBoxButton button, System.Windows.MessageBoxImage icon, System.Windows.MessageBoxResult defaultResult, System.Windows.MessageBoxOptions options) { throw null; }
+        public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText) { throw null; }
+        public static System.Windows.MessageBoxResult Show(System.Windows.Window owner, string messageBoxText, string caption) { throw null; }
     }
     public enum MessageBoxButton
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
@@ -237,6 +237,76 @@ namespace System.Windows
         }
         #endregion
 #endif
+        
+        #region IntPtr Methods
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text, caption, and style.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, 
+            MessageBoxResult defaultResult, MessageBoxOptions options) 
+        {
+            return ShowCore(owner, messageBoxText, caption, button, icon, defaultResult, options);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text, caption, and style.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon, 
+            MessageBoxResult defaultResult) 
+        {
+            return ShowCore(owner, messageBoxText, caption, button, icon, defaultResult, 0);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text, caption, and style.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon) 
+        {
+            return ShowCore(owner, messageBoxText, caption, button, icon, 0, 0);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text, caption, and style.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption, MessageBoxButton button) 
+        {
+            return ShowCore(owner, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text and caption.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText, string caption) 
+        {
+            return ShowCore(owner, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
+        }
+
+        /// <devdoc>
+        ///    <para>
+        ///       Displays a message box with specified text.
+        ///    </para>
+        /// </devdoc>
+        /// <ExternalAPI/> 
+        public static MessageBoxResult Show(IntPtr owner, string messageBoxText) 
+        {
+            return ShowCore(owner, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
+        }
+        #endregion
         #region Window Methods
         /// <devdoc>
         ///    <para>


### PR DESCRIPTION
From all existing overloads it takes the window handle (IntPtr) and call its core functionality in `ShowCore` method anyway. But it has no public overload for IntPtr yet. But one reason why this could be useful is that it allows us to do something like:

```C#
MessageBox.Show(Application.Current?.MainWindow == null ?
    IntPtr.Zero :
    new WindowInteropHelper(Application.Current.MainWindow).Handle, "Hello world");
```

Using the window overload the messagebox will be shown centered at the application window. However sometimes `Application.Current.MainWindow` can be null for example when called before the window is shown. And in this case it will throw an exception, rather than just fallback to IntPtr.Zero in which case the messagebox appears centered at the desktop. This is because it creates a new instance of `WindowInteropHelper` on the existing window overloads to obtain the window handle. But `WindowInteropHelper` does not allow NULL on its `ctor`.

Intially I wanted to just add nullify support of the window overloads but I don't know if the WPF project supports it, it seems like it does not. This would also be problematically since it modifies existing code. Adding IntPtr overloads was the safest solution as it has zero risk by not modifying existing code.