### PR TITLE
Updating Compression Native dll Name (dotnet#505)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -32,6 +32,6 @@ internal static partial class Interop
         internal const string WinMM = "winmm.dll";
         internal const string Ws2_32 = "ws2_32.dll";
         internal const string Wtsapi32 = "wtsapi32.dll";
-        internal const string CompressionNative = "clrcompression.dll";
+        internal const string CompressionNative = "System.IO.Compression.Native.dll";
     }
 }


### PR DESCRIPTION
Fixes Issue #505

## Description
WPF makes calls into this private DLL:
https://github.com/dotnet/wpf/blob/89d172db0b7a192de720c6cfba5e28a1e7d46123/src/Microsoft.DotNet.Wpf/src/Common/src/Interop/Windows/Interop.Libraries.cs#L35
https://github.com/dotnet/wpf/blob/89d172db0b7a192de720c6cfba5e28a1e7d46123/src/Microsoft.DotNet.Wpf/src/Common/src/Interop/Windows/zlib/zlib.cs#L43
https://github.com/dotnet/wpf/blob/89d172db0b7a192de720c6cfba5e28a1e7d46123/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Compoundfile/CompoundFileDeflateTransform.cs

clrcompression.dll has been renamed to System.IO.Compression.Native. After renaming clrcompression.dll, **createStream** [API](https://docs.microsoft.com/en-us/dotnet/api/system.io.packaging.storageinfo.createstream?view=net-5.0) is not working due to its dependency on clrcompression, So, It needs to be fixed to use the new name for 6.0.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
