### PR TITLE
Use generic Marshal.PtrToStructure

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DpiChangedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DpiChangedEventArgs.cs
@@ -10,6 +10,7 @@
 //              different DPI, or the dpi of the current monitor changes.
 
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 using System.Windows.Interop;
@@ -48,7 +49,7 @@ namespace System.Windows
         {
             OldDpi = new DpiScale(oldDpiX / DpiUtil.DefaultPixelsPerInch, oldDpiY / DpiUtil.DefaultPixelsPerInch);
             NewDpi = new DpiScale(newDpiX / DpiUtil.DefaultPixelsPerInch, newDpiY / DpiUtil.DefaultPixelsPerInch);
-            NativeMethods.RECT suggestedRect = (NativeMethods.RECT)UnsafeNativeMethods.PtrToStructure(lParam, typeof(NativeMethods.RECT));
+            NativeMethods.RECT suggestedRect = Marshal.PtrToStructure<NativeMethods.RECT>(lParam);
             this.SuggestedRect = new Rect((double)suggestedRect.left, (double)suggestedRect.top, (double)suggestedRect.Width, (double)suggestedRect.Height);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
@@ -160,7 +160,7 @@ namespace System.Windows.Input
                  for (int i = 0; i < nCount; i++)
                  {
                      // Unmarshal each langid from short array.
-                     short langid = (short)Marshal.PtrToStructure((IntPtr)((Int64)langids + sizeOfShort * i), typeof(short));
+                     short langid = Marshal.PtrToStructure<short>((IntPtr)((Int64)langids + sizeOfShort * i));
                      arrayLang.Add(new CultureInfo(langid));
                  }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -1368,7 +1368,7 @@ namespace System.Windows.Interop
 
                 // Get WINDOWPOS structure data from lParam; it contains information about the window's
                 // new size and position.
-                NativeMethods.WINDOWPOS windowPos = (NativeMethods.WINDOWPOS)UnsafeNativeMethods.PtrToStructure(lParam, typeof(NativeMethods.WINDOWPOS));
+                NativeMethods.WINDOWPOS windowPos = Marshal.PtrToStructure<NativeMethods.WINDOWPOS>(lParam);
 
                 bool sizeChanged = false;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -876,7 +876,7 @@ namespace System.Windows.Interop
                     if (oldDpi != newDpi)
                     {
                         var nativeRect =
-                            UnsafeNativeMethods.PtrToStructure<NativeMethods.RECT>(lParam);
+                            Marshal.PtrToStructure<NativeMethods.RECT>(lParam);
                         var suggestedRect =
                             new Rect(nativeRect.left, nativeRect.top, nativeRect.Width, nativeRect.Height);
 
@@ -1870,7 +1870,7 @@ namespace System.Windows.Interop
             // size or position changed.  If so, we need to pass this information to
             // the render thread.
             //
-            NativeMethods.WINDOWPOS windowPos = (NativeMethods.WINDOWPOS)UnsafeNativeMethods.PtrToStructure(lParam, typeof(NativeMethods.WINDOWPOS));
+            NativeMethods.WINDOWPOS windowPos = Marshal.PtrToStructure<NativeMethods.WINDOWPOS>(lParam);
             bool isMove = (windowPos.flags & NativeMethods.SWP_NOMOVE) == 0;
             bool isSize = (windowPos.flags & NativeMethods.SWP_NOSIZE) == 0;
             bool positionChanged = (isMove || isSize);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
@@ -261,7 +261,7 @@ namespace System.Windows.Media
                 //
                 // http://support.microsoft.com/default.aspx?scid=KB;EN-US;Q175261
                 //
-                OBJECTHEADER pHeader = (OBJECTHEADER)Marshal.PtrToStructure(addr, typeof(OBJECTHEADER));
+                OBJECTHEADER pHeader = Marshal.PtrToStructure<OBJECTHEADER>(addr);
 
                 //
                 // "PBrush" should be the 6 chars after position 12 as well.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -1847,7 +1847,7 @@ namespace System.Windows.Media.Imaging
                     }
                     else
                     {
-                        rc = (Int32Rect)Marshal.PtrToStructure(prc, typeof(Int32Rect));
+                        rc = Marshal.PtrToStructure<Int32Rect>(prc);
                     }
                     
                     int rectHeight, rectWidth;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/printdlgexmarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/printdlgexmarshaler.cs
@@ -235,9 +235,7 @@ namespace MS.Internal.Printing
                 //
                 if (!Is64Bit())
                 {
-                    NativeMethods.PRINTDLGEX32 pdex = (NativeMethods.PRINTDLGEX32)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX32));
+                    NativeMethods.PRINTDLGEX32 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX32>(unmanagedBuffer);
                     devModeHandle = pdex.hDevMode;
                     devNamesHandle = pdex.hDevNames;
                     flags = pdex.Flags;
@@ -245,9 +243,7 @@ namespace MS.Internal.Printing
                 }
                 else
                 {
-                    NativeMethods.PRINTDLGEX64 pdex = (NativeMethods.PRINTDLGEX64)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX64));
+                    NativeMethods.PRINTDLGEX64 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX64>(unmanagedBuffer);
                     devModeHandle = pdex.hDevMode;
                     devNamesHandle = pdex.hDevNames;
                     flags = pdex.Flags;
@@ -261,9 +257,7 @@ namespace MS.Internal.Printing
                 if (((flags & NativeMethods.PD_PAGENUMS) == NativeMethods.PD_PAGENUMS) &&
                      (pageRangePtr != IntPtr.Zero))
                 {
-                    NativeMethods.PRINTPAGERANGE pageRangeStruct = (NativeMethods.PRINTPAGERANGE)Marshal.PtrToStructure(
-                            pageRangePtr,
-                            typeof(NativeMethods.PRINTPAGERANGE));
+                    NativeMethods.PRINTPAGERANGE pageRangeStruct = Marshal.PtrToStructure<NativeMethods.PRINTPAGERANGE>(pageRangePtr);
 
                     pageRange = new PageRange((int)pageRangeStruct.nFromPage, (int)pageRangeStruct.nToPage);
                 }
@@ -282,9 +276,7 @@ namespace MS.Internal.Printing
                     {
                         pDevNames = UnsafeNativeMethods.GlobalLock(devNamesHandle);
 
-                        NativeMethods.DEVNAMES devNames = (NativeMethods.DEVNAMES)Marshal.PtrToStructure(
-                            pDevNames,
-                            typeof(NativeMethods.DEVNAMES));
+                        NativeMethods.DEVNAMES devNames = Marshal.PtrToStructure<NativeMethods.DEVNAMES>(pDevNames);
                         int devNamesOffset = checked(devNames.wDeviceOffset * Marshal.SystemDefaultCharSize);
                         printerName = Marshal.PtrToStringAuto(pDevNames + devNamesOffset);
                     }
@@ -380,9 +372,7 @@ namespace MS.Internal.Printing
                 {
                     pDevMode = UnsafeNativeMethods.GlobalLock(devModeHandle);
 
-                    NativeMethods.DEVMODE devMode = (NativeMethods.DEVMODE)Marshal.PtrToStructure(
-                        pDevMode,
-                        typeof(NativeMethods.DEVMODE));
+                    NativeMethods.DEVMODE devMode = Marshal.PtrToStructure<NativeMethods.DEVMODE>(pDevMode);
                     devModeData = new byte[devMode.dmSize + devMode.dmDriverExtra];
                     Marshal.Copy(pDevMode, devModeData, 0, devModeData.Length);
                 }
@@ -428,16 +418,12 @@ namespace MS.Internal.Printing
                 //
                 if (!Is64Bit())
                 {
-                    NativeMethods.PRINTDLGEX32 pdex = (NativeMethods.PRINTDLGEX32)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX32));
+                    NativeMethods.PRINTDLGEX32 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX32>(unmanagedBuffer);
                     result = pdex.dwResultAction;
                 }
                 else
                 {
-                    NativeMethods.PRINTDLGEX64 pdex = (NativeMethods.PRINTDLGEX64)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX64));
+                    NativeMethods.PRINTDLGEX64 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX64>(unmanagedBuffer);
                     result = pdex.dwResultAction;
                 }
 
@@ -668,18 +654,14 @@ namespace MS.Internal.Printing
                 //
                 if (!Is64Bit())
                 {
-                    NativeMethods.PRINTDLGEX32 pdex = (NativeMethods.PRINTDLGEX32)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX32));
+                    NativeMethods.PRINTDLGEX32 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX32>(unmanagedBuffer);
                     devModeHandle = pdex.hDevMode;
                     devNamesHandle = pdex.hDevNames;
                     pageRangePtr = pdex.lpPageRanges;
                 }
                 else
                 {
-                    NativeMethods.PRINTDLGEX64 pdex = (NativeMethods.PRINTDLGEX64)Marshal.PtrToStructure(
-                        unmanagedBuffer,
-                        typeof(NativeMethods.PRINTDLGEX64));
+                    NativeMethods.PRINTDLGEX64 pdex = Marshal.PtrToStructure<NativeMethods.PRINTDLGEX64>(unmanagedBuffer);
                     devModeHandle = pdex.hDevMode;
                     devNamesHandle = pdex.hDevNames;
                     pageRangePtr = pdex.lpPageRanges;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -589,7 +589,7 @@ namespace Microsoft.Win32
                     //    }
                     // 
                     // Convert the pointer to our OFNOTIFY stored in lparam to an object using PtrToStructure.
-                    NativeMethods.OFNOTIFY notify = (NativeMethods.OFNOTIFY)UnsafeNativeMethods.PtrToStructure(lParam, typeof(NativeMethods.OFNOTIFY));
+                    NativeMethods.OFNOTIFY notify = Marshal.PtrToStructure<NativeMethods.OFNOTIFY>(lParam);
 
                     // WM_NOTIFY indicates that the dialog is sending us a notification message.
                     // notify.hdr_code is an int defining which notification is being received.
@@ -623,8 +623,7 @@ namespace Microsoft.Win32
 
                             // Retrieve the OPENFILENAME structure from the OFNOTIFY structure
                             // so we can access the CharBuffer inside it.
-                            NativeMethods.OPENFILENAME_I ofn = (NativeMethods.OPENFILENAME_I)
-                                UnsafeNativeMethods.PtrToStructure(notify.lpOFN, typeof(NativeMethods.OPENFILENAME_I));
+                            NativeMethods.OPENFILENAME_I ofn = Marshal.PtrToStructure<NativeMethods.OPENFILENAME_I>(notify.lpOFN);
 
 
                             // Get the buffer size required to store the selected file names.
@@ -1162,7 +1161,7 @@ namespace Microsoft.Win32
         /// </returns>
         private bool DoFileOk(IntPtr lpOFN)
         {
-            NativeMethods.OPENFILENAME_I ofn = (NativeMethods.OPENFILENAME_I)UnsafeNativeMethods.PtrToStructure(lpOFN, typeof(NativeMethods.OPENFILENAME_I));
+            NativeMethods.OPENFILENAME_I ofn = Marshal.PtrToStructure<NativeMethods.OPENFILENAME_I>(lpOFN);
 
             // While processing the results we get from the OPENFILENAME struct,
             // we will adjust several properties of our own class to reflect the

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
@@ -1358,7 +1358,7 @@ namespace System.Windows.Documents
                 string surrounding = GetSurroundingText(range, out offsetStart);
 
                 // Create RECONVERTSTRING structure from lParam.
-                NativeMethods.RECONVERTSTRING reconv = (NativeMethods.RECONVERTSTRING)Marshal.PtrToStructure(lParam, typeof(NativeMethods.RECONVERTSTRING));
+                NativeMethods.RECONVERTSTRING reconv = Marshal.PtrToStructure<NativeMethods.RECONVERTSTRING>(lParam);
 
                 reconv.dwSize = requestSize;
                 reconv.dwVersion = 0;                                                         // must be 0
@@ -1520,7 +1520,7 @@ namespace System.Windows.Documents
                 return IntPtr.Zero;
             }
 
-            NativeMethods.RECONVERTSTRING reconv = (NativeMethods.RECONVERTSTRING)Marshal.PtrToStructure(lParam, typeof(NativeMethods.RECONVERTSTRING));
+            NativeMethods.RECONVERTSTRING reconv = Marshal.PtrToStructure<NativeMethods.RECONVERTSTRING>(lParam);
 
             // If the entire string in RECONVERTSTRING has been changed, we don't handle it.
             if (_reconv.dwStrLen != reconv.dwStrLen)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChromeWorker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Shell/WindowChromeWorker.cs
@@ -588,7 +588,7 @@ namespace Microsoft.Windows.Shell
 #else
                 Thickness windowResizeBorderThicknessDevice = DpiHelper.LogicalThicknessToDevice(SystemParameters2.Current.WindowResizeBorderThickness, dpi.DpiScaleX, dpi.DpiScaleY);
 #endif
-                var rcClientArea = (RECT)Marshal.PtrToStructure(lParam, typeof(RECT));
+                var rcClientArea = Marshal.PtrToStructure<RECT>(lParam);
                 if (Utility.IsFlagSet((int)_chromeInfo.NonClientFrameEdges, (int)NonClientFrameEdges.Top))
                 {
                     rcClientArea.Top += (int)windowResizeBorderThicknessDevice.Top;
@@ -751,7 +751,7 @@ namespace Microsoft.Windows.Shell
             // reliably use it to react to the window being shown or hidden.
 
             Assert.IsNotDefault(lParam);
-            var wp = (WINDOWPOS)Marshal.PtrToStructure(lParam, typeof(WINDOWPOS));
+            var wp = Marshal.PtrToStructure<WINDOWPOS>(lParam);
 
             // We only care to take action when the window dimensions are changing.
             // Otherwise, we may get a StackOverflowException. 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/MessageWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/MessageWindow.cs
@@ -150,7 +150,7 @@ namespace Standard
 
             if (msg == WM.CREATE)
             {
-                var createStruct = (CREATESTRUCT)Marshal.PtrToStructure(lParam, typeof(CREATESTRUCT));
+                var createStruct = Marshal.PtrToStructure<CREATESTRUCT>(lParam);
                 GCHandle gcHandle = GCHandle.FromIntPtr(createStruct.lpCreateParams);
                 hwndWrapper = (MessageWindow)gcHandle.Target;
                 s_windowLookup.Add(hwnd, hwndWrapper);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/documents/PeoplePickerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/documents/PeoplePickerWrapper.cs
@@ -331,10 +331,7 @@ namespace MS.Internal.Documents
 
                 //Get a DsObjectNames structure out of the pointer we
                 //were handed.
-                _dsObjectNames =
-                    (UnsafeNativeMethods.DsObjectNames)Marshal.PtrToStructure(
-                        _ptrToDsObjectNames, typeof(UnsafeNativeMethods.DsObjectNames)); 
-                                                 
+                _dsObjectNames = Marshal.PtrToStructure<UnsafeNativeMethods.DsObjectNames>(_ptrToDsObjectNames);  
             }
 
             /// <summary>
@@ -456,12 +453,9 @@ namespace MS.Internal.Documents
                     index * _sizeOfDsObject);
 
                 //Marshal that to a DsObject structure.
-                UnsafeNativeMethods.DsObject dsObject =
-                        (UnsafeNativeMethods.DsObject)Marshal.PtrToStructure(offset, 
-                            typeof(UnsafeNativeMethods.DsObject));
+                UnsafeNativeMethods.DsObject dsObject = Marshal.PtrToStructure<UnsafeNativeMethods.DsObject>(offset);
 
                 return dsObject;
-
             }
 
             /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -4628,11 +4628,11 @@ namespace MS.Win32 {
                     return (val != IntPtr.Zero);
 
                 case (int)tagVT.VT_VARIANT:
-                    VARIANT varStruct = (VARIANT)UnsafeNativeMethods.PtrToStructure(val, typeof(VARIANT));
+                    VARIANT varStruct = Marshal.PtrToStructure<VARIANT>(val);
                     return varStruct.ToObject();
                 case (int)tagVT.VT_CLSID:
                     //Debug.Fail("PtrToStructure will not work with System.Guid...");
-                    Guid guid =(Guid)UnsafeNativeMethods.PtrToStructure(val, typeof(Guid));
+                    Guid guid = Marshal.PtrToStructure<Guid>(val);
                     return guid;
 
                 case (int)tagVT.VT_FILETIME:

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -46,23 +46,6 @@ namespace MS.Win32
 
     internal partial class UnsafeNativeMethods {
 
-        // For some reason "PtrToStructure" requires super high permission.
-        public static object PtrToStructure(IntPtr lparam, Type cls) {
-            return Marshal.PtrToStructure(lparam, cls);
-        }
-
-        /// <summary>
-        /// Generic PtrToStructure(T) - because Marshal.PtrToStructure(T) doesn't
-        /// seem to be available in our build environment.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="lParam"></param>
-        /// <returns></returns>
-        public static T PtrToStructure<T>(IntPtr lParam)
-        {
-            return (T)Marshal.PtrToStructure(lParam, typeof(T));
-        }
-
         // For some reason "StructureToPtr" requires super high permission.
         public static void StructureToPtr(object structure, IntPtr ptr, bool fDeleteOld)
         {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -692,14 +692,14 @@ namespace MS.Internal.Automation
 
                 case EventArgsType.Notification:
                     {
-                        UiaNotificationEventArgs nargs = (UiaNotificationEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaNotificationEventArgs));
+                        UiaNotificationEventArgs nargs = Marshal.PtrToStructure<UiaNotificationEventArgs>(argsAddr);
                         return new NotificationEventArgs(nargs._notificationKind, nargs._notificationProcessing,
                             Marshal.PtrToStringUni(nargs._displayString), Marshal.PtrToStringUni(nargs._activityId));
                     }
 
                 case EventArgsType.ActiveTextPositionChanged:
                     {
-                        UiaActiveTextPositionChangedEventArgs atpcargs = (UiaActiveTextPositionChangedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaActiveTextPositionChangedEventArgs));
+                        UiaActiveTextPositionChangedEventArgs atpcargs = Marshal.PtrToStructure<UiaActiveTextPositionChangedEventArgs>(argsAddr);
                         return new ActiveTextPositionChangedEventArgs(atpcargs._textRange);
                     }
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/UiaCoreApi.cs
@@ -640,7 +640,7 @@ namespace MS.Internal.Automation
         // into something more managable.
         internal static AutomationEventArgs GetUiaEventArgs(IntPtr argsAddr)
         {
-            UiaEventArgs args = (UiaEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaEventArgs));
+            UiaEventArgs args = Marshal.PtrToStructure<UiaEventArgs>(argsAddr);
 
             AutomationEvent eventId = AutomationEvent.LookupById(args._eventId);
             if (eventId == null)
@@ -658,7 +658,7 @@ namespace MS.Internal.Automation
 
                 case EventArgsType.PropertyChanged:
                     {
-                        UiaPropertyChangedEventArgs pcargs = (UiaPropertyChangedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaPropertyChangedEventArgs));
+                        UiaPropertyChangedEventArgs pcargs = Marshal.PtrToStructure<UiaPropertyChangedEventArgs>(argsAddr);
 
                         AutomationProperty propertyId = AutomationProperty.LookupById(pcargs._propertyId);
                         if (propertyId == null)
@@ -672,20 +672,20 @@ namespace MS.Internal.Automation
 
                 case EventArgsType.StructureChanged:
                     {
-                        UiaStructureChangedEventArgs scargs = (UiaStructureChangedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaStructureChangedEventArgs));
+                        UiaStructureChangedEventArgs scargs = Marshal.PtrToStructure<UiaStructureChangedEventArgs>(argsAddr);
                         int[] runtimeId = ArrayFromIntPtr(scargs._pRuntimeId, scargs._cRuntimeIdLen);
                         return new StructureChangedEventArgs(scargs._structureChangeType, runtimeId);
                     }
 
                 case EventArgsType.AsyncContentLoaded:
                     {
-                        UiaAsyncContentLoadedEventArgs aclargs = (UiaAsyncContentLoadedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaAsyncContentLoadedEventArgs));
+                        UiaAsyncContentLoadedEventArgs aclargs = Marshal.PtrToStructure<UiaAsyncContentLoadedEventArgs>(argsAddr);
                         return new AsyncContentLoadedEventArgs(aclargs._asyncContentLoadedState, aclargs._percentComplete);
                     }
 
                 case EventArgsType.WindowClosed:
                     {
-                        UiaWindowClosedEventArgs wcargs = (UiaWindowClosedEventArgs)Marshal.PtrToStructure(argsAddr, typeof(UiaWindowClosedEventArgs));
+                        UiaWindowClosedEventArgs wcargs = Marshal.PtrToStructure<UiaWindowClosedEventArgs>(argsAddr);
                         int[] runtimeId = ArrayFromIntPtr(wcargs._pRuntimeId, wcargs._cRuntimeIdLen);
                         return new WindowClosedEventArgs(runtimeId);
                     }


### PR DESCRIPTION
## Description
Use generic Marshal.PtrToStructure instead of the non-generic. The generic one is slightly faster than the non-generic. Also, I removed the customs UnsafeNativeMethods.PtrToStructure which justs forwards to Marshal.PtrToStructure because it causes linker warnings because Marshal.PtrToStructure is annotated while UnsafeNativeMethods.PtrToStructure isn't.

Contributes to #3811

## Customer Impact
None, same behavior as the non-generic.

## Regression
No

## Testing
I manually tested a few of the generic and non-generic and they gave the same result.

## Risk
None, same behavior as the non-generic.
