### PR TITLE
Glyphs.cs code cleanup

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/glyphs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/glyphs.cs
@@ -111,18 +111,9 @@ namespace System.Windows.Documents
         {
             base.ArrangeOverride(finalSize);
 
-            Rect inkBoundingBox;
-
             if (_measurementGlyphRun != null)
-                inkBoundingBox = _measurementGlyphRun.ComputeInkBoundingBox();
-            else
-                inkBoundingBox = Rect.Empty;
-
-            if (!inkBoundingBox.IsEmpty)
-            {
-                inkBoundingBox.X += _glyphRunOrigin.X;
-                inkBoundingBox.Y += _glyphRunOrigin.Y;
-            }
+                _measurementGlyphRun.ComputeInkBoundingBox();
+            
             return finalSize;
         }
 


### PR DESCRIPTION
Fixes Issue [#5330 ](https://github.com/dotnet/wpf/issues/5330)

## Description

The method calls _measurementGlyphRun.ComputeInkBoundingBox(), does some additional calculations, throws the result away and returns the original finalSize

wpf/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/glyphs.cs

protected override Size ArrangeOverride(Size finalSize)

## Customer Impact

Code cleanup

## Regression

No

## Testing

Developer Regression Suite

## Risk

No Risk
