### PR TITLE
Consume the updated WPF Intellisense files for 6.0 RC2

### DIFF
--- a/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
+++ b/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
@@ -46,13 +46,13 @@
           Outputs="$(IntellisenseXmlDir)$(AssemblyName).xml">
     <PropertyGroup>
       <!-- Also in global.json -->
-      <DotNetApiDocsNet50>0.0.0.3</DotNetApiDocsNet50>
+      <DotNetApiDocsNet60>0.0.0.4</DotNetApiDocsNet60>
 
       <!-- 
         This blob lives in Azure storage at https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/dotnet-api-docs_net6.0/
         Instructions for updating these artifacts are at https://github.com/dotnet/wpf/blob/master/docs/intellisense.md
       -->
-      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net5.0\$(DotNetApiDocsNet50)\_intellisense\net-5.0\</IntellisenseXmlDir>
+      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net6.0\$(DotNetApiDocsNet60)\_intellisense\net-6.0\</IntellisenseXmlDir>
     </PropertyGroup>
     
     <Error Condition="!Exists('$(IntellisenseXmlDir)')"

--- a/global.json
+++ b/global.json
@@ -21,6 +21,6 @@
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
-    "dotnet-api-docs_net5.0": "0.0.0.3"
+    "dotnet-api-docs_net6.0": "0.0.0.4"
   }
 }


### PR DESCRIPTION
Consume the WPF Intellisense files with .NET 6.0 API updates:

`dotnet-api-docs_net6.0-0.0.0.4-win32-x86` 
`dotnet-api-docs_net6.0-0.0.0.4-win64-x64`

/cc @MattGal @carlossanlop 