### PR TITLE
[release/3.1] Port HwndHost stack trace fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -983,7 +983,6 @@ namespace System.Windows.Interop
                     // window later when a new parent is available
                     var hwnd = SystemResources.GetDpiAwarenessCompatibleNotificationWindow(_hwnd);
                     Debug.Assert(hwnd != null);
-                    Trace.WriteLineIf(hwnd == null, $"- Warning - Notification Window is null\n{new System.Diagnostics.StackTrace(true).ToString()}");
                     if (hwnd != null)
                     {
                         UnsafeNativeMethods.SetParent(_hwnd, new HandleRef(null, hwnd.Handle));
@@ -997,6 +996,10 @@ namespace System.Windows.Interop
                         // To avoid this situation, we make sure SystemResources responds to the Dispatcher 
                         // shutdown event after this HwndHost.
                         SystemResources.DelayHwndShutdown();
+                    }
+                    else
+                    {
+                        Trace.WriteLineIf(hwnd == null, $"- Warning - Notification Window is null\n{new System.Diagnostics.StackTrace(true).ToString()}");
                     }
                 }
             }


### PR DESCRIPTION
Addresses #3114
This is a port of a servicing fix in .NET 4.8

Issue: Expensive diagnostic code is running on the normal code-path.

Discussion:
A recent servicing fix added code to capture a stack trace whenever a certain anomalous condition occurs. However it always creates the stack trace, and merely discards it in the normal case.

Fixed by moving the creation of the stack trace into the anomalous branch.