### PR TITLE
Update the SDK version and disable module initializer warning

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21379.2",
+    "dotnet": "6.0.100-rc.1.21416.15",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -8,7 +8,7 @@
       ]
     },
     "vs": {
-      "version": "16.8"
+      "version": "16.11"
     }
   },
   "msbuild-sdks": {
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21413.4"
   },
   "sdk": {
-    "version": "6.0.100-rc.1.21379.2"
+    "version": "6.0.100-rc.1.21416.15"
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
@@ -15,9 +15,11 @@ internal static class ModuleInitializer
     /// operations are carried out.  To do this, we simply call LoadDwrite
     /// as the module constructor for DirectWriteForwarder would do this anyway.
     /// </summary>
+    #pragma warning disable CA2255 
     [ModuleInitializer]
     public static void Initialize()
     {
         MS.Internal.NativeWPFDLLLoader.LoadDwrite();
     }
+    #pragma warning restore CA2255 
 }


### PR DESCRIPTION
WPF relies on a module initializer to load DirectWriteForwarder before PresentationCore is used.   WPF previously used ILasm/ILdasm to create the module initializer but now uses the language feature.  In new versions of the SDK, the analyzer gives a warning that must be suppressed: https://github.com/dotnet/runtime/issues/43328.