### PR TITLE
Update LangVersion to C# 9

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <GenXmlStringTable>$(WpfArcadeSdkToolsDir)GenXmlStringTable.pl</GenXmlStringTable>
-    <LangVersion Condition="'$(LangVersion)'==''">8.0</LangVersion>
+    <LangVersion Condition="'$(LangVersion)'==''">9.0</LangVersion>
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
     <IncludeDllSafeSearchPathAttribute Condition="'$(IncludeDllSafeSearchPathAttribute )'==''">true</IncludeDllSafeSearchPathAttribute>
 


### PR DESCRIPTION
## Description
Update LangVersion to C# 9. WPF seems to be the only repo that still use C# 8.

Here's a list of popular dotnet repos and their version:
aspnetcore: [9.0](https://github.com/dotnet/aspnetcore/blob/main/eng/targets/CSharp.Common.props#L4)
efcore: [9.0](https://github.com/dotnet/efcore/blob/main/Directory.Build.props#L24)
runtime: [preview](https://github.com/dotnet/runtime/blob/main/Directory.Build.props#L282)
winforms: [preview](https://github.com/dotnet/winforms/blob/main/Directory.Build.props#L16)

This change allows us to use newer feature (E.g. Static anonymous functions: https://github.com/dotnet/wpf/pull/4717#discussion_r656966634)

## Customer Impact
None

## Regression
No

## Testing
I tested by doing a build locally.

## Risk
There shouldn't be any risk, C# 9 is already the default version for .Net 6.