### PR TITLE
Fix GetStreamCore in ContentFilePart

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.AppModel
                 // File name will be a path relative to the applications directory.
                 // - We do not want to use SiteOfOriginContainer.SiteOfOrigin because
                 //   for deployed files the <Content> files are deployed with the application.
-                string codeBase = GetEntryAssemblyLocation();
+                string location = GetEntryAssemblyLocation();
 
                 string assemblyName, assemblyVersion, assemblyKey;
                 string filePath;
@@ -73,7 +73,7 @@ namespace MS.Internal.AppModel
                 BaseUriHelper.GetAssemblyNameAndPart(Uri, out filePath, out assemblyName, out assemblyVersion, out assemblyKey);
 
                 // filePath should not have leading slash.  GetAssemblyNameAndPart( ) can guarantee it.
-                _fullPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(codeBase), filePath);
+                _fullPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(location), filePath);
             }
 
             stream = CriticalOpenFile(_fullPath);
@@ -108,8 +108,6 @@ namespace MS.Internal.AppModel
 
             try
             {
-                // We do not want to use Application.ResourceAssembly.CodeBase
-                // because it is obsolete.
                 entryLocation = Application.ResourceAssembly.Location;
             }
             catch (Exception ex)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ContentFilePart.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.AppModel
                 // File name will be a path relative to the applications directory.
                 // - We do not want to use SiteOfOriginContainer.SiteOfOrigin because
                 //   for deployed files the <Content> files are deployed with the application.
-                Uri codeBase = GetEntryAssemblyLocation();
+                string codeBase = GetEntryAssemblyLocation();
 
                 string assemblyName, assemblyVersion, assemblyKey;
                 string filePath;
@@ -73,8 +73,7 @@ namespace MS.Internal.AppModel
                 BaseUriHelper.GetAssemblyNameAndPart(Uri, out filePath, out assemblyName, out assemblyVersion, out assemblyKey);
 
                 // filePath should not have leading slash.  GetAssemblyNameAndPart( ) can guarantee it.
-                Uri file = new Uri(codeBase, filePath);
-                _fullPath = file.LocalPath;
+                _fullPath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(codeBase), filePath);
             }
 
             stream = CriticalOpenFile(_fullPath);
@@ -103,15 +102,15 @@ namespace MS.Internal.AppModel
         #region Private Methods
 
 
-        private Uri GetEntryAssemblyLocation()
+        private string GetEntryAssemblyLocation()
         {
-            Uri entryLocation = null;
+            string entryLocation = null;
 
             try
             {
-                #pragma warning disable // Type or member is obsolete
-                entryLocation = new Uri(Application.ResourceAssembly.CodeBase);
-                #pragma warning restore // Type or member is obsolete
+                // We do not want to use Application.ResourceAssembly.CodeBase
+                // because it is obsolete.
+                entryLocation = Application.ResourceAssembly.Location;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes Issue #4781 #4987

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

The Application.ResourceAssembly.CodeBase is the string without escaped.

See:

- https://github.com/dotnet/wpf/issues/4781
- https://github.com/dotnet/wpf/pull/5004
- https://github.com/dotnet/wpf/pull/4799

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
See https://github.com/dotnet/wpf/issues/4781

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI and my demo code.

The test package: https://www.nuget.org/packages/Lindexi.Src.CustomWPF/1.0.6

The test demo: https://github.com/lindexi/lindexi_gd/tree/5f274174e8fd12fe6f4738c0e4605b22a3252901/WhejohafaChalehelair

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.