### PR TITLE
Draft: Performance improvement for UIElement.Arrange and UIElement.Measure

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/TextOptionsInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/TextOptionsInternal.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Media;
 using MS.Internal.PresentationCore;
+using PresentationCore;
 
 namespace MS.Internal.Media
 {
@@ -45,9 +46,9 @@ namespace MS.Internal.Media
         [FriendAccessAllowed]   // used by Framework
         public static void SetTextHintingMode(DependencyObject element, TextHintingMode value)
         {
-            if (element == null)
+            if (element is null)
             {
-                throw new ArgumentNullException("element");
+                ThrowHelper.ThrowArgumentNullException(nameof(element));
             }
 
             element.SetValue(TextHintingModeProperty, value);
@@ -58,19 +59,12 @@ namespace MS.Internal.Media
         {
             if (element is null)
             {
-                ThrowArgumentNullException(nameof(element));
+                ThrowHelper.ThrowArgumentNullException(nameof(element));
             }
 
             return (TextHintingMode)element.GetValue(TextHintingModeProperty);
         }
 
         #endregion Attached Groperties Getters and Setters
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [DoesNotReturn]
-        private static void ThrowArgumentNullException(string paramName)
-        {
-            throw new ArgumentNullException(paramName);
-        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/TextOptionsInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Media/TextOptionsInternal.cs
@@ -10,6 +10,8 @@
 //
 
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Media;
 using MS.Internal.PresentationCore;
@@ -54,14 +56,21 @@ namespace MS.Internal.Media
         [FriendAccessAllowed]   // used by Framework
         public static TextHintingMode GetTextHintingMode(DependencyObject element)
         {
-            if (element == null)
+            if (element is null)
             {
-                throw new ArgumentNullException("element");
+                ThrowArgumentNullException(nameof(element));
             }
 
             return (TextHintingMode)element.GetValue(TextHintingModeProperty);
         }
 
         #endregion Attached Groperties Getters and Setters
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
+        private static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -1361,6 +1361,7 @@
     <Compile Include="System\Windows\Media3D\Generated\Visual3D.cs" />
     <Compile Include="System\Windows\Navigation\BaseUriHelper.cs" />
     <Compile Include="System\Windows\Resources\AssemblyAssociatedContentFileAttribute.cs" />
+    <Compile Include="ThrowHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -2137,17 +2137,12 @@ namespace System.Windows.Automation.Peers
         /// </summary>
         internal void InvalidateAncestorsRecursive()
         {
-            if (!AncestorsInvalid)
-            {
-                AncestorsInvalid = true;
-                if (EventsSource != null)
-                {
-                    EventsSource.InvalidateAncestorsRecursive();
-                }
+            if (AncestorsInvalid) return;
 
-                if (_parent != null)
-                    _parent.InvalidateAncestorsRecursive();
-            }
+            AncestorsInvalid = true;
+            EventsSource?.InvalidateAncestorsRecursive();
+
+            _parent?.InvalidateAncestorsRecursive();
         }
 
         private static object UpdatePeer(object arg)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/LayoutManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/LayoutManager.cs
@@ -153,7 +153,7 @@ namespace System.Windows
             _lastExceptionElement = null;
             _measuresOnStack++;
             if(_measuresOnStack > s_LayoutRecursionLimit)
-                throw new InvalidOperationException(SR.Get(SRID.LayoutManager_DeepRecursion, s_LayoutRecursionLimit));
+                ThrowInvalidOperationForDeepRecursion();
 
             _firePostLayoutEvents = true;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/LayoutManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/LayoutManager.cs
@@ -13,7 +13,8 @@
 using System;
 using System.Windows.Threading;
 using System.Collections;
-
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Windows.Automation.Peers;
@@ -164,9 +165,16 @@ namespace System.Windows
             _lastExceptionElement = null;
             _arrangesOnStack++;
             if(_arrangesOnStack > s_LayoutRecursionLimit)
-                throw new InvalidOperationException(SR.Get(SRID.LayoutManager_DeepRecursion, s_LayoutRecursionLimit));
+                ThrowInvalidOperationForDeepRecursion();
 
             _firePostLayoutEvents = true;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
+        private static void ThrowInvalidOperationForDeepRecursion()
+        {
+            throw new InvalidOperationException(SR.Get(SRID.LayoutManager_DeepRecursion, s_LayoutRecursionLimit));
         }
 
         internal void ExitArrange()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
@@ -630,13 +630,13 @@ namespace System.Windows.Media
 
         #region Internal Methods
 
+        internal Span<double> ToSpan()
+        {
+            if (_collection.ToArray() is not { } array) return Span<double>.Empty;
 
-
-
-
-
-
-
+            ref double reference = ref MemoryMarshal.GetArrayDataReference(array);
+            return MemoryMarshal.CreateSpan(ref reference, array.Length);
+        }
 
         #endregion Internal Methods
 
@@ -933,6 +933,16 @@ namespace System.Windows.Media
         public DoubleCollection(int capacity)
         {
             _collection = new FrugalStructList<double>(capacity);
+        }
+
+        internal DoubleCollection(ReadOnlySpan<double> data)
+        {
+            var dataLength = data.Length;
+            _collection = new FrugalStructList<double>(dataLength);
+            for (int i = 0; i < dataLength; i++)
+            {
+                _collection[i] = data[i];
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
@@ -13,6 +13,8 @@ using MS.Win32.PresentationCore;
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Security;
 using System.Windows.Interop;
 
@@ -45,7 +47,10 @@ namespace System.Windows.Media
         [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
         public static EdgeMode GetEdgeMode(DependencyObject target)
         {
-            if (target == null) { throw new ArgumentNullException("target"); }
+            if (target is null)
+            {
+                ThrowArgumentNullException(nameof(target));
+            }
             return (EdgeMode)target.GetValue(EdgeModeProperty);
         }
 
@@ -54,8 +59,18 @@ namespace System.Windows.Media
         /// </summary>
         public static void SetEdgeMode(DependencyObject target, EdgeMode edgeMode)
         {
-            if (target == null) { throw new ArgumentNullException("target"); }
+            if (target is null)
+            {
+                ThrowArgumentNullException(nameof(target));
+            }
             target.SetValue(EdgeModeProperty, edgeMode);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
+        private static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
         }
 
         //
@@ -78,7 +93,10 @@ namespace System.Windows.Media
         [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
         public static BitmapScalingMode GetBitmapScalingMode(DependencyObject target)
         {
-            if (target == null) { throw new ArgumentNullException("target"); }
+            if (target is null)
+            {
+                ThrowArgumentNullException(nameof(target));
+            }
             return (BitmapScalingMode)target.GetValue(BitmapScalingModeProperty);
         }
 
@@ -111,7 +129,10 @@ namespace System.Windows.Media
         [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
         public static ClearTypeHint GetClearTypeHint(DependencyObject target)
         {
-            if (target == null) { throw new ArgumentNullException("target"); }
+            if (target is null)
+            {
+                ThrowArgumentNullException(nameof(target));
+            }
             return (ClearTypeHint)target.GetValue(ClearTypeHintProperty);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RenderOptions.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Security;
 using System.Windows.Interop;
+using PresentationCore;
 
 namespace System.Windows.Media
 {
@@ -49,7 +50,7 @@ namespace System.Windows.Media
         {
             if (target is null)
             {
-                ThrowArgumentNullException(nameof(target));
+                ThrowHelper.ThrowArgumentNullException(nameof(target));
             }
             return (EdgeMode)target.GetValue(EdgeModeProperty);
         }
@@ -61,16 +62,9 @@ namespace System.Windows.Media
         {
             if (target is null)
             {
-                ThrowArgumentNullException(nameof(target));
+                ThrowHelper.ThrowArgumentNullException(nameof(target));
             }
             target.SetValue(EdgeModeProperty, edgeMode);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [DoesNotReturn]
-        private static void ThrowArgumentNullException(string paramName)
-        {
-            throw new ArgumentNullException(paramName);
         }
 
         //
@@ -95,7 +89,7 @@ namespace System.Windows.Media
         {
             if (target is null)
             {
-                ThrowArgumentNullException(nameof(target));
+                ThrowHelper.ThrowArgumentNullException(nameof(target));
             }
             return (BitmapScalingMode)target.GetValue(BitmapScalingModeProperty);
         }
@@ -131,7 +125,7 @@ namespace System.Windows.Media
         {
             if (target is null)
             {
-                ThrowArgumentNullException(nameof(target));
+                ThrowHelper.ThrowArgumentNullException(nameof(target));
             }
             return (ClearTypeHint)target.GetValue(ClearTypeHintProperty);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/SizeChangedInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/SizeChangedInfo.cs
@@ -94,8 +94,8 @@ namespace System.Windows
         //there could be several size changes before it will actually fire.
         internal void Update(bool widthChanged, bool heightChanged)
         {
-            _widthChanged = _widthChanged | widthChanged;
-            _heightChanged = _heightChanged | heightChanged;
+            _widthChanged |= widthChanged;
+            _heightChanged |= heightChanged;
         }
 
         internal UIElement Element

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -790,8 +790,6 @@ namespace System.Windows
 
             try
             {
-                //             VerifyAccess();
-
                 // Disable reentrancy during the arrange pass.  This is because much work is done
                 // during arrange - such as formatting PTS stuff, creating
                 // fonts, etc.  Generally speaking, we cannot survive reentrancy in these code

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -796,7 +796,7 @@ namespace System.Windows
                 // paths.
                 using (Dispatcher.DisableProcessing())
                 {
-                    //enforce that Arrange can not come with Infinity size or NaN
+                    // Enforce that Arrange can not come with Infinity size or NaN
                     if (double.IsPositiveInfinity(finalRect.Width)
                         || double.IsPositiveInfinity(finalRect.Height)
                         || double.IsNaN(finalRect.Width)
@@ -808,19 +808,19 @@ namespace System.Windows
                             SR.Get(
                                 SRID.UIElement_Layout_InfinityArrange,
                                     (parent == null ? "" : parent.GetType().FullName),
-                                    this.GetType().FullName));
+                                    GetType().FullName));
                     }
 
 
-                    //if Collapsed, we should not Arrange, keep dirty bit but remove request
-                    if (this.Visibility == Visibility.Collapsed
-                        || ((Visual)this).CheckFlagsAnd(VisualFlags.IsLayoutSuspended))
+                    // If Collapsed, we should not Arrange, keep dirty bit but remove request
+                    if (Visibility == Visibility.Collapsed
+                        || CheckFlagsAnd(VisualFlags.IsLayoutSuspended))
                     {
-                        //reset arrange request.
+                        // Reset arrange request.
                         if (ArrangeRequest != null)
                             ContextLayoutManager.From(Dispatcher).ArrangeQueue.Remove(this);
 
-                        //  remember though that parent tried to arrange at this rect
+                        //  Remember though that parent tried to arrange at this rect
                         //  in case when later this element is called to arrange incrementally
                         //  it has up-to-date information stored in _finalRect
                         _finalRect = finalRect;
@@ -828,24 +828,24 @@ namespace System.Windows
                         return;
                     }
 
-                    //in case parent did not call Measure on a child, we call it now.
-                    //parent can skip calling Measure on a child if it does not care about child's size
-                    //passing finalSize practically means "set size" because that's what Measure(sz)/Arrange(same_sz) means
-                    //Note that in case of IsLayoutSuspended (temporarily out of the tree) the MeasureDirty can be true
-                    //while it does not indicate that we should re-measure - we just came of Measure that did nothing
-                    //because of suspension
+                    // In case parent did not call Measure on a child, we call it now.
+                    // parent can skip calling Measure on a child if it does not care about child's size
+                    // passing finalSize practically means "set size" because that's what Measure(sz)/Arrange(same_sz) means
+                    // Note that in case of IsLayoutSuspended (temporarily out of the tree) the MeasureDirty can be true
+                    // while it does not indicate that we should re-measure - we just came of Measure that did nothing
+                    // because of suspension
                     if (MeasureDirty
                        || NeverMeasured)
                     {
                         try
                         {
                             MeasureDuringArrange = true;
-                            //If never measured - that means "set size", arrange-only scenario
-                            //Otherwise - the parent previosuly measured the element at constriant
-                            //and the fact that we are arranging the measure-dirty element now means
-                            //we are not in the UpdateLayout loop but rather in manual sequence of Measure/Arrange
-                            //(like in HwndSource when new RootVisual is attached) so there are no loops and there could be
-                            //measure-dirty elements left after previosu single Measure pass) - so need to use cached constraint
+                            // If never measured - that means "set size", arrange-only scenario
+                            // Otherwise - the parent previosuly measured the element at constriant
+                            // and the fact that we are arranging the measure-dirty element now means
+                            // we are not in the UpdateLayout loop but rather in manual sequence of Measure/Arrange
+                            // (like in HwndSource when new RootVisual is attached) so there are no loops and there could be
+                            // measure-dirty elements left after previosu single Measure pass) - so need to use cached constraint
                             if (NeverMeasured)
                                 Measure(finalRect.Size);
                             else
@@ -859,7 +859,7 @@ namespace System.Windows
                         }
                     }
 
-                    //bypass - if clean and rect is the same, no need to re-arrange
+                    // Bypass - if clean and rect is the same, no need to re-arrange
                     if (!IsArrangeValid
                         || NeverArranged
                         || !DoubleUtil.AreClose(finalRect, _finalRect))
@@ -885,13 +885,13 @@ namespace System.Windows
                         {
                             layoutManager.EnterArrange();
 
-                            //This has to update RenderSize
+                            // This has to update RenderSize
                             ArrangeCore(finalRect);
 
-                            //to make sure Clip is tranferred to Visual
+                            // to make sure Clip is tranferred to Visual
                             ensureClip(finalRect.Size);
 
-                            //  see if we need to call OnRenderSizeChanged on this element
+                            // See if we need to call OnRenderSizeChanged on this element
                             sizeChanged = markForSizeChangedIfNeeded(oldSize, RenderSize);
 
                             gotException = false;
@@ -916,8 +916,8 @@ namespace System.Windows
 
                         ArrangeDirty = false;
 
-                        //reset request.
-                        if (ArrangeRequest != null)
+                        // Reset request.
+                        if (ArrangeRequest is not null)
                             ContextLayoutManager.From(Dispatcher).ArrangeQueue.Remove(this);
 
                         if ((sizeChanged || RenderingInvalidated || firstArrange) && IsRenderable())

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -981,50 +981,66 @@ namespace System.Windows
 
         private void UpdatePixelSnappingGuidelines()
         {
-            if((!SnapsToDevicePixels) || (_drawingContent == null))
+            if(!SnapsToDevicePixels || _drawingContent is null)
             {
-                VisualXSnappingGuidelines = VisualYSnappingGuidelines = null;
+                VisualXSnappingGuidelines = null;
+                VisualYSnappingGuidelines = null;
             }
             else
             {
                 DoubleCollection xLines = VisualXSnappingGuidelines;
 
-                if(xLines == null)
+                Span<double> xLinesData;
+                if (xLines is null)
                 {
-                    xLines = new DoubleCollection
+                    unsafe
                     {
-                        0d,
-                        RenderSize.Width
-                    };
-                    VisualXSnappingGuidelines = xLines;
+                        var xLinesStackData = stackalloc double[2];
+                        xLinesData = new Span<double>(xLinesStackData, 2);
+                    }
+
+                    xLinesData[0] = 0d;
+                    xLinesData[1] = RenderSize.Width;
+
                 }
                 else
                 {
+                    xLinesData = xLines.ToSpan();
+
                     // xLines[0] = 0d;  - this already should be so
                     // check to avoid potential dirtiness in renderer
-                    int lastGuideline = xLines.Count - 1;
-                    if(!DoubleUtil.AreClose(xLines[lastGuideline], RenderSize.Width))
-                        xLines[lastGuideline] = RenderSize.Width;
+                    int lastGuideline = xLinesData.Length - 1;
+                    if(!DoubleUtil.AreClose(xLinesData[lastGuideline], RenderSize.Width))
+                        xLinesData[lastGuideline] = RenderSize.Width;
                 }
 
+                VisualXSnappingGuidelines = new DoubleCollection(xLinesData);
+
                 DoubleCollection yLines = VisualYSnappingGuidelines;
-                if(yLines == null)
+                Span<double> yLinesData;
+                if (yLines == null)
                 {
-                    yLines = new DoubleCollection
+                    unsafe
                     {
-                        0d,
-                        RenderSize.Height
-                    };
-                    VisualYSnappingGuidelines = yLines;
+                        var yLinesStackData = stackalloc double[2];
+                        yLinesData = new Span<double>(yLinesStackData, 2);
+                    }
+
+                    yLinesData[0] = 0d;
+                    yLinesData[1] = RenderSize.Height;
                 }
                 else
                 {
+                    yLinesData = yLines.ToSpan();
+
                     // yLines[0] = 0d;  - this already should be so
                     // check to avoid potential dirtiness in renderer
-                    int lastGuideline = yLines.Count - 1;
-                    if(!DoubleUtil.AreClose(yLines[lastGuideline], RenderSize.Height))
-                        yLines[lastGuideline] = RenderSize.Height;
+                    int lastGuideline = yLinesData.Length - 1;
+                    if(!DoubleUtil.AreClose(yLinesData[lastGuideline], RenderSize.Height))
+                        yLinesData[lastGuideline] = RenderSize.Height;
                 }
+
+                VisualYSnappingGuidelines = new DoubleCollection(yLinesData);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1000,8 +1000,8 @@ namespace System.Windows
                 }
                 else
                 {
-                // xLines[0] = 0d;  - this already should be so
-                // check to avoid potential dirtiness in renderer
+                    // xLines[0] = 0d;  - this already should be so
+                    // check to avoid potential dirtiness in renderer
                     int lastGuideline = xLines.Count - 1;
                     if(!DoubleUtil.AreClose(xLines[lastGuideline], RenderSize.Width))
                         xLines[lastGuideline] = RenderSize.Width;
@@ -1019,8 +1019,8 @@ namespace System.Windows
                 }
                 else
                 {
-                // yLines[0] = 0d;  - this already should be so
-                // check to avoid potential dirtiness in renderer
+                    // yLines[0] = 0d;  - this already should be so
+                    // check to avoid potential dirtiness in renderer
                     int lastGuideline = yLines.Count - 1;
                     if(!DoubleUtil.AreClose(yLines[lastGuideline], RenderSize.Height))
                         yLines[lastGuideline] = RenderSize.Height;
@@ -1041,28 +1041,26 @@ namespace System.Windows
                 info.Update(widthChanged, heightChanged);
                 return true;
             }
-            else if(widthChanged || heightChanged)
-            {
-                info = new SizeChangedInfo(this, oldSize, widthChanged, heightChanged);
-                sizeChangedInfo = info;
-                ContextLayoutManager.From(Dispatcher).AddToSizeChangedChain(info);
 
-                //
-                // This notifies Visual layer that hittest boundary potentially changed
-                //
 
-                PropagateFlags(
-                    this,
-                    VisualFlags.IsSubtreeDirtyForPrecompute,
-                    VisualProxyFlags.IsSubtreeDirtyForRender);
+            // This result is used to determine if we need to call OnRender after Arrange
+            // OnRender is called for 2 reasons - someone called InvalidateVisual - then OnRender is called
+            // on next Arrange, or the size changed.
+            if (!widthChanged && !heightChanged) return false;
 
-                return true;
-            }
+            info = new SizeChangedInfo(this, oldSize, widthChanged, heightChanged);
+            sizeChangedInfo = info;
+            ContextLayoutManager.From(Dispatcher).AddToSizeChangedChain(info);
 
-            //this result is used to determine if we need to call OnRender after Arrange
-            //OnRender is called for 2 reasons - someone called InvalidateVisual - then OnRender is called
-            //on next Arrange, or the size changed.
-            return false;
+            //
+            // This notifies Visual layer that hittest boundary potentially changed
+            //
+            PropagateFlags(
+                this,
+                VisualFlags.IsSubtreeDirtyForPrecompute,
+                VisualProxyFlags.IsSubtreeDirtyForRender);
+
+            return true;
         }
 
         /// <summary>
@@ -1278,10 +1276,10 @@ namespace System.Windows
                 VisualOffset = new Vector(finalRect.X, finalRect.Y);
             }
 
-            if (renderTransform != null)
+            if (renderTransform is not null)
             {
                 //render transform + layout offset, create a collection
-                TransformGroup t = new TransformGroup();
+                TransformGroup t = new();
 
                 Point origin = RenderTransformOrigin;
                 bool hasOrigin = (origin.X != 0d || origin.Y != 0d);
@@ -3095,7 +3093,7 @@ namespace System.Windows
                     clipGeometry = Clip;
                 else
                 {
-                    CombinedGeometry cg = new CombinedGeometry(
+                    CombinedGeometry cg = new(
                         GeometryCombineMode.Intersect,
                         clipGeometry,
                         Clip);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ThrowHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ThrowHelper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace PresentationCore;
+
+internal static class ThrowHelper
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DoesNotReturn]
+    internal static void ThrowArgumentNullException(string paramName)
+    {
+        throw new ArgumentNullException(paramName);
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/DoubleUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/DoubleUtil.cs
@@ -240,11 +240,11 @@ namespace MS.Internal
             // At this point, rect1 isn't empty, so the first thing we can test is
             // rect2.IsEmpty, followed by property-wise compares.
 
-            return (!rect2.IsEmpty) &&
-                DoubleUtil.AreClose(rect1.X, rect2.X) &&
-                DoubleUtil.AreClose(rect1.Y, rect2.Y) &&
-                DoubleUtil.AreClose(rect1.Height, rect2.Height) &&
-                DoubleUtil.AreClose(rect1.Width, rect2.Width);
+            return !rect2.IsEmpty &&
+                AreClose(rect1.X, rect2.X) &&
+                AreClose(rect1.Y, rect2.Y) &&
+                AreClose(rect1.Height, rect2.Height) &&
+                AreClose(rect1.Width, rect2.Width);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -2918,23 +2918,18 @@ namespace System.Windows
         {
             IsInPropertyInitialization = false;
 
-            if (_effectiveValues != null)
-            {
-                uint effectiveValuesCount = EffectiveValuesCount;
-                if (effectiveValuesCount != 0)
-                {
-                    uint endLength = effectiveValuesCount;
-                    if (((float) endLength / (float) _effectiveValues.Length) < 0.8)
-                    {
-                        // For thread-safety, sealed DOs can't modify _effectiveValues.
-                        Debug.Assert(!DO_Sealed, "A Sealed DO cannot be modified");
+            if (_effectiveValues is null) return;
+            uint effectiveValuesCount = EffectiveValuesCount;
+            if (effectiveValuesCount == 0) return;
 
-                        EffectiveValueEntry[] destEntries = new EffectiveValueEntry[endLength];
-                        Array.Copy(_effectiveValues, 0, destEntries, 0, effectiveValuesCount);
-                        _effectiveValues = destEntries;
-                    }
-                }
-            }
+            if (!(effectiveValuesCount / (float)_effectiveValues.Length < 0.8)) return;
+
+            // For thread-safety, sealed DOs can't modify _effectiveValues.
+            Debug.Assert(!DO_Sealed, "A Sealed DO cannot be modified");
+
+            EffectiveValueEntry[] destEntries = new EffectiveValueEntry[effectiveValuesCount];
+            Array.Copy(_effectiveValues, 0, destEntries, 0, effectiveValuesCount);
+            _effectiveValues = destEntries;
         }
 
 


### PR DESCRIPTION
---

⚠️ **CAUTION:** This is a draft pull request - **DO NOT MERGE**

---

It will not fix the issue #4768 completely but may improve the performance already

## Description

I tried to replace some heap allocations with stack "allocations" using `Span<T>` and `ReadOnlySpan<T>`

A bottleneck is unfortunately in the PresentationNative part (`LoCreateLine`), on which I can unfortunately not influence
![grafik](https://user-images.githubusercontent.com/10373452/143088451-998a82a3-f09c-4858-afa4-6532acc631a6.png)


## Testing

(todo)

## Benchmarks

(todo)

## Risk

⚠️ Critical API has changed - All edge cases must be tested
