### PR TITLE
Stop allocating new delegates in WriterDelegate.Dispose

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/WriterDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/WriterDelegate.cs
@@ -72,10 +72,11 @@ namespace System.Xaml
                 if (disposing && !IsDisposed)
                 {
                     _addDelegate(XamlNodeType.None, XamlNode.InternalNodeType.EndOfStream);
-                    _addDelegate = new XamlNodeAddDelegate(ThrowBecauseWriterIsClosed);
-                    _addLineInfoDelegate = (_addLineInfoDelegate != null)
-                                ? new XamlLineInfoAddDelegate(ThrowBecauseWriterIsClosed2)
-                                : null;
+                    _addDelegate = delegate { throw new XamlException(SR.Get(SRID.WriterIsClosed)); };
+                    if (_addLineInfoDelegate != null)
+                    {
+                        _addLineInfoDelegate = delegate { throw new XamlException(SR.Get(SRID.WriterIsClosed)); };
+                    }
                 }
             }
             finally
@@ -110,17 +111,6 @@ namespace System.Xaml
             }
         }
         #endregion
-
-
-        private void ThrowBecauseWriterIsClosed(XamlNodeType nodeType, object data)
-        {
-            throw new XamlException(SR.Get(SRID.WriterIsClosed));
-        }
-
-        private void ThrowBecauseWriterIsClosed2(int lineNumber, int linePosition)
-        {
-            throw new XamlException(SR.Get(SRID.WriterIsClosed));
-        }
 
         private void ThrowIsDisposed()
         {


### PR DESCRIPTION
## Description

Every call to Dispose is allocating one or two delegates.  They're not unique to this instance; we can let the compiler cache them for us.

## Customer Impact

Less allocation, less GC impact.

## Regression

No

## Testing

Just CI

## Risk

Minimal.  It's just changing one form of delegate creation to another.