### PR TITLE
Fix #5471 Corrected case of variable name 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RectangleGeometry.cs
@@ -439,9 +439,9 @@ namespace System.Windows.Media
             else
             {   
                 ctx.BeginFigure(rect.TopLeft, true /* is filled */, true /* is closed */);
-                ctx.LineTo(Rect.TopRight, true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(Rect.BottomRight, true /* is stroked */, false /* is smooth join */);
-                ctx.LineTo(Rect.BottomLeft, true /* is stroked */, false /* is smooth join */);
+                ctx.LineTo(rect.TopRight, true /* is stroked */, false /* is smooth join */);
+                ctx.LineTo(rect.BottomRight, true /* is stroked */, false /* is smooth join */);
+                ctx.LineTo(rect.BottomLeft, true /* is stroked */, false /* is smooth join */);
             }
 
             ctx.Close();


### PR DESCRIPTION
Corrected case of variable name from upper case to lower case in the internal GetPathGeometryData method of the System.Windows.Media.RectangleGeometry class.

The value of "Rect" dependency property had been assigned to local variable "rect", but had been misspelled in three places making unnecessary lookup.


Fixes Issue #5471

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

This is fixing a misspelled variable name that was "hidden" due to that only the case of first letter of the variable maned differed from the property.

## Customer Impact

It should have a minimal positive impact to performance.
Because three unnecessary dependency property get/lookups are eliminated without any additional footprint to memory. 

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

Low risk.

Fixing the variable name has no change to behavior of method.

