### PR TITLE
Remove master branch links from documentations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,9 +11,9 @@ assignees: ''
 * Windows version: (`winver`)
 * Does the bug reproduce also in WPF for .NET Framework 4.8?: Yes/No
 * Is this bug related specifically to tooling in Visual Studio (e.g. XAML Designer, Code editing, etc...)? If yes, please file the issue via the instructions [here](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio?view=vs-2019).
-* Security issues and bugs should be reported privately, learn more via our [responsible disclosure guidelines](https://github.com/dotnet/wpf/blob/master/README.md#reporting-security-issues-and-security-bugs).
+* Security issues and bugs should be reported privately, learn more via our [responsible disclosure guidelines](https://github.com/dotnet/wpf/blob/main/README.md#reporting-security-issues-and-security-bugs).
 
- <!-- Read https://github.com/dotnet/wpf/blob/master/Documentation/issue-guide.md -->
+ <!-- Read https://github.com/dotnet/wpf/blob/main/Documentation/issue-guide.md -->
  
  **Problem description:**
  

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,4 +9,4 @@ assignees: SamBent
 
 Is this feature request related specifically to tooling in Visual Studio (e.g. XAML Designer, Code editing, etc...)? If yes, please file the request via the instructions here: https://docs.microsoft.com/visualstudio/ide/suggest-a-feature?view=vs-2019
 
-<!-- Read https://github.com/dotnet/wpf/blob/master/Documentation/issue-guide.md -->
+<!-- Read https://github.com/dotnet/wpf/blob/main/Documentation/issue-guide.md -->

--- a/Documentation/api-compat.md
+++ b/Documentation/api-compat.md
@@ -5,7 +5,7 @@ For `WPF on .NET Core`, this means the following:
 * All `WPF on .NET Core` reference assemblies contain **at least** the API surface area contained by `WPF on .NET Framework 4.8` reference assemblies.
 * All hand-crafted reference assemblies for `WPF on .NET Core` contain **exactly** the needed API surface area defined by their corresponding runtime assemblies.  (If you're adding new API surface area, you will need to update the hand-crafted reference assemblies, following [these instructions](https://github.com/dotnet/wpf/blob/main/Documentation/gen-api.md).)
 
-This is accomplished by the use of the [Arcade API Compatibility tool](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.ApiCompat) with some modifications to fit our specific needs.
+This is accomplished by the use of the [Arcade API Compatibility tool](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.ApiCompat) with some modifications to fit our specific needs.
 
 ## [ApiCompat.props](/eng/WpfArcadeSdk/tools/ApiCompat.props)
 This props file implements necessary elements to trigger and control the usage of API Compatibility checks.

--- a/Documentation/c++-private-tools.md
+++ b/Documentation/c++-private-tools.md
@@ -8,7 +8,7 @@ A fix was available in mid Mar, 2019, but this change could not make it into Dev
 
 In collaboration with the C++ team, we decided to build our repo using private (but signed) copies of `c1xx.dll` and `msvcurt(d)_netcore.dll`. 
 
-We have uploaded these private DLL's to an Azure blob at this location using Arcade's [_Native Toolset Bootstrapping_](https://github.com/dotnet/arcade/blob/master/Documentation/NativeToolBootstrapping.md) process. 
+We have uploaded these private DLL's to an Azure blob at this location using Arcade's [_Native Toolset Bootstrapping_](https://github.com/dotnet/arcade/blob/main/Documentation/NativeToolBootstrapping.md) process. 
 
 This results in the the packages being uploaded to locations like these: 
 
@@ -36,7 +36,7 @@ In Azure Storage Explorer, the blobs can be found at this location:
          - msvcurt-c1xx-0.0.0.3-win32-x86.zip
 ```
 
-Writing to this storage account requires special permissions and is only available to Microsoft Employees - please work with DncEng if you need to do this. Also refer to [Native Toolset Bootstrapping documentation](https://github.com/dotnet/arcade/blob/master/Documentation/NativeToolBootstrapping.md).
+Writing to this storage account requires special permissions and is only available to Microsoft Employees - please work with DncEng if you need to do this. Also refer to [Native Toolset Bootstrapping documentation](https://github.com/dotnet/arcade/blob/main/Documentation/NativeToolBootstrapping.md).
 
 
 #### How does msvcurt-c1xx work? 

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -176,7 +176,7 @@ If you don't have the ability to build from source, you can update the *.runtime
 ```
 
 #### Finding a specific version of Microsoft.WindowsDesktop.App that interests you
-Follow the steps defined [here](https://github.com/dotnet/arcade/blob/master/Documentation/SeePackagesLatestVersion.md) to get setup for [swagger API](https://maestro-prod.westus2.cloudapp.azure.com/swagger/ui/index.html). Note that you need to authorize each time you login, so keep note of your token or you'll have to generate a new one. Assuming you have a commit (and therefore an Azure DevOps build id) that you are interested in, you can enter the build id into your query.
+Follow the steps defined [here](https://github.com/dotnet/arcade/blob/main/Documentation/SeePackagesLatestVersion.md) to get setup for [swagger API](https://maestro-prod.westus2.cloudapp.azure.com/swagger/ui/index.html). Note that you need to authorize each time you login, so keep note of your token or you'll have to generate a new one. Assuming you have a commit (and therefore an Azure DevOps build id) that you are interested in, you can enter the build id into your query.
 
 ### Testing PresentationBuildTasks
 -- add more content here --

--- a/Documentation/gen-api.md
+++ b/Documentation/gen-api.md
@@ -1,5 +1,5 @@
 # GenApi Usage in WPF on .NET Core
-In WPF on .NET Core, C# reference assemblies are created via the use of [GenAPI](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.GenAPI) and a separate reference assembly project located in the `ref` directory under a particular assemblies source directory.
+In WPF on .NET Core, C# reference assemblies are created via the use of [GenAPI](https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.GenAPI) and a separate reference assembly project located in the `ref` directory under a particular assemblies source directory.
 
 WPF assemblies make extensive use of the [InternalsVisibleToAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute?view=netcore-3.0) which precludes the use of [ProduceReferenceAssembly](https://docs.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties?view=vs-2019) or [ProduceOnlyReferenceAssembly](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/refonly-compiler-option).  This is because these compiler options will include internal types and members in the reference assembly.  In WPF, this creates dangling references to assemblies that do not exist in the `WindowsDesktop` reference pack.
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -7,7 +7,7 @@ This document describes the experience of using WPF on .NET Core. The [Developer
 Choose one of these options:
 
 1. [.NET Core 3.1 SDK (recommended)](https://www.microsoft.com/net/download)
-2. [.NET Core 3.1 daily build (latest changes, but less stable)](https://github.com/dotnet/core/blob/master/daily-builds.md)
+2. [.NET Core 3.1 daily build (latest changes, but less stable)](https://github.com/dotnet/core/blob/main/daily-builds.md)
 
 ## Creating new applications
 
@@ -23,7 +23,7 @@ dotnet run
 
 ## Samples
 
-Check out the [WPF for .NET Core 3 samples](https://github.com/dotnet/samples/tree/master/wpf) for HelloWorld example. The existing [WPF for .NET Framework samples](https://github.com/Microsoft/WPF-Samples) have also been updated to dual-target .NET Framework and .NET Core 3.
+Check out the [WPF for .NET Core 3 samples](https://github.com/dotnet/samples/tree/main/wpf) for HelloWorld example. The existing [WPF for .NET Framework samples](https://github.com/Microsoft/WPF-Samples) have also been updated to dual-target .NET Framework and .NET Core 3.
 
 
 ## Documentation

--- a/Documentation/testing-in-helix.md
+++ b/Documentation/testing-in-helix.md
@@ -1,6 +1,6 @@
 # Testing in Helix
 
-I'd recommend seeing the official Helix [readme](https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Helix/Sdk/Readme.md) if you are interested in some of the general Helix concepts. I'll briefly outline what we are doing that is a bit unique:
+I'd recommend seeing the official Helix [readme](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Helix/Sdk/Readme.md) if you are interested in some of the general Helix concepts. I'll briefly outline what we are doing that is a bit unique:
 
 1. Helix has built-in support for running xUnit tests. Since we are not using xUnit, we have to manually setup our machines so that they work with QualityVault and STI. During the build, we create a payload directory that contains the infrastructure we need. A single project (in our case `DrtXaml`) is responsible for creating this directory (see instances of the MSBuild property `CreateTestPayload`).
 2. After the build is done, we utilize Arcade's `AfterSolutionBuild.targets` extension point to finish creating the rest of the payload if the `-test` parameter is passed to the build. Here we add the just built DRTs and if `-ci` was **not** passed into to the build, run the tests. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Windows Presentation Foundation (WPF)
 [![.NET Foundation](https://img.shields.io/badge/.NET%20Foundation-blueviolet.svg)](https://www.dotnetfoundation.org/)
 [![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/wpf/dotnet-wpf%20CI)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=270)
-[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/dotnet/wpf/blob/master/LICENSE.TXT)
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/dotnet/wpf/blob/main/LICENSE.TXT)
 
 Windows Presentation Foundation (WPF) is a UI framework for building Windows desktop applications. WPF supports a broad set of application development features, including an application model, resources, controls, graphics, layout, data binding and documents. WPF uses the Extensible Application Markup Language (XAML) to provide a declarative model for application programming.
 
@@ -39,7 +39,7 @@ The Visual Studio WPF designer is now available as part of Visual Studio 2019.
 
 Some of the best ways to contribute are to try things out, file bugs, join in design conversations, and fix issues.
 
-* This repo defines [contributing guidelines](Documentation/contributing.md) and also follows the more general [.NET Core contributing guide](https://github.com/dotnet/runtime/blob/master/CONTRIBUTING.md).
+* This repo defines [contributing guidelines](Documentation/contributing.md) and also follows the more general [.NET Core contributing guide](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md).
 * If you have a question or have found a bug, [file an issue](https://github.com/dotnet/wpf/issues/new).
 * Use [daily builds](Documentation/getting-started.md#installation) if you want to contribute and stay up to date with the team.
 


### PR DESCRIPTION
## Description
Small documentation cleanup to remove links to master branch in Github repos. Most repos renamed master -> main and Github does the redirection automatically but we should use the right branch name.

Also removes the message "Branch master was renamed to main." when navigating to a link.

## Customer Impact
None, developer doc only.

## Regression
No.

## Testing
Manually tested every modified link.

## Risk
None, developer doc only.