### PR TITLE
Remove the redundant type cast in TextFormatterImp.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -257,7 +257,7 @@ namespace MS.Internal.TextFormatting
                     firstCharIndex,
                     RealToIdealFloor(paragraphWidth),
                     textSource.PixelsPerDip
-                    ) as TextLine;
+                    );
             }
 
             if (textLine == null)


### PR DESCRIPTION

## Description

The return type of SimpleTextLine.Create is TextLine

See https://github.com/dotnet/wpf/blob/777598c7a00386c6cf7cb21da3d05b624fdddb52/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/SimpleTextLine.cs#L89-L94

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI

## Risk

Low.
