### PR TITLE
Enable Single File Analyzer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,10 @@
     <WpfArcadeSdkTargets>$(WpfArcadeSdkPath)Sdk\Sdk.targets</WpfArcadeSdkTargets>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsTestProject)'!='true'">
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
+
   <Import Project="$(WpfArcadeSdkProps)"
           Condition="Exists('$(WpfArcadeSdkProps)') And Exists('$(WpfArcadeSdkTargets)')"/>
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -52,13 +52,10 @@ namespace MS.Internal.Tasks
         // </summary>
         internal static void DisplayLogo(TaskLoggingHelper log, string taskName)
         {
-            string acPath = Assembly.GetExecutingAssembly().Location;
-            FileVersionInfo acFileVersionInfo = FileVersionInfo.GetVersionInfo(acPath);
-
-            string avalonFileVersion = acFileVersionInfo.FileVersion;
+            Version avalonFileVersion = Assembly.GetExecutingAssembly().GetName().Version;
 
             log.LogMessage(MessageImportance.Low,Environment.NewLine);
-            log.LogMessageFromResources(MessageImportance.Low, SRID.TaskLogo, taskName, avalonFileVersion);
+            log.LogMessageFromResources(MessageImportance.Low, SRID.TaskLogo, taskName, avalonFileVersion.ToString());
             log.LogMessageFromResources(MessageImportance.Low, SRID.TaskRight);
             log.LogMessage(MessageImportance.Low, Environment.NewLine);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -28,6 +28,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(CopyTransitiveReferences)'=='true'">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AssemblyFilter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AssemblyFilter.cs
@@ -43,13 +43,12 @@ namespace MS.Internal
         //appends assembly name with file version to generate a unique entry for the assembly lookup process
         private string AssemblyNameWithFileVersion(Assembly a)
         {
-            FileVersionInfo fileVersionInfo;
             StringBuilder sb = new StringBuilder(a.FullName);
 
-            fileVersionInfo = FileVersionInfo.GetVersionInfo(a.Location);
-            if (fileVersionInfo != null && fileVersionInfo.ProductVersion != null)
+            Version assemblyVersion = a.GetName().Version;
+            if (assemblyVersion != null)
             {
-                sb.Append(FILEVERSION_STRING + fileVersionInfo.ProductVersion);
+                sb.Append(FILEVERSION_STRING + assemblyVersion.ToString());
             }
             return ((sb.ToString()).ToLower(System.Globalization.CultureInfo.InvariantCulture)).Trim();
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT.cs
@@ -15,6 +15,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable 0169 // The field 'xxx' is never used
 #pragma warning disable 0649 // Field 'xxx' is never assigned to, and will always have its default value
@@ -111,6 +112,8 @@ namespace WinRT
         readonly DllGetActivationFactory _GetActivationFactory;
         readonly DllCanUnloadNow _CanUnloadNow; // TODO: Eventually periodically call
 
+        // Fix for this single file dangerous pattern needs to come from CsWinRT repo https://github.com/microsoft/CsWinRT/issues/992
+        [UnconditionalSuppressMessage ("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file")]
         static readonly string _currentModuleDirectory = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
         static Dictionary<string, DllModule> _cache = new System.Collections.Generic.Dictionary<string, DllModule>();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Serialization/SerializerDescriptor.cs
@@ -61,6 +61,8 @@ namespace System.Windows.Documents.Serialization
         ///
         ///     This method currently requires full trust to run.
         /// </remarks>
+        // Suppressing the single file warning til the problem is fixed, tracking in https://github.com/dotnet/wpf/issues/5226
+        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file")]
         public static SerializerDescriptor CreateFromFactoryInstance(
             ISerializerFactory  factoryInstance
             )

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
@@ -572,9 +572,7 @@ namespace System.Windows.Documents
             if (customTextElement)
             {
                 // If the element is not from PresentationFramework, we'll need to serialize a namespace
-                // Will module name always have a '.'?  If so, can remove conditional in assembly assignment below
-                int index = elementTypeStandardized.Module.Name.LastIndexOf('.');
-                string assembly = (index == -1 ? elementTypeStandardized.Module.Name : elementTypeStandardized.Module.Name.Substring(0, index));
+                string assembly = elementTypeStandardized.Assembly.GetName().Name;
                 string nameSpace = "clr-namespace:" + elementTypeStandardized.Namespace + ";" + "assembly=" + assembly;
                 string prefix = elementTypeStandardized.Namespace;
                 xmlWriter.WriteStartElement(prefix, elementTypeStandardized.Name, nameSpace);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -11057,6 +11057,7 @@ namespace System.Windows.Documents.Serialization
         public string ManufacturerName { get { throw null; } }
         public System.Uri ManufacturerWebsite { get { throw null; } }
         public System.Version WinFXVersion { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file")]
         public static System.Windows.Documents.Serialization.SerializerDescriptor CreateFromFactoryInstance(System.Windows.Documents.Serialization.ISerializerFactory factoryInstance) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }


### PR DESCRIPTION
Address some of the issues described in https://github.com/dotnet/wpf/issues/5226

## Description
- Enable the single file analyzer in the WPF repo to prevent a regression on the current number of single file incompatibilities
- Fix some of the issues 
- Suppress some of the patterns that don't have a fix yet

## Customer Impact
Apps might have an undesired behavior when deploying as single-file

## Testing
Build the repo to verify the analyzer doesn't flag more patterns

## Risk
Suppressed patterns can still produce undesired behavior for the user when deploying as single-file
