### PR TITLE
Remove references now included in the Microsoft.NETCore.App.Ref targeting pack + update SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,10 +9,6 @@
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>150ac71c9536e0932fbf27356751193b0a3894db</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry" Version="6.0.0-preview.6.21314.2" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>bc16a7bd2dcca7f1f8ce70e75dc86a3fac3ffcd2</Sha>
-    </Dependency>
     <Dependency Name="System.CodeDom" Version="6.0.0-preview.7.21317.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>96a4671bc52e70024da409f5f48b0abaa30cb901</Sha>
@@ -37,10 +33,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>96a4671bc52e70024da409f5f48b0abaa30cb901</Sha>
     </Dependency>
-    <Dependency Name="System.Security.AccessControl" Version="6.0.0-preview.6.21314.2" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>bc16a7bd2dcca7f1f8ce70e75dc86a3fac3ffcd2</Sha>
-    </Dependency>
     <Dependency Name="System.Security.Cryptography.Xml" Version="6.0.0-preview.7.21317.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>96a4671bc52e70024da409f5f48b0abaa30cb901</Sha>
@@ -48,10 +40,6 @@
     <Dependency Name="System.Security.Permissions" Version="6.0.0-preview.7.21317.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>96a4671bc52e70024da409f5f48b0abaa30cb901</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Principal.Windows" Version="6.0.0-preview.6.21314.2" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>bc16a7bd2dcca7f1f8ce70e75dc86a3fac3ffcd2</Sha>
     </Dependency>
     <Dependency Name="System.Windows.Extensions" Version="6.0.0-preview.7.21317.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,15 +29,12 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/corefx via core-setup coherency parent dependency -->
   <PropertyGroup>
-    <MicrosoftWin32RegistryPackageVersion>6.0.0-preview.6.21314.2</MicrosoftWin32RegistryPackageVersion>
     <SystemCodeDomPackageVersion>6.0.0-preview.7.21317.1</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>6.0.0-preview.7.21317.1</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>6.0.0-preview.7.21317.1</SystemDiagnosticsEventLogPackageVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview4.19176.11</SystemReflectionTypeExtensionsPackageVersion>
-    <SystemSecurityAccessControlPackageVersion>6.0.0-preview.6.21314.2</SystemSecurityAccessControlPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>6.0.0-preview.7.21317.1</SystemSecurityCryptographyXmlPackageVersion>
     <SystemSecurityPermissionsPackageVersion>6.0.0-preview.7.21317.1</SystemSecurityPermissionsPackageVersion>
-    <SystemSecurityPrincipalWindowsPackageVersion>6.0.0-preview.6.21314.2</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>6.0.0-preview.7.21317.1</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/arcade -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.4.21255.9",
+    "dotnet": "6.0.100-preview.6.21317.3",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21319.2"
   },
   "sdk": {
-    "version": "6.0.100-preview.4.21255.9"
+    "version": "6.0.100-preview.6.21317.3"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-preview.6.21317.3",
+    "dotnet": "6.0.100-preview.4.21255.9",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21319.2"
   },
   "sdk": {
-    "version": "6.0.100-preview.6.21317.3"
+    "version": "6.0.100-preview.4.21255.9"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -1364,7 +1364,7 @@
 
   <ItemGroup>
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="netstandard" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Collections.NonGeneric" />
@@ -1375,38 +1375,38 @@
     <NetCoreReference Include="System.ComponentModel.TypeConverter" />
     <NetCoreReference Include="System.Console" />
     <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
     <NetCoreReference Include="System.Diagnostics.Debug" />
     <NetCoreReference Include="System.Diagnostics.Process" />
+    <NetCoreReference Include="System.Diagnostics.StackTrace" />
+    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
+    <NetCoreReference Include="System.Diagnostics.Tools" />
+    <NetCoreReference Include="System.Diagnostics.TraceSource" />
+    <NetCoreReference Include="System.Diagnostics.Tracing" />
     <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.Net.Primitives" />
     <NetCoreReference Include="System.Net.Requests" />
     <NetCoreReference Include="System.Net.WebHeaderCollection" />
     <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
+    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
     <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
+    <NetCoreReference Include="System.Text.Encoding.Extensions" />
+    <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Tasks" />
     <NetCoreReference Include="System.Threading.Thread" />
     <NetCoreReference Include="System.Threading.ThreadPool" />
     <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Xml.ReaderWriter" />
+    <NetCoreReference Include="netstandard" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
-    <NetCoreReference Include="netstandard" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Collections.NonGeneric" />
@@ -33,37 +33,37 @@
     <NetCoreReference Include="System.ComponentModel.TypeConverter" />
     <NetCoreReference Include="System.Console" />
     <NetCoreReference Include="System.Diagnostics.Contracts" />
-    <NetCoreReference Include="System.Diagnostics.Tools" />
-    <NetCoreReference Include="System.Diagnostics.Tracing" />
-    <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
-    <NetCoreReference Include="System.Diagnostics.StackTrace" />
     <NetCoreReference Include="System.Diagnostics.Debug" />
     <NetCoreReference Include="System.Diagnostics.Process" />
+    <NetCoreReference Include="System.Diagnostics.StackTrace" />
+    <NetCoreReference Include="System.Diagnostics.TextWriterTraceListener" />
+    <NetCoreReference Include="System.Diagnostics.Tools" />
+    <NetCoreReference Include="System.Diagnostics.TraceSource" />
+    <NetCoreReference Include="System.Diagnostics.Tracing" />
     <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.Net.Primitives" />
     <NetCoreReference Include="System.Net.Requests" />
     <NetCoreReference Include="System.Net.WebHeaderCollection" />
     <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
+    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
     <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
+    <NetCoreReference Include="System.Text.Encoding.Extensions" />
+    <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Tasks" />
     <NetCoreReference Include="System.Threading.Thread" />
     <NetCoreReference Include="System.Threading.ThreadPool" />
     <NetCoreReference Include="System.Threading.Timer" />
-    <NetCoreReference Include="System.Text.Encoding.Extensions" />
-    <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Xml.ReaderWriter" />
+    <NetCoreReference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -1374,6 +1374,7 @@
   <ItemGroup>
     <NetCoreReference Include="netstandard" />
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Console" />
     <NetCoreReference Include="System.Collections" />
@@ -1449,7 +1450,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <NetCoreReference Include="netstandard" />
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Console" />
     <NetCoreReference Include="System.Collections" />
@@ -89,7 +90,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -218,7 +218,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="$(SystemDirectoryServicesPackage)" Version="$(SystemDirectoryServicesVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
@@ -230,6 +229,7 @@
   -->
   <ItemGroup>
     <NetCoreReference Include="netstandard" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Collections.Generic" />
     <NetCoreReference Include="System.Collections.NonGeneric" />
@@ -249,6 +249,7 @@
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
     <NetCoreReference Include="System.Runtime.Loader" />
+    <NetCoreReference Include="System.Security.AccessControl" />
     <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
     <NetCoreReference Include="System.Security.Cryptography.Primitives" />
     <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -154,7 +154,6 @@
     PackageReferences to pass to CppCliHelper target
   -->
   <ItemGroup>
-    <AdditionalPackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <AdditionalPackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>
   <!--

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -379,6 +379,7 @@
   <ItemGroup>
     <NetCoreReference Include="netstandard" />
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Collections.NonGeneric" />
@@ -386,30 +387,32 @@
     <NetCoreReference Include="System.ComponentModel" />
     <NetCoreReference Include="System.ComponentModel.Primitives" />
     <NetCoreReference Include="System.ComponentModel.TypeConverter" />
+    <NetCoreReference Include="System.Diagnostics.Debug" />
     <NetCoreReference Include="System.Diagnostics.Process" />
     <NetCoreReference Include="System.Diagnostics.Tools" />
     <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.IO.Compression" />
+    <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.IO.IsolatedStorage" />
     <NetCoreReference Include="System.Linq" />
     <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
+    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.Extensions" />
+    <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Security.AccessControl" />
     <NetCoreReference Include="System.Security.Claims" />
     <NetCoreReference Include="System.Security.Cryptography" />
     <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
     <NetCoreReference Include="System.Security.Cryptography.Primitives" />
     <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
+    <NetCoreReference Include="System.Security.Principal.Windows" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
+    <NetCoreReference Include="System.Threading" />
+    <NetCoreReference Include="System.Threading.Tasks" />
+    <NetCoreReference Include="System.Threading.Thread" />
+    <NetCoreReference Include="System.Threading.ThreadPool" />
+    <NetCoreReference Include="System.Threading.Timer" />
     <NetCoreReference Include="System.Xml" />
     <NetCoreReference Include="System.Xml.Document" />
     <NetCoreReference Include="System.Xml.ReaderWriter" />
@@ -419,10 +422,7 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
-    <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlPackageVersion)" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase-ref.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <NetCoreReference Include="netstandard" />
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
+    <NetCoreReference Include="Microsoft.Win32.Registry" />
     <NetCoreReference Include="System" />
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Collections.NonGeneric" />
@@ -27,30 +28,32 @@
     <NetCoreReference Include="System.ComponentModel" />
     <NetCoreReference Include="System.ComponentModel.Primitives" />
     <NetCoreReference Include="System.ComponentModel.TypeConverter" />
+    <NetCoreReference Include="System.Diagnostics.Debug" />
     <NetCoreReference Include="System.Diagnostics.Process" />
     <NetCoreReference Include="System.Diagnostics.Tools" />
     <NetCoreReference Include="System.Diagnostics.TraceSource" />
-    <NetCoreReference Include="System.Diagnostics.Debug" />
-    <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.IO.Compression" />
+    <NetCoreReference Include="System.IO.FileSystem" />
     <NetCoreReference Include="System.IO.IsolatedStorage" />
     <NetCoreReference Include="System.Linq" />
     <NetCoreReference Include="System.ObjectModel" />
-    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
-    <NetCoreReference Include="System.Runtime.InteropServices" />
-    <NetCoreReference Include="System.Threading" />
-    <NetCoreReference Include="System.Threading.Tasks" />
-    <NetCoreReference Include="System.Threading.Thread" />
-    <NetCoreReference Include="System.Threading.ThreadPool" />
-    <NetCoreReference Include="System.Threading.Timer" />
+    <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.Extensions" />
+    <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Security.AccessControl" />
     <NetCoreReference Include="System.Security.Claims" />
     <NetCoreReference Include="System.Security.Cryptography" />
     <NetCoreReference Include="System.Security.Cryptography.Algorithms" />
     <NetCoreReference Include="System.Security.Cryptography.Primitives" />
     <NetCoreReference Include="System.Security.Cryptography.X509Certificates" />
+    <NetCoreReference Include="System.Security.Principal.Windows" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
+    <NetCoreReference Include="System.Threading" />
+    <NetCoreReference Include="System.Threading.Tasks" />
+    <NetCoreReference Include="System.Threading.Thread" />
+    <NetCoreReference Include="System.Threading.ThreadPool" />
+    <NetCoreReference Include="System.Threading.Timer" />
     <NetCoreReference Include="System.Xml" />
     <NetCoreReference Include="System.Xml.Document" />
     <NetCoreReference Include="System.Xml.ReaderWriter" />
@@ -59,10 +62,7 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
-    <PackageReference Include="System.Security.AccessControl" Version="$(SystemSecurityAccessControlPackageVersion)" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/TestServices.csproj
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/TestServices.csproj
@@ -11,10 +11,6 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="$(PkgMicrosoft_Private_Winforms)\lib\$(TargetFramework)\Accessibility.dll" />
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Remove references now included in the Microsoft.NETCore.App.Ref targeting pack + update SDK

https://github.com/dotnet/runtime/pull/54147 exposed reference assemblies in the NetCore.App targeting pack.  Remove versioning and references to these assemblies from WPF. 

(This unblocks the most recent WinForms + runtime updates: https://github.com/dotnet/wpf/pull/4697.)
