### PR TITLE
[release/5.0] Port UpdatePeer fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -148,6 +148,22 @@ namespace System.Windows.Automation.Peers
         }
 
 
+        ///
+        override internal bool IgnoreUpdatePeer()
+        {
+            // Ignore UpdatePeer if the we're no longer in the automation tree.
+            // There's no need to update such a peer, as it no longer
+            // participates in automation.  And UpdatePeer actually throws exceptions
+            // in some cases.
+
+            if (!IsItemInAutomationTree())
+            {
+                return true;
+            }
+
+            return base.IgnoreUpdatePeer();
+        }
+
         override internal bool IsDataItemAutomationPeer()
         {
             return true;


### PR DESCRIPTION
Addresses Issue #4992
This is a port of a servicing fix in .NET 4.7-4.8.

## Description

The root cause is calling peer.InvalidatePeer(), which schedules an asynchronous call to peer.UpdatePeer(), then removing the peer from the automation tree before the async call happens.  UpdatePeer calls several methods that look for context in the automation tree and throw ElementNotAvailableException if the context can't be found.

This is similar to a bug fixed 3 years ago.  The differences are
  1. old bug: peer represents a FrameworkElement
       this bug:  peer represents a data item
  2. old bug: peer invalidated because fe.IsEnabled changed
      this bug:  peer invalidated because GridViewColumnCollection changed

There are two factors in the customer's app that contribute to the crash, both having to do with the grouped ListView control:
  1.  The app responds to a system theme change by changing the control's column collection and by removing grouping (which removes peers from the automation tree).
  2.  The control uses custom components and custom automation peers.  The custom data-item peer does not derive from GridViewItemAutomationPeer, but rather directly from ItemAutomationPeer.

Theme changes happen when you reconnect to RDP, but the bug also repros if the end-user simply changes the theme, e.g. by turning HighContrast on or off.

The overrides in ItemAutomationPeer that throw ElementNotAvailableException check explicitly for GridViewItemAutomationPeer and bypass the throw.  This explains why the crash doesn't occur in apps that use the built-in ListView/GridView and peers, even if they change the column collection and remove items in the same way the customer's app does.

The fix is to extend the mechanism we introduced to fix the older bug - a check to ignore the async call to UpdatePeer if the peer has left the automation tree - to handle the data-item peer case.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Crash when reconnecting to RDP.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No. 

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc around customer scenario.
Standard regression testing.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.   Port of a .NETFx servicing fix released earlier this year.