### PR TITLE
Using span to replace Substring in parserscommon.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ParsersCommon.cs
@@ -435,6 +435,7 @@ namespace MS.Internal.Markup
             }
             else
             {
+#if NETFRAMEWORK
                 string subString = _pathString.Substring(start, _curIndex - start);
 
                 try
@@ -445,6 +446,17 @@ namespace MS.Internal.Markup
                 {
                     throw new System.FormatException(SR.Get(SRID.Parser_UnexpectedToken, _pathString, start), except);
                 }
+#else
+                var span = _pathString.AsSpan(start, _curIndex - start);
+                try
+                {
+                    return double.Parse(span, provider: _formatProvider);
+                }
+                catch (FormatException except)
+                {
+                    throw new System.FormatException(SR.Get(SRID.Parser_UnexpectedToken, _pathString, start), except);
+                }
+#endif
             }
         }
         


### PR DESCRIPTION

## Description

Using span to replace Substring in parserscommon.cs. It will be called multiple times to parse the geometry string.

## Customer Impact

None.

## Regression

dotnet 7.0

## Testing

Just CI.

## Risk

Low. I did not change the results of the code.
