### PR TITLE
Replacing expensive type checks with "is" checks

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/SynchronizedInputHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/SynchronizedInputHelper.cs
@@ -297,21 +297,18 @@ namespace MS.Internal
 
         internal static void RaiseAutomationEvents()
         {
-            if (InputElement.IsUIElement(InputManager.ListeningElement))
+            if (InputManager.ListeningElement is UIElement e)
             {
-                UIElement e = (UIElement)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(e.GetAutomationPeer());
             }
-            else if (InputElement.IsContentElement(InputManager.ListeningElement))
+            else if (InputManager.ListeningElement is ContentElement ce)
             {
-                ContentElement ce = (ContentElement)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(ce.GetAutomationPeer());
             }
-            else if (InputElement.IsUIElement3D(InputManager.ListeningElement))
+            else if (InputManager.ListeningElement is UIElement3D e3D)
             {
-                UIElement3D e3D = (UIElement3D)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(e3D.GetAutomationPeer());
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
@@ -141,7 +141,7 @@ namespace MS.Internal
         [FriendAccessAllowed]
         internal static bool IsUIElementOrUIElement3D(DependencyObject o)
         {
-            return (o is UIElement || o is UIElement3D);
+            return (o is UIElement or UIElement3D);
         }
 
         [FriendAccessAllowed]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
@@ -352,7 +352,6 @@ namespace System.Windows.Input
 
             // Determine UIElement/ContentElement/Neither type
             DependencyObject targetElementAsDO = targetElement as DependencyObject;
-            // todo patternmatching: Would an as cast and null checks be faster here instead of casting multiple times?
             bool isUIElement = targetElementAsDO is UIElement;
             bool isContentElement = !isUIElement && targetElementAsDO is ContentElement;
             bool isUIElement3D = !isUIElement && !isContentElement && targetElementAsDO is UIElement3D;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
@@ -352,9 +352,10 @@ namespace System.Windows.Input
 
             // Determine UIElement/ContentElement/Neither type
             DependencyObject targetElementAsDO = targetElement as DependencyObject;
-            bool isUIElement = InputElement.IsUIElement(targetElementAsDO);
-            bool isContentElement = !isUIElement && InputElement.IsContentElement(targetElementAsDO);
-            bool isUIElement3D = !isUIElement && !isContentElement && InputElement.IsUIElement3D(targetElementAsDO);
+            // todo patternmatching: Would an as cast and null checks be faster here instead of casting multiple times?
+            bool isUIElement = targetElementAsDO is UIElement;
+            bool isContentElement = !isUIElement && targetElementAsDO is ContentElement;
+            bool isUIElement3D = !isUIElement && !isContentElement && targetElementAsDO is UIElement3D;
 
             // Step 1: Check local input bindings
             InputBindingCollection localInputBindings = null;
@@ -370,6 +371,7 @@ namespace System.Windows.Input
             {
                 localInputBindings = ((UIElement3D)targetElement).InputBindingsInternal;
             }
+
             if (localInputBindings != null)
             {
                 InputBinding inputBinding = localInputBindings.FindMatch(targetElement, inputEventArgs);
@@ -423,6 +425,7 @@ namespace System.Windows.Input
                 {
                     localCommandBindings = ((UIElement3D)targetElement).CommandBindingsInternal;
                 }
+
                 if (localCommandBindings != null)
                 {
                     command = localCommandBindings.FindMatch(targetElement, inputEventArgs);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
@@ -362,17 +362,17 @@ namespace System.Windows.Input
             // both of which derive from DO
             DependencyObject targetAsDO = (DependencyObject)target;
             
-            if (InputElement.IsUIElement(targetAsDO))
+            if (targetAsDO is UIElement uie)
             {
-                ((UIElement)targetAsDO).RaiseEvent(args, trusted);
+                uie.RaiseEvent(args, trusted);
             }
-            else if (InputElement.IsContentElement(targetAsDO))
+            else if (targetAsDO is ContentElement ce)
             {
-                ((ContentElement)targetAsDO).RaiseEvent(args, trusted);
+                ce.RaiseEvent(args, trusted);
             }
-            else if (InputElement.IsUIElement3D(targetAsDO))
+            else if (targetAsDO is UIElement3D uie3D)
             {
-                ((UIElement3D)targetAsDO).RaiseEvent(args, trusted);
+                uie3D.RaiseEvent(args, trusted);
             }            
         }
         internal bool ExecuteCore(object parameter, IInputElement target, bool userInitiated)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -25,62 +25,42 @@ namespace System.Windows.Input
 
         internal static bool IsValid(DependencyObject o)
         {
-            return IsUIElement(o) || IsContentElement(o) || IsUIElement3D(o); 
+            return o is UIElement or ContentElement or UIElement3D; 
 }
-
-        // Returns whether the given DynamicObject is a UIElement or not.
-        internal static bool IsUIElement(DependencyObject o)
-        {
-            return UIElementType.IsInstanceOfType(o);     
-        }
-
-        // Returns whether the given DynamicObject is a UIElement3D or not.
-        internal static bool IsUIElement3D(DependencyObject o)
-        {
-            return UIElement3DType.IsInstanceOfType(o);                       
-        }
-                
-        // Returns whether the given DynamicObject is a ContentElement or not.
-        internal static bool IsContentElement(DependencyObject o)
-        {
-            return ContentElementType.IsInstanceOfType(o);
-        }
 
         // Returns the containing input element of the given DynamicObject.
         // If onlyTraverse2D is set to true, then we stop once we see a 3D object and return null
         internal static DependencyObject GetContainingUIElement(DependencyObject o, bool onlyTraverse2D)
         {
             DependencyObject container = null;
-            Visual v;
-            Visual3D v3D;
 
             if(o != null)
             {
-                if(IsUIElement(o))
+                if(o is UIElement)
                 {
                     container = o;
                 }
-                else if (IsUIElement3D(o) && !onlyTraverse2D)
+                else if (o is UIElement3D && !onlyTraverse2D)
                 {
                     container = o;
                 } 
-                else if(IsContentElement(o))
+                else if(o is ContentElement contentElement)
                 {
-                    DependencyObject parent = ContentOperations.GetParent((ContentElement)o);
+                    DependencyObject parent = ContentOperations.GetParent(contentElement);
                     if(parent != null)
                     {
                         container = GetContainingUIElement(parent, onlyTraverse2D);
                     }
                     else
                     {
-                        parent = ((ContentElement)o).GetUIParentCore();
+                        parent = contentElement.GetUIParentCore();
                         if(parent != null)
                         {
                             container = GetContainingUIElement(parent, onlyTraverse2D);
                         }
                     }
                 }
-                else if ((v = o as Visual) != null)
+                else if (o is Visual v)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v);
                     if(parent != null)
@@ -88,7 +68,7 @@ namespace System.Windows.Input
                         container = GetContainingUIElement(parent, onlyTraverse2D);
                     }
                 }
-                else if (!onlyTraverse2D && (v3D = o as Visual3D) != null)
+                else if (!onlyTraverse2D && o is Visual3D v3D)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v3D);
                     if (parent != null)
@@ -113,24 +93,22 @@ namespace System.Windows.Input
         internal static IInputElement GetContainingInputElement(DependencyObject o, bool onlyTraverse2D)
         {
             IInputElement container = null;
-            Visual v;            
-            Visual3D v3D;
 
             if(o != null)
             {
-                if(IsUIElement(o))
+                if(o is UIElement uiElement)
                 {
-                    container = (UIElement) o;
+                    container = uiElement;
                 }
-                else if(IsContentElement(o))
+                else if(o is ContentElement contentElement)
                 {
-                    container = (ContentElement) o;
+                    container = contentElement;
                 }
-                else if (IsUIElement3D(o) && !onlyTraverse2D)
+                else if (o is UIElement3D uIElement3D && !onlyTraverse2D)
                 {
-                    container = (UIElement3D)o;
+                    container = uIElement3D;
                 }
-                else if((v = o as Visual) != null)
+                else if(o is Visual v)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v);
                     if(parent != null)
@@ -138,7 +116,7 @@ namespace System.Windows.Input
                         container = GetContainingInputElement(parent, onlyTraverse2D);
                     }
                 }
-                else if (!onlyTraverse2D && (v3D = o as Visual3D) != null)
+                else if (!onlyTraverse2D && o is Visual3D v3D)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v3D);
                     if (parent != null)
@@ -165,24 +143,24 @@ namespace System.Windows.Input
 
             if(o != null)
             {
-                if(IsUIElement(o))
+                if(o is UIElement uiElement)
                 {
-                    v = (Visual)o;
+                    v = uiElement;
                 }
-                else if (IsUIElement3D(o))
+                else if (o is Visual3D visual3D)
                 {
-                    v = (Visual3D)o;
+                    v = visual3D;
                 }
-                else if(IsContentElement(o))
+                else if(o is ContentElement contentElement)
                 {
-                    DependencyObject parent = ContentOperations.GetParent((ContentElement)o);
+                    DependencyObject parent = ContentOperations.GetParent(contentElement);
                     if(parent != null)
                     {
                         v = GetContainingVisual(parent);
                     }
                     else
                     {
-                        parent = ((ContentElement)o).GetUIParentCore();
+                        parent = contentElement.GetUIParentCore();
                         if(parent != null)
                         {
                             v = GetContainingVisual(parent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
@@ -801,22 +801,16 @@ namespace System.Windows.Input
                     {
                         if (eventSource != null)
                         {
-                            if (InputElement.IsUIElement(eventSource))
+                            if (eventSource is UIElement e)
                             {
-                                UIElement e = (UIElement)eventSource;
-
                                 e.RaiseEvent(input, true); // Call the "trusted" flavor of RaiseEvent. 
                             }
-                            else if (InputElement.IsContentElement(eventSource))
+                            else if (eventSource is ContentElement ce)
                             {
-                                ContentElement ce = (ContentElement)eventSource;
-
                                 ce.RaiseEvent(input, true);// Call the "trusted" flavor of RaiseEvent.
                             }
-                            else if (InputElement.IsUIElement3D(eventSource))
+                            else if (eventSource is UIElement3D e3D)
                             {
-                                UIElement3D e3D = (UIElement3D)eventSource;
-
                                 e3D.RaiseEvent(input, true); // Call the "trusted" flavor of RaiseEvent
                             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -420,46 +420,48 @@ namespace System.Windows.Input
                     if(oldFocus != null)
                     {
                         o = oldFocus;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged -= _isVisibleChangedEventHandler;
-                            ((UIElement)o).FocusableChanged -= _focusableChangedEventHandler;
+                            uie.IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            uie.IsVisibleChanged -= _isVisibleChangedEventHandler;
+                            uie.FocusableChanged -= _focusableChangedEventHandler;
                         }
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            ce.IsEnabledChanged -= _isEnabledChangedEventHandler;
                             // NOTE: there is no IsVisible property for ContentElements.
-                            ((ContentElement)o).FocusableChanged -= _focusableChangedEventHandler;
+                            ce.FocusableChanged -= _focusableChangedEventHandler;
                         }
-                        else
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged -= _isVisibleChangedEventHandler;
-                            ((UIElement3D)o).FocusableChanged -= _focusableChangedEventHandler;
+                            uie3D.IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged -= _isVisibleChangedEventHandler;
+                            uie3D.FocusableChanged -= _focusableChangedEventHandler;
                         }
+                        // todo patternmatching: Should we throw here?
                     }
                     if(_focus != null)
                     {
                         o = _focus;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged += _isEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged += _isVisibleChangedEventHandler;
-                            ((UIElement)o).FocusableChanged += _focusableChangedEventHandler;
+                            uie.IsEnabledChanged += _isEnabledChangedEventHandler;
+                            uie.IsVisibleChanged += _isVisibleChangedEventHandler;
+                            uie.FocusableChanged += _focusableChangedEventHandler;
                         }                        
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged += _isEnabledChangedEventHandler;
+                            ce.IsEnabledChanged += _isEnabledChangedEventHandler;
                             // NOTE: there is no IsVisible property for ContentElements.
-                            ((ContentElement)o).FocusableChanged += _focusableChangedEventHandler;
+                            ce.FocusableChanged += _focusableChangedEventHandler;
                         }
-                        else
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged += _isEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged += _isVisibleChangedEventHandler;
-                            ((UIElement3D)o).FocusableChanged += _focusableChangedEventHandler;
+                            uie3D.IsEnabledChanged += _isEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged += _isVisibleChangedEventHandler;
+                            uie3D.FocusableChanged += _focusableChangedEventHandler;
                         }
+                        // todo patternmatching: Should we throw here?
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -438,7 +438,10 @@ namespace System.Windows.Input
                             uie3D.IsVisibleChanged -= _isVisibleChangedEventHandler;
                             uie3D.FocusableChanged -= _focusableChangedEventHandler;
                         }
-                        // todo patternmatching: Should we throw here?
+                        else
+                        {
+                            throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                        }
                     }
                     if(_focus != null)
                     {
@@ -461,7 +464,10 @@ namespace System.Windows.Input
                             uie3D.IsVisibleChanged += _isVisibleChangedEventHandler;
                             uie3D.FocusableChanged += _focusableChangedEventHandler;
                         }
-                        // todo patternmatching: Should we throw here?
+                        else
+                        {
+                            throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                        }
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -739,17 +739,17 @@ namespace System.Windows.Input
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement)
+            if (dependencyObject is UIElement uie)
             {
-                killCapture = !ValidateUIElementForCapture((UIElement)_mouseCapture);
+                killCapture = !ValidateUIElementForCapture(uie);
             }
-            else if (dependencyObject is ContentElement)
+            else if (dependencyObject is ContentElement ce)
             {
-                killCapture = !ValidateContentElementForCapture((ContentElement)_mouseCapture);
+                killCapture = !ValidateContentElementForCapture(ce);
             }
-            else if (dependencyObject is UIElement3D)
+            else if (dependencyObject is UIElement3D uie3D)
             {
-                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_mouseCapture);
+                killCapture = !ValidateUIElement3DForCapture(uie3D);
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -739,15 +739,15 @@ namespace System.Windows.Input
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (InputElement.IsUIElement(dependencyObject))
+            if (dependencyObject is UIElement)
             {
                 killCapture = !ValidateUIElementForCapture((UIElement)_mouseCapture);
             }
-            else if (InputElement.IsContentElement(dependencyObject))
+            else if (dependencyObject is ContentElement)
             {
                 killCapture = !ValidateContentElementForCapture((ContentElement)_mouseCapture);
             }
-            else if (InputElement.IsUIElement3D(dependencyObject))
+            else if (dependencyObject is UIElement3D)
             {
                 killCapture = !ValidateUIElement3DForCapture((UIElement3D)_mouseCapture);
             }
@@ -993,51 +993,51 @@ namespace System.Windows.Input
                     if(oldMouseOver != null)
                     {
                         o = oldMouseOver as DependencyObject;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsUIElement3D(o))
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
                     }
                     if(_mouseOver != null)
                     {
                         o = _mouseOver as DependencyObject;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsUIElement3D(o))
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
                     }
                 }
@@ -1087,51 +1087,51 @@ namespace System.Windows.Input
                     if (oldMouseCapture != null)
                     {
                         o = oldMouseCapture as DependencyObject;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            ((UIElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            uie.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            uie.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            uie.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ((ContentElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            // ((ContentElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            // ce.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            // ce.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsUIElement3D(o))
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            ((UIElement3D)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            uie3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            uie3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
                     }
                     if (_mouseCapture != null)
                     {
                         o = _mouseCapture as DependencyObject;
-                        if (InputElement.IsUIElement(o))
+                        if (o is UIElement uie)
                         {
-                            ((UIElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                            ((UIElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            ((UIElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            uie.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            uie.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            uie.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsContentElement(o))
+                        else if (o is ContentElement ce)
                         {
-                            ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ((ContentElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            // ((ContentElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            // ce.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            // ce.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (InputElement.IsUIElement3D(o))
+                        else if (o is UIElement3D uie3D)
                         {
-                            ((UIElement3D)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                            ((UIElement3D)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            ((UIElement3D)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            uie3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            uie3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            uie3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
                     }
                 }
@@ -1538,9 +1538,13 @@ namespace System.Windows.Input
                                             // If we are over something else (like a raw visual)
                                             // find the containing element.
                                             if (!InputElement.IsValid(mouseOver))
+                                            {
                                                 mouseOver = InputElement.GetContainingInputElement(mouseOver as DependencyObject);
+                                            }
                                             if ((rawMouseOver != null) && !InputElement.IsValid(rawMouseOver))
+                                            {
                                                 rawMouseOver = InputElement.GetContainingInputElement(rawMouseOver as DependencyObject);
+                                            }
                                         }
                                         break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -779,17 +779,17 @@ namespace System.Windows.Input.StylusPointer
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement)
+            if (dependencyObject is UIElement uie)
             {
-                killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
+                killCapture = !ValidateUIElementForCapture(uie);
             }
-            else if (dependencyObject is ContentElement)
+            else if (dependencyObject is ContentElement ce)
             {
-                killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
+                killCapture = !ValidateContentElementForCapture(ce);
             }
-            else if (dependencyObject is UIElement3D)
+            else if (dependencyObject is UIElement3D uie3D)
             {
-                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
+                killCapture = !ValidateUIElement3DForCapture(uie3D);
             }
             // todo patternmatching: Should we throw here?
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -530,49 +530,47 @@ namespace System.Windows.Input.StylusPointer
                 if (oldCapture != null)
                 {
                     o = oldCapture as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement element)
                     {
-                        UIElement element = o as UIElement;
                         element.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
                         element.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
-                        ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D element3D)
                     {
-                        UIElement3D element = o as UIElement3D;
-                        element.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        element.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        element.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        element3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        element3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        element3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
 
                 if (_stylusCapture != null)
                 {
                     o = _stylusCapture as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement element)
                     {
-                        UIElement element = o as UIElement;
                         element.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
                         element.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
-                        ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D element3D)
                     {
-                        UIElement3D element = o as UIElement3D;
-                        element.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        element.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        element.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        element3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        element3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        element3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
 
                 // Oddly enough, update the IsStylusCaptureWithin property first.  This is
@@ -613,56 +611,54 @@ namespace System.Windows.Input.StylusPointer
                 if (oldOver != null)
                 {
                     o = oldOver as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement element)
                     {
-                        UIElement element = o as UIElement;
                         element.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
                         element.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D element3D)
                     {
-                        UIElement3D element = o as UIElement3D;
-                        element.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        element.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        element.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        element3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        element3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        element3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
                 if (_stylusOver != null)
                 {
                     o = _stylusOver as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement element)
                     {
-                        UIElement element = o as UIElement;
                         element.IsEnabledChanged += _overIsEnabledChangedEventHandler;
                         element.IsVisibleChanged += _overIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D element3D)
                     {
-                        UIElement3D element = o as UIElement3D;
-                        element.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        element.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        element.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        element3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        element3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        element3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
 
                 // Oddly enough, update the IsStylusOver property first.  This is
@@ -783,18 +779,19 @@ namespace System.Windows.Input.StylusPointer
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (InputElement.IsUIElement(dependencyObject))
+            if (dependencyObject is UIElement)
             {
                 killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
             }
-            else if (InputElement.IsContentElement(dependencyObject))
+            else if (dependencyObject is ContentElement)
             {
                 killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
             }
-            else
+            else if (dependencyObject is UIElement3D)
             {
                 killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
             }
+            // todo patternmatching: Should we throw here?
 
             //
             // Second, if we still haven't thought of a reason to kill capture, validate

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -547,7 +547,10 @@ namespace System.Windows.Input.StylusPointer
                         element3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
                         element3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldCapture.GetType())); 
+                    }
                 }
 
                 if (_stylusCapture != null)
@@ -570,7 +573,10 @@ namespace System.Windows.Input.StylusPointer
                         element3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
                         element3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                    }
                 }
 
                 // Oddly enough, update the IsStylusCaptureWithin property first.  This is
@@ -632,7 +638,10 @@ namespace System.Windows.Input.StylusPointer
                         element3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
                         element3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                    }
                 }
                 if (_stylusOver != null)
                 {
@@ -658,7 +667,10 @@ namespace System.Windows.Input.StylusPointer
                         element3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
                         element3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                    }
                 }
 
                 // Oddly enough, update the IsStylusOver property first.  This is
@@ -791,7 +803,10 @@ namespace System.Windows.Input.StylusPointer
             {
                 killCapture = !ValidateUIElement3DForCapture(uie3D);
             }
-            // todo patternmatching: Should we throw here?
+            else
+            {
+                throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+            }
 
             //
             // Second, if we still haven't thought of a reason to kill capture, validate

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -2413,17 +2413,17 @@ namespace System.Windows.Input.StylusWisp
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement)
+            if (dependencyObject is UIElement uie)
             {
-                killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
+                killCapture = !ValidateUIElementForCapture(uie);
             }
-            else if (dependencyObject is ContentElement)
+            else if (dependencyObject is ContentElement ce)
             {
-                killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
+                killCapture = !ValidateContentElementForCapture(ce);
             }
-            else if (dependencyObject is UIElement3D)
+            else if (dependencyObject is UIElement3D uie3D)
             {
-                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
+                killCapture = !ValidateUIElement3DForCapture(uie3D);
             }
             // todo patternmatching: Should we throw here?
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -2080,7 +2080,10 @@ namespace System.Windows.Input.StylusWisp
                         uie3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
                         uie3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldCapture.GetType())); 
+                    }
                 }
                 if (_stylusCapture != null)
                 {
@@ -2106,7 +2109,10 @@ namespace System.Windows.Input.StylusWisp
                         uie3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
                         uie3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                    }
                 }
 
                 // Oddly enough, update the IsStylusCaptureWithin property first.  This is
@@ -2162,7 +2168,10 @@ namespace System.Windows.Input.StylusWisp
                         uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
                         uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                    }
                 }
                 if (_stylusOver != null)
                 {
@@ -2188,7 +2197,10 @@ namespace System.Windows.Input.StylusWisp
                         uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
                         uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    // todo patternmatching: Should we throw here?
+                    else
+                    {
+                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                    }
                 }
 
                 // Oddly enough, update the IsStylusOver property first.  This is
@@ -2425,7 +2437,10 @@ namespace System.Windows.Input.StylusWisp
             {
                 killCapture = !ValidateUIElement3DForCapture(uie3D);
             }
-            // todo patternmatching: Should we throw here?
+            else
+            {
+                throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+            }
 
             //
             // Second, if we still haven't thought of a reason to kill capture, validate

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -2059,52 +2059,54 @@ namespace System.Windows.Input.StylusWisp
                 if (oldCapture != null)
                 {
                     o = oldCapture as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement uie)
                     {
-                        ((UIElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        ((UIElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        ((UIElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        uie.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        uie.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        uie.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D uie3D)
                     {
-                        ((UIElement3D)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        ((UIElement3D)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        ((UIElement3D)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        uie3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        uie3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        uie3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
                 if (_stylusCapture != null)
                 {
                     o = _stylusCapture as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement uie)
                     {
-                        ((UIElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        ((UIElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        ((UIElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        uie.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        uie.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        uie.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D uie3D)
                     {
-                        ((UIElement3D)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        ((UIElement3D)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        ((UIElement3D)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        uie3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        uie3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        uie3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
 
                 // Oddly enough, update the IsStylusCaptureWithin property first.  This is
@@ -2139,52 +2141,54 @@ namespace System.Windows.Input.StylusWisp
                 if (oldOver != null)
                 {
                     o = oldOver as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement uie)
                     {
-                        ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D uie3D)
                     {
-                        ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
                 if (_stylusOver != null)
                 {
                     o = _stylusOver as DependencyObject;
-                    if (InputElement.IsUIElement(o))
+                    if (o is UIElement uie)
                     {
-                        ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (InputElement.IsContentElement(o))
+                    else if (o is ContentElement ce)
                     {
-                        ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else
+                    else if (o is UIElement3D uie3D)
                     {
-                        ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
+                    // todo patternmatching: Should we throw here?
                 }
 
                 // Oddly enough, update the IsStylusOver property first.  This is
@@ -2409,18 +2413,19 @@ namespace System.Windows.Input.StylusWisp
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (InputElement.IsUIElement(dependencyObject))
+            if (dependencyObject is UIElement)
             {
                 killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
             }
-            else if (InputElement.IsContentElement(dependencyObject))
+            else if (dependencyObject is ContentElement)
             {
                 killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
             }
-            else
+            else if (dependencyObject is UIElement3D)
             {
                 killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
             }
+            // todo patternmatching: Should we throw here?
 
             //
             // Second, if we still haven't thought of a reason to kill capture, validate

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
@@ -418,52 +418,54 @@ namespace System.Windows.Input.StylusWisp
             if (oldOver != null)
             {
                 o = oldOver as DependencyObject;
-                if (InputElement.IsUIElement(o))
+                if (o is UIElement uie)
                 {
-                    ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                    ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                    uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
-                else if (InputElement.IsContentElement(o))
+                else if (o is ContentElement ce)
                 {
-                    ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                     // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                     //
-                    // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                    // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
-                else
+                else if (o is UIElement3D uie3D)
                 {
-                    ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                    ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                    uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
+                // todo patternmatching: Should we throw here?
             }
             if (_stylusOver != null)
             {
                 o = _stylusOver as DependencyObject;
-                if (InputElement.IsUIElement(o))
+                if (o is UIElement uie)
                 {
-                    ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                    ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                    uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
-                else if (InputElement.IsContentElement(o))
+                else if (o is ContentElement ce)
                 {
-                    ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                     // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                     //
-                    // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                    // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
-                else
+                else if (o is UIElement3D uie3D)
                 {
-                    ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                    ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                    uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
+                // todo patternmatching: Should we throw here?
             }
 
             // Oddly enough, update the IsStylusOver property first.  This is

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
@@ -439,7 +439,10 @@ namespace System.Windows.Input.StylusWisp
                     uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
                     uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
-                // todo patternmatching: Should we throw here?
+                else
+                {
+                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                }
             }
             if (_stylusOver != null)
             {
@@ -465,7 +468,10 @@ namespace System.Windows.Input.StylusWisp
                     uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
                     uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
-                // todo patternmatching: Should we throw here?
+                else
+                {
+                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                }
             }
 
             // Oddly enough, update the IsStylusOver property first.  This is

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
@@ -436,11 +436,10 @@ namespace System.Windows.Media.Effects
 
             if (newValue != null)
             {
-                if (!(typeof(VisualBrush).IsInstanceOfType(newValue) ||
-                      typeof(BitmapCacheBrush).IsInstanceOfType(newValue) ||
-                      typeof(ImplicitInputBrush).IsInstanceOfType(newValue) ||
-                      typeof(ImageBrush).IsInstanceOfType(newValue))
-                      )
+                if (newValue is not VisualBrush
+                    and not BitmapCacheBrush
+                    and not ImplicitInputBrush
+                    and not ImageBrush)
                 {
                     // Note that if the type of the brush is ImplicitInputBrush and the value is non null, the value is actually
                     // Effect.ImplicitInput. This is because ImplicitInputBrush is internal and the user can only get to the singleton

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
@@ -254,14 +254,11 @@ namespace System.Windows.Media
 
             while ((current != null) && (current != ancestor) && !stopType.IsInstanceOfType(current))
             {
-                Visual visual;
-                Visual3D visual3D;
-
-                if ((visual = current as Visual) != null)
+                if (current is Visual visual)
                 {
                     current = visual.InternalVisualParent;
                 }
-                else if ((visual3D = current as Visual3D) != null)
+                else if (current is Visual3D visual3D)
                 {
                     current = visual3D.InternalVisualParent;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -145,9 +145,8 @@ namespace System.Windows
             {
                 FrugalObjectList<RoutedEventHandlerInfo> info;
 
-                if (InputElement.IsUIElement(o))
+                if (o is UIElement uie)
                 {
-                    UIElement uie = o as UIElement;
                     uie.AddHandler(SourceChangedEvent, handler);
                     info = uie.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
@@ -156,9 +155,8 @@ namespace System.Windows
                         AddElementToWatchList(uie);
                     }
                 }
-                else if (InputElement.IsUIElement3D(o))
+                else if (o is UIElement3D uie3D)
                 {
-                    UIElement3D uie3D = o as UIElement3D;
                     uie3D.AddHandler(SourceChangedEvent, handler);
                     info = uie3D.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
@@ -167,14 +165,16 @@ namespace System.Windows
                         AddElementToWatchList(uie3D);
                     }
                 }
-                else
+                else if (o is ContentElement ce)
                 {
-                    ContentElement ce = o as ContentElement;
                     ce.AddHandler(SourceChangedEvent, handler);
                     info = ce.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
+                    {
                         AddElementToWatchList(ce);
+                    }
                 }
+                // todo patternmatching: Should we throw here?
             }
         }
 
@@ -211,9 +211,8 @@ namespace System.Windows
                 EventHandlersStore store;
 
                 // Either UIElement or ContentElement.
-                if (InputElement.IsUIElement(o))
+                if (o is UIElement uie)
                 {
-                    UIElement uie = o as UIElement;
                     uie.RemoveHandler(SourceChangedEvent, handler);
                     store = uie.EventHandlersStore;
                     if (store != null)
@@ -226,9 +225,8 @@ namespace System.Windows
                         RemoveElementFromWatchList(uie);
                     }
                 }
-                else if (InputElement.IsUIElement3D(o))
+                else if (o is UIElement3D uie3D)
                 {
-                    UIElement3D uie3D = o as UIElement3D;
                     uie3D.RemoveHandler(SourceChangedEvent, handler);
                     store = uie3D.EventHandlersStore;
                     if (store != null)
@@ -241,9 +239,8 @@ namespace System.Windows
                         RemoveElementFromWatchList(uie3D);
                     }
                 }
-                else
+                else if (o is ContentElement ce)
                 {
-                    ContentElement ce = o as ContentElement;
                     ce.RemoveHandler(SourceChangedEvent, handler);
                     store = ce.EventHandlersStore;
                     if (store != null)
@@ -255,6 +252,7 @@ namespace System.Windows
                         RemoveElementFromWatchList(ce);
                     }
                 }
+                // todo patternmatching: Should we throw here?
             }
         }
 
@@ -548,7 +546,7 @@ namespace System.Windows
         /// <param name="e">  Event Args.</param>
         internal static void OnVisualAncestorChanged(DependencyObject uie, AncestorChangedEventArgs e)
         {
-            Debug.Assert(InputElement.IsUIElement3D(uie) || InputElement.IsUIElement(uie));
+            Debug.Assert(uie is UIElement3D or UIElement);
             
             if (true == (bool)uie.GetValue(GetsSourceChangedEventProperty))
             {
@@ -740,18 +738,19 @@ namespace System.Windows
                 SourceChangedEventArgs args = new SourceChangedEventArgs(cachedSource, realSource);
 
                 args.RoutedEvent=SourceChangedEvent;
-                if (InputElement.IsUIElement(doTarget))
+                if (doTarget is UIElement uiElement)
                 {
-                    ((UIElement)doTarget).RaiseEvent(args);
+                    uiElement.RaiseEvent(args);
                 }                
-                else if (InputElement.IsContentElement(doTarget))
+                else if (doTarget is ContentElement contentElement)
                 {
-                    ((ContentElement)doTarget).RaiseEvent(args);
+                    contentElement.RaiseEvent(args);
                 }
-                else
+                else if (doTarget is UIElement3D uiElement3D)
                 {
-                    ((UIElement3D)doTarget).RaiseEvent(args);
+                    uiElement3D.RaiseEvent(args);
                 }
+                // todo patternmatching: Should we throw here?
 
                 calledOut = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -174,7 +174,10 @@ namespace System.Windows
                         AddElementToWatchList(ce);
                     }
                 }
-                // todo patternmatching: Should we throw here?
+                else
+                {
+                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                }
             }
         }
 
@@ -252,7 +255,10 @@ namespace System.Windows
                         RemoveElementFromWatchList(ce);
                     }
                 }
-                // todo patternmatching: Should we throw here?
+                else
+                {
+                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                }
             }
         }
 
@@ -750,7 +756,10 @@ namespace System.Windows
                 {
                     uiElement3D.RaiseEvent(args);
                 }
-                // todo patternmatching: Should we throw here?
+                else
+                {
+                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, doTarget.GetType())); 
+                }
 
                 calledOut = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1443,7 +1443,7 @@ namespace System.Windows
             {
                 DependencyObject parent = _parent;
 
-                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
+                if (parent is not UIElement and not UIElement3D)
                 {
                     Visual parentAsVisual = parent as Visual;
 
@@ -1490,7 +1490,7 @@ namespace System.Windows
             {
                 DependencyObject parent = oldParent;
 
-                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
+                if (parent is not UIElement and not UIElement3D)
                 {
                     // We are being unplugged from a non-UIElement visual. This
                     // means that our parent didn't play by the same rules we

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
@@ -148,7 +148,7 @@ namespace System.Windows
             {
                 DependencyObject parent = InternalVisualParent;
 
-                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
+                if (parent is not UIElement and not UIElement3D)
                 {
                     Visual parentAsVisual = parent as Visual;
 
@@ -192,7 +192,7 @@ namespace System.Windows
             {
                 DependencyObject parent = oldParent;
 
-                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
+                if (parent is not UIElement and not UIElement3D)
                 {
                     // We are being unplugged from a non-UIElement visual. This
                     // means that our parent didn't play by the same rules we

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
@@ -229,7 +229,7 @@ namespace MS.Internal.Annotations.Anchoring
             Debug.Assert(node != null, "node can not be null");
 
             DependencyObject current = node;
-            DependencyObject parent = null;
+            DependencyObject parent;
 
             while (true)
             {
@@ -255,16 +255,15 @@ namespace MS.Internal.Annotations.Anchoring
                 }
 
                 // Check if located a parent, if so, check if it's the correct type
-                if ((parent == null) ||
-                    FrameworkElement.DType.IsInstanceOfType(parent) ||
-                    FrameworkContentElement.DType.IsInstanceOfType(parent))
+                if (parent is null
+                    or FrameworkElement
+                    or FrameworkContentElement)
                 {
                     break;
                 }
 
                 // Parent found but not of correct type, continue
                 current = parent;
-                parent = null;
             }
 
             return parent;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkObject.cs
@@ -57,21 +57,8 @@ namespace MS.Internal
             // [code should be identical to Reset(d)]
             _do = d;
 
-            if (FrameworkElement.DType.IsInstanceOfType(d))
-            {
-                _fe = (FrameworkElement)d;
-                _fce = null;
-            }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
-            {
-                _fe = null;
-                _fce = (FrameworkContentElement)d;
-            }
-            else
-            {
-                _fe = null;
-                _fce = null;
-            }
+            _fe = d as FrameworkElement;
+            _fce = d as FrameworkContentElement;
         }
 
         internal FrameworkObject(DependencyObject d, bool throwIfNeither)
@@ -99,21 +86,8 @@ namespace MS.Internal
         {
             _do = d;
 
-            if (FrameworkElement.DType.IsInstanceOfType(d))
-            {
-                _fe = (FrameworkElement)d;
-                _fce = null;
-            }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
-            {
-                _fe = null;
-                _fce = (FrameworkContentElement)d;
-            }
-            else
-            {
-                _fe = null;
-                _fce = null;
-            }
+            _fe = d as FrameworkElement;
+            _fce = d as FrameworkContentElement;
         }
 
         #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -286,15 +286,15 @@ namespace MS.Internal
                                     out FrameworkElement fe, out FrameworkContentElement fce,
                                     bool throwIfNeither)
         {
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement frameworkElement)
             {
-                fe = (FrameworkElement)d;
+                fe = frameworkElement;
                 fce = null;
             }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            else if (d is FrameworkContentElement frameworkContentElement)
             {
                 fe = null;
-                fce = (FrameworkContentElement)d;
+                fce = frameworkContentElement;
             }
             else if (throwIfNeither)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ClipboardProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ClipboardProcessor.cs
@@ -213,9 +213,9 @@ namespace MS.Internal.Ink
                                 // If the Xaml data has been set in an InkCanvas, the top element will be a container InkCanvas.
                                 // In this case, the new elements will be the children of the container.
                                 // Otherwise, the new elements will be whatever data from the data object.
-                                if (elements.Count == 1 && ClipboardProcessor.InkCanvasDType.IsInstanceOfType(elements[0]))
+                                if (elements.Count == 1 && elements[0] is InkCanvas inkCanvas)
                                 {
-                                    TearDownInkCanvasContainer((InkCanvas)( elements[0] ), ref newStrokes, ref newElements);
+                                    TearDownInkCanvasContainer(inkCanvas, ref newStrokes, ref newElements);
                                 }
                                 else
                                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PrePostDescendentsWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PrePostDescendentsWalker.cs
@@ -72,7 +72,7 @@ namespace MS.Internal
                     {
                         // This type checking is done in DescendentsWalker.  Doing it here
                         // keeps us consistent.
-                        if (FrameworkElement.DType.IsInstanceOfType(startNode) || FrameworkContentElement.DType.IsInstanceOfType(startNode))
+                        if (startNode is FrameworkElement or FrameworkContentElement)
                         {
                             _postCallback(startNode, this.Data, _priority == TreeWalkPriority.VisualTree);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
@@ -292,12 +292,10 @@ namespace System.Windows
             DependencyObject root = data.Root;
             RoutedEvent routedEvent = data.RoutedEvent;
             List<DependencyObject> eventRoute = data.EventRoute;
-            
-            if (FrameworkElement.DType.IsInstanceOfType(d))
-            {
-                // If this is a FrameworkElement
-                FrameworkElement fe = (FrameworkElement)d;
 
+            // If this is a FrameworkElement            
+            if (d is FrameworkElement fe)
+            {
                 if (fe != root && routedEvent == FrameworkElement.LoadedEvent && fe.UnloadedPending != null)
                 {
                     // If there is a pending Unloaded event wait till we've broadcast 
@@ -422,22 +420,22 @@ namespace System.Windows
 
         private static bool SubtreeHasLoadedChangeHandlerHelper(DependencyObject d)
         {
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement fe)
             {
-                return ((FrameworkElement)d).SubtreeHasLoadedChangeHandler;
+                return fe.SubtreeHasLoadedChangeHandler;
             }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            else if (d is FrameworkContentElement fce)
             {
-                return ((FrameworkContentElement)d).SubtreeHasLoadedChangeHandler;
+                return fce.SubtreeHasLoadedChangeHandler;
             }
             return false;
         }
 
         private static void FireLoadedOnDescendentsHelper(DependencyObject d)
         {
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement fe)
             {
-                ((FrameworkElement)d).FireLoadedOnDescendentsInternal();
+                fe.FireLoadedOnDescendentsInternal();
             }
             else
             {
@@ -447,9 +445,9 @@ namespace System.Windows
 
         private static void FireUnloadedOnDescendentsHelper(DependencyObject d)
         {
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement fe)
             {
-                ((FrameworkElement)d).FireUnloadedOnDescendentsInternal();
+                fe.FireUnloadedOnDescendentsInternal();
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -942,17 +942,17 @@ namespace System.Windows.Controls
             DependencyObject sourceDO = source as DependencyObject;
             if (userInitiated && sourceDO != null)
             {
-                if (InputElement.IsUIElement(sourceDO))
+                if (sourceDO is UIElement uiElement)
                 {
-                    ((UIElement)sourceDO).RaiseEvent(args, userInitiated);
+                    uiElement.RaiseEvent(args, userInitiated);
                 }
-                else if (InputElement.IsContentElement(sourceDO))
+                else if (sourceDO is ContentElement contentElement)
                 {
-                    ((ContentElement)sourceDO).RaiseEvent(args, userInitiated);
+                    contentElement.RaiseEvent(args, userInitiated);
                 }
-                else if (InputElement.IsUIElement3D(sourceDO))
+                else if (sourceDO is UIElement3D uiElement3D)
                 {
-                    ((UIElement3D)sourceDO).RaiseEvent(args, userInitiated);
+                    uiElement3D.RaiseEvent(args, userInitiated);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DatePickerTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DatePickerTextBox.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Controls.Primitives
         private static T ExtractTemplatePart<T>(string partName, DependencyObject obj) where T : DependencyObject
         {
             Debug.Assert(
-                obj == null || typeof(T).IsInstanceOfType(obj),
+                obj == null || obj is T,
                 string.Format(CultureInfo.InvariantCulture, SR.Get(SRID.DatePickerTextBox_TemplatePartIsOfIncorrectType), partName, typeof(T).Name));
             return obj as T;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalker.cs
@@ -56,8 +56,8 @@ namespace System.Windows
 
             if (!skipStartNode)
             {
-                if (FrameworkElement.DType.IsInstanceOfType(_startNode) ||
-                    FrameworkContentElement.DType.IsInstanceOfType(_startNode))
+                if (_startNode is FrameworkElement
+                    or FrameworkContentElement)
                 {
                     // Callback for the root of the subtree
                     continueWalk = _callback(_startNode, _data, _priority == TreeWalkPriority.VisualTree);
@@ -79,9 +79,8 @@ namespace System.Windows
         {
             _recursionDepth++;
 
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement fe)
             {
-                FrameworkElement fe = (FrameworkElement) d;
                 bool hasLogicalChildren = fe.HasLogicalChildren;
 
                 // FrameworkElement have both a visual and a logical tree.
@@ -100,11 +99,10 @@ namespace System.Windows
                     Debug.Assert( false, "Tree walk priority should be Visual first or Logical first - but this instance of DescendentsWalker has an invalid priority setting that's neither of the two." );
                 }
             }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            else if (d is FrameworkContentElement fce)
             {
                 // FrameworkContentElement only has a logical tree, so we
                 // Walk logical children
-                FrameworkContentElement fce = d as FrameworkContentElement;
                 if (fce.HasLogicalChildren)
                 {
                     WalkLogicalChildren( null, fce, fce.LogicalChildren );
@@ -114,18 +112,13 @@ namespace System.Windows
             {
                 // Neither a FrameworkElement nor FrameworkContentElement.  See
                 //  if it's a Visual and if so walk the Visual collection
-                Visual v = d as Visual;
-                if (v != null)
+                if (d is Visual v)
                 {
                     WalkVisualChildren(v);
                 }
-                else
+                else if (d is Visual3D v3D)
                 {
-                    Visual3D v3D = d as Visual3D;
-                    if (v3D != null)
-                    {
-                        WalkVisualChildren(v3D);
-                    }
+                    WalkVisualChildren(v3D);
                 }
             }
 
@@ -324,12 +317,12 @@ namespace System.Windows
                 for(int i = 0; i < count; i++)
                 {
                     Visual child = feParent.InternalGetVisualChild(i);
-                    if (child != null && FrameworkElement.DType.IsInstanceOfType(child))
+                    if (child != null && child is FrameworkElement fe)
                     {
                         // For the case that both parents are identical, this node should
                         // have already been visited when walking through logical
                         // children, hence we short-circuit here
-                        if (VisualTreeHelper.GetParent(child) != ((FrameworkElement) child).Parent)
+                        if (VisualTreeHelper.GetParent(child) != fe.Parent)
                         {
                             bool visitedViaVisualTree = true;
                             VisitNode(child, visitedViaVisualTree);
@@ -404,11 +397,11 @@ namespace System.Windows
         {
             if (_recursionDepth <= ContextLayoutManager.s_LayoutRecursionLimit)
             {
-                if (FrameworkElement.DType.IsInstanceOfType(d))
+                if (d is FrameworkElement fe)
                 {
-                    VisitNode(d as FrameworkElement, visitedViaVisualTree);
+                    VisitNode(fe, visitedViaVisualTree);
                 }
-                else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+                else if (d is FrameworkContentElement)
                 {
                     _VisitNode(d, visitedViaVisualTree);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalkerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalkerBase.cs
@@ -38,9 +38,8 @@ namespace System.Windows
             {
                 DependencyObject logicalParent;
 
-                if (FrameworkElement.DType.IsInstanceOfType(ancestor))
+                if (ancestor is FrameworkElement fe)
                 {
-                    FrameworkElement fe = ancestor as FrameworkElement;
                     logicalParent = fe.Parent;
                     // FrameworkElement
                     DependencyObject dependencyObjectParent = VisualTreeHelper.GetParent(fe);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -2233,8 +2233,10 @@ namespace System.Windows
                                 {
                                     //let incrementally-updating FrameworkElements to mark the vicinity of the affected child
                                     //to perform partial update.
-                                    if(FrameworkElement.DType.IsInstanceOfType(layoutParent))
-                                        ((FrameworkElement)layoutParent).ParentLayoutInvalidated(this);
+                                    if(layoutParent is FrameworkElement fe)
+                                    {
+                                        fe.ParentLayoutInvalidated(this);
+                                    }
 
                                     if (affectsParentMeasure)
                                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
@@ -1227,6 +1227,7 @@ namespace System.Windows
         #region Internal Fields
 
         // Optimization, to avoid calling FromSystemType too often
+        // todo BSC: type
         internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkContentElement));
 
         #endregion Internal Fields

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
@@ -1220,20 +1220,6 @@ namespace System.Windows
 
         //------------------------------------------------------
         //
-        //  Internal Fields
-        //
-        //------------------------------------------------------
-
-        #region Internal Fields
-
-        // Optimization, to avoid calling FromSystemType too often
-        // todo BSC: type
-        internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkContentElement));
-
-        #endregion Internal Fields
-
-        //------------------------------------------------------
-        //
         //  Private Fields
         //
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
@@ -1269,20 +1269,6 @@ namespace System.Windows
 
         //------------------------------------------------------
         //
-        //  Internal Fields
-        //
-        //------------------------------------------------------
-
-        #region Internal Fields
-
-        // Optimization, to avoid calling FromSystemType too often
-        // todo BSC: type
-        internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkElement));
-
-        #endregion Internal Fields
-
-        //------------------------------------------------------
-        //
         //  Private Fields
         //
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
@@ -1276,6 +1276,7 @@ namespace System.Windows
         #region Internal Fields
 
         // Optimization, to avoid calling FromSystemType too often
+        // todo BSC: type
         internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkElement));
 
         #endregion Internal Fields

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Storyboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Storyboard.cs
@@ -929,13 +929,13 @@ public class Storyboard : ParallelTimeline
     /// </summary>
     private void VerifyComplexPathSupport( DependencyObject targetObject )
     {
-        if( FrameworkElement.DType.IsInstanceOfType(targetObject) )
+        if(targetObject is FrameworkElement)
         {
             // FrameworkElement and derived types are supported.
             return;
         }
 
-        if( FrameworkContentElement.DType.IsInstanceOfType(targetObject) )
+        if(targetObject is FrameworkContentElement)
         {
             // FrameworkContentElement and derived types are supported.
             return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -2327,15 +2327,15 @@ namespace System.Windows
                                     out FrameworkElement fe, out FrameworkContentElement fce,
                                     bool throwIfNeither)
         {
-            if (FrameworkElement.DType.IsInstanceOfType(d))
+            if (d is FrameworkElement frameworkElement)
             {
-                fe = (FrameworkElement)d;
+                fe = frameworkElement;
                 fce = null;
             }
-            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            else if (d is FrameworkContentElement frameworkContentElement)
             {
                 fe = null;
-                fce = (FrameworkContentElement)d;
+                fce = frameworkContentElement;
             }
             else if (throwIfNeither && !(d is System.Windows.Media.Media3D.Visual3D) )
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -1000,7 +1000,7 @@ namespace System.Windows
                 // only then do we need to Invalidate the property
                 if (BaseValueSourceInternal.Inherited >= oldEntry.BaseValueSourceInternal)
                 {
-                    if (visitedViaVisualTree && FrameworkElement.DType.IsInstanceOfType(d))
+                    if (visitedViaVisualTree && d is FrameworkElement)
                     {
                         DependencyObject logicalParent = LogicalTreeHelper.GetParent(d);
                         if (logicalParent != null)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializer.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializerAsync.cs
@@ -232,7 +232,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializer.cs
@@ -277,7 +277,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializerAsync.cs
@@ -317,7 +317,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializer.cs
@@ -350,7 +350,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializerAsync.cs
@@ -322,7 +322,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMFixedPageSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMFixedPageSerializer.cs
@@ -308,7 +308,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (typeof(Type).IsInstanceOfType(propertyValue))
+                if (propertyValue is Type)
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(


### PR DESCRIPTION
Fixes Issue 
#4936

## Description

Replacing expensive type checks with "is" checks.
I added a few todos to the code as i am not sure if we should throw explicit exceptions in those places. Before my changes those place would have thrown an InvalidCastException or a NullReferenceException.

## Customer Impact

Slower performance.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
