### PR TITLE
Remove ILAsm/ILDasm

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -57,14 +57,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>3cd4e393d9cb69bcb6f53db80998b6c45693e117</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="7.0.0-alpha.1.21427.1" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3cd4e393d9cb69bcb6f53db80998b6c45693e117</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="7.0.0-alpha.1.21427.1" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3cd4e393d9cb69bcb6f53db80998b6c45693e117</Sha>
-    </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="7.0.0-alpha.1.21427.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>3cd4e393d9cb69bcb6f53db80998b6c45693e117</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,8 +14,6 @@
   <!-- Packages that come from https://github.com/dotnet/coreclr -->
   <PropertyGroup>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19562.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
-    <MicrosoftNETCoreILDAsmVersion>7.0.0-alpha.1.21427.1</MicrosoftNETCoreILDAsmVersion>
-    <MicrosoftNETCoreILAsmVersion>7.0.0-alpha.1.21427.1</MicrosoftNETCoreILAsmVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/core-setup -->
   <PropertyGroup>


### PR DESCRIPTION
## Description
Just a small cleanup because ILAsm and ILDasm looks unused after the move to C# 9 module initializer.

## Customer Impact
None, only used at build time.

## Regression
No.

## Testing
Local build & CI.

## Risk
None, only used at build time.
