### PR TITLE
Port WebBrowser completion events fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
@@ -261,10 +261,12 @@ namespace MS.Internal.Controls
 
         public void CommandStateChange(long command, bool enable)
         {
-            if (command == NativeMethods.CSC_NAVIGATEBACK) {
+            if (command == NativeMethods.CSC_NAVIGATEBACK)
+            {
                 _parent._canGoBack = enable;
             }
-            else if (command == NativeMethods.CSC_NAVIGATEFORWARD) {
+            else if (command == NativeMethods.CSC_NAVIGATEFORWARD)
+            {
                 _parent._canGoForward = enable;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
@@ -24,8 +24,8 @@ using MS.Win32;
 using MS.Internal.AppModel;
 using MS.Internal.Interop;
 
-//In order to avoid generating warnings about unknown message numbers and 
-//unknown pragmas when compiling your C# source code with the actual C# compiler, 
+//In order to avoid generating warnings about unknown message numbers and
+//unknown pragmas when compiling your C# source code with the actual C# compiler,
 //you need to disable warnings 1634 and 1691. (Presharp Documentation)
 #pragma warning disable 1634, 1691
 
@@ -72,15 +72,15 @@ namespace MS.Internal.Controls
 
                 UnsafeNativeMethods.IWebBrowser2 axIWebBrowser2 = (UnsafeNativeMethods.IWebBrowser2)pDisp;
                 // If _parent.AxIWebBrowser2 != axIWebBrowser2, navigation happens in a nested [i]frame.
-                // in that case we do not want to enforce site locking as we want the default IE behavior to take 
-                // over. 
+                // in that case we do not want to enforce site locking as we want the default IE behavior to take
+                // over.
                 if (_parent.AxIWebBrowser2 == axIWebBrowser2)
                 {
                     // The NavigatingToAboutBlank property indicates whether we are navigating to "about:blank"
                     // as a result of navigating to null or stream/string navigation.
                     // We set the NavigatingToAboutBlank bit to true in the WebBrowser DoNavigate method. When the above
-                    // conditions occur, the NavigatingToAboutBlank is true and the source must be "about:blank". 
-                    // 
+                    // conditions occur, the NavigatingToAboutBlank is true and the source must be "about:blank".
+                    //
                     // But when end user navigates away from the current about:blank page (by clicking
                     // on a hyperlink, Goback/Forward), or programmatically call GoBack and Forward,
                     // When we get the navigating event, NavigatingToAboutBlank is true, but the source is not "about:blank".
@@ -174,11 +174,11 @@ namespace MS.Internal.Controls
         {
             Debug.Assert(url == null || url is string, "invalid url type");
 
-            // Events only fired for top level navigation. 
+            // Events only fired for top level navigation.
             UnsafeNativeMethods.IWebBrowser2 axIWebBrowser2 = (UnsafeNativeMethods.IWebBrowser2)pDisp;
-            if (_parent.AxIWebBrowser2 == axIWebBrowser2)
+            if (_parent.AxIWebBrowser2 == axIWebBrowser2 && !ShouldIgnoreCompletionEvent(ref url))
             {
-                // If we are loading from stream.                
+                // If we are loading from stream.
                 if (_parent.DocumentStream != null)
                 {
                     Invariant.Assert(_parent.NavigatingToAboutBlank &&
@@ -207,7 +207,7 @@ namespace MS.Internal.Controls
                 {
                     string urlString = (string)url;
                     // When source set to null or navigating to stream/string, we navigate to "about:blank"
-                    // internally. Make sure we pass null in the event args. 
+                    // internally. Make sure we pass null in the event args.
                     if (_parent.NavigatingToAboutBlank)
                     {
                         Invariant.Assert(String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) == 0);
@@ -229,13 +229,13 @@ namespace MS.Internal.Controls
         {
             Debug.Assert(url == null || url is string, "invalid url type");
 
-            // Events only fired for top level navigation. 
+            // Events only fired for top level navigation.
             UnsafeNativeMethods.IWebBrowser2 axIWebBrowser2 = (UnsafeNativeMethods.IWebBrowser2)pDisp;
-            if (_parent.AxIWebBrowser2 == axIWebBrowser2)
+            if (_parent.AxIWebBrowser2 == axIWebBrowser2 && !ShouldIgnoreCompletionEvent(ref url))
             {
                 string urlString = (string)url;
                 // When source set to null or navigating to stream/string, we navigate to "about:blank"
-                // internally. Make sure we pass null in the event args. 
+                // internally. Make sure we pass null in the event args.
                 if (_parent.NavigatingToAboutBlank)
                 {
                     Invariant.Assert(String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) == 0);
@@ -248,14 +248,23 @@ namespace MS.Internal.Controls
             }
         }
 
+        // if we are navigating to "about:blank", ignore completion events
+        // for any other url.  These can happen despite our attempt to cancel
+        // outstanding navigations (see WebBrowser.DoNavigate), due to race
+        // conditions between the browser and us.
+        private bool ShouldIgnoreCompletionEvent(ref object url)
+        {
+            string urlString = url as string;
+            return (_parent.NavigatingToAboutBlank &&
+                    String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) != 0);
+        }
+
         public void CommandStateChange(long command, bool enable)
         {
-            if (command == NativeMethods.CSC_NAVIGATEBACK)
-            {
+            if (command == NativeMethods.CSC_NAVIGATEBACK) {
                 _parent._canGoBack = enable;
             }
-            else if (command == NativeMethods.CSC_NAVIGATEFORWARD)
-            {
+            else if (command == NativeMethods.CSC_NAVIGATEFORWARD) {
                 _parent._canGoForward = enable;
             }
         }


### PR DESCRIPTION
Addresses Issue #4990

## Description

When WebBrowser navigates to about:blank, it cancels outstanding navigations.  However it may still receive completion events for those navigations, due to race conditions between the browser process and the WPF app.  When this happens, ignore the completion event (instead of failing an assert and crashing).

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Intermittent crashes.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No.

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc around customer scenario.
Standard regressions testing.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.  Port of .NETFx servicing fix released earlier this year.