### PR TITLE
Using ArrayPool in RenderData

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderData.cs
@@ -53,11 +53,6 @@ namespace System.Windows.Media
             CanBeInheritanceContext = false;
         }
 
-        ~RenderData()
-        {
-            ArrayPool<byte>.Shared.Return(_buffer);
-        }
-
         /// <summary>
         /// RecordHeader - This struct is the header for each record entry
         /// </summary>


### PR DESCRIPTION
## Description

Using ArrayPool in RenderData. The max length is 72, see MILCMD_DRAW_ROUNDED_RECTANGLE_ANIMATE

https://github.com/dotnet/wpf/blob/89d172db0b7a192de720c6cfba5e28a1e7d46123/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/RenderData.cs#L149-L184

## Customer Impact

None. But it will affect the rendering of all DrawingVisual and UIElement 

## Regression

dotnet 7

## Testing

Just CI and my [demo](https://github.com/lindexi/lindexi_gd/commit/d40a0dd82fb7d6bf8fa24b4b4206b968ec44a07d)

## Risk

Low
