### PR TITLE
Avoid unnecessary boxing in calls to EasyTraceEvent

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/Trace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/Trace.cs
@@ -50,7 +50,7 @@ namespace MS.Utility
 
         // EasyTraceEvent
         // Checks the keyword and level before emiting the event
-        static internal void EasyTraceEvent(Keyword keywords, Event eventID, object param1)
+        static internal void EasyTraceEvent<T1>(Keyword keywords, Event eventID, T1 param1)
         {
             if (IsEnabled(keywords, Level.Info))
             {
@@ -60,7 +60,7 @@ namespace MS.Utility
 
         // EasyTraceEvent
         // Checks the keyword and level before emiting the event
-        static internal void EasyTraceEvent(Keyword keywords, Level level, Event eventID, object param1)
+        static internal void EasyTraceEvent<T1>(Keyword keywords, Level level, Event eventID, T1 param1)
         {
             if (IsEnabled(keywords, level))
             {
@@ -70,7 +70,7 @@ namespace MS.Utility
 
         // EasyTraceEvent
         // Checks the keyword and level before emiting the event
-        static internal void EasyTraceEvent(Keyword keywords, Event eventID, object param1, object param2)
+        static internal void EasyTraceEvent<T1, T2>(Keyword keywords, Event eventID, T1 param1, T2 param2)
         {
             if (IsEnabled(keywords, Level.Info))
             {
@@ -78,7 +78,7 @@ namespace MS.Utility
             }
         }
 
-        static internal void EasyTraceEvent(Keyword keywords, Level level, Event eventID, object param1, object param2)
+        static internal void EasyTraceEvent<T1, T2>(Keyword keywords, Level level, Event eventID, T1 param1, T2 param2)
         {
             if (IsEnabled(keywords, Level.Info))
             {
@@ -88,7 +88,7 @@ namespace MS.Utility
 
         // EasyTraceEvent
         // Checks the keyword and level before emiting the event
-        static internal void EasyTraceEvent(Keyword keywords, Event eventID, object param1, object param2, object param3)
+        static internal void EasyTraceEvent<T1, T2, T3>(Keyword keywords, Event eventID, T1 param1, T2 param2, T3 param3)
         {
             if (IsEnabled(keywords, Level.Info))
             {


### PR DESCRIPTION
## Description

There are a multitude of call sites to EventTrace.EasyTraceEvent that pass value type arguments as the param1/param2/param3 arguments, e.g.
https://github.com/dotnet/wpf/blob/5695fbe1b5767bc318f6630d2245b5376be8d779/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs#L669
https://github.com/dotnet/wpf/blob/5695fbe1b5767bc318f6630d2245b5376be8d779/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs#L829
These, however, are defined to take `object`, which means the arguments are boxed.  And that boxing happens before we even check whether the provider is enabled, as the call sites aren't guarded by checks for IsEnabled.  That ends up meaning we potentially do lots of boxing only to immediately find that the data isn't required as tracing is disabled or isn't at a sufficient level.  The fix this commit provides is to make these tracing methods generic, such that nothing need be boxed until after we know tracing is enabled.

## Customer Impact

Less allocation leading to less garbage collection leading to fewer pauses and hiccups in the user experience.

## Regression

No

## Testing

Just CI

## Risk

Minimal.  We're simply avoiding some unnecessary work by passing state as generics rather than as object.