### PR TITLE
Disable NETFX WinFX targets only when the SDK is used directly

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Sdk/Sdk.props
@@ -15,10 +15,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_MicrosoftWindowsDesktopSdkImported>true</_MicrosoftWindowsDesktopSdkImported>
   </PropertyGroup>
 
+  <!--
+    Workaround: https://github.com/microsoft/msbuild/issues/4948
+    Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
+    and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
+    Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK's version.
+  -->
+  <PropertyGroup>
+    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
+  </PropertyGroup>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
-  <!-- Set ImportWindowsDesktopTargets to force import WindowsDesktop Targets to enable pre 5.0 behavior.
-      Post 5.0, Microsoft.NET.Sdk.WindowsDesktop.props will always be imported by SDK
+  <!--
+    Set 'ImportWindowsDesktopTargets' to force import Windows Desktop targets to enable pre 5.0 behavior.
+    Post 5.0, 'Microsoft.NET.Sdk.WindowsDesktop.props' will always be imported by SDK
   -->
   <PropertyGroup>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -161,14 +161,4 @@
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
 
-  <!--
-    Workaround: https://github.com/microsoft/msbuild/issues/4948
-    Disable .NET Framework's inbox WinFX targets when using the SDK, since, we really don't use it's build logic
-    and is superseded by 'WindowsDesktop' SDK that provides it's own WinFX for both NETFX and CoreCLR targets.
-    Make it opt-out, just in case, if something fails or we don't want to use 'WindowsDesktop' SDK's version.
-  -->
-  <PropertyGroup>
-    <ImportFrameworkWinFXTargets Condition="'$(ImportFrameworkWinFXTargets)' == ''">false</ImportFrameworkWinFXTargets>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Partially Fixes #4515
Partially Fixes dotnet/sdk#18062

## Description

Disable .NET Framework's WinFX targets import only when the Windows Desktop SDK is used directly instead!

Example:
```xml
<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" />
```

Here, we're simply moving the logic to the `Sdk.props`. This still does not fix the root of the problem
where the SDK provided WinFX targets should work properly when targeting .NET Framework only projects.

## Customer Impact

As per the issues mentioned above, the .NET Framework projects that depends on older inbox WinFX targets no longer used those targets and so, the build fails.

## Regression

Yes, it was a regression of a Desktop SDK's PBT bug that revealed itself through #2976.

## Testing

Works when tested locally.

## Risk

Low, since the .NET 6 is still in preview.

It only fixes when the SDK used is .NET SDK instead of Windows Desktop SDK. Since .NET SDK in post 5.0 imports
`WindowsDesktop.props` and so, we simply move the logic to `Sdk.props`. So, for those who depends on this behavior
should use Windows Desktop SDK instead of the Main SDK, as shown above.
