### PR TITLE
Improve performance of DynamicResource usages

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1735,15 +1735,6 @@ namespace System.Windows
                     DeferredResourceReference deferredResourceReference;
                     if (!IsThemeDictionary)
                     {
-                        if (_ownerApps != null)
-                        {
-                            deferredResourceReference = new DeferredAppResourceReference(this, resourceKey);
-                        }
-                        else
-                        {
-                            deferredResourceReference = new DeferredResourceReference(this, resourceKey);
-                        }
-
                         // Cache the deferredResourceReference so that it can be validated
                         // in case of a dictionary change prior to its inflation
                         if (_deferredResourceReferences == null)
@@ -1751,7 +1742,24 @@ namespace System.Windows
                             _deferredResourceReferences = new DeferredResourceReferenceList();
                         }
 
-                        _deferredResourceReferences.AddOrSet(deferredResourceReference);
+                        if (_deferredResourceReferences.Get(resourceKey) is DeferredResourceReference existingDeferredResourceReference
+                            && existingDeferredResourceReference.Dictionary == this)
+                        {
+                            deferredResourceReference = existingDeferredResourceReference;
+                        }
+                        else
+                        {
+                            if (_ownerApps != null)
+                            {
+                                deferredResourceReference = new DeferredAppResourceReference(this, resourceKey);
+                            }
+                            else
+                            {
+                                deferredResourceReference = new DeferredResourceReference(this, resourceKey);
+                            }
+
+                            _deferredResourceReferences.AddOrSet(deferredResourceReference);
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1742,7 +1742,7 @@ namespace System.Windows
                             _deferredResourceReferences = new DeferredResourceReferenceList();
                         }
 
-                        if (_deferredResourceReferences.Get(resourceKey) is DeferredResourceReference existingDeferredResourceReference
+                        if (_deferredResourceReferences.Get(resourceKey) is { } existingDeferredResourceReference
                             && existingDeferredResourceReference.Dictionary == this)
                         {
                             deferredResourceReference = existingDeferredResourceReference;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceDictionary.cs
@@ -1748,10 +1748,10 @@ namespace System.Windows
                         // in case of a dictionary change prior to its inflation
                         if (_deferredResourceReferences == null)
                         {
-                            _deferredResourceReferences = new WeakReferenceList();
+                            _deferredResourceReferences = new DeferredResourceReferenceList();
                         }
 
-                        _deferredResourceReferences.Add( deferredResourceReference, true /*SkipFind*/);
+                        _deferredResourceReferences.AddOrSet(deferredResourceReference);
                     }
                     else
                     {
@@ -1775,21 +1775,17 @@ namespace System.Windows
         {
             if (_deferredResourceReferences != null)
             {
-                foreach (Object o in _deferredResourceReferences)
-                {
+                DeferredResourceReference deferredResourceReference = _deferredResourceReferences.Get(resourceKey);
 
-                    DeferredResourceReference deferredResourceReference = o as DeferredResourceReference;
-                    if (deferredResourceReference != null && (resourceKey == null || Object.Equals(resourceKey, deferredResourceReference.Key)))
-                    {
-                        // This will inflate the deferred reference, causing it
-                        // to be removed from the list.  The list may also be
-                        // purged of dead references.
-                        deferredResourceReference.GetValue(BaseValueSourceInternal.Unknown);
-                    }
+                if (deferredResourceReference is not null)
+                {
+                    // This will inflate the deferred reference, causing it
+                    // to be removed from the list.  The list may also be
+                    // purged of dead references.
+                    deferredResourceReference.GetValue(BaseValueSourceInternal.Unknown);
                 }
             }
         }
-
 
         /// <summary>
         /// Called when the MergedDictionaries collection changes
@@ -2053,7 +2049,7 @@ namespace System.Windows
 
         #region Properties
 
-        internal WeakReferenceList DeferredResourceReferences
+        internal DeferredResourceReferenceList DeferredResourceReferences
         {
             get { return _deferredResourceReferences; }
         }
@@ -2478,10 +2474,7 @@ namespace System.Windows
             // redirect each entry toward its new owner
             if (_deferredResourceReferences != null)
             {
-                foreach (DeferredResourceReference drr in _deferredResourceReferences)
-                {
-                    drr.Dictionary = this;
-                }
+                _deferredResourceReferences.ChangeDictionary(this);
             }
         }
 
@@ -2548,7 +2541,7 @@ namespace System.Windows
         private WeakReferenceList                         _ownerFEs = null;
         private WeakReferenceList                         _ownerFCEs = null;
         private WeakReferenceList                         _ownerApps = null;
-        private WeakReferenceList                         _deferredResourceReferences = null;
+        private DeferredResourceReferenceList             _deferredResourceReferences = null;
         private ObservableCollection<ResourceDictionary>  _mergedDictionaries = null;
         private Uri                                       _source = null;
         private Uri                                       _baseUri = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -2037,7 +2037,7 @@ namespace System.Windows
     internal class DeferredResourceReferenceList : IEnumerable
     {
         private readonly object _syncRoot = new();
-        private readonly Dictionary<object,  WeakReference<DeferredResourceReference>> _entries = new();
+        private readonly Dictionary<object, WeakReference<DeferredResourceReference>> _entries = new();
         private int _potentiallyDeadEntryCount = 0;
 
         public void AddOrSet(DeferredResourceReference deferredResourceReference)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -2058,24 +2058,23 @@ namespace System.Windows
 
         internal DeferredResourceReference Get(object resourceKey)
         {
-            WeakReference<DeferredResourceReference> weakReference;
             lock (_syncRoot)
             {
-                _entries.TryGetValue(resourceKey, out weakReference);
-            }
+                _entries.TryGetValue(resourceKey, out var weakReference);
 
-            if (weakReference is null)
-            {
-                return null;
-            }
+                if (weakReference is null)
+                {
+                    return null;
+                }
 
-            if (weakReference.TryGetTarget(out DeferredResourceReference deferredResourceReference))
-            {
-                return deferredResourceReference;
-            }
-            else
-            {
-                ++_potentiallyDeadEntryCount;
+                if (weakReference.TryGetTarget(out var deferredResourceReference))
+                {
+                    return deferredResourceReference;
+                }
+                else
+                {
+                    ++_potentiallyDeadEntryCount;
+                }
             }
 
             PurgeIfRequired();
@@ -2089,7 +2088,7 @@ namespace System.Windows
             {
                 foreach (WeakReference<DeferredResourceReference> weakReference in _entries.Values)
                 {
-                    if (weakReference.TryGetTarget(out DeferredResourceReference deferredResourceReference))
+                    if (weakReference.TryGetTarget(out var deferredResourceReference))
                     {
                         deferredResourceReference.Dictionary = resourceDictionary;
                     }
@@ -2141,7 +2140,7 @@ namespace System.Windows
 
                 foreach (KeyValuePair<object, WeakReference<DeferredResourceReference>> entry in _entries)
                 {
-                    if (entry.Value.TryGetTarget(out DeferredResourceReference deferredResourceReference))
+                    if (entry.Value.TryGetTarget(out var deferredResourceReference))
                     {
                         list.Add(deferredResourceReference);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -2034,7 +2034,7 @@ namespace System.Windows
         #endregion Properties
     }
 
-    internal class DeferredResourceReferenceList : IEnumerable
+    internal class DeferredResourceReferenceList
     {
         private readonly object _syncRoot = new();
         private readonly Dictionary<object, WeakReference<DeferredResourceReference>> _entries = new();
@@ -2131,28 +2131,5 @@ namespace System.Windows
                 }
             }
         }
-
-        public IEnumerator GetEnumerator()
-        {
-            lock (_syncRoot)
-            {
-                var list = new List<DeferredResourceReference>(_entries.Count);
-
-                foreach (KeyValuePair<object, WeakReference<DeferredResourceReference>> entry in _entries)
-                {
-                    if (entry.Value.TryGetTarget(out var deferredResourceReference))
-                    {
-                        list.Add(deferredResourceReference);
-                    }
-                }
-
-                return list.GetEnumerator();
-            }
-        }
     }
 }
-
-
-
-
-


### PR DESCRIPTION
Fixes Issue #4468 

## Description

The currently used implementation to keep track of DynamicResource usages is suboptimal as the list can grow quite large and scanning gets very expensive.
That's caused by two issues:
- Every call to FetchResource adds a new entry to the list
- The list implementation is slow as it does not use keys

The improved implementation only adds items with the same key once by checking for existing items before adding new ones. As the new implementation uses keys, retrieval of items is very fast. 

## Customer Impact

Slow performance.

## Testing

Tested the app from #4468
