### PR TITLE
[release/6.0] Overbuild caused by PackageReference support (Remove WPF Arcade workaround)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,12 @@
   <PropertyGroup>
     <RepositoryName>wpf</RepositoryName>
     <WindowsDesktopARM64Support>true</WindowsDesktopARM64Support>
+     <!-- WPF's new PackageReference support conflicts with the existing Arcade's WPF temp project 
+          workaround.  Disable IsWpfTempProject to prevent Arcade's WPF temp workaround from colliding 
+          with PackageReference support during WPF Framework compilation.  See 
+          https://github.com/dotnet/arcade/pull/1581.  This property can be removed when 1518 (the 
+          workaround in the Arcade SDK) is removed.  -->
+    <IsWpfTempProject>false</IsWpfTempProject>
   </PropertyGroup>
 
   <!-- Normalize $(TestWpfArcadeSdkPath) by appending a '\' to it if one is missing -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,6 @@
   <PropertyGroup>
     <RepositoryName>wpf</RepositoryName>
     <WindowsDesktopARM64Support>true</WindowsDesktopARM64Support>
-     <!-- WPF's new PackageReference support conflicts with the existing Arcade's WPF temp project 
-          workaround.  Disable IsWpfTempProject to prevent Arcade's WPF temp workaround from colliding 
-          with PackageReference support during WPF Framework compilation.  See 
-          https://github.com/dotnet/arcade/pull/1581.  This property can be removed when 1518 (the 
-          workaround in the Arcade SDK) is removed.  -->
-    <IsWpfTempProject>false</IsWpfTempProject>
   </PropertyGroup>
 
   <!-- Normalize $(TestWpfArcadeSdkPath) by appending a '\' to it if one is missing -->

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -281,15 +281,11 @@ namespace Microsoft.Build.Tasks.Windows
                 // Save the xmlDocument content into the temporary project file.
                 xmlProjectDoc.Save(TemporaryTargetAssemblyProjectName);
 
-                // Disable conflicting Arcade SDK workaround that imports NuGet props/targets
-                Hashtable globalProperties = new Hashtable(1);
-                globalProperties["_WpfTempProjectNuGetFilePathNoExt"] = "";
-
                 //
                 //  Compile the temporary target assembly project
                 //
                 Dictionary<string, ITaskItem[]> targetOutputs = new Dictionary<string, ITaskItem[]>();
-                retValue = BuildEngine.BuildProjectFile(TemporaryTargetAssemblyProjectName, new string[] { CompileTargetName }, globalProperties, targetOutputs);
+                retValue = BuildEngine.BuildProjectFile(TemporaryTargetAssemblyProjectName, new string[] { CompileTargetName }, null, targetOutputs);
 
                 // If the inner build succeeds, retrieve the path to the local type assembly from the task's TargetOutputs.
                 if (retValue)


### PR DESCRIPTION


## Description

[release/6.0] Overbuild caused by PackageReference support (Remove WPF Arcade workaround)

WPF PackageReference support conflicted with an existing Arcade workaround.  The WPF workaround (for the Arcade workaround) changed a global property that caused project references to be rebuilt in WPF's temporary project.  

This removes the global property.
 
The issue is described here: 
https://github.com/dotnet/wpf/issues/5448
https://github.com/dotnet/wpf/issues/4119

## Customer Impact

Project references will be built a second time by the internal WPF project.  

## Regression

This is a regression from 5.0.

## Risk

Low.  

## Testing

Tested the updated WindowsDesktop SDK containing the change against AppCompat applications and WPF samples.  


