### PR TITLE
Revert "Remove analyzers from framework references"

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,16 +1,9 @@
 <Project>
+
   <Import Project="$(WpfArcadeSdkTargets)"
           Condition="Exists('$(WpfArcadeSdkProps)') And Exists('$(WpfArcadeSdkTargets)')"/>
 
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk"
           Project="Sdk.targets"
           Condition="!Exists('$(WpfArcadeSdkProps)') Or !Exists('$(WpfArcadeSdkTargets)')"/>
-
-  <!-- Temporarily remove analyzers from references until we can update to a Preview7 SDK which handles them correctly 
-       https://github.com/dotnet/wpf/issues/4848 -->
-  <Target Name="_RemoveAnalyzersFromReference" AfterTargets="ResolveTargetingPackAssets">
-    <ItemGroup>
-      <Reference Remove="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' != '' and $([System.String]::Copy('%(Directory)').IndexOf('analyzers', StringComparison.OrdinalIgnoreCase)) > 0" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Reverts dotnet/wpf#4849

This should no longer needed now that WPF is consuming an RC SDK.  Don't merge this until we manually validate the C++/CLI binaries don't have references to the JSON source generator (since that would only fail after ingestion upstack).