### PR TITLE
Ingest and import Windows Forms analyzer props

### DIFF
--- a/eng/WindowsForms.targets
+++ b/eng/WindowsForms.targets
@@ -1,0 +1,19 @@
+<Project>
+
+  <!-- 
+    This target *only* validates the content of Microsoft.Private.Winforms NuGet package
+    to ensure we correctly import and reference props and targets.
+   -->
+  <Target Name="_EnsureWindowsFormsPackagingContent" BeforeTargets="IdentifyPackageAssets">
+    <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
+           Condition="'$(_WinFormsNuGetPath)' == ''"/>
+
+    <ItemGroup>
+      <_WinFormsContent Include="$(_WinFormsContentPath)" />
+    </ItemGroup>
+
+    <Error Text="Microsoft.Private.Winforms NuGet package contains no content. Is this expected?"
+           Condition="@(_WinFormsContent->Count()) == 0"/>
+  </Target>
+
+</Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>net6.0</TargetFramework>
@@ -25,4 +25,30 @@
     <PackagingContent Include="targets\*" SubFolder="root\targets" />
     <PackagingContent Include="useSharedDesignerContext.txt" SubFolder="root" />
   </ItemGroup>
+
+  <!-- Windows Forms specific -->
+  <PropertyGroup>
+    <_WinFormsNuGetPath>$(PkgMicrosoft_Private_Winforms)</_WinFormsNuGetPath>
+    <_WinFormsContentPath>$(_WinFormsNuGetPath)\sdk\dotnet-wpf\*</_WinFormsContentPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackagingContent Include="$(_WinFormsContentPath)" SubFolder="root\targets" />
+  </ItemGroup>
+
+  <!-- 
+    This target *only* validates the content of Microsoft.Private.Winforms NuGet package
+    to ensure we correctly import and reference props and targets.
+   -->
+  <Target Name="_EnsureWindowsFormsPackagingContent" BeforeTargets="IdentifyPackageAssets">
+    <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
+           Condition="'$(_WinFormsNuGetPath)' == ''"/>
+
+    <ItemGroup>
+      <_WinFormsContent Include="$(_WinFormsContentPath)" />
+    </ItemGroup>
+
+    <Error Text="Microsoft.Private.Winforms NuGet package contains no content. Is this expected?"
+           Condition="@(_WinFormsContent->Count()) == 0"/>
+  </Target>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -1,4 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>net6.0</TargetFramework>
@@ -27,6 +28,8 @@
   </ItemGroup>
 
   <!-- Windows Forms specific -->
+  <Import Project="$(RepositoryEngineeringDir)WindowsForms.targets" />
+
   <PropertyGroup>
     <_WinFormsNuGetPath>$(PkgMicrosoft_Private_Winforms)</_WinFormsNuGetPath>
     <_WinFormsContentPath>$(_WinFormsNuGetPath)\sdk\dotnet-wpf\*</_WinFormsContentPath>
@@ -36,19 +39,4 @@
     <PackagingContent Include="$(_WinFormsContentPath)" SubFolder="root\targets" />
   </ItemGroup>
 
-  <!-- 
-    This target *only* validates the content of Microsoft.Private.Winforms NuGet package
-    to ensure we correctly import and reference props and targets.
-   -->
-  <Target Name="_EnsureWindowsFormsPackagingContent" BeforeTargets="IdentifyPackageAssets">
-    <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
-           Condition="'$(_WinFormsNuGetPath)' == ''"/>
-
-    <ItemGroup>
-      <_WinFormsContent Include="$(_WinFormsContentPath)" />
-    </ItemGroup>
-
-    <Error Text="Microsoft.Private.Winforms NuGet package contains no content. Is this expected?"
-           Condition="@(_WinFormsContent->Count()) == 0"/>
-  </Target>
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -161,4 +161,7 @@
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
 
+  <!-- Import Windows Forms specific props -->
+  <Import Project="System.Windows.Forms.Analyzers.props" />
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -155,4 +155,7 @@
   <!-- Import WPF Build logic only when we don't import NETFX's WinFX targets -->
   <Import Project="Microsoft.WinFX.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'true'"/>
 
+  <!-- Import Windows Forms specific targets -->
+  <Import Project="System.Windows.Forms.Analyzers.targets" />
+
 </Project>


### PR DESCRIPTION
## Description

This work relates to [Streamline Windows Forms application configuration and bootstrap design proposal](https://github.com/dotnet/designs/pull/223), and acts as a workaround until [Proposal to add Framework specific inbox source generators design proposal](https://github.com/dotnet/designs/pull/181) is approved and implemented.

Provide a mechanism to ingest Windows Forms specific analyzer props into Microsoft.NET.Sdk.WindowsDesktop from Windows Forms transport package, and copy the props file into `targets` folder of the SDK, so that the props file is resolved and imported when a developer builds a Windows Forms app.

In the end the new props file will end up in a location similar to this: `C:\Program Files\dotnet\sdk\6.0.<version>\Sdks\Microsoft.NET.Sdk.WindowsDesktop\targets\`.

The build process looks something like this:
* import props and targets
    ![image](https://user-images.githubusercontent.com/4403806/120258730-ede59200-c2d5-11eb-91dd-8801e06cecac.png)
    ![image](https://user-images.githubusercontent.com/4403806/120258748-f76efa00-c2d5-11eb-8bc4-092c9ac97b5f.png)
* execute the task that resolves and references Windows Forms analyzers:
    ![image](https://user-images.githubusercontent.com/4403806/120258942-4f0d6580-c2d6-11eb-8afa-f072e8e2f80a.png)




## Testing

A lot of manual testing

1. Create a Windows Forms transport package, e.g.: `winforms> .\build.cmd -pack`
2. Copy the build transport package from .\winforms\artifacts\packages\Debug\NonShipping over the currently referenced by WPF microsoft.private.winforms package in C:\Users\\<user\>\\.nuget\packages\microsoft.private.winforms
3. Build and pack WPF: `wpf> .\build -pack`
4. Inspect .\wpf\artifacts\packaging\Debug\Microsoft.NET.Sdk.WindowsDesktop.Debug\targets folder and see System.Windows.Forms.Analyzers.props and System.Windows.Forms.Analyzers.targets present