### PR TITLE
Remove the unnecessary Array code in FontTypeConverter.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
@@ -255,18 +255,7 @@ namespace System.Windows.Xps.Serialization
             Type            type
             )
         {
-            bool isSupported = false;
-
-            foreach (Type t in SupportedTargetTypes)
-            {
-                if (t.Equals(type))
-                {
-                    isSupported = true;
-                    break;
-                }
-            }
-
-            return isSupported;
+            return typeof(string).Equals(type);
         }
 
         #endregion Private static helper methods
@@ -385,13 +374,6 @@ namespace System.Windows.Xps.Serialization
         #endregion Public static helper methods
 
         #region Private static data
-
-        /// <summary>
-        /// A table of supported types for this type converter
-        /// </summary>
-        private static Type[] SupportedTargetTypes = {
-            typeof(string)
-        };
 
         #endregion Private static data
     }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/FontTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/FontTypeConverter.cs
@@ -246,30 +246,12 @@ namespace System.Windows.Xps.Serialization
             Type    type
             )
         {
-            bool bSupported = false;
-
-            foreach (Type t in SupportedTargetTypes)
-            {
-                if (t.Equals(type))
-                {
-                    bSupported = true;
-                    break;
-                }
-            }
-
-            return bSupported;
+            return typeof(Uri).Equals(type);
         }
 
         #endregion Private static helper methods
 
         #region Private static data
-
-        /// <summary>
-        /// A table of supported types for this type converter
-        /// </summary>
-        private static Type[] SupportedTargetTypes = {
-            typeof(Uri)
-        };
 
         #endregion Private static data
     }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
@@ -331,18 +331,7 @@ namespace System.Windows.Xps.Serialization
             Type            type
             )
         {
-            bool isSupported = false;
-
-            foreach (Type t in SupportedTargetTypes)
-            {
-                if (t.Equals(type))
-                {
-                    isSupported = true;
-                    break;
-                }
-            }
-
-            return isSupported;
+            return typeof(Uri).Equals(type);
         }
 
         private
@@ -533,13 +522,7 @@ namespace System.Windows.Xps.Serialization
         #endregion Private static helper methods
 
         #region Private static data
-
-        /// <summary>
-        /// A table of supported types for this type converter
-        /// </summary>
-        private static Type[] SupportedTargetTypes = {
-            typeof(Uri)
-        };
+        
         private static readonly int _readBlockSize = 1048576; //1MB
 
         /// <summary>


### PR DESCRIPTION


## Description

We can reduce the allocation of a static array. And it can run faster than traversing the array.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI.

## Risk

Low.
