### PR TITLE
Avoid new delegate allocation on each DispatcherTimer tick

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherTimer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherTimer.cs
@@ -267,8 +267,8 @@ namespace System.Windows.Threading
                 // BeginInvoke a new operation.
                 _operation = _dispatcher.BeginInvoke(
                     DispatcherPriority.Inactive,
-                    new DispatcherOperationCallback(FireTick),
-                    null);
+                    (DispatcherOperationCallback)(state => ((DispatcherTimer)state).FireTick()),
+                    this);
 
                 
                 _dueTimeInTicks = Environment.TickCount + (int) _interval.TotalMilliseconds;
@@ -297,7 +297,7 @@ namespace System.Windows.Threading
             }
         }
 
-        private object FireTick(object unused)
+        private object FireTick()
         {
             // The operation has been invoked, so forget about it.
             _operation = null;


### PR DESCRIPTION
## Description

Every time DispatcherTimer.Restart is called (which may happen on every tick), it's allocating a new delegate to point to the instance's FireTick method.  We can instead make it a non-capturing delegate, such that the compiler caches it on first use and never has to allocate it again, passing in `this` via the object state.

## Customer Impact

Less garbage allocated for the GC to clean up.

## Regression

No

## Testing

Only what's done by CI.

## Risk

Minimal.  The change just modifies how `this` is passed to the callback.