### PR TITLE
Turn on loc PRs

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -10,7 +10,7 @@ parameters:
   repoName: dotnet/wpf
 
 jobs:
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
   - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
       MirrorRepo: wpf

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
-      CreatePr: false
+      MirrorRepo: wpf
       LclSource: lclFilesfromPackage
       LclPackageId: 'LCL-JUNO-PROD-WPF'
 - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
## Description

Currently OneLocBuild does not automatically make PRs back to GitHub. This will make it automatically make PRs back to GitHub. Documentation [here](https://github.com/dotnet/arcade/blob/main/Documentation/OneLocBuild.md).

## Customer Impact

Customers will be able to use WPF in languages other than English.

## Regression

No.

## Testing

N/A

## Risk

PRs may be noisy. If this occurs, please file an issue with the localization team.
