### PR TITLE
[release/5.0] Fixing deterministic build bug in WPF's BAML files

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -94,7 +94,7 @@ namespace System.Windows.Markup
             List<Assembly> interestingAssemblies = new List<Assembly>();
 
             // Load all the assemblies into a list.
-            foreach(string assemblyName in _assemblyPathTable.Keys.OfType<string>().OrderBy(s => s))
+            foreach(string assemblyName in _assemblyPathTable.Keys.OfType<string>().OrderBy(s => s, StringComparer.Ordinal))
             {
                 bool hasCacheInfo = true;
                 Assembly assy;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -93,7 +94,7 @@ namespace System.Windows.Markup
             List<Assembly> interestingAssemblies = new List<Assembly>();
 
             // Load all the assemblies into a list.
-            foreach(string assemblyName in _assemblyPathTable.Keys)
+            foreach(string assemblyName in _assemblyPathTable.Keys.OfType<string>().OrderBy(s => s))
             {
                 bool hasCacheInfo = true;
                 Assembly assy;


### PR DESCRIPTION
Fixes Issue #3876

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Building a WPF .NET Core project with dotnet.exe is not deterministic, but building it with msbuild.exe is deterministic as expected:  .NET Core does not create identical .BAML files.

During compilation, WPF creates an optimized binary version of .XAML files, called .BAML.  The .BAML files between two different builds sometimes have references in the references section written in a different order.  .BAML created from the same .XAML file should always be the same.  

This PR is based on [this](https://github.com/MichaeIDietrich/wpf/commit/cff984aaf851ba126a822190bf815d0bf5c4d40e) fix from @MichaeIDietrich.


## Customer Impact

Builds may not be deterministic.

## Regression

No regression.

## Testing

The fix was testing building some projects using the `dotnet build` command, and comparing the generated files using a diff program. Without the fix, the files are almost always different. 

## Risk

Low.  This change only makes the order of references written to BAML consistent. 
