### PR TITLE
Using `Array.Copy` to make array copy faster in StylusPointCollection

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
@@ -195,9 +195,8 @@ namespace System.Windows.Input
                 if (dataLength > 0)
                 {
                     //copy the rest of the data
-                    data = new int[dataLength];
                     var rawArrayStartIndex = i + startIndex;
-                    Array.Copy(rawPacketData, rawArrayStartIndex, data, 0, dataLength);
+                    data = rawPacketData.AsSpan(rawArrayStartIndex, dataLength).ToArray();
                 }
 
                 StylusPoint newPoint = new StylusPoint(p.X, p.Y, StylusPoint.DefaultPressure, _stylusPointDescription, data, false, false);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
@@ -196,16 +196,14 @@ namespace System.Windows.Input
                 {
                     //copy the rest of the data
                     data = new int[dataLength];
-                    for (int localIndex = 0, rawArrayIndex = i + startIndex; localIndex < data.Length; localIndex++, rawArrayIndex++)
-                    {
-                        data[localIndex] = rawPacketData[rawArrayIndex];
-                    }
+                    var rawArrayStartIndex = i + startIndex;
+                    Array.Copy(rawPacketData, rawArrayStartIndex, data, 0, dataLength);
                 }
 
                 StylusPoint newPoint = new StylusPoint(p.X, p.Y, StylusPoint.DefaultPressure, _stylusPointDescription, data, false, false);
                 if (containsTruePressure)
                 {
-                    //use the algoritm to set pressure in StylusPoint
+                    //use the algorithm to set pressure in StylusPoint
                     int pressure = rawPacketData[i + 2];
                     newPoint.SetPropertyValue(StylusPointProperties.NormalPressure, pressure);
                 }


### PR DESCRIPTION
## Description

Benchmark:

|      Method | start | length |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|------------ |------ |------- |----------:|----------:|----------:|-------:|-------:|----------:|
|   CopyByFor |     0 |     10 | 10.940 ns | 0.0908 ns | 0.0850 ns | 0.0102 |      - |      64 B |
| CopyByArray |     0 |     10 |  9.861 ns | 0.0784 ns | 0.0655 ns | 0.0102 |      - |      64 B |
|   CopyByFor |     0 |     20 | 18.666 ns | 0.2216 ns | 0.2073 ns | 0.0166 |      - |     104 B |
| CopyByArray |     0 |     20 | 13.494 ns | 0.1908 ns | 0.1785 ns | 0.0166 |      - |     104 B |
|   CopyByFor |     0 |    100 | 88.846 ns | 0.5168 ns | 0.4834 ns | 0.0675 |      - |     424 B |
| CopyByArray |     0 |    100 | 32.594 ns | 0.4785 ns | 0.4476 ns | 0.0675 | 0.0001 |     424 B |
|   CopyByFor |    10 |     10 | 10.966 ns | 0.1215 ns | 0.1136 ns | 0.0102 |      - |      64 B |
| CopyByArray |    10 |     10 | 10.383 ns | 0.1375 ns | 0.1286 ns | 0.0102 |      - |      64 B |
|   CopyByFor |    10 |     20 | 18.866 ns | 0.1972 ns | 0.1844 ns | 0.0166 |      - |     104 B |
| CopyByArray |    10 |     20 | 13.001 ns | 0.1484 ns | 0.1239 ns | 0.0166 |      - |     104 B |
|   CopyByFor |    10 |    100 | 88.808 ns | 0.7298 ns | 0.6826 ns | 0.0675 |      - |     424 B |
| CopyByArray |    10 |    100 | 32.444 ns | 0.5749 ns | 0.5378 ns | 0.0675 | 0.0001 |     424 B |
|   CopyByFor |   100 |     10 | 11.253 ns | 0.1088 ns | 0.1018 ns | 0.0102 |      - |      64 B |
| CopyByArray |   100 |     10 |  9.738 ns | 0.1242 ns | 0.1162 ns | 0.0102 |      - |      64 B |
|   CopyByFor |   100 |     20 | 18.925 ns | 0.3305 ns | 0.2930 ns | 0.0166 |      - |     104 B |
| CopyByArray |   100 |     20 | 13.211 ns | 0.0924 ns | 0.0819 ns | 0.0166 |      - |     104 B |
|   CopyByFor |   100 |    100 | 87.571 ns | 0.5975 ns | 0.5589 ns | 0.0675 |      - |     424 B |
| CopyByArray |   100 |    100 | 35.169 ns | 0.5966 ns | 0.5581 ns | 0.0675 | 0.0001 |     424 B |

Benchmark code: https://github.com/lindexi/lindexi_gd/tree/07e92a85c104b760def5a87aac1c0e6c237311f5/CejelfairqereKecelherwelka

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI.

## Risk

Low.
