### PR TITLE
Update FxCop analyzers

### DIFF
--- a/eng/WpfArcadeSdk/tools/CodeAnalysis.targets
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis.targets
@@ -6,8 +6,7 @@
   <ItemGroup Condition="'$(IsTestProject)'!='true' AND '$(EnableAnalyzers)'=='true'">
     <!-- Managed Code Reference analyzers -->
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.Analyzers" Version="1.1.0" />
   </ItemGroup>

--- a/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
@@ -21,7 +21,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2002" Action="None" />
   </Rules>
 </RuleSet>

--- a/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
@@ -21,7 +21,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA1805" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2002" Action="None" />
   </Rules>

--- a/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
@@ -21,7 +21,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA1310" Action="None" />
     <Rule Id="CA1805" Action="None" />
     <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2002" Action="None" />

--- a/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
@@ -19,4 +19,11 @@
   <Rules AnalyzerId="System.Runtime.CSharp.Analyzers" RuleNamespace="System.Runtime.CSharp.Analyzers">
     <Rule Id="CA2213" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1310" Action="None" />
+    <Rule Id="CA1805" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2002" Action="None" />
+  </Rules>
 </RuleSet>

--- a/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
+++ b/eng/WpfArcadeSdk/tools/CodeAnalysis/WpfCodeAnalysis.ruleset
@@ -21,6 +21,5 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA2002" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -106,7 +106,7 @@ namespace MS.Internal.Xaml.Parser
 
         internal bool Match(char start, char end)
         {
-            return _endChars.IndexOf(end.ToString()) == _startChars.IndexOf(start.ToString());
+            return _endChars.IndexOf(end.ToString(), StringComparison.Ordinal) == _startChars.IndexOf(start.ToString(), StringComparison.Ordinal);
         }
 
         internal string StartBracketCharacters

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Markup
             }
         }
 
-        private string _name = null;
+        private string _name;
     }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
@@ -54,6 +54,6 @@ namespace System.Windows.Markup
         }
 
         // The name of the property that is designated to accept the x:Uid value
-        private string _name = null;
+        private string _name;
     }    
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -17,7 +17,7 @@ namespace MS.Internal.Xaml.Context
     {
         private XamlContextStack<ObjectWriterFrame> _stack;
 
-        private object _rootInstance = null;
+        private object _rootInstance;
 
         ServiceProviderContext _serviceProviderContext;
         XamlRuntime _runtime;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -38,7 +38,7 @@ namespace System.Xaml.MS.Impl
         }
 
         // Note this, is the only dictionary that we synchronize, because XamlSchemaContext adds to it
-        private ConcurrentDictionary<string, IList<string>> _clrToXmlNs = null;
+        private ConcurrentDictionary<string, IList<string>> _clrToXmlNs;
         internal ConcurrentDictionary<string, IList<string>> ClrToXmlNs
         {
             get
@@ -64,7 +64,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        private Dictionary<string, string> _oldToNewNs = null;
+        private Dictionary<string, string> _oldToNewNs;
         internal Dictionary<string, string> OldToNewNs
         {
             get
@@ -77,7 +77,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        private Dictionary<string, string> _prefixes = null;
+        private Dictionary<string, string> _prefixes;
         internal Dictionary<string, string> Prefixes
         {
             get
@@ -90,7 +90,7 @@ namespace System.Xaml.MS.Impl
             }
         }
 
-        private string _rootNamespace = null;
+        private string _rootNamespace;
         internal string RootNamespace
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
@@ -20,7 +20,7 @@ namespace MS.Internal.Xaml.Parser
 
         #region INamespacePrefixLookup Members
 
-        private int n = 0;
+        private int n;
         public string LookupPrefix(string ns)
         {
             // we really shouldn't generate extraneous new namespaces

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -33,7 +33,7 @@ namespace MS.Internal.Xaml
         }
 
         List<SeenCtorDirectiveFlags> _seenStack = new List<SeenCtorDirectiveFlags>();
-        int _startObjectDepth = 0;
+        int _startObjectDepth;
 
         List<int> _moveList;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
@@ -30,7 +30,7 @@ namespace MS.Internal.Xaml.Parser
         public abstract string ScopedName { get; }
 
         protected string _prefix;
-        protected string _namespace = null;
+        protected string _namespace;
 
         public string Prefix { get { return _prefix; } }
         public string Namespace { get { return _namespace; } }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
@@ -931,7 +931,7 @@ namespace MS.Internal.Xaml.Parser
 
         #region Optimizations
         private readonly XamlTypeName arrayType = new XamlTypeName(@"http://schemas.microsoft.com/winfx/2006/xaml", "Array");
-        private XamlType _arrayExtensionType = null;
+        private XamlType _arrayExtensionType;
         private XamlType ArrayExtensionType
         {
             get
@@ -944,7 +944,7 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        private XamlMember _arrayTypeMember = null;
+        private XamlMember _arrayTypeMember;
         private XamlMember ArrayTypeMember
         {
             get
@@ -957,7 +957,7 @@ namespace MS.Internal.Xaml.Parser
             }
         }
 
-        private XamlMember _itemsTypeMember = null;
+        private XamlMember _itemsTypeMember;
         private XamlMember ItemsTypeMember
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
@@ -29,14 +29,14 @@ namespace MS.Internal.Xaml.Parser
         XamlScannerStack _scannerStack;
         XamlParserContext _parserContext;
 
-        XamlText _accumulatedText = null;
+        XamlText _accumulatedText;
         List<XamlAttribute> _attributes;
         int _nextAttribute;
         XamlScannerNode _currentNode;
         Queue<XamlScannerNode> _readNodesQueue;
         XamlXmlReaderSettings _settings;
         XamlAttribute _typeArgumentAttribute;
-        bool _hasKeyAttribute = false;
+        bool _hasKeyAttribute;
 
         internal XamlScanner(XamlParserContext context, XmlReader xmlReader, XamlXmlReaderSettings settings)
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
@@ -29,8 +29,8 @@ namespace System.Xaml
         XamlWriter _writer;
 
         bool _wrappedReaderHasLineInfo;
-        int _lineNumber=0;
-        int _linePosition=0;
+        int _lineNumber;
+        int _linePosition;
         
         Thread _thread;
         Exception _caughtException;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
@@ -16,7 +16,7 @@ namespace System.Xaml
     public class XamlNodeList
     {
         List<XamlNode> _nodeList;
-        bool _readMode = false;
+        bool _readMode;
         XamlWriter _writer;
         bool _hasLineInfo;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
@@ -13,6 +13,7 @@ using XAML3 = System.Windows.Markup;
 
 namespace System.Xaml.Schema
 {
+    [Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2002:Do not lock on objects with weak identity", Justification = "This type is internal.")]
     class TypeReflector : Reflector
     {
         private const XamlCollectionKind XamlCollectionKindInvalid = (XamlCollectionKind)byte.MaxValue;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -994,7 +994,7 @@ namespace System.Xaml
         class ObjectMarkupInfo : ObjectOrValueMarkupInfo
         {
             List<MarkupInfo> properties = new List<MarkupInfo>();
-            bool? isAttributableMarkupExtension = null;
+            bool? isAttributableMarkupExtension;
 
             public List<MarkupInfo> Properties { get { return properties; } }
             public string Name { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -683,7 +683,7 @@ namespace System.Xaml
         #region Settings
 
         // Unchanging, initialized in ctor
-        private readonly XamlSchemaContextSettings _settings = null;
+        private readonly XamlSchemaContextSettings _settings;
 
         public bool SupportMarkupExtensionsWithDuplicateArity
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
@@ -8,6 +8,7 @@ using System.Xml;
 
 namespace System.Xaml
 {
+    [Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The IDisposable types in this class don't require dispose.")]
     public static class XamlServices
     {
         // The main function is Load(XamlReader)


### PR DESCRIPTION
## Description
Update Microsoft.CodeAnalysis.FxCopAnalyzers to 3.3.1 and activate valid rules.

## Customer Impact
None, there are no behavior changes. The last version before the deprecated warning. I plan on doing a follow-up PR on chaning FxCopAnalyzers for NetAnalyzers.

## Regression
None.

## Testing
Local build.

## Risk
None.
