### PR TITLE
Stop allocating two RawMouseActions[] arrays in PreNotifyInput

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -1736,7 +1736,7 @@ namespace System.Windows.Input
                             actions |= RawMouseActions.QueryCursor;
                         }
 
-                        RawMouseActions[] ButtonPressActions =
+                        ReadOnlySpan<RawMouseActions> ButtonPressActions = stackalloc RawMouseActions[5]
                         {
                             RawMouseActions.Button1Press,
                             RawMouseActions.Button2Press,
@@ -1745,7 +1745,7 @@ namespace System.Windows.Input
                             RawMouseActions.Button5Press
                         };
 
-                        RawMouseActions[] ButtonReleaseActions =
+                        ReadOnlySpan<RawMouseActions> ButtonReleaseActions = stackalloc RawMouseActions[5]
                         {
                             RawMouseActions.Button1Release,
                             RawMouseActions.Button2Release,


### PR DESCRIPTION
## Description

Calls to MouseDevice.PreNotifyInput are allocating two arrays unnecessarily.

![image](https://user-images.githubusercontent.com/2642209/123481941-73591b00-d5d2-11eb-97f1-3b26419d1ff5.png)

## Customer Impact

Less allocation means less GC means less pauses.

## Regression

No

## Testing

Just CI

## Risk

Minimal.  The arrays were simply iterated through and were used for convenience; we can trivially do so with a span instead.