### PR TITLE
Avoid boxing in FrugalList

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -265,12 +265,12 @@ namespace MS.Utility
 
         public override bool Contains(T value)
         {
-            return _loneEntry.Equals(value);
+            return EqualityComparer<T>.Default.Equals(_loneEntry, value);
         }
 
         public override int IndexOf(T value)
         {
-            if (_loneEntry.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_loneEntry, value))
             {
                 return 0;
             }
@@ -298,7 +298,7 @@ namespace MS.Utility
         public override bool Remove(T value)
         {
             // Wipe out the info in the only entry if it matches the item.
-            if (_loneEntry.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_loneEntry, value))
             {
                 _loneEntry = default(T);
                 --_count;
@@ -440,17 +440,17 @@ namespace MS.Utility
 
         public override int IndexOf(T value)
         {
-            if (_entry0.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_entry0, value))
             {
                 return 0;
             }
             if (_count > 1)
             {
-                if (_entry1.Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entry1, value))
                 {
                     return 1;
                 }
-                if ((3 == _count) && (_entry2.Equals(value)))
+                if ((3 == _count) && EqualityComparer<T>.Default.Equals(_entry2, value))
                 {
                     return 2;
                 }
@@ -516,19 +516,19 @@ namespace MS.Utility
             // If the item matches an existing entry, wipe out the last
             // entry and move all the other entries up.  Because we only
             // have three entries we can just unravel all the cases.
-            if (_entry0.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_entry0, value))
             {
                 RemoveAt(0);
                 return true;
             }
             else if ( _count > 1)
             {
-                if (_entry1.Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entry1, value))
                 {
                     RemoveAt(1);
                     return true;
                 }
-                else if ((3 == _count) && (_entry2.Equals(value)))
+                else if ((3 == _count) && EqualityComparer<T>.Default.Equals(_entry2, value))
                 {
                     RemoveAt(2);
                     return true;
@@ -781,35 +781,35 @@ namespace MS.Utility
 
         public override int IndexOf(T value)
         {
-            if (_entry0.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_entry0, value))
             {
                 return 0;
             }
             if (_count > 1)
             {
-                if (_entry1.Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entry1, value))
                 {
                     return 1;
                 }
                 if (_count > 2)
                 {
-                    if (_entry2.Equals(value))
+                    if (EqualityComparer<T>.Default.Equals(_entry2, value))
                     {
                         return 2;
                     }
                     if (_count > 3)
                     {
-                        if (_entry3.Equals(value))
+                        if (EqualityComparer<T>.Default.Equals(_entry3, value))
                         {
                             return 3;
                         }
                         if (_count > 4)
                         {
-                            if (_entry4.Equals(value))
+                            if (EqualityComparer<T>.Default.Equals(_entry4, value))
                             {
                                 return 4;
                             }
-                            if ((6 == _count) && (_entry5.Equals(value)))
+                            if ((6 == _count) && EqualityComparer<T>.Default.Equals(_entry5, value))
                             {
                                 return 5;
                             }
@@ -914,40 +914,40 @@ namespace MS.Utility
             // If the item matches an existing entry, wipe out the last
             // entry and move all the other entries up.  Because we only
             // have six entries we can just unravel all the cases.
-            if (_entry0.Equals(value))
+            if (EqualityComparer<T>.Default.Equals(_entry0, value))
             {
                 RemoveAt(0);
                 return true;
             }
             else if (_count > 1)
             {
-                if (_entry1.Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entry1, value))
                 {
                     RemoveAt(1);
                     return true;
                 }
                 else if (_count > 2)
                 {
-                    if (_entry2.Equals(value))
+                    if (EqualityComparer<T>.Default.Equals(_entry2, value))
                     {
                         RemoveAt(2);
                         return true;
                     }
                     else if (_count > 3)
                     {
-                        if (_entry3.Equals(value))
+                        if (EqualityComparer<T>.Default.Equals(_entry3, value))
                         {
                             RemoveAt(3);
                             return true;
                         }
                         else if (_count > 4)
                         {
-                            if (_entry4.Equals(value))
+                            if (EqualityComparer<T>.Default.Equals(_entry4, value))
                             {
                                 RemoveAt(4);
                                 return true;
                             }
-                            else if ((6 == _count) && (_entry5.Equals(value)))
+                            else if ((6 == _count) && EqualityComparer<T>.Default.Equals(_entry5, value))
                             {
                                 RemoveAt(5);
                                 return true;
@@ -1392,7 +1392,7 @@ namespace MS.Utility
         {
             for (int index = 0; index < _count; ++index)
             {
-                if (_entries[index].Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entries[index], value))
                 {
                     return index;
                 }
@@ -1425,7 +1425,7 @@ namespace MS.Utility
         {
             for (int index = 0; index < _count; ++index)
             {
-                if (_entries[index].Equals(value))
+                if (EqualityComparer<T>.Default.Equals(_entries[index], value))
                 {
                     RemoveAt(index);
                     return true;


### PR DESCRIPTION
## Description

All comparisons are being performed with object.Equals(object).  If T is a value type, every comparison ends up boxing the argument.

## Customer Impact

Less boxing means less garbage generated and less time spent on collections.

## Regression

No

## Testing

Just CI

## Risk

Minimal. `EqualityComparer<T>.Default.Equals` will use `object.Equals` if the type doesn't provide an `IEquatable<T>` implementation.