### PR TITLE
Switch to 1ES servicing pools on release/6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019.pre
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
         # runAsPublic is used in expressions, which can't read from user-defined variables
         runAsPublic: false
 

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -34,11 +34,11 @@ jobs:
         # Will eventually change this to two BYOC pools.
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019.pre
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.windows.10.amd64.vs2019.pre
       variables:
         # needed for signing
         - name: _TeamName

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals Build.windows.10.amd64.vs2019.pre
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
       variables:
         # needed for signing
         - name: _TeamName


### PR DESCRIPTION
Tracking  Issue: https://github.com/dotnet/core-eng/issues/14276

~Main PR~ N/A

## Description

We need to move over to 1ES servicing pools for servicing branches. This accomplishes this in release/6.0.

## Customer Impact

N/A

## Regression

None.

## Testing

N/A

## Risk

If tests fail in this PR, it's due to interactive mode not being turned on. That's being tracked here: https://github.com/dotnet/core-eng/issues/14358.
