### PR TITLE
Revert ILDasm/ILAsm tools version to 4.6.2 to fix module initializer in PresentationCore

### DIFF
--- a/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
+++ b/eng/WpfArcadeSdk/tools/InjectModuleInitializer.targets
@@ -62,8 +62,8 @@
           try
           {
             var bitness = (DotNetFrameworkArchitecture)Enum.Parse(typeof(DotNetFrameworkArchitecture), DotNetBitness);
-            ILAsm = ToolLocationHelper.GetPathToDotNetFrameworkFile("ILAsm.exe", TargetDotNetFrameworkVersion.Latest, bitness);
-            ILDAsm = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("ILDAsm.exe", TargetDotNetFrameworkVersion.Latest, bitness);
+            ILAsm = ToolLocationHelper.GetPathToDotNetFrameworkFile("ILAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
+            ILDAsm = ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("ILDAsm.exe", TargetDotNetFrameworkVersion.VersionLatest, bitness);
           }
           catch(Exception e)
           {


### PR DESCRIPTION
Revert ildasm/ilasm tools to 4.6.2.  

Apply @ThomasGoulet73's fix for module initializer injection regression in release/3.1.  This fixed PresentionCore when building locally.  

Fixes https://github.com/dotnet/wpf/issues/5375.  