### PR TITLE
Localization request for WPF templates

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/template.json
@@ -111,6 +111,7 @@
   "defaultName": "WpfApp1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -120,6 +121,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens MainWindow.xaml in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Application",
+  "description": "A project for creating a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens MainWindow.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
@@ -105,6 +105,7 @@
   "defaultName": "WpfApp1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -114,6 +115,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens MainWindow.xaml in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/template.json
@@ -107,6 +107,7 @@
   "defaultName": "WpfLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -116,6 +117,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Class1.cs in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Class Library",
+  "description": "A project for creating a class library that targets a .NET WPF Application",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens Class1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/template.json
@@ -101,6 +101,7 @@
   "defaultName": "WpfLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -110,6 +111,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Class1.vb in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.cs in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/template.json
@@ -107,6 +107,7 @@
   "defaultName": "WpfCustomControlLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -116,6 +117,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens CustomControl1.cs in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF Custom Control Library",
+  "description": "A project for creating a custom control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens CustomControl1.vb in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/template.json
@@ -101,6 +101,7 @@
   "defaultName": "WpfCustomControlLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -110,6 +111,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens CustomControl1.vb in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,17 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/template.json
@@ -111,6 +111,7 @@
   "defaultName": "WpfControlLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -120,6 +121,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens UserControl1.xaml in the editor",
       "manualInstructions": [ ],

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,16 @@
+{
+  "author": "Microsoft",
+  "name": "WPF User Control Library",
+  "description": "A project for creating a user control library for .NET WPF Applications",
+  "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
+  "symbols/Framework/description": "The target framework for the project.",
+  "symbols/Framework/choices/netcoreapp3.0/description": "Target netcoreapp3.0",
+  "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
+  "symbols/Framework/choices/net5.0/description": "Target net5.0",
+  "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/langVersion/description": "Sets langVersion in the created project file",
+  "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
+  "postActions/restore/description": "Restore NuGet packages required by this project.",
+  "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
+  "postActions/editor/description": "Opens UserControl1.xaml in the editor"
+}

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/template.json
@@ -105,6 +105,7 @@
   "defaultName": "WpfControlLibrary1",
   "postActions": [
     {
+      "id": "restore",
       "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
@@ -114,6 +115,7 @@
       "continueOnError": true
     },
     {
+      "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens UserControl1.xaml in the editor",
       "manualInstructions": [ ],


### PR DESCRIPTION
Use the new Microsoft.TemplateEngine.TemplateLocalizer to create localization files and request for the following  WPF templates:

```
WpfApplication-CSharp
WpfApplication-VisualBasic
WpfClassLibrary-CSharp
WpfClassLibrary-VisualBasic
WpfCustomControlLibrary-CSharp
WpfCustomControlLibrary-VisualBasic
WpfUserControlLibrary-CSharp
WpfUserControlLibrary-VisualBasic
```
This is a required step to fix https://github.com/dotnet/wpf/issues/3663. 