### PR TITLE
Using the `Clone` method to fast clone the array in StylusPoint

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPoint.cs
@@ -694,16 +694,7 @@ namespace System.Windows.Input
         /// <returns></returns>        
         private void CopyAdditionalData()
         {
-            if (null != _additionalValues)
-            {
-                int[] newData = new int[_additionalValues.Length];
-                for (int x = 0; x < _additionalValues.Length; x++)
-                {
-                    newData[x] = _additionalValues[x];
-                }
-
-                _additionalValues = newData;
-            }
+            _additionalValues = (int[])_additionalValues?.Clone();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Benchmark:

|      Method |     Mean |   Error |  StdDev |  Gen 0 |  Gen 1 | Allocated |
|------------ |---------:|--------:|--------:|-------:|-------:|----------:|
|   CopyByFor | 765.7 ns | 3.72 ns | 3.11 ns | 0.6409 | 0.0095 |      4 KB |
| CopyByArray | 260.6 ns | 3.39 ns | 3.17 ns | 0.6413 | 0.0095 |      4 KB |
| CopyByClone | 250.3 ns | 2.04 ns | 1.70 ns | 0.6390 | 0.0095 |      4 KB |

Benchmark code: https://github.com/lindexi/lindexi_gd/tree/5aef1567e56bf2b8a67c21f94b18f9827c18aaf4/CejelfairqereKecelherwelka

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI.

## Risk

Low.
