### PR TITLE
Update SDK to Preview 4 and remove workaround for SDK bug

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -9,11 +9,6 @@
     <!-- 17134 is Windows 10 v1903 (19H1) SDK -->
     <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
 
-    <!-- This should be removed when .NET 6 Preview 4 becomes available. P4 contains the SDK fix. --> 
-    <!--    https://github.com/dotnet/core/issues/6066 -->
-    <!--    https://github.com/dotnet/sdk/issues/16725 -->
-    <ILLinkTasksAssembly>DummyPropertyValueForILLinkTasksAssembly</ILLinkTasksAssembly>
-    
     <ConfigurationType Condition="'$(ConfigurationType)'==''">DynamicLibrary</ConfigurationType>
     
     <!-- Windows 10 installation location is often not reliably set in msbuild -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.3.21202.5",
+    "dotnet": "6.0.100-preview.4.21255.9",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21304.1"
   },
   "sdk": {
-    "version": "6.0.100-preview.3.21202.5"
+    "version": "6.0.100-preview.4.21255.9"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",


### PR DESCRIPTION
Update the SDK version that WPF builds against to Preview 4 and remove workaround for Preview 3 SDK bug.   Fixes Issue https://github.com/dotnet/wpf/issues/4526.
