### PR TITLE
Switch to 1ES servicing pools on release/6.0-rc2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019.pre
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
         # runAsPublic is used in expressions, which can't read from user-defined variables
         runAsPublic: false
 

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -34,11 +34,11 @@ jobs:
         # Will eventually change this to two BYOC pools.
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.Windows.10.Amd64.VS2019.Pre.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2019.pre
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre
       variables:
         # needed for signing
         - name: _TeamName


### PR DESCRIPTION
Same as https://github.com/dotnet/wpf/pull/5372 but for `release/6.0-rc2`.