### PR TITLE
 Add WPF .vsconfig to release/3.1 (contains 4.6.2 required for module initializer injection)

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -10,12 +10,8 @@ Follow the [Building CoreFX on Windows](https://github.com/dotnet/corefx/blob/ma
 
 WPF requires the following workloads and  components be selected when installing Visual Studio:
 
-* Required Workloads:
-  * .NET Desktop Development
-  * Desktop development with C++
-* Required Individual Components:
-  * C++/CLI support
-  * Windows 10 SDK
+* Required Workloads: [wpf.vsconfig](wpf.vsconfig)
+    *  Also see [Import or export installation configurations](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2019)
 
 ## Workflow
 

--- a/Documentation/wpf.vsconfig
+++ b/Documentation/wpf.vsconfig
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Component.CodeAnalysis.SDK",
+    "Microsoft.Component.MSBuild",
+    "Microsoft.Component.VC.Runtime.UCRTSDK",
+    "Microsoft.Net.Component.4.6.2.SDK",
+    "Microsoft.Net.Component.4.7.2.TargetingPack",
+    "Microsoft.NetCore.Component.DevelopmentTools",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.Git",
+    "Microsoft.VisualStudio.Component.NuGet",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+    "Microsoft.VisualStudio.Component.TextTemplating",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATLMFC",
+    "Microsoft.VisualStudio.Component.VC.CLI.Support",
+    "Microsoft.VisualStudio.Component.VC.CoreIde",
+    "Microsoft.VisualStudio.Component.VC.Modules.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.VSSDK",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362"
+  ]
+}

--- a/Documentation/wpf.vsconfig
+++ b/Documentation/wpf.vsconfig
@@ -21,6 +21,8 @@
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
     "Microsoft.VisualStudio.Component.VSSDK",
+     "Microsoft.VisualStudio.Component.Windows10SDK.17134",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362"
+
   ]
 }


### PR DESCRIPTION
This was missing from release/3.1.  .NET Framework 4.6.2 is required to build locally.