### PR TITLE
Client-side support for new UIA events

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
@@ -308,8 +308,9 @@ namespace MS.Internal.Automation
                 rangeEnd = rangeStart;
             }
 
-            // return the resulting range
-            return new TextRangeAdaptor(this, rangeStart, rangeEnd, _textPeer);
+            // return the resulting range, wrapped so that it's ready for use by UIA
+            ITextRangeProvider textRange = new TextRangeAdaptor(this, rangeStart, rangeEnd, _textPeer);
+            return TextRangeProviderWrapper.WrapArgument(textRange, _textPeer);
         }
 
         #endregion Internal Methods

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -679,8 +679,8 @@ namespace MS.Internal.Automation
 
                 case EventArgsType.AsyncContentLoaded:
                     {
-                        UiaAsyncContentLoadedEventArgs aclargs = (UiaAsyncContentLoadedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaAsyncContentLoadedEventArgs));
-                        return new AsyncContentLoadedEventArgs(aclargs._asyncContentLoadedState, aclargs._percentComplete);
+                        UiaAsyncContentLoadedEventArgs nargs = (UiaAsyncContentLoadedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaAsyncContentLoadedEventArgs));
+                        return new AsyncContentLoadedEventArgs(nargs._asyncContentLoadedState, nargs._percentComplete);
                     }
 
                 case EventArgsType.WindowClosed:
@@ -688,6 +688,19 @@ namespace MS.Internal.Automation
                         UiaWindowClosedEventArgs wcargs = (UiaWindowClosedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaWindowClosedEventArgs));
                         int[] runtimeId = ArrayFromIntPtr(wcargs._pRuntimeId, wcargs._cRuntimeIdLen);
                         return new WindowClosedEventArgs(runtimeId);
+                    }
+
+                case EventArgsType.Notification:
+                    {
+                        UiaNotificationEventArgs nargs = (UiaNotificationEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaNotificationEventArgs));
+                        return new NotificationEventArgs(nargs._notificationKind, nargs._notificationProcessing,
+                            Marshal.PtrToStringUni(nargs._displayString), Marshal.PtrToStringUni(nargs._activityId));
+                    }
+
+                case EventArgsType.ActiveTextPositionChanged:
+                    {
+                        UiaActiveTextPositionChangedEventArgs atpcargs = (UiaActiveTextPositionChangedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaActiveTextPositionChangedEventArgs));
+                        return new ActiveTextPositionChangedEventArgs(atpcargs._textRange);
                     }
             }
 
@@ -1448,7 +1461,11 @@ namespace MS.Internal.Automation
             PropertyChanged,
             StructureChanged,
             AsyncContentLoaded,
-            WindowClosed
+            WindowClosed,
+            TextEditTextChanged,
+            Changes,
+            Notification,
+            ActiveTextPositionChanged
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -1496,6 +1513,25 @@ namespace MS.Internal.Automation
             internal int _eventId;
             internal IntPtr _pRuntimeId;
             internal int _cRuntimeIdLen;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct UiaNotificationEventArgs
+        {
+            internal EventArgsType _type;
+            internal int _eventId;
+            internal AutomationNotificationKind _notificationKind;
+            internal AutomationNotificationProcessing _notificationProcessing;
+            internal IntPtr _displayString;
+            internal IntPtr _activityId;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct UiaActiveTextPositionChangedEventArgs
+        {
+            internal EventArgsType _type;
+            internal int _eventId;
+            internal ITextRangeProvider _textRange;
         }
 
         #endregion Private types

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -679,8 +679,8 @@ namespace MS.Internal.Automation
 
                 case EventArgsType.AsyncContentLoaded:
                     {
-                        UiaAsyncContentLoadedEventArgs nargs = (UiaAsyncContentLoadedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaAsyncContentLoadedEventArgs));
-                        return new AsyncContentLoadedEventArgs(nargs._asyncContentLoadedState, nargs._percentComplete);
+                        UiaAsyncContentLoadedEventArgs aclargs = (UiaAsyncContentLoadedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaAsyncContentLoadedEventArgs));
+                        return new AsyncContentLoadedEventArgs(aclargs._asyncContentLoadedState, aclargs._percentComplete);
                     }
 
                 case EventArgsType.WindowClosed:


### PR DESCRIPTION
## Description

Fixing two problems with the recent work to support new UIA events (#4850):
1. New events were not delivered to client-side code.  More precisely, UIA delivers the events to our internal client-side listener, but it lacked the plumbing needed to forward the event to user client-side listeners (decoding the event type, converting event args from native to managed, etc.).
2. The TextRange argument to the ActiveTextPositionChanged event was set to a raw ITextRangeProvider, instead of a wrapper.  

## Customer Impact

1. Managed clients don't receive the new events.
2. An ActiveTextPositionChanged listener that calls one of the ITextRangeProvider methods crashes the target app.  

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Problems only affect usage of the new events.

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc.  New test cases are being added.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
These fixes are required.