### PR TITLE
Migrate DPI awareness initialization to managed

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 internal static class ModuleInitializer
 {
@@ -15,11 +13,32 @@ internal static class ModuleInitializer
     /// operations are carried out.  To do this, we simply call LoadDwrite
     /// as the module constructor for DirectWriteForwarder would do this anyway.
     /// </summary>
-    #pragma warning disable CA2255 
+#pragma warning disable CA2255
     [ModuleInitializer]
     public static void Initialize()
     {
+        IsProcessDpiAware();
+
         MS.Internal.NativeWPFDLLLoader.LoadDwrite();
     }
-    #pragma warning restore CA2255 
+#pragma warning restore CA2255
+
+    private static void IsProcessDpiAware()
+    {
+        // By default, Application is DPIAware.
+        Assembly assemblyApp = Assembly.GetEntryAssembly();
+
+        // Check if the Application has explicitly set DisableDpiAwareness attribute.
+        if (assemblyApp != null && Attribute.IsDefined(assemblyApp, typeof(System.Windows.Media.DisableDpiAwarenessAttribute)))
+        {
+            // DpiAware composition is enabled for this application.
+            SetProcessDPIAware_Internal();
+        }
+
+        // Only when DisableDpiAwareness attribute is set in Application assembly,
+        // It will ignore the SetProcessDPIAware API call.
+    }
+
+    [DllImport("user32.dll", EntryPoint = "SetProcessDPIAware")]
+    private static extern void SetProcessDPIAware_Internal();
 }


### PR DESCRIPTION
Contributes #5305

## Description
Migrate DPI awareness initialization to managed.

I removed the OS check used to only do the initialization on Windows Vista or later since every version of Windows supported by .Net 6 are more recent than Windows Vista, which renders the check unnecessary.

## Customer Impact
None.

## Regression
No.

## Testing
I tested a WPF application with this PR with high DPI and the DPI awareness was initialized properly.

## Risk
Seems pretty low.