### PR TITLE
Import Windows Forms related props and targets into Windows Desktop

### DIFF
--- a/eng/WindowsFormsImports.targets
+++ b/eng/WindowsFormsImports.targets
@@ -1,0 +1,51 @@
+<Project>
+
+  <PropertyGroup>
+    <_WindowsFormsNuGetPath>$(PkgMicrosoft_Private_Winforms)</_WindowsFormsNuGetPath>
+  </PropertyGroup>
+
+  <!--
+    ============================================================
+                      _ValidateWindowsFormsPackagingContent
+    Validates the content of Microsoft.Private.Winforms NuGet package
+    to ensure we correctly import and reference props and targets.
+    ============================================================
+   -->
+  <Target Name="_ValidateWindowsFormsPackagingContent">
+    <PropertyGroup>
+      <_WindowsFormsContentPath>$(_WindowsFormsNuGetPath)\sdk\dotnet-wpf\*</_WindowsFormsContentPath>
+      <_WindowsFormsRequiredFileName>Microsoft.NET.SDk.WindowsDesktop.WindowsForms</_WindowsFormsRequiredFileName>
+    </PropertyGroup>
+
+    <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
+           Condition="'$(_WindowsFormsNuGetPath)' == ''"/>
+
+    <ItemGroup>
+      <!-- Enumerate all transported files -->
+      <_WindowsFormsContent Include="$(_WindowsFormsContentPath)" />
+      <!-- ...and verify Microsoft.NET.SDk.WindowsDesktop.WindowsForms.props/.targets are present -->
+      <_WindowsFormsContentFiles Include="@(_WindowsFormsContent->'%(FileName)%(Extension)')"
+          Condition=" '%(FileName)%(Extension)' == '$(_WindowsFormsRequiredFileName).props'
+                   or '%(FileName)%(Extension)' == '$(_WindowsFormsRequiredFileName).targets' "/>
+    </ItemGroup>
+
+    <!-- Fail if the required files are missing -->
+    <Error Text="Microsoft.Private.Winforms NuGet package does not contain $(_WindowsFormsRequiredFileName).props or $(_WindowsFormsRequiredFileName).targets"
+           Condition="@(_WindowsFormsContentFiles->Count()) != 2"/>
+  </Target>
+
+
+  <!--
+    ============================================================
+                      _IdentifyWindowsFormsPackageAssets
+    Add props/targets shipped by Windows Forms to the collection of files that get packaged
+    in to Microsoft.NET.Sdk.WindowsDesktop.<configuration>.<version>.nupkg.
+    ============================================================
+  -->
+  <Target Name="_IdentifyWindowsFormsPackageAssets" BeforeTargets="IdentifyPackageAssets" DependsOnTargets="_ValidateWindowsFormsPackagingContent">
+    <ItemGroup>
+      <PackagingContent Include="$(_WindowsFormsContentPath)" SubFolder="root\targets" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -27,7 +27,7 @@
     <PackagingContent Include="useSharedDesignerContext.txt" SubFolder="root" />
   </ItemGroup>
 
-  <!-- Windows Forms specific -->
-  <Import Project="$(RepositoryEngineeringDir)WindowsFormsImports.targets" />
+  <!-- Windows Forms validation and packaging -->
+  <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WinForms.Packaging.targets" />
 
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.ArchNeutral.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <ProjectGuid>{440d06b8-e3de-4c0d-ad25-cd4f43d836e1}</ProjectGuid>
     <TargetFramework>net6.0</TargetFramework>
@@ -25,4 +26,8 @@
     <PackagingContent Include="targets\*" SubFolder="root\targets" />
     <PackagingContent Include="useSharedDesignerContext.txt" SubFolder="root" />
   </ItemGroup>
+
+  <!-- Windows Forms specific -->
+  <Import Project="$(RepositoryEngineeringDir)WindowsFormsImports.targets" />
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.WinForms.Packaging.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/Microsoft.NET.Sdk.WindowsDesktop.WinForms.Packaging.targets
@@ -14,7 +14,7 @@
   <Target Name="_ValidateWindowsFormsPackagingContent">
     <PropertyGroup>
       <_WindowsFormsContentPath>$(_WindowsFormsNuGetPath)\sdk\dotnet-wpf\*</_WindowsFormsContentPath>
-      <_WindowsFormsRequiredFileName>Microsoft.NET.SDk.WindowsDesktop.WindowsForms</_WindowsFormsRequiredFileName>
+      <_WindowsFormsRequiredFileName>Microsoft.NET.Sdk.WindowsDesktop.WindowsForms</_WindowsFormsRequiredFileName>
     </PropertyGroup>
 
     <Error Text="Unable to resolve path to Microsoft.Private.Winforms NuGet package. Is %24(PkgMicrosoft_Private_Winforms) defined?"
@@ -23,7 +23,7 @@
     <ItemGroup>
       <!-- Enumerate all transported files -->
       <_WindowsFormsContent Include="$(_WindowsFormsContentPath)" />
-      <!-- ...and verify Microsoft.NET.SDk.WindowsDesktop.WindowsForms.props/.targets are present -->
+      <!-- ...and verify Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.props/.targets are present -->
       <_WindowsFormsContentFiles Include="@(_WindowsFormsContent->'%(FileName)%(Extension)')"
           Condition=" '%(FileName)%(Extension)' == '$(_WindowsFormsRequiredFileName).props'
                    or '%(FileName)%(Extension)' == '$(_WindowsFormsRequiredFileName).targets' "/>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -161,4 +161,11 @@
     <SupportedTargetFramework Remove="@(_UnsupportedNETCoreAppTargetFramework);@(_UnsupportedNETStandardTargetFramework);@(_UnsupportedNETFrameworkTargetFramework)" />
   </ItemGroup>
 
+  <!--
+    Import Windows Forms props.
+    These come via the Windows Forms transport package, that can be found under
+    https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk
+  -->
+  <Import Project="Microsoft.NET.SDk.WindowsDesktop.WindowsForms.props" />
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -166,6 +166,6 @@
     These come via the Windows Forms transport package, that can be found under
     https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk
   -->
-  <Import Project="Microsoft.NET.SDk.WindowsDesktop.WindowsForms.props" />
+  <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.props" />
 
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -160,6 +160,6 @@
     These come via the Windows Forms transport package, that can be found under
     https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk
   -->
-  <Import Project="Microsoft.NET.SDk.WindowsDesktop.WindowsForms.targets" Condition="'$(UseWindowsForms)' == 'true'"/>
+  <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets" Condition="'$(UseWindowsForms)' == 'true'"/>
 
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -155,4 +155,11 @@
   <!-- Import WPF Build logic only when we don't import NETFX's WinFX targets -->
   <Import Project="Microsoft.WinFX.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'true'"/>
 
+  <!--
+    Import Windows Forms targets.
+    These come via the Windows Forms transport package, that can be found under
+    https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk
+  -->
+  <Import Project="Microsoft.NET.SDk.WindowsDesktop.WindowsForms.targets" Condition="'$(UseWindowsForms)' == 'true'"/>
+
 </Project>


### PR DESCRIPTION
## Proposed Changes:

* Establish a mechanism to import Windows Forms related functionality into Windows Desktop SDK via the Windows Forms transport package.
* Add a basic validation of the content of the shipping package in .\eng\WindowsFormsImports.targets.

Enables https://github.com/dotnet/winforms/pull/5183


## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/4403806/126631934-8abb4c16-744c-4836-81fb-41c23b4c7671.png)



## Test methodology <!-- How did you ensure quality? -->

- Manually locally modifying the installed SDK
- Building winforms -> wpf -> windowsdesktop
