### PR TITLE
System.Windows.Markup.XamlParseException when reading resource file 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -73,7 +73,8 @@ namespace MS.Internal.AppModel
                 BaseUriHelper.GetAssemblyNameAndPart(Uri, out filePath, out assemblyName, out assemblyVersion, out assemblyKey);
 
                 // filePath should not have leading slash.  GetAssemblyNameAndPart( ) can guarantee it.
-                _fullPath = System.IO.Path.Combine(codeBase.LocalPath, filePath);
+                Uri file = new Uri(codeBase, filePath);
+                _fullPath = file.LocalPath;
             }
 
             stream = CriticalOpenFile(_fullPath);


### PR DESCRIPTION
The failure looks like an unintended consequence of #4799. The path incorrectly contains the filename of the application assembly.  Reverting the change for now, since we are so close to snapping the release candidate for .NET 6.0.  

Fixes issue https://github.com/dotnet/wpf/issues/4987.  