### PR TITLE
Only enable `DisableImplicitNamespaceImports` when `UseWPF` is set

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -19,8 +19,8 @@
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(AlwaysCompileMarkupFilesInSeparateDomain)' == '' ">true</AlwaysCompileMarkupFilesInSeparateDomain>
     <LocalizationDirectivesToLocFile Condition="'$(LocalizationDirectivesToLocFile)' == ''">None</LocalizationDirectivesToLocFile>
 
-    <!-- Disable implicit namespace imports for WPF.  This should be removed after support is added in .NET 6.0 Preview 8. -->
-    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitNamespaceImports)' != 'false'">true</DisableImplicitNamespaceImports>
+    <!-- Disable implicit namespace imports for WPF.  This should be removed after support is added in .NET 6.0 rc 1. -->
+    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitNamespaceImports)' != 'false' and '$(UseWPF)' == 'true'">true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <!-- Some Default Settings -->


### PR DESCRIPTION
WinForms project also import Microsoft.WinFX.targets, and WinForms now relies on implicit imports.  Scope disabling implicit imports to WPF.  This broke WinForms VB projects.

> But it wasn't @JunTaoLuo's change(s). It's actually caused by DisableImplicitNamespaceImports here: dotnet/wpf@ff1be8e#diff-681ca681001fbc20488df7fdbb46a8c40ac2df9dc2210df5ad869aee6a56df16R23
This disables these VB imports:
https://github.com/dotnet/sdk/blob/55195f3c4ba3f582aa91ec824bd24a7ba3e73528/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.props#L118-L129

/cc @dotnet/wpf-developers 
