### PR TITLE
Fix ClickablePoint property when IsOffscreen is true.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -1181,7 +1181,14 @@ namespace System.Windows.Automation.Peers
             try
             {
                 _publicCallInProgress = true;
-                result = GetClickablePointCore();
+                if (IsOffscreenCore())
+                {
+                    result = new Point(double.NaN, double.NaN);
+                }
+                else
+                {
+                    result = GetClickablePointCore();
+                }
             }
             finally
             {


### PR DESCRIPTION
Fixes Issue #4631

## Description

The automation ClickablePoint property shouldn't be an onscreen point, when the IsOffscreen property is true.

## Customer Impact

Accessibility Insights for Windows flags this as an accessibility error.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->
The test cases that claimed to check this didn't work, for 3 independent reasons.  I've repaired them in a companion PR in the test repo.  That PR is _much_ more interesting than this one.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.   Changing this case to conform to the expected behavior, per UIA docs.  The new return value is the same as we return in other "no clickable point" scenarios.