### PR TITLE
Update implicit global namespace support for WPF

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WPF.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WPF.props
@@ -1,0 +1,13 @@
+<Project>
+  <!--
+    Generates implicit global namespace imports file <projectname>.ImplicitGlobalNamespaceImports.cs.
+  -->
+  <ItemGroup Condition="'$(DisableImplicitNamespaceImports_WPF)' != 'true'
+                        and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                        and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))
+                        and '$(UseWPF)' == 'true'">
+    <Import Remove="System.IO" />
+    <Import Remove="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WPF.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.WPF.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <DisableImplicitNamespaceImports_WPF Condition="'$(DisableImplicitNamespaceImports_WPF)' == ''
+                   and '$(DisableImplicitNamespaceImports)' != 'true'">false</DisableImplicitNamespaceImports_WPF>
+  </PropertyGroup>
+
+</Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -168,4 +168,6 @@
   -->
   <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.props" />
 
+  <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WPF.props" />
+
 </Project>

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets
@@ -152,14 +152,17 @@
     <NetSdkWarning ResourceName="WindowsDesktopFrameworkRequiresVersion30" />
   </Target>
 
-  <!-- Import WPF Build logic only when we don't import NETFX's WinFX targets -->
-  <Import Project="Microsoft.WinFX.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'true'"/>
-
   <!--
     Import Windows Forms targets.
     These come via the Windows Forms transport package, that can be found under
     https://github.com/dotnet/winforms/tree/main/pkg/Microsoft.Private.Winforms/sdk
   -->
   <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets" Condition="'$(UseWindowsForms)' == 'true'"/>
+
+  <!-- Import WPF-specific targets -->
+  <Import Project="Microsoft.NET.Sdk.WindowsDesktop.WPF.targets" Condition="'$(UseWPF)' == 'true'"/>
+
+  <!-- Import WPF Build logic only when we don't import NETFX's WinFX targets -->
+  <Import Project="Microsoft.WinFX.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'true'"/>
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -19,8 +19,6 @@
     <AlwaysCompileMarkupFilesInSeparateDomain Condition="'$(AlwaysCompileMarkupFilesInSeparateDomain)' == '' ">true</AlwaysCompileMarkupFilesInSeparateDomain>
     <LocalizationDirectivesToLocFile Condition="'$(LocalizationDirectivesToLocFile)' == ''">None</LocalizationDirectivesToLocFile>
 
-    <!-- Disable implicit namespace imports for WPF.  This should be removed after support is added in .NET 6.0 rc 1. -->
-    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitNamespaceImports)' != 'false' and '$(UseWPF)' == 'true'">true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <!-- Some Default Settings -->


### PR DESCRIPTION
Remove `System.IO` and `System.Net.Http` from the list of generated global usings and enable implicit global namespaces.

These are the global usings that will be included in the generated file when compiling a WPF application: 

```cs
// <autogenerated />
global using global::System;
global using global::System.Collections.Generic;
global using global::System.Linq;
global using global::System.Threading;
global using global::System.Threading.Tasks;
```