### PR TITLE
Fix and workaround various issues with dependency updates and Preview 3 SDK

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -8,6 +8,11 @@
 
     <!-- 17134 is Windows 10 v1903 (19H1) SDK -->
     <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+
+    <!-- This should be removed when .NET 6 Preview 4 becomes available. P4 contains the SDK fix. --> 
+    <!--    https://github.com/dotnet/core/issues/6066 -->
+    <!--    https://github.com/dotnet/sdk/issues/16725 -->
+    <ILLinkTasksAssembly>DummyPropertyValueForILLinkTasksAssembly</ILLinkTasksAssembly>
     
     <ConfigurationType Condition="'$(ConfigurationType)'==''">DynamicLibrary</ConfigurationType>
     

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerDescriptor.cs
@@ -202,7 +202,11 @@ namespace System.Windows.Documents.Serialization
 
             if (sd != null)
             {
+                // This will be noted in the release notes as an unsupported API until 4479 is fixed.
+                // https://github.com/dotnet/wpf/issues/4479 
+                #pragma warning disable SYSLIB0018 // 'Assembly.ReflectionOnlyLoadFrom(string)' is obsolete: 'ReflectionOnly loading is not su pported and throws PlatformNotSupportedException.'
                 Assembly plugIn = Assembly.ReflectionOnlyLoadFrom(sd._assemblyPath);
+                #pragma warning restore SYSLIB0018 // 'Assembly.ReflectionOnlyLoadFrom(string)' is obsolete: 'ReflectionOnly loading is not supported and throws PlatformNotSupportedException.'
                 if (typeof(System.Windows.Controls.Button).Assembly.GetName().Version == sd._winFXVersion &&
                         plugIn != null &&
                         plugIn.GetName().Version == sd._assemblyVersion)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -253,6 +253,7 @@
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Thread" />
     <NetCoreReference Include="System.Threading.ThreadPool" />
+    <NetCoreReference Include="System.Runtime.Loader" />
 
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms" />
     <MicrosoftPrivateWinFormsReference Include="System.Windows.Forms.Primitives" />


### PR DESCRIPTION
These changes are necessary to take the most dependency updates required for the Preview 5 branch snap.

* Add temporary workaround for SDK props import bug affecting C++/CLI projects (ILLinkTasksAssembly is empty)
    * https://github.com/dotnet/sdk/issues/16725
* Suppress obsolete API warning:  This `SerializerDescriptor` will be added to the release notes as 'not supported'.
* Add `System.Runtime.Loader` now required by `PresentationUI`
