### PR TITLE
Fix GetEntryAssemblyLocation Uri

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -73,8 +73,7 @@ namespace MS.Internal.AppModel
                 BaseUriHelper.GetAssemblyNameAndPart(Uri, out filePath, out assemblyName, out assemblyVersion, out assemblyKey);
 
                 // filePath should not have leading slash.  GetAssemblyNameAndPart( ) can guarantee it.
-                Uri file = new Uri(codeBase, filePath);
-                _fullPath = file.LocalPath;
+                _fullPath = System.IO.Path.Combine(codeBase.LocalPath, filePath);
             }
 
             stream = CriticalOpenFile(_fullPath);


### PR DESCRIPTION


Fixes Issue #4781



## Description

We do not escape the path string in GetEntryAssemblyLocation method. And it will break when the application in the special path, such as the path contains a `#`. See https://github.com/dotnet/wpf/issues/4781

## Customer Impact

All the GetContentStream

## Regression

No.

## Testing

Just CI

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
