### PR TITLE
Remove unuse static field in ImageDrawing.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageDrawing.cs
@@ -327,8 +327,6 @@ namespace System.Windows.Media
 
         internal System.Windows.Media.Composition.DUCE.MultiChannelResource _duceResource = new System.Windows.Media.Composition.DUCE.MultiChannelResource();
 
-        internal static Rect s_Rect = Rect.Empty;
-
         #endregion Internal Fields
 
 


### PR DESCRIPTION


## Description

Remove unuse static field in ImageDrawing.cs

## Customer Impact

No.

## Regression

.NET 7

## Testing

Just CI

## Risk

Low.
