### PR TITLE
Remove more unnecessary DispatcherOperationCallbacks instances

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/TouchDevice.cs
@@ -507,10 +507,11 @@ namespace System.Windows.Input
                 _reevaluateCapture = Dispatcher.BeginInvoke(DispatcherPriority.Input,
                     (DispatcherOperationCallback)delegate(object args)
                     {
-                        _reevaluateCapture = null;
-                        OnReevaluateCapturedWithinAsync();
+                        TouchDevice thisRef = (TouchDevice)args;
+                        thisRef._reevaluateCapture = null;
+                        thisRef.OnReevaluateCapturedWithinAsync();
                         return null;
-                    }, null);
+                    }, this);
             }
         }
 
@@ -593,10 +594,11 @@ namespace System.Windows.Input
                     _reevaluateCapture = Dispatcher.BeginInvoke(DispatcherPriority.Input,
                         (DispatcherOperationCallback)delegate(object args)
                         {
-                            _reevaluateCapture = null;
-                            Capture(null);
+                            TouchDevice thisRef = (TouchDevice)args;
+                            thisRef._reevaluateCapture = null;
+                            thisRef.Capture(null);
                             return null;
-                        }, null);
+                        }, this);
                 }
             }
         }
@@ -847,10 +849,11 @@ namespace System.Windows.Input
                 _reevaluateOver = Dispatcher.BeginInvoke(DispatcherPriority.Input,
                     (DispatcherOperationCallback)delegate(object args)
                     {
-                        _reevaluateOver = null;
-                        OnHitTestInvalidatedAsync(this, EventArgs.Empty);
+                        TouchDevice thisRef = (TouchDevice)args;
+                        thisRef._reevaluateOver = null;
+                        thisRef.OnHitTestInvalidatedAsync(this, EventArgs.Empty);
                         return null;
-                    }, null);
+                    }, this);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
@@ -806,22 +806,24 @@ namespace System.Windows.Interop
                         // the queue to do this work. If a WM_MOUSEMOVE comes in earlier, then the operation
                         // is aborted, else it comes through and we update the cursor.
                         _queryCursorOperation = Dispatcher.BeginInvoke(DispatcherPriority.Input,
-                            (DispatcherOperationCallback)delegate(object sender)
+                            (DispatcherOperationCallback)(sender =>
                             {
+                                HwndMouseInputProvider thisRef = (HwndMouseInputProvider)sender;
+
                                 // Since this is an asynchronous operation and an arbitrary amount of time has elapsed
                                 // since we received the WM_SETCURSOR, we need to be careful that the mouse hasn't
                                 // been deactivated in the meanwhile. This is also another reason that we do not ReportInput,
                                 // because the implicit assumption in doing that is to activate the MouseDevice. All we want
                                 // to do is passively try to update the cursor.
-                                if (_active)
+                                if (thisRef._active)
                                 {
                                     Mouse.UpdateCursor();
                                 }
 
-                                _queryCursorOperation = null;
+                                thisRef._queryCursorOperation = null;
                                 return null;
-                            },
-                            null);
+                            }),
+                            this);
                     }
 
                     // MITIGATION_SETCURSOR

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/HostVisual.cs
@@ -182,10 +182,10 @@ namespace System.Windows.Media
                         DispatcherPriority.Normal,
                         (DispatcherOperationCallback)delegate(object args)
                         {
-                            Invalidate();
+                            ((HostVisual)args).Invalidate();
                             return null;
                         },
-                        null
+                        this
                         );
                 }
             }
@@ -363,10 +363,10 @@ namespace System.Windows.Media
                         DispatcherPriority.Normal,
                         (DispatcherOperationCallback)delegate(object args)
                         {
-                            Invalidate();
+                            ((HostVisual)args).Invalidate();
                             return null;
                         },
-                        null
+                        this
                         );
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -615,10 +615,11 @@ namespace System.Windows.Controls
                 _contentRenderedCallback.Abort();
             }
             _contentRenderedCallback = Dispatcher.BeginInvoke(DispatcherPriority.Input,
-                                   (DispatcherOperationCallback) delegate (object unused)
+                                   (DispatcherOperationCallback) delegate (object arg)
                                    {
-                                       _contentRenderedCallback = null;
-                                       OnContentRendered(EventArgs.Empty);
+                                       Frame thisRef = (Frame)arg;
+                                       thisRef._contentRenderedCallback = null;
+                                       thisRef.OnContentRendered(EventArgs.Empty);
                                        return null;
                                    },
                                    this);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3373,13 +3373,14 @@ namespace System.Windows
                 _contentRenderedCallback.Abort();
             }
             _contentRenderedCallback = Dispatcher.BeginInvoke(DispatcherPriority.Input,
-                                   (DispatcherOperationCallback) delegate (object unused)
+                                   (DispatcherOperationCallback) delegate (object arg)
                                    {
                                        // Event handler exception continuality: there are no state related/depending on ContentRendered event.
                                        // If an exception occurs in event handler, our state will not be corrupted.
                                        // Please check event handler exception continuality if the logic changes.
-                                       _contentRenderedCallback = null;
-                                       OnContentRendered(EventArgs.Empty);
+                                       Window thisRef = (Window)arg;
+                                       thisRef._contentRenderedCallback = null;
+                                       thisRef.OnContentRendered(EventArgs.Empty);
                                        return null;
                                    },
                                    this);

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/NGCSerializationManagerAsync.cs
@@ -1023,8 +1023,7 @@ namespace System.Windows.Xps.Serialization
         {
             do
             {
-                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)DoNothingCallback, null);
-
+                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)(_ => null), null);
             }
             while (IsAsyncWorkPending());
         }
@@ -1058,15 +1057,6 @@ namespace System.Windows.Xps.Serialization
             }
 
             return false;
-        }
-
-        private static
-        object
-        DoNothingCallback(
-            object notUsed
-            )
-        {
-            return null;
         }
 
         #endregion Internal Methods

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManagerAsync.cs
@@ -456,7 +456,7 @@ namespace System.Windows.Xps.Serialization
         {
             do
             {
-                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)DoNothingCallback, null);
+                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)(_ => null), null);
 
             }
             while (IsAsyncWorkPending());
@@ -492,15 +492,6 @@ namespace System.Windows.Xps.Serialization
             }
 
             return false;
-        }
-
-        private static
-        object
-        DoNothingCallback(
-            object notUsed
-            )
-        {
-            return null;
         }
 
         #endregion private methods

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManagerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsSerializationManagerAsync.cs
@@ -542,7 +542,7 @@ namespace System.Windows.Xps.Serialization
         {
             do
             {
-                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)DoNothingCallback, null);
+                _dispatcher.Invoke(DispatcherPriority.Background, (DispatcherOperationCallback)(_ => null), null);
 
             }
             while (IsAsyncWorkPending());
@@ -577,15 +577,6 @@ namespace System.Windows.Xps.Serialization
             }
 
             return false;
-        }
-
-        private static
-        object
-        DoNothingCallback(
-            object notUsed
-            )
-        {
-            return null;
         }
 
         private

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonGalleryItem.cs
@@ -102,11 +102,11 @@ namespace Microsoft.Windows.Controls.Ribbon
         protected internal virtual void OnSelected(RoutedEventArgs e)
         {
             RaiseEvent(e);
-            Dispatcher.BeginInvoke(DispatcherPriority.Normal, (DispatcherOperationCallback)delegate(object unused)
+            Dispatcher.BeginInvoke(DispatcherPriority.Normal, (DispatcherOperationCallback)delegate(object arg)
             {
-                BringIntoView();
+                ((RibbonGalleryItem)arg).BringIntoView();
                 return null;
-            }, null);
+            }, this);
 
             RibbonGalleryItemAutomationPeer peer = UIElementAutomationPeer.CreatePeerForElement(this) as RibbonGalleryItemAutomationPeer;
             if (peer != null)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -84,7 +84,11 @@ namespace System.Windows
                         {
                             Dispatcher.CurrentDispatcher.BeginInvoke(
                                 DispatcherPriority.Loaded,
-                                (DispatcherOperationCallback)ShowCallback,
+                                (DispatcherOperationCallback)(arg =>
+                                {
+                                    ((SplashScreen)arg).Close(TimeSpan.FromSeconds(0.3));
+                                    return null;
+                                }),
                                 this);
                         }
                         // The HWND that we just created is owned by this thread.  When we close we should ensure that it 
@@ -98,13 +102,6 @@ namespace System.Windows
                     }
                 }
             }
-        }
-        
-        private static object ShowCallback(object arg)
-        {
-            SplashScreen splashScreen = (SplashScreen)arg;
-            splashScreen.Close(TimeSpan.FromSeconds(0.3));
-            return null;
         }
 
         // This is 200-300 ms slower than Assembly.GetManifestResourceStream() but works with localization.


### PR DESCRIPTION
## Description

A bunch of DispatcherOperationCallback delegates that with trivial changes the compiler can easily cache, e.g.
![image](https://user-images.githubusercontent.com/2642209/123485941-2298f080-d5d9-11eb-84c9-8e1919e34a72.png)


## Customer Impact

Less memory allocation.

## Regression

No

## Testing

Just CI

## Risk

Minimal.  It's just removing some unecessary allocations.