### PR TITLE
Remove unneeded Directory.Build.props file

### DIFF
--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -1,3 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-</Project>


### PR DESCRIPTION
## Description

This file does nothing (MSBuild will evaluate the same way without it), and its existence prevents GitHub from collapsing the src/Microsoft.DotNet.Wpf subdirectory into one link.

## Customer Impact

Developers will be able to enter the src/Microsoft.DotNet.Wpf subdirectory from the repo homepage with one click, rather than having to click into the src subdirectory and then into Microsoft.DotNet.Wpf. I find this latter behavior very annoying whenever I browse the WPF repo on GitHub.