### PR TITLE
Debugging locally built WPF assemblies with WPF Application

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -47,6 +47,24 @@ If there were any failures, you can cd into $(RepoRoot)\artifacts\test\$(Configu
 
 *NOTE: This requires being run from an admin window at the moment. Removing this restriction is tracked by https://github.com/dotnet/wpf/issues/816.*
 
+### Debugging locally build WPF assemblies with WPF Application
+This section is intended to simplify the steps needed to be able to debug the locally built WPF Assemblies, with any sample app. 
+Configure the project to build x86 or x64, as per the platform architecture you have selected while performing the build for WPF assemblies.
+Go to the csproj file and append this line at the bottom of it. `<Import Project="$(WpfRepoRoot)\eng\wpf-debug.targets" />`. The resultant csproj will look like this:
+```xml
+    <PropertyGroup>
+      <OutputType>WinExe</OutputType>
+      <TargetFramework>net6.0-windows</TargetFramework>
+      <UseWPF>true</UseWPF>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <WpfRepoRoot>C:\wpf</WpfRepoRoot>
+    </PropertyGroup>
+    <Import Project="$(WpfRepoRoot)\eng\wpf-debug.targets" />
+```
+
+
 ### Testing Locally built WPF assemblies (excluding PresentationBuildTasks)
 This section of guide is intended to discuss the different approaches for ad-hoc testing of WPF assemblies,
 and not automated testing. For automated testing, see the [Running DRTs locally](#Running-DRTs-locally) section above. There are a few different ways this can be done, and for the most part, it depends on what you are trying to accomplish. This section tries to lay out which scenarios require which workflow.

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -47,7 +47,7 @@ If there were any failures, you can cd into $(RepoRoot)\artifacts\test\$(Configu
 
 *NOTE: This requires being run from an admin window at the moment. Removing this restriction is tracked by https://github.com/dotnet/wpf/issues/816.*
 
-### Debugging locally build WPF assemblies with WPF Application
+### Debugging locally built WPF assemblies with WPF Application
 This section is intended to simplify the steps needed to be able to debug the locally built WPF Assemblies, with any sample app. 
 Configure the project to build x86 or x64, as per the platform architecture you have selected while performing the build for WPF assemblies.
 Go to the csproj file and append this line at the bottom of it. `<Import Project="$(WpfRepoRoot)\eng\wpf-debug.targets" />`. The resultant csproj will look like this:

--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -11,7 +11,7 @@
     -->
 
   <PropertyGroup>
-    <WpfConfig>Debug</WpfConfig>
+    <WpfConfig Condition="'$(WpfConfig)'==''">Debug</WpfConfig>
     <RuntimeIdentifier>win-$(PlatformTarget)</RuntimeIdentifier>
     <WPFArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
   </PropertyGroup>

--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!--
+    Copy PropertyGroup and Import item into the csproj file.
+    Update the path, as per the path to repo.
+
+    <PropertyGroup>
+      <WpfRepoRoot>C:\wpf</WpfRepoRoot>
+    </PropertyGroup>
+    <Import Project="$(WpfRepoRoot)\eng\wpf-debug.targets" />
+    -->
+
+  <PropertyGroup>
+    <WpfConfig>Debug</WpfConfig>
+    <RuntimeIdentifier>win-$(PlatformTarget)</RuntimeIdentifier>
+    <WPFArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="$(WPFArtifactsPath)\lib\$(TargetFramework.Split('-')[0])\*.dll" />
+    <ReferenceCopyLocalPaths Include="$(WPFArtifactsPath)\runtimes\$(RuntimeIdentifier)\native\*.dll" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The copy operation using PowerShell script was a quick setup for developer to debug WPF project locally.

## Description

**Developer Guide:** Added section _Debugging locally build WPF assemblies with WPF Application_. The section explains, what changes are required in CSPROJ, which is configured to consume the WPF project. The steps are simplified by adding a wpf-debug.targets file.

**Targets file:** This is just to simplify the setting up of the project consuming WPF. Instead of using installed assemblies, the project will use assemblies built using this project.

## Customer Impact

This presents ease of setup for the developers. 

## Testing

Tested using guidelines added in Developer Guide. 

