### PR TITLE
[release/5.0] Use reflection-only context for InternalsVisibleToAttribute type comparison

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -505,7 +505,7 @@ namespace System.Xaml
 
             for (int j = 0; j < list.Count; j++)
             {
-                friendAssemblyName = GetCustomAttributeData(list[j], typeof(InternalsVisibleToAttribute), out typeValue, false, false, false);
+                friendAssemblyName = GetCustomAttributeData(list[j], GetMscorlibType(typeof(InternalsVisibleToAttribute)), out typeValue, false, false, false);
                 if (friendAssemblyName != null && friendAssemblyName == LocalAssemblyName)
                 {
                     isFriend = true;


### PR DESCRIPTION
## Description

Backport fix from 6.0 to 5.0:  Compilation error MC3064 when importing internal user control from signed class library.

> Use reflection-only context for InternalsVisibleToAttribute type comparison.

> Fixes Issue #2492: Compilation error MC3064 when importing internal user control from signed class library.  The wrong load context was used for a type comparison that always failed.  

## Customer Impact

Internal types contained in assemblies with InternalsVisibleTo attributes that are referenced in markup cause a markup compiler error:  *error MC3064: Only public or internal classes can be used within markup. 'InternalClass' type is not public or internal.*

## Regression

This is a regression from .NET Framework.  

## Risk

Very low.  This code is only exercised when WPF applications are compiled.  This is a single-line change that has been in .NET 6.0 since February. 

## Testing

Repro'd the issue on release/5.0 when importing an internal user control from signed class library:  

*error MC3064: Only public or internal classes can be used within markup.*

After applying the fix and rebuilding the WindowsDesktop SDK, referencing internal types in markup that are contained in an assembly with InternalsVisibleTo (which grants access to the target assembly) now works as expected when targeting .NET 5.0.
