### PR TITLE
Avoid POINT allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
@@ -152,15 +152,15 @@ namespace System.Windows.Interop
             // WORKAROUND for the fact that WM_MOUSELEAVE not sent when capture changes
             if (success && !_active)
             {
-                NativeMethods.POINT ptCursor = new NativeMethods.POINT();
+                NativeMethods.POINT ptCursor = default;
 
-                success = UnsafeNativeMethods.TryGetCursorPos(ptCursor);
+                success = UnsafeNativeMethods.TryGetCursorPos(ref ptCursor);
 
                 if(success)
                 {
                     try
                     {
-                        SafeNativeMethods.ScreenToClient(new HandleRef(this, _source.Value.CriticalHandle), ptCursor);
+                        SafeNativeMethods.ScreenToClient(new HandleRef(this, _source.Value.CriticalHandle), ref ptCursor);
                     }
                     catch(System.ComponentModel.Win32Exception)
                     {
@@ -334,7 +334,7 @@ namespace System.Windows.Interop
                 return result;
             }
             /*
-            NativeMethods.POINT ptCursor = new NativeMethods.POINT();
+            NativeMethods.POINT ptCursor = default;
             int messagePos = 0;
             try
             {
@@ -471,7 +471,7 @@ namespace System.Windows.Interop
                     NativeMethods.POINT pt = new NativeMethods.POINT(x,y);
                     try
                     {
-                        SafeNativeMethods.ScreenToClient(new HandleRef(this,hwnd), pt);
+                        SafeNativeMethods.ScreenToClient(new HandleRef(this,hwnd), ref pt);
 
                         x = pt.x;
                         y = pt.y;
@@ -956,7 +956,7 @@ namespace System.Windows.Interop
                     {
                         NativeMethods.RECT rcClient = new NativeMethods.RECT();
                         SafeNativeMethods.GetClientRect(new HandleRef(this,hwndToCheck), ref rcClient);
-                        SafeNativeMethods.ScreenToClient(new HandleRef(this,hwndToCheck), ptCursor);
+                        SafeNativeMethods.ScreenToClient(new HandleRef(this,hwndToCheck), ref ptCursor);
 
                         if(ptCursor.x < rcClient.left || ptCursor.x >= rcClient.right ||
                            ptCursor.y < rcClient.top || ptCursor.y >= rcClient.bottom)
@@ -1163,10 +1163,10 @@ namespace System.Windows.Interop
                     {
                         // If we get this far, "A" does NOT have capture
                         // - now ensure mouse is over "A"
-                        NativeMethods.POINT ptCursor = new NativeMethods.POINT();
+                        NativeMethods.POINT ptCursor = default;
                         try
                         {
-                            UnsafeNativeMethods.GetCursorPos(ptCursor);
+                            UnsafeNativeMethods.GetCursorPos(ref ptCursor);
                         }
                         catch(System.ComponentModel.Win32Exception)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndStylusInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndStylusInputProvider.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Interop
                     NativeMethods.POINT pt1 = new NativeMethods.POINT(
                                             NativeMethods.SignedLOWORD(lParam),
                                             NativeMethods.SignedHIWORD(lParam));
-                    SafeNativeMethods.ScreenToClient(new HandleRef(this, hwnd), pt1);
+                    SafeNativeMethods.ScreenToClient(new HandleRef(this, hwnd), ref pt1);
                     Point ptClient1 = new Point(pt1.x, pt1.y);
 
                     IInputElement inputElement = StylusDevice.LocalHitTest(_source.Value, ptClient1);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -1636,10 +1636,10 @@ namespace System.Windows.Interop
 
             // Convert the client rect to screen coordinates, adjusting for RTL
             NativeMethods.POINT ptClientTopLeft = new NativeMethods.POINT(rcClient.left, rcClient.top);
-            UnsafeNativeMethods.ClientToScreen(hWnd, ptClientTopLeft);
+            UnsafeNativeMethods.ClientToScreen(hWnd, ref ptClientTopLeft);
 
             NativeMethods.POINT ptClientBottomRight = new NativeMethods.POINT(rcClient.right, rcClient.bottom);
-            UnsafeNativeMethods.ClientToScreen(hWnd, ptClientBottomRight);
+            UnsafeNativeMethods.ClientToScreen(hWnd, ref ptClientBottomRight);
 
             if(ptClientBottomRight.x >= ptClientTopLeft.x)
             {
@@ -2201,7 +2201,10 @@ namespace System.Windows.Interop
                 NativeMethods.BLENDFUNCTION blend = new NativeMethods.BLENDFUNCTION();
                 blend.BlendOp = NativeMethods.AC_SRC_OVER;
                 blend.SourceConstantAlpha = 0; // transparent
-                UnsafeNativeMethods.UpdateLayeredWindow(_hWnd.h, IntPtr.Zero, null, null, IntPtr.Zero, null, 0, ref blend, NativeMethods.ULW_ALPHA);
+                unsafe
+                {
+                    UnsafeNativeMethods.UpdateLayeredWindow(_hWnd.h, IntPtr.Zero, null, null, IntPtr.Zero, null, 0, ref blend, NativeMethods.ULW_ALPHA);
+                }
             }
             isLayered = (flags != MILTransparencyFlags.Opaque);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ActiveXSite.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/ActiveXSite.cs
@@ -69,7 +69,7 @@ namespace MS.Internal.Controls
             return NativeMethods.E_NOTIMPL;
         }
 
-        int UnsafeNativeMethods.IOleControlSite.TransformCoords(NativeMethods.POINT pPtlHimetric, NativeMethods.POINTF pPtfContainer, int dwFlags)
+        int UnsafeNativeMethods.IOleControlSite.TransformCoords(ref NativeMethods.POINT pPtlHimetric, ref NativeMethods.POINTF pPtfContainer, int dwFlags)
         {
             if ((dwFlags & NativeMethods.XFORMCOORDS_HIMETRICTOCONTAINER) != 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/webbrowsersite.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/webbrowsersite.cs
@@ -65,7 +65,7 @@ namespace MS.Internal.Controls
 
         #region IDocHostUIHandler Implementation
 
-        int UnsafeNativeMethods.IDocHostUIHandler.ShowContextMenu(int dwID, NativeMethods.POINT pt, object pcmdtReserved, object pdispReserved)
+        int UnsafeNativeMethods.IDocHostUIHandler.ShowContextMenu(int dwID, ref NativeMethods.POINT pt, object pcmdtReserved, object pdispReserved)
         {
             //
             // Returning S_FALSE will allow the native control to do default processing,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -1595,7 +1595,7 @@ namespace System.Windows.Controls.Primitives
             // the Display on which the PopupRoot is situated, and return that value here. 
             var origin =
                 _positionInfo != null
-                ? new NativeMethods.POINTSTRUCT(_positionInfo.X, _positionInfo.Y)
+                ? new NativeMethods.POINT(_positionInfo.X, _positionInfo.Y)
                 : PopupInitialPlacementHelper.GetPlacementOrigin(this);
 
             _secHelper.BuildWindow(origin.x, origin.y, targetVisual, IsTransparent, PopupFilterMessage, OnWindowResize, OnDpiChanged);
@@ -3057,7 +3057,7 @@ namespace System.Windows.Controls.Primitives
                 // This is a fallback if we couldn't convert Mouse.GetPosition
                 NativeMethods.POINT mousePoint = new NativeMethods.POINT(0, 0);
 
-                UnsafeNativeMethods.TryGetCursorPos(mousePoint);
+                UnsafeNativeMethods.TryGetCursorPos(ref mousePoint);
 
                 return mousePoint;
             }
@@ -3527,7 +3527,7 @@ namespace System.Windows.Controls.Primitives
             /// <summary>
             /// Finds the screen coordinates of the PlacementTarget's (left, top)
             /// </summary>
-            private static NativeMethods.POINTSTRUCT? GetPlacementTargetOriginInScreenCoordinates(Popup popup)
+            private static NativeMethods.POINT? GetPlacementTargetOriginInScreenCoordinates(Popup popup)
             {
                 var target = popup?.GetTarget() as UIElement;
                 if (target != null)
@@ -3541,7 +3541,7 @@ namespace System.Windows.Controls.Primitives
                     if (targetToClientTransform.TryTransform(new Point(0, 0), out ptPlacementTargetOrigin))
                     {
                         var screenOrigin = popup._secHelper.ClientToScreen(rootVisual, ptPlacementTargetOrigin);
-                        return new NativeMethods.POINTSTRUCT((int)screenOrigin.X, (int)screenOrigin.Y);
+                        return new NativeMethods.POINT((int)screenOrigin.X, (int)screenOrigin.Y);
                     }
                 }
 
@@ -3551,13 +3551,13 @@ namespace System.Windows.Controls.Primitives
             /// <summary>
             /// Finds the (top,left) screen coordinates of the monitor that contains the placement target
             /// </summary>
-            internal static NativeMethods.POINTSTRUCT GetPlacementOrigin(Popup popup)
+            internal static NativeMethods.POINT GetPlacementOrigin(Popup popup)
             {
-                var placementOrigin = new NativeMethods.POINTSTRUCT(0, 0);
+                NativeMethods.POINT placementOrigin = default;
 
                 if (IsPerMonitorDpiScalingActive)
                 {
-                    var screenOrigin = GetPlacementTargetOriginInScreenCoordinates(popup);
+                    NativeMethods.POINT? screenOrigin = GetPlacementTargetOriginInScreenCoordinates(popup);
                     if (screenOrigin.HasValue)
                     {
                         try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
@@ -606,7 +606,7 @@ namespace System.Windows.Documents
                         candform.rcArea.right = 0;
                         candform.rcArea.top = 0;
                         candform.rcArea.bottom = 0;
-                        candform.ptCurrentPos = new NativeMethods.POINT(0, 0);
+                        candform.ptCurrentPos = default;
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -793,7 +793,7 @@ namespace System.Windows.Documents
             compositionTarget = source.CompositionTarget;
 
             // Convert to client coordinates.
-            SafeNativeMethods.ScreenToClient(new HandleRef(null,win32Window.Handle), point);
+            SafeNativeMethods.ScreenToClient(new HandleRef(null, win32Window.Handle), ref point);
 
             // Convert to mil measure units.
             milPoint = new Point(point.x, point.y);
@@ -2347,8 +2347,8 @@ namespace System.Windows.Documents
             hwnd = win32Window.Handle;
 
             // Transform to screen coords.
-            clientPoint = new NativeMethods.POINT();
-            UnsafeNativeMethods.ClientToScreen(new HandleRef(null, hwnd), /* ref by interop */ clientPoint);
+            clientPoint = default;
+            UnsafeNativeMethods.ClientToScreen(new HandleRef(null, hwnd), ref clientPoint);
 
             rect.left = (int)(clientPoint.x + milPointTopLeft.X);
             rect.right = (int)(clientPoint.x + milPointBottomRight.X);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -3212,10 +3212,10 @@ namespace Standard
         private static extern bool _UpdateLayeredWindow(
             IntPtr hwnd,
             SafeDC hdcDst,
-            [In] ref POINT pptDst,
-            [In] ref SIZE psize,
+            ref POINT pptDst,
+            ref SIZE psize,
             SafeDC hdcSrc,
-            [In] ref POINT pptSrc,
+            ref POINT pptSrc,
             int crKey,
             ref BLENDFUNCTION pblend,
             ULW dwFlags);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3582,12 +3582,11 @@ namespace System.Windows
         IntPtr GetCurrentMonitorFromMousePosition()
         {
             // center on the screen on which the mouse is on
-            NativeMethods.POINT pt = new NativeMethods.POINT();
+            NativeMethods.POINT pt = default;
 
-            UnsafeNativeMethods.TryGetCursorPos(pt);
+            UnsafeNativeMethods.TryGetCursorPos(ref pt);
 
-            NativeMethods.POINTSTRUCT ptStruct = new NativeMethods.POINTSTRUCT(pt.x, pt.y);
-            return SafeNativeMethods.MonitorFromPoint(ptStruct, NativeMethods.MONITOR_DEFAULTTONEAREST);
+            return SafeNativeMethods.MonitorFromPoint(pt, NativeMethods.MONITOR_DEFAULTTONEAREST);
         }
 
         // <summary>
@@ -4699,7 +4698,11 @@ namespace System.Windows
 
         private bool WmGetMinMaxInfo( IntPtr lParam )
         {
-            NativeMethods.MINMAXINFO mmi = (NativeMethods.MINMAXINFO)UnsafeNativeMethods.PtrToStructure( lParam, typeof(NativeMethods.MINMAXINFO));
+            NativeMethods.MINMAXINFO mmi;
+            unsafe
+            {
+                mmi = *(NativeMethods.MINMAXINFO*)lParam;
+            }
 
             //
             // For Bug 1380569: Window SizeToContent does not work after changing Max size properties
@@ -4760,7 +4763,10 @@ namespace System.Windows
 
                 // Notify Win32 of the new Min/Max value for this HWND.
 
-                Marshal.StructureToPtr(mmi, lParam, true);
+                unsafe
+                {
+                    *(NativeMethods.MINMAXINFO*)lParam = mmi;
+                }
             }
 
             return true;
@@ -7277,7 +7283,7 @@ namespace System.Windows
                 private NativeMethods.POINT GetWindowScreenLocation(FlowDirection flowDirection)
                 {
                     Debug.Assert(IsSourceWindowNull != true, "IsSourceWindowNull cannot be true here");
-                    NativeMethods.POINT pt = new NativeMethods.POINT(0, 0);
+                    NativeMethods.POINT pt = default;
                     if (flowDirection == FlowDirection.RightToLeft)
                     {
                         NativeMethods.RECT rc = new NativeMethods.RECT(0, 0, 0, 0);
@@ -7288,7 +7294,7 @@ namespace System.Windows
                         // note that we use rc.right here for the RTL case and client to screen that point
                         pt = new NativeMethods.POINT(rc.right, rc.top);
                     }
-                    UnsafeNativeMethods.ClientToScreen(new HandleRef(this, _sourceWindow.CriticalHandle), pt);
+                    UnsafeNativeMethods.ClientToScreen(new HandleRef(this, _sourceWindow.CriticalHandle), ref pt);
 
                     return pt;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PointUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PointUtil.cs
@@ -178,7 +178,7 @@ namespace MS.Internal
             NativeMethods.POINT ptClient            = FromPoint(pointClient);
             NativeMethods.POINT ptClientRTLAdjusted = AdjustForRightToLeft(ptClient, handleRef);
 
-            UnsafeNativeMethods.ClientToScreen(handleRef, ptClientRTLAdjusted);
+            UnsafeNativeMethods.ClientToScreen(handleRef, ref ptClientRTLAdjusted);
 
             return ToPoint(ptClientRTLAdjusted);
         }
@@ -200,7 +200,7 @@ namespace MS.Internal
 
             NativeMethods.POINT ptClient = FromPoint(pointScreen);
 
-            SafeNativeMethods.ScreenToClient(handleRef, ptClient);
+            SafeNativeMethods.ScreenToClient(handleRef, ref ptClient);
 
             ptClient = AdjustForRightToLeft(ptClient, handleRef);
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -2996,12 +2996,9 @@ namespace MS.Win32 {
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class POINT {
+        public struct POINT {
             public int x;
             public int y;
-
-            public POINT() {
-            }
 
             public POINT(int x, int y) {
                 this.x = x;
@@ -3013,18 +3010,6 @@ namespace MS.Win32 {
             }
 #endif
         }
-
-        // use this in cases where the Native API takes a POINT not a POINT*
-        // classes marshal by ref.
-        [StructLayout(LayoutKind.Sequential)]
-        public struct POINTSTRUCT {
-            public int x;
-            public int y;
-            public POINTSTRUCT(int x, int y) {
-              this.x = x;
-              this.y = y;
-            }
-      }
 
         public delegate IntPtr WndProc(IntPtr hWnd, Int32 msg, IntPtr wParam, IntPtr lParam);
 
@@ -4216,14 +4201,11 @@ namespace MS.Win32 {
 #endif
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class POINTF
+        public struct POINTF
         {
-          [MarshalAs(UnmanagedType.R4)/*leftover(offset=0, x)*/]
           public float x;
-
-          [MarshalAs(UnmanagedType.R4)/*leftover(offset=4, y)*/]
           public float y;
-}
+        }
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
         public sealed class OLEINPLACEFRAMEINFO
@@ -4237,7 +4219,7 @@ namespace MS.Win32 {
 
           [MarshalAs(UnmanagedType.U4)/*leftover(offset=16, cAccelEntries)*/]
           public uint cAccelEntries;
-}
+        }
 
 #if never
         [StructLayout(LayoutKind.Sequential)]
@@ -5216,12 +5198,12 @@ namespace MS.Win32 {
 #endif
 
         [StructLayout(LayoutKind.Sequential)]
-        public class MINMAXINFO {
-            public POINT ptReserved = new POINT();
-            public POINT ptMaxSize = new POINT();
-            public POINT ptMaxPosition = new POINT();
-            public POINT ptMinTrackSize = new POINT();
-            public POINT ptMaxTrackSize = new POINT();
+        public struct MINMAXINFO {
+            public POINT ptReserved;
+            public POINT ptMaxSize;
+            public POINT ptMaxPosition;
+            public POINT ptMinTrackSize;
+            public POINT ptMaxTrackSize;
         }
 #if never
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
@@ -63,7 +63,7 @@ namespace MS.Internal.Drt
         public static extern int MapWindowPoints(NativeMethods.HWND hWndFrom, NativeMethods.HWND hWndTo, [In, Out] ref NativeMethods.RECT rect, int cPoints);
 
         [DllImport(PresentationNativeDll, EntryPoint="MapWindowPointsWrapper", SetLastError = true, ExactSpelling=true, CharSet=CharSet.Auto)]
-        public static extern int MapWindowPoints(NativeMethods.HWND hWndFrom, NativeMethods.HWND hWndTo, [In, Out] ref NativeMethods.POINT pt, int cPoints);
+        public static extern int MapWindowPoints(NativeMethods.HWND hWndFrom, NativeMethods.HWND hWndTo, ref NativeMethods.POINT pt, int cPoints);
 
 #elif UIAUTOMATIONCLIENTSIDEPROVIDERS   // UIAutomationClientSideProviders
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
@@ -77,7 +77,7 @@ namespace MS.Win32
         }
 
 
-        public static  IntPtr MonitorFromPoint(NativeMethods.POINTSTRUCT pt, int flags)
+        public static  IntPtr MonitorFromPoint(NativeMethods.POINT pt, int flags)
         {
             return SafeNativeMethodsPrivate.MonitorFromPoint(pt,flags);
         }
@@ -259,9 +259,9 @@ namespace MS.Win32
 
         // not used by compiler - don't include.
 
-        public static void ScreenToClient(HandleRef hWnd, [In, Out] NativeMethods.POINT pt)
+        public static void ScreenToClient(HandleRef hWnd, ref NativeMethods.POINT pt)
         {
-            if(SafeNativeMethodsPrivate.IntScreenToClient(hWnd, pt) == 0)
+            if(SafeNativeMethodsPrivate.IntScreenToClient(hWnd, ref pt) == 0)
             {
                 throw new Win32Exception();
             }
@@ -653,7 +653,7 @@ namespace MS.Win32
             public static extern IntPtr MonitorFromRect(ref NativeMethods.RECT rect, int flags);
 
             [DllImport(ExternDll.User32, ExactSpelling = true)]
-            public static extern IntPtr MonitorFromPoint(NativeMethods.POINTSTRUCT pt, int flags);
+            public static extern IntPtr MonitorFromPoint(NativeMethods.POINT pt, int flags);
 
             [DllImport(ExternDll.User32, ExactSpelling=true, CharSet=CharSet.Auto)]
             public static extern IntPtr ActivateKeyboardLayout(HandleRef hkl, int uFlags);
@@ -719,7 +719,7 @@ namespace MS.Win32
 #endif
 
             [DllImport(ExternDll.User32, EntryPoint="ScreenToClient", SetLastError=true, ExactSpelling=true, CharSet=CharSet.Auto)]
-            public static extern int IntScreenToClient(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);
+            public static extern int IntScreenToClient(HandleRef hWnd, ref NativeMethods.POINT pt);
 
 #if BASE_NATIVEMETHODS
             [DllImport(ExternDll.User32)]
@@ -825,7 +825,7 @@ namespace MS.Win32
             [return: MarshalAs(UnmanagedType.Bool)]
             internal static extern bool PhysicalToLogicalPointForPerMonitorDPI(
                 [In] HandleRef hWnd,
-                [In] [Out] ref NativeMethods.POINT lpPoint);
+                ref NativeMethods.POINT lpPoint);
 
             /// <summary>
             /// Converts a point in a window from logical coordinates into physical coordinates, regardless of
@@ -846,7 +846,7 @@ namespace MS.Win32
             [return: MarshalAs(UnmanagedType.Bool)]
             internal static extern bool LogicalToPhysicalPointForPerMonitorDPI(
                 [In] HandleRef hWnd,
-                [In] [Out] ref NativeMethods.POINT lpPoint);
+                ref NativeMethods.POINT lpPoint);
 
 #if !DRT && !UIAUTOMATIONTYPES
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -45,15 +45,6 @@ namespace MS.Win32
     using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
     internal partial class UnsafeNativeMethods {
-        private struct POINTSTRUCT {
-            public int x;
-            public int y;
-
-            public POINTSTRUCT(int x, int y) {
-                this.x = x;
-                this.y = y;
-            }
-        }
 
         // For some reason "PtrToStructure" requires super high permission.
         public static object PtrToStructure(IntPtr lparam, Type cls) {
@@ -461,11 +452,11 @@ namespace MS.Win32
         public static extern IntPtr GetFocus();
 
         [DllImport(ExternDll.User32, EntryPoint = "GetCursorPos", ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern bool IntGetCursorPos([In, Out] NativeMethods.POINT pt);
+        private static extern bool IntGetCursorPos(ref NativeMethods.POINT pt);
 
-        internal static bool GetCursorPos([In, Out] NativeMethods.POINT pt)
+        internal static bool GetCursorPos(ref NativeMethods.POINT pt)
         {
-            bool returnValue = IntGetCursorPos(pt);
+            bool returnValue = IntGetCursorPos(ref pt);
             if (returnValue == false)
             {
                 throw new Win32Exception();
@@ -474,11 +465,11 @@ namespace MS.Win32
         }
 
         [DllImport(ExternDll.User32, EntryPoint = "GetCursorPos", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern bool IntTryGetCursorPos([In, Out] NativeMethods.POINT pt);
+        private static extern bool IntTryGetCursorPos(ref NativeMethods.POINT pt);
 
-        internal static bool TryGetCursorPos([In, Out] NativeMethods.POINT pt)
+        internal static bool TryGetCursorPos(ref NativeMethods.POINT pt)
         {
-            bool returnValue = IntTryGetCursorPos(pt);
+            bool returnValue = IntTryGetCursorPos(ref pt);
 
             // Sometimes Win32 will fail this call, such as if you are
             // not running in the interactive desktop.  For example,
@@ -963,11 +954,11 @@ namespace MS.Win32
         public static extern bool GetSystemPowerStatus(ref NativeMethods.SYSTEM_POWER_STATUS systemPowerStatus);
 
         [DllImport(ExternDll.User32, EntryPoint="ClientToScreen", SetLastError=true, ExactSpelling=true, CharSet=CharSet.Auto)]
-        private static extern int IntClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);
+        private static extern int IntClientToScreen(HandleRef hWnd, ref NativeMethods.POINT pt);
 
-        public static void ClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt)
+        public static void ClientToScreen(HandleRef hWnd, ref NativeMethods.POINT pt)
         {
-            if(IntClientToScreen(hWnd, pt) == 0)
+            if(IntClientToScreen(hWnd, ref pt) == 0)
             {
                 throw new Win32Exception();
             }
@@ -1074,7 +1065,7 @@ namespace MS.Win32
 
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst, NativeMethods.POINT pptDst, NativeMethods.POINT pSizeDst, IntPtr hdcSrc, NativeMethods.POINT pptSrc, int crKey, ref NativeMethods.BLENDFUNCTION pBlend, int dwFlags);
+        public static extern unsafe bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst, NativeMethods.POINT* pptDst, NativeMethods.POINT* pSizeDst, IntPtr hdcSrc, NativeMethods.POINT* pptSrc, int crKey, ref NativeMethods.BLENDFUNCTION pBlend, int dwFlags);
 
         [DllImport(ExternDll.User32, SetLastError = true)]
         public static extern IntPtr SetActiveWindow(HandleRef hWnd);
@@ -1266,10 +1257,10 @@ namespace MS.Win32
 #if BASE_NATIVEMETHODS
 
         [DllImport(ExternDll.User32, EntryPoint="WindowFromPoint", ExactSpelling=true, CharSet=CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPoint(POINT pt);
 
         public static IntPtr WindowFromPoint(int x, int y) {
-            POINTSTRUCT ps = new POINTSTRUCT(x, y);
+            POINT ps = new POINT(x, y);
             return IntWindowFromPoint(ps);
         }
 #endif
@@ -1412,10 +1403,8 @@ namespace MS.Win32
 
             [PreserveSig]
             int TransformCoords(
-                [In, Out]
-                NativeMethods.POINT pPtlHimetric,
-                [In, Out]
-                NativeMethods.POINTF pPtfContainer,
+                ref NativeMethods.POINT pPtlHimetric,
+                ref NativeMethods.POINTF pPtfContainer,
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwFlags);
 
@@ -2625,8 +2614,7 @@ namespace MS.Win32
             int ShowContextMenu(
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwID,
-                [In]
-                NativeMethods.POINT pt,
+                ref NativeMethods.POINT pt,
                 [In, MarshalAs(UnmanagedType.Interface)]
                 object pcmdtReserved,
                 [In, MarshalAs(UnmanagedType.Interface)]

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsTextServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsTextServices.cs
@@ -757,6 +757,12 @@ namespace MS.Win32
             /// 
             /// </summary>
             public int y;
+
+            public POINT(int x, int y)
+            {
+                this.x = x;
+                this.y = y;
+            }
         }
 
         /// <summary></summary>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -792,7 +792,7 @@ namespace MS.Internal.Automation
             if ( ! ((ITransformProvider)this).CanResize )
                 throw new InvalidOperationException(SR.Get(SRID.OperationCannotBePerformed));
 
-            UnsafeNativeMethods.MINMAXINFO minMaxInfo = new UnsafeNativeMethods.MINMAXINFO();
+            UnsafeNativeMethods.MINMAXINFO minMaxInfo = default;
 
             // get the largest window size that can be produced by using the borders to size the window
             int x = SafeNativeMethods.GetSystemMetrics(SafeNativeMethods.SM_CXMAXTRACK);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Win32/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Win32/UnsafeNativeMethods.cs
@@ -156,12 +156,12 @@ namespace MS.Win32
         [DllImport("user32.dll")]
         internal static extern bool UnhookWinEvent(IntPtr winEventHook);
 
-        private struct POINTSTRUCT
+        private struct POINT
         {
             public int x;
             public int y;
 
-            public POINTSTRUCT(int x, int y)
+            public POINT(int x, int y)
             {
                 this.x = x;
                 this.y = y;
@@ -169,14 +169,14 @@ namespace MS.Win32
         }
 
         [DllImport("user32.dll", EntryPoint = "WindowFromPoint", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPoint(POINT pt);
 
         [DllImport("user32.dll", EntryPoint = "WindowFromPhysicalPoint", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPhysicalPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPhysicalPoint(POINT pt);
 
         public static IntPtr WindowFromPhysicalPoint(int x, int y)
         {
-            POINTSTRUCT ps = new POINTSTRUCT(x, y);
+            POINT ps = new POINT(x, y);
             if (System.Environment.OSVersion.Version.Major >= 6)
                 return IntWindowFromPhysicalPoint(ps);
             else

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/UnsafeNativeMethods.cs
@@ -297,12 +297,12 @@ namespace MS.Win32
             internal NativeMethods.Win32Point ptStart;
         }
 
-        private struct POINTSTRUCT
+        private struct POINT
         {
             public int x;
             public int y;
 
-            public POINTSTRUCT(int x, int y)
+            public POINT(int x, int y)
             {
                 this.x = x;
                 this.y = y;
@@ -310,14 +310,14 @@ namespace MS.Win32
         }
 
         [DllImport(ExternDll.User32, EntryPoint = "WindowFromPoint", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPoint(POINT pt);
 
         [DllImport(ExternDll.User32, EntryPoint = "WindowFromPhysicalPoint", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPhysicalPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPhysicalPoint(POINT pt);
 
         public static IntPtr WindowFromPhysicalPoint(int x, int y)
         {
-            POINTSTRUCT ps = new POINTSTRUCT(x, y);
+            POINT ps = new POINT(x, y);
             if (System.Environment.OSVersion.Version.Major >= 6)
                 return IntWindowFromPhysicalPoint(ps);
             else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -187,8 +187,12 @@ namespace System.Windows
             _blendFunc.SourceConstantAlpha = 255;
             _blendFunc.AlphaFormat = 1; /*AC_SRC_ALPHA*/
 
-            bool result = UnsafeNativeMethods.UpdateLayeredWindow(hWnd, hScreenDC, newLocation, newSize,
-                memDC, sourceLocation, 0, ref _blendFunc, NativeMethods.ULW_ALPHA);
+            bool result;
+            unsafe
+            {
+                result = UnsafeNativeMethods.UpdateLayeredWindow(hWnd, hScreenDC, &newLocation, &newSize,
+                    memDC, &sourceLocation, 0, ref _blendFunc, NativeMethods.ULW_ALPHA);
+            }
 
             UnsafeNativeMethods.SelectObject(new HandleRef(null, memDC), hOldBitmap);
             UnsafeNativeMethods.ReleaseDC(new HandleRef(), new HandleRef(null, memDC));
@@ -277,7 +281,10 @@ namespace System.Windows
             {
                 double progress = (_fadeoutEnd - dtNow).TotalMilliseconds / _fadeoutDuration.TotalMilliseconds;
                 _blendFunc.SourceConstantAlpha = (byte)(255 * progress);
-                UnsafeNativeMethods.UpdateLayeredWindow(_hwnd, IntPtr.Zero, null, null, IntPtr.Zero, null, 0, ref _blendFunc, NativeMethods.ULW_ALPHA);
+                unsafe
+                {
+                    UnsafeNativeMethods.UpdateLayeredWindow(_hwnd, IntPtr.Zero, null, null, IntPtr.Zero, null, 0, ref _blendFunc, NativeMethods.ULW_ALPHA);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/DrtBase.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/DrtBase.cs
@@ -2493,14 +2493,10 @@ namespace DRT
 
 
         [StructLayout(LayoutKind.Sequential)]
-        public class POINT
+        public struct POINT
         {
             public int x = 0;
             public int y = 0;
-
-            public POINT()
-            {
-            }
 
             public POINT(int x, int y)
             {

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Internal/PointUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Internal/PointUtil.cs
@@ -153,7 +153,7 @@ namespace MS.Internal
                 ptScreen.x = rcClient.right - ptScreen.x;
             }
 
-            UnsafeNativeMethods.ClientToScreen( handleRef , ptScreen);
+            UnsafeNativeMethods.ClientToScreen( handleRef , ref ptScreen);
             
             return new Point(ptScreen.x, ptScreen.y);
         }
@@ -175,7 +175,7 @@ namespace MS.Internal
             
             // Convert the point from screen coordinates back to client coordinates.
             NativeMethods.POINT ptClient = new NativeMethods.POINT((int)ptScreen.X, (int)ptScreen.Y);
-            SafeNativeMethods.ScreenToClient(handleRef , ptClient);
+            SafeNativeMethods.ScreenToClient(handleRef , ref ptClient);
 
             // MITIGATION: WIN32_AND_AVALON_RTL
             //

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/NativeMethodsCLR.cs
@@ -2998,12 +2998,9 @@ namespace MS.Win32 {
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class POINT {
+        public struct POINT {
             public int x;
             public int y;
-
-            public POINT() {
-            }
 
             public POINT(int x, int y) {
                 this.x = x;
@@ -3019,10 +3016,10 @@ namespace MS.Win32 {
         // use this in cases where the Native API takes a POINT not a POINT*
         // classes marshal by ref.
         [StructLayout(LayoutKind.Sequential)]
-        public struct POINTSTRUCT {
+        public struct POINT {
             public int x;
             public int y;
-            public POINTSTRUCT(int x, int y) {
+            public POINT(int x, int y) {
               this.x = x;
               this.y = y;
             }
@@ -4220,14 +4217,10 @@ namespace MS.Win32 {
 #endif
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
-        public sealed class POINTF
+        public sealed struct POINTF
         {
-          [MarshalAs(UnmanagedType.R4)/*leftover(offset=0, x)*/]
           public float x;
-
-          [MarshalAs(UnmanagedType.R4)/*leftover(offset=4, y)*/]
           public float y;
-
         }
 
         [StructLayout(LayoutKind.Sequential)/*leftover(noAutoOffset)*/]
@@ -5224,12 +5217,12 @@ namespace MS.Win32 {
 #endif
 
         [StructLayout(LayoutKind.Sequential)]
-        public class MINMAXINFO {
-            public POINT ptReserved = new POINT();
-            public POINT ptMaxSize = new POINT();
-            public POINT ptMaxPosition = new POINT();
-            public POINT ptMinTrackSize = new POINT();
-            public POINT ptMaxTrackSize = new POINT();
+        public struct MINMAXINFO {
+            public POINT ptReserved;
+            public POINT ptMaxSize;
+            public POINT ptMaxPosition;
+            public POINT ptMinTrackSize;
+            public POINT ptMaxTrackSize;
         }
 #if never
         [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/SafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/SafeNativeMethodsCLR.cs
@@ -75,7 +75,7 @@ namespace MS.Win32
         }
 
 
-        public static  IntPtr MonitorFromPoint(NativeMethods.POINTSTRUCT pt, int flags)
+        public static  IntPtr MonitorFromPoint(NativeMethods.POINT pt, int flags)
         {
             return SafeNativeMethodsPrivate.MonitorFromPoint(pt,flags);
         }
@@ -247,7 +247,7 @@ namespace MS.Win32
 
         // not used by compiler - don't include.
 
-        public static void ScreenToClient(HandleRef hWnd, [In, Out] NativeMethods.POINT pt)
+        public static void ScreenToClient(HandleRef hWnd, NativeMethods.POINT pt)
         {
             if(SafeNativeMethodsPrivate.IntScreenToClient(hWnd, pt) == 0)
             {
@@ -405,7 +405,7 @@ namespace MS.Win32
             public static extern IntPtr MonitorFromRect(ref NativeMethods.RECT rect, int flags);
 
             [DllImport(ExternDll.User32, ExactSpelling = true)]
-            public static extern IntPtr MonitorFromPoint(NativeMethods.POINTSTRUCT pt, int flags);
+            public static extern IntPtr MonitorFromPoint(NativeMethods.POINT pt, int flags);
 
             [DllImport(ExternDll.User32, ExactSpelling=true, CharSet=CharSet.Auto)]
             public static extern IntPtr ActivateKeyboardLayout(HandleRef hkl, int uFlags);
@@ -471,7 +471,7 @@ namespace MS.Win32
 #endif
 
             [DllImport(ExternDll.User32, EntryPoint="ScreenToClient", SetLastError=true, ExactSpelling=true, CharSet=CharSet.Auto)]
-            public static extern int IntScreenToClient(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);
+            public static extern int IntScreenToClient(HandleRef hWnd, ref NativeMethods.POINT pt);
 
 #if BASE_NATIVEMETHODS
             [DllImport(ExternDll.User32)]

--- a/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/test/Common/DRT/TestServices/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -44,16 +44,6 @@ namespace MS.Win32
 
     public partial class UnsafeNativeMethods {
 
-        private struct POINTSTRUCT {
-            public int x;
-            public int y;
-
-            public POINTSTRUCT(int x, int y) {
-                this.x = x;
-                this.y = y;
-            }
-        }
-
         // For some reason "PtrToStructure" requires super high permission.
         public static object PtrToStructure(IntPtr lparam, Type cls) {
             return Marshal.PtrToStructure(lparam, cls);
@@ -473,9 +463,9 @@ namespace MS.Win32
         public static extern IntPtr GetFocus();
 
         [DllImport(ExternDll.User32, EntryPoint = "GetCursorPos", ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern bool IntGetCursorPos([In, Out] NativeMethods.POINT pt);
+        private static extern bool IntGetCursorPos(ref NativeMethods.POINT pt);
 
-        internal static bool GetCursorPos([In, Out] NativeMethods.POINT pt)
+        internal static bool GetCursorPos(ref NativeMethods.POINT pt)
         {
             bool returnValue = IntGetCursorPos(pt);
             if (returnValue == false)
@@ -486,9 +476,9 @@ namespace MS.Win32
         }
 
         [DllImport(ExternDll.User32, EntryPoint = "GetCursorPos", ExactSpelling = true, CharSet = CharSet.Auto)]
-        private static extern bool IntTryGetCursorPos([In, Out] NativeMethods.POINT pt);
+        private static extern bool IntTryGetCursorPos(ref NativeMethods.POINT pt);
 
-        internal static bool TryGetCursorPos([In, Out] NativeMethods.POINT pt)
+        internal static bool TryGetCursorPos(ref NativeMethods.POINT pt)
         {
             bool returnValue = IntTryGetCursorPos(pt);
 
@@ -975,9 +965,9 @@ namespace MS.Win32
         public static extern bool GetSystemPowerStatus(ref NativeMethods.SYSTEM_POWER_STATUS systemPowerStatus);
 
         [DllImport(ExternDll.User32, EntryPoint="ClientToScreen", SetLastError=true, ExactSpelling=true, CharSet=CharSet.Auto)]
-        private static extern int IntClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt);
+        private static extern int IntClientToScreen(HandleRef hWnd, [In, Out] ref NativeMethods.POINT pt);
 
-        public static void ClientToScreen(HandleRef hWnd, [In, Out] NativeMethods.POINT pt)
+        public static void ClientToScreen(HandleRef hWnd, [In, Out] ref NativeMethods.POINT pt)
         {
             if(IntClientToScreen(hWnd, pt) == 0)
             {
@@ -1086,7 +1076,7 @@ namespace MS.Win32
 
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst, NativeMethods.POINT pptDst, NativeMethods.POINT pSizeDst, IntPtr hdcSrc, NativeMethods.POINT pptSrc, int crKey, ref NativeMethods.BLENDFUNCTION pBlend, int dwFlags);
+        public static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst, ref NativeMethods.POINT pptDst, ref NativeMethods.POINT pSizeDst, IntPtr hdcSrc, ref NativeMethods.POINT pptSrc, int crKey, ref NativeMethods.BLENDFUNCTION pBlend, int dwFlags);
 
         [DllImport(ExternDll.User32, SetLastError = true)]
         public static extern IntPtr SetActiveWindow(HandleRef hWnd);
@@ -1278,10 +1268,10 @@ namespace MS.Win32
 #if BASE_NATIVEMETHODS
 
         [DllImport(ExternDll.User32, EntryPoint="WindowFromPoint", ExactSpelling=true, CharSet=CharSet.Auto)]
-        private static extern IntPtr IntWindowFromPoint(POINTSTRUCT pt);
+        private static extern IntPtr IntWindowFromPoint(POINT pt);
 
         public static IntPtr WindowFromPoint(int x, int y) {
-            POINTSTRUCT ps = new POINTSTRUCT(x, y);
+            POINT ps = new POINT(x, y);
             return IntWindowFromPoint(ps);
         }
 #endif
@@ -1430,10 +1420,8 @@ namespace MS.Win32
 
             [PreserveSig]
             int TransformCoords(
-                [In, Out]
-                NativeMethods.POINT pPtlHimetric,
-                [In, Out]
-                NativeMethods.POINTF pPtfContainer,
+                ref NativeMethods.POINT pPtlHimetric,
+                ref NativeMethods.POINTF pPtfContainer,
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwFlags);
 
@@ -2695,8 +2683,7 @@ namespace MS.Win32
             int ShowContextMenu(
                 [In, MarshalAs(UnmanagedType.U4)]
                 int dwID,
-                [In]
-                NativeMethods.POINT pt,
+                ref NativeMethods.POINT pt,
                 [In, MarshalAs(UnmanagedType.Interface)]
                 object pcmdtReserved,
                 [In, MarshalAs(UnmanagedType.Interface)]


### PR DESCRIPTION
## Description

There are a bunch of copies around the tree of POINT interop types: some are structs (as they should be), some are classes.  The latter are resulting in tons of allocations.  This standardizes on using structs for all of them.

In a simple WPF app just moving my mouse around for a few seconds, these are the resulting top allocations:
![image](https://user-images.githubusercontent.com/2642209/123479156-7d791a80-d5ce-11eb-9850-2aaed951a993.png)
With this PR, the highlighted line goes away.

## Customer Impact

Less allocation, less GC, less pause time.

## Regression

No

## Testing

CI, plus validation that the allocations went away in the example scenarios I was looking at.

## Risk

There is some risk here.  The change itself is sound. However, the interop definitions throughout the repo are in a bit of disarray, with many different copies of the same interop types and functions, all defined subtly differently.  I believe I caught all of the relevant paths interacting with these types, but it's definitely possible something could have slipped through.