### PR TITLE
Update release/6.0 branding to rc2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>6.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <SystemIOPackagingVersion>6.0.0-rc.1.21417.1</SystemIOPackagingVersion>
     <SystemResourcesExtensionsVersion>6.0.0-rc.1.21417.1</SystemResourcesExtensionsVersion>
   </PropertyGroup>


### PR DESCRIPTION
release/6.0 will be branched to release/6.0-rc2 when rc2 snaps.  Any final fixes to rc1 should go in release/6.0-rc1.