### PR TITLE
[release/3.1] ILDasm build break

### DIFF
--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -62,8 +62,8 @@
           try
           {
             var bitness = (DotNetFrameworkArchitecture)Enum.Parse(typeof(DotNetFrameworkArchitecture), DotNetBitness);
-            ILAsm = ToolLocationHelper.GetPathToDotNetFrameworkFile("ILAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
-            ILDAsm = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("ILDAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
+            ILAsm = ToolLocationHelper.GetPathToDotNetFrameworkFile("ILAsm.exe", TargetDotNetFrameworkVersion.Latest, bitness);
+            ILDAsm = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("ILDAsm.exe", TargetDotNetFrameworkVersion.Latest, bitness);
           }
           catch(Exception e)
           {


### PR DESCRIPTION
The release/3.1 build breaks on machines that don't have an .NET Framework SDK for version 4.6.2 or lower.

This fixes the break by asking MSBuild to look for ILDasm.exe in all versions it knows about.
