### PR TITLE
Add the SelectableProperty in Selector.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -201,6 +201,33 @@ namespace System.Windows.Controls.Primitives
             return (bool) element.GetValue(IsSelectionActiveProperty);
         }
 
+        public static readonly DependencyProperty SelectableProperty =
+            DependencyProperty.RegisterAttached(
+                "SelectableProperty",
+                typeof(bool),
+                typeof(Selector),
+                new PropertyMetadata(BooleanBoxes.TrueBox));
+
+        public static bool GetSelectable(DependencyObject element)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            return (bool) element.GetValue(SelectableProperty);
+        }
+
+        public static void SetSelectable(DependencyObject element, bool selectable)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            element.SetValue(SelectableProperty, BooleanBoxes.Box(selectable));
+        }
+
         /// <summary>
         ///     Specifies whether a UI container for an item in a Selector should appear selected.
         /// </summary>
@@ -1865,7 +1892,19 @@ namespace System.Windows.Controls.Primitives
         {
             if (item != null)
             {
-                return !(item is Separator);
+                if (item is Separator)
+                {
+                    return false;
+                }
+                else
+                {
+                    if (item is DependencyObject dependencyObject)
+                    {
+                        return GetSelectable(dependencyObject);
+                    }
+
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -1857,7 +1857,7 @@ namespace System.Windows.Controls.Primitives
         }
 
         /// <summary>
-        /// Returns false if FrameworkElement representing this item has Selector.SelectableProperty set to false.  True otherwise.
+        /// Returns false if FrameworkElement representing this item is not selectable. True otherwise. If the FrameworkElement is Separator or null, we return False.
         /// </summary>
         /// <param name="item"></param>
         /// <returns></returns>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Selector.cs
@@ -201,33 +201,6 @@ namespace System.Windows.Controls.Primitives
             return (bool) element.GetValue(IsSelectionActiveProperty);
         }
 
-        public static readonly DependencyProperty SelectableProperty =
-            DependencyProperty.RegisterAttached(
-                "SelectableProperty",
-                typeof(bool),
-                typeof(Selector),
-                new PropertyMetadata(BooleanBoxes.TrueBox));
-
-        public static bool GetSelectable(DependencyObject element)
-        {
-            if (element == null)
-            {
-                throw new ArgumentNullException(nameof(element));
-            }
-
-            return (bool) element.GetValue(SelectableProperty);
-        }
-
-        public static void SetSelectable(DependencyObject element, bool selectable)
-        {
-            if (element == null)
-            {
-                throw new ArgumentNullException(nameof(element));
-            }
-
-            element.SetValue(SelectableProperty, BooleanBoxes.Box(selectable));
-        }
-
         /// <summary>
         ///     Specifies whether a UI container for an item in a Selector should appear selected.
         /// </summary>
@@ -1892,19 +1865,7 @@ namespace System.Windows.Controls.Primitives
         {
             if (item != null)
             {
-                if (item is Separator)
-                {
-                    return false;
-                }
-                else
-                {
-                    if (item is DependencyObject dependencyObject)
-                    {
-                        return GetSelectable(dependencyObject);
-                    }
-
-                    return true;
-                }
+                return !(item is Separator);
             }
 
             return false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -8436,6 +8436,7 @@ namespace System.Windows.Controls.Primitives
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public abstract partial class Selector : System.Windows.Controls.ItemsControl
     {
+        public static readonly System.Windows.DependencyProperty SelectableProperty;
         public static readonly System.Windows.DependencyProperty IsSelectedProperty;
         public static readonly System.Windows.DependencyProperty IsSelectionActiveProperty;
         public static readonly System.Windows.DependencyProperty IsSynchronizedWithCurrentItemProperty;
@@ -8475,6 +8476,7 @@ namespace System.Windows.Controls.Primitives
         public static void AddSelectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void AddUnselectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         protected override void ClearContainerForItemOverride(System.Windows.DependencyObject element, object item) { }
+        public static bool GetSelectable(System.Windows.DependencyObject element) { throw null; }
         [System.Windows.AttachedPropertyBrowsableForChildrenAttribute]
         public static bool GetIsSelected(System.Windows.DependencyObject element) { throw null; }
         public static bool GetIsSelectionActive(System.Windows.DependencyObject element) { throw null; }
@@ -8487,6 +8489,7 @@ namespace System.Windows.Controls.Primitives
         public static void RemoveSelectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void RemoveUnselectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void SetIsSelected(System.Windows.DependencyObject element, bool isSelected) { }
+        public static void SetSelectable(System.Windows.DependencyObject element, bool selectable) { }
     }
     [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.Primitives.StatusBarItem))]
     public partial class StatusBar : System.Windows.Controls.ItemsControl

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -8436,7 +8436,6 @@ namespace System.Windows.Controls.Primitives
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public abstract partial class Selector : System.Windows.Controls.ItemsControl
     {
-        public static readonly System.Windows.DependencyProperty SelectableProperty;
         public static readonly System.Windows.DependencyProperty IsSelectedProperty;
         public static readonly System.Windows.DependencyProperty IsSelectionActiveProperty;
         public static readonly System.Windows.DependencyProperty IsSynchronizedWithCurrentItemProperty;
@@ -8476,7 +8475,6 @@ namespace System.Windows.Controls.Primitives
         public static void AddSelectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void AddUnselectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         protected override void ClearContainerForItemOverride(System.Windows.DependencyObject element, object item) { }
-        public static bool GetSelectable(System.Windows.DependencyObject element) { throw null; }
         [System.Windows.AttachedPropertyBrowsableForChildrenAttribute]
         public static bool GetIsSelected(System.Windows.DependencyObject element) { throw null; }
         public static bool GetIsSelectionActive(System.Windows.DependencyObject element) { throw null; }
@@ -8489,7 +8487,6 @@ namespace System.Windows.Controls.Primitives
         public static void RemoveSelectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void RemoveUnselectedHandler(System.Windows.DependencyObject element, System.Windows.RoutedEventHandler handler) { }
         public static void SetIsSelected(System.Windows.DependencyObject element, bool isSelected) { }
-        public static void SetSelectable(System.Windows.DependencyObject element, bool selectable) { }
     }
     [System.Windows.StyleTypedPropertyAttribute(Property="ItemContainerStyle", StyleTargetType=typeof(System.Windows.Controls.Primitives.StatusBarItem))]
     public partial class StatusBar : System.Windows.Controls.ItemsControl


### PR DESCRIPTION
Fixes Issue #4501

## Description

Adding the SelectableProperty in Selector. And we can set the item not to be selected by SelectableProperty.

See:

- https://github.com/dotnet/wpf/issues/5143
- https://github.com/dotnet/wpf/issues/4501

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

No.

## Testing

Just CI and my [demo](https://github.com/lindexi/lindexi_gd/tree/ef2c5fe539e051953ad6bae969f4161a1f0b85ee/WPFDemo).

## Risk

Low.
