### PR TITLE
[release/3.1] Port FixedPage SOM fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedSOMPageConstructor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedSOMPageConstructor.cs
@@ -717,13 +717,15 @@ namespace System.Windows.Documents
                 //These two overlap vertically. Let's check whether there is a vertical separator in between
                 double left = (fixedBlockRect.Right < textRunRect.Right) ? fixedBlockRect.Right: textRunRect.Right;
                 double right =(fixedBlockRect.Left > textRunRect.Left) ? fixedBlockRect.Left: textRunRect.Left;
-                if (left > right)
+                if (left < right)
                 {
-                    double temp = left;
-                    left = right;
-                    right = temp;
+                    return (!_lines.IsVerticallySeparated(left, textRunRect.Top, right, textRunRect.Bottom));
                 }
-                return (!_lines.IsVerticallySeparated(left, textRunRect.Top, right, textRunRect.Bottom));
+                else
+                {
+                    // they also overlap horizontally, so they should be combined
+                    return true;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextBuilder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedTextBuilder.cs
@@ -1033,7 +1033,7 @@ namespace System.Windows.Documents
                                 newPathPrefix,         // otherwise use this path prefix
                                 constructLines,
                                 fixedNodes,
-                                transform * localTransform.Value
+                                localTransform.Value * transform
                                 );
                     }//endofElementIsCanvas
                 }


### PR DESCRIPTION
Addresses #3115
This is a port of a servicing fix in .NET 4.7-4.8.

Issue: For certain XPS documents, DocumentViewer cannot select text correctly.

Discussion:
There are actually two bugs, both affecting the construction of the FixedPage's "Semantic Object Model".

1. Each text run is tested to see if it can be combined into the current text block. The test is intended to recognize when the text and the block are separated by a line drawn somewhere on the page. The bug arises when the text and the block overlap in both the x- and y-directions, and there is a vertical line that touches the overlap. The test erroneously thinks the line separates the text from the block, and doesn't combine them.

2. The lines come from a recursive tree walk of the XPS elements. The tree walk combines transforms of parent and child elements in the wrong order, leading to the wrong overall transform if the individual transforms don't commute.

