### PR TITLE
Improve LookupContentTypeForImageUri performance in XpsFixedPageReaderWriter.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
@@ -1867,23 +1867,22 @@ namespace System.Windows.Xps.Packaging
             )
         {
             //Extract file extension without '.'
-            String path = imageUri.OriginalString;
-            ReadOnlySpan<char> extension = Path.GetExtension(path).ToLower(CultureInfo.InvariantCulture).AsSpan(1);
-
+            ReadOnlySpan<char> path = imageUri.OriginalString.AsSpan();
+            ReadOnlySpan<char> extension = Path.GetExtension(path).Slice(1);
             ContentType contentType;
-            if (extension.Equals(XpsS0Markup.JpgExtension, StringComparison.Ordinal))
+            if (extension.Equals(XpsS0Markup.JpgExtension, StringComparison.OrdinalIgnoreCase))
             {
-                contentType =  XpsS0Markup.JpgContentType;
+                contentType = XpsS0Markup.JpgContentType;
             }
-            else if (extension.Equals(XpsS0Markup.PngExtension, StringComparison.Ordinal))
+            else if (extension.Equals(XpsS0Markup.PngExtension, StringComparison.OrdinalIgnoreCase))
             {
                 contentType = XpsS0Markup.PngContentType;
             }
-            else if (extension.Equals(XpsS0Markup.TifExtension, StringComparison.Ordinal))
+            else if (extension.Equals(XpsS0Markup.TifExtension, StringComparison.OrdinalIgnoreCase))
             {
                 contentType = XpsS0Markup.TifContentType;
             }
-            else if (extension.Equals(XpsS0Markup.WdpExtension, StringComparison.Ordinal))
+            else if (extension.Equals(XpsS0Markup.WdpExtension, StringComparison.OrdinalIgnoreCase))
             {
                 contentType = XpsS0Markup.WdpContentType;
             }
@@ -1892,9 +1891,8 @@ namespace System.Windows.Xps.Packaging
                 //default to PNG
                 contentType = XpsS0Markup.PngContentType;
             }
-
             return contentType;
-         }
+        }
 
 
         /// <summary>


### PR DESCRIPTION

## Description


I wrote the test demo code and I found an improvement in performance.

|                                 Method |      Mean |    Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |----------:|---------:|----------:|-------:|------:|------:|----------:|
|           LookupContentTypeForImageUri | 114.17 ns | 3.096 ns |  9.130 ns | 0.0153 |     - |     - |      64 B |
| LookupContentTypeForImageUriIgnoreCase |  40.84 ns | 0.975 ns |  2.874 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri | 115.00 ns | 3.858 ns | 11.375 ns | 0.0153 |     - |     - |      64 B |
| LookupContentTypeForImageUriIgnoreCase |  55.19 ns | 1.913 ns |  5.642 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  84.97 ns | 1.773 ns |  3.198 ns | 0.0153 |     - |     - |      64 B |
| LookupContentTypeForImageUriIgnoreCase |  40.82 ns | 0.869 ns |  1.099 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  91.29 ns | 1.693 ns |  1.322 ns | 0.0153 |     - |     - |      64 B |
| LookupContentTypeForImageUriIgnoreCase |  47.45 ns | 0.961 ns |  0.852 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri | 103.35 ns | 1.876 ns |  2.234 ns | 0.0153 |     - |     - |      64 B |
| LookupContentTypeForImageUriIgnoreCase |  58.83 ns | 1.231 ns |  1.643 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  52.88 ns | 0.973 ns |  0.911 ns | 0.0076 |     - |     - |      32 B |
| LookupContentTypeForImageUriIgnoreCase |  31.78 ns | 0.701 ns |  1.264 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  65.51 ns | 1.325 ns |  1.361 ns | 0.0076 |     - |     - |      32 B |
| LookupContentTypeForImageUriIgnoreCase |  44.33 ns | 0.949 ns |  0.841 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  66.49 ns | 1.383 ns |  2.386 ns | 0.0076 |     - |     - |      32 B |
| LookupContentTypeForImageUriIgnoreCase |  40.33 ns | 0.688 ns |  0.643 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  76.48 ns | 1.560 ns |  1.669 ns | 0.0076 |     - |     - |      32 B |
| LookupContentTypeForImageUriIgnoreCase |  47.74 ns | 1.015 ns |  1.640 ns |      - |     - |     - |         - |
|           LookupContentTypeForImageUri |  83.05 ns | 1.536 ns |  1.769 ns | 0.0076 |     - |     - |      32 B |
| LookupContentTypeForImageUriIgnoreCase |  58.10 ns | 1.177 ns |  1.156 ns |      - |     - |     - |         - |

Benchmark: https://github.com/lindexi/lindexi_gd/tree/983c668ea7cd308a510c043b5d2e5de74da8efe7/ColalejayJearbearlerlekere

See https://github.com/dotnet/wpf/pull/4766

## Customer Impact

None

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI and my demo code.

## Risk

Low. I did not change the behavior of the code.
