### PR TITLE
Fix Popup Focus State Not Reacting with WebView2

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
@@ -117,6 +117,13 @@ namespace System.Windows.Interop
                         // window handle for windows attached to the calling
                         // thread's queue.
                         //
+                        int thisPid = 0;
+                        int childPid = 0;
+                        UnsafeNativeMethods.GetWindowThreadProcessId(new HandleRef(null, focus), out childPid);
+                        UnsafeNativeMethods.GetWindowThreadProcessId(thisWindow, out thisPid);
+
+                        if (childPid != thisPid)
+                            UnsafeNativeMethods.TrySetFocus(thisWindow);
                         result = focus != IntPtr.Zero;
                     }
                 }


### PR DESCRIPTION
Fixes Issue 1366812
https://github.com/MicrosoftEdge/WebView2Feedback/issues/1134

## Description

If we create a popup without losing focus of the WebView2 element (e.g. by using a context menu, rather than clicking a focusable button), the popup looks and feels as if it has keyboard focus, but all keyboard inputs go to the WebView2 instead.

This does not happen if focus is lost by WebView by clicking some focusable WPF element first (e.g. clicking the button, rather than right-clicking it).

The problem is with out-of-proc, In this fix we are comparing the process IDs.
If process IDs don’t match, call the TrySetFocus() function inside the if condition for WS_EX_NOACTIVATE.

## Customer Impact
Unable to write inside the popup text box.

## Regression
No

## Testing
Build and verify the fix.

## Risk
Extra processing for fetching the pid.