### PR TITLE
Port fix for VSP floating-point hang from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -931,16 +931,19 @@ namespace System.Windows.Controls
                     // situations where the viewport size has changed)
                     if (!success)
                     {
+                        double computedOffset, maxOffset;
                         if (isHorizontal)
                         {
-                            success = DoubleUtil.GreaterThanOrClose(_scrollData._computedOffset.X,
-                                                                _scrollData._extent.Width - _scrollData._viewport.Width);
+                            computedOffset = _scrollData._computedOffset.X;
+                            maxOffset = _scrollData._extent.Width - _scrollData._viewport.Width;
                         }
                         else
                         {
-                            success = DoubleUtil.GreaterThanOrClose(_scrollData._computedOffset.Y,
-                                                                _scrollData._extent.Height - _scrollData._viewport.Height);
+                            computedOffset = _scrollData._computedOffset.Y;
+                            maxOffset = _scrollData._extent.Height - _scrollData._viewport.Height;
                         }
+                        success = LayoutDoubleUtil.LessThan(maxOffset, computedOffset) ||
+                                  LayoutDoubleUtil.AreClose(maxOffset, computedOffset);
                     }
                 }
             }
@@ -973,7 +976,7 @@ namespace System.Windows.Controls
             else
             {
                 bool remeasure = false;
-                double actualOffset, expectedOffset;
+                double actualOffset, expectedOffset, maxOffset;
 
                 if (isHorizontal)
                 {
@@ -981,13 +984,14 @@ namespace System.Windows.Controls
 
                     actualOffset = _scrollData._computedOffset.X + actualDistanceBetweenViewports;
                     expectedOffset = _scrollData._computedOffset.X + _scrollData._expectedDistanceBetweenViewports;
+                    maxOffset = _scrollData._extent.Width - _scrollData._viewport.Width;
 
-                    if (DoubleUtil.LessThan(expectedOffset, 0) || DoubleUtil.GreaterThan(expectedOffset, _scrollData._extent.Width - _scrollData._viewport.Width))
+                    if (LayoutDoubleUtil.LessThan(expectedOffset, 0) || LayoutDoubleUtil.LessThan(maxOffset, expectedOffset))
                     {
                         // the condition can fail due to estimated sizes in subtrees that contribute
                         // to FindScrollOffset(_scrollData._firstContainerInViewport) but not to
                         // _scrollData._extent.  If that happens, remeasure.
-                        if (DoubleUtil.AreClose(actualOffset, 0) || DoubleUtil.AreClose(actualOffset, _scrollData._extent.Width - _scrollData._viewport.Width))
+                        if (LayoutDoubleUtil.AreClose(actualOffset, 0) || LayoutDoubleUtil.AreClose(actualOffset, maxOffset))
                         {
                             _scrollData._computedOffset.X = actualOffset;
                             _scrollData._offset.X = actualOffset;
@@ -1010,13 +1014,14 @@ namespace System.Windows.Controls
 
                     actualOffset = _scrollData._computedOffset.Y + actualDistanceBetweenViewports;
                     expectedOffset = _scrollData._computedOffset.Y + _scrollData._expectedDistanceBetweenViewports;
+                    maxOffset = _scrollData._extent.Height - _scrollData._viewport.Height;
 
-                    if (DoubleUtil.LessThan(expectedOffset, 0) || DoubleUtil.GreaterThan(expectedOffset, _scrollData._extent.Height - _scrollData._viewport.Height))
+                    if (LayoutDoubleUtil.LessThan(expectedOffset, 0) || LayoutDoubleUtil.LessThan(maxOffset, expectedOffset))
                     {
                         // the condition can fail due to estimated sizes in subtrees that contribute
                         // to FindScrollOffset(_scrollData._firstContainerInViewport) but not to
                         // _scrollData._extent.  If that happens, remeasure.
-                        if (DoubleUtil.AreClose(actualOffset, 0) || DoubleUtil.AreClose(actualOffset, _scrollData._extent.Height - _scrollData._viewport.Height))
+                        if (LayoutDoubleUtil.AreClose(actualOffset, 0) || LayoutDoubleUtil.AreClose(actualOffset, maxOffset))
                         {
                             _scrollData._computedOffset.Y = actualOffset;
                             _scrollData._offset.Y = actualOffset;
@@ -2824,11 +2829,11 @@ namespace System.Windows.Controls
                                 ref scrollGeneration);
 
                             if (ItemsChangedDuringMeasure)
-                                {
-                                    // if the Items collection changed, our state is now invalid.  Start over.
-                                    remeasure = true;
-                                    goto EscapeMeasure;
-                                }
+                            {
+                                // if the Items collection changed, our state is now invalid.  Start over.
+                                remeasure = true;
+                                goto EscapeMeasure;
+                            }
                         }
                     }
 
@@ -2873,11 +2878,11 @@ namespace System.Windows.Controls
                                 ref scrollGeneration);
 
                             if (ItemsChangedDuringMeasure)
-                                {
-                                    // if the Items collection changed, our state is now invalid.  Start over.
-                                    remeasure = true;
-                                    goto EscapeMeasure;
-                                }
+                            {
+                                // if the Items collection changed, our state is now invalid.  Start over.
+                                remeasure = true;
+                                goto EscapeMeasure;
+                            }
                         }
                     }
 
@@ -12320,6 +12325,12 @@ namespace System.Windows.Controls
                     "VirtMode:", VirtualizingPanel.GetVirtualizationMode(ic),
                     "ScrollUnit:", VirtualizingPanel.GetScrollUnit(ic),
                     "CacheLen:", VirtualizingPanel.GetCacheLength(ic), VirtualizingPanel.GetCacheLengthUnit(ic));
+
+                DpiScale dpiScale = vsp.GetDpi();
+                AddTrace(null, ScrollTraceOp.ID, _nullInfo,
+                    "DPIScale:", dpiScale.DpiScaleX, dpiScale.DpiScaleY,
+                    "UseLayoutRounding:", vsp.UseLayoutRounding,
+                    "Rounding Quantum:", 1.0/dpiScale.DpiScaleY);
 
                 AddTrace(null, ScrollTraceOp.ID, _nullInfo,
                     "CanContentScroll:", ScrollViewer.GetCanContentScroll(ic),


### PR DESCRIPTION
Addresses Issue #4978.  This is a port of a servicing fix in .NET 4.7-4.8.

## Description

The hang is due to floating-point drift.  After any scroll, VSP runs logic to verify that it scrolled to the right place (it can be wrong due to new information discovered while de-virtualizing).  There's a special case when the scroll reaches the end of the data, comparing the actual offset to the maximum (extent - viewport height).  This uses the strict test DoubleUtil.AreClose(actual, maximum), which tolerates floating-point drift of 10^-16 pixel.  But the difference in the repro is 10^-14 pixel, so the test fails.

Prior to the 2020-08 update, this would have merely triggered a Debug.Assert, invisible to customers.  With the update, it now requests a re-measure, fixing a bug that arose when the numbers were legitimately different.  But when the numbers are so close and layout rounding is enabled, the re-measure just ends up in the same situation, and the app hangs.

The fix is to use the looser test LayoutDoubleUtil.AreClose(actual, maximum), which tolerates floating-point drift of 10^-6 pixel.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Hang while scrolling.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Exposed by PR #3564.

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc with customer scenarios.
Standard regression testing.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.  Straightforward port of .NETFx fix that was released earlier this year.
