### PR TITLE
Improve pre-commit githook

### DIFF
--- a/eng/WpfArcadeSdk/tools/WPF_Generated_Files.txt
+++ b/eng/WpfArcadeSdk/tools/WPF_Generated_Files.txt
@@ -187,9 +187,9 @@ src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Ima
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/ImageSource.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32Collection.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32CollectionConverter.cs
+src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineGeometry.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LineSegment.cs
-src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/LinearGradientBrush.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MatrixTransform.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/MediaTimeline.cs
 src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigure.cs
@@ -345,9 +345,9 @@ src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/TextDecorationUnitVali
 src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/TextHintingModeValidation.cs
 src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/TextRenderingModeValidation.cs
 src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Generated/TileModeValidation.cs
-src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/MS/Internal/Generated/DoubleUtil.cs
 src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Generated/PropertyHelper.cs
 src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Generated/TreeHelper.cs
+src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/MS/Internal/Generated/DoubleUtil.cs
 src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/Int32RectValueSerializer.cs
 src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/PointValueSerializer.cs
 src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Converters/Generated/RectValueSerializer.cs

--- a/eng/WpfArcadeSdk/tools/pre-commit.githook
+++ b/eng/WpfArcadeSdk/tools/pre-commit.githook
@@ -40,8 +40,9 @@ STAGED_GENERATED_FILES=$(comm -12 $TEMP_FILE_FULL_PATH $GENERATED_FILE_LIST)
 # the user from committing their change locally. 
 if test -n "$STAGED_GENERATED_FILES"
 then
-    echo "Error: WPF generated staged files detected. These files must not be modified."
+    echo "*** Commit aborted because it includes the following WPF generated staged files: "
     echo "$STAGED_GENERATED_FILES"
+    echo "*** If you have generated them properly, use the '--no-verify' to override this check."
 
     exit 1
 fi

--- a/eng/WpfArcadeSdk/tools/pre-commit.githook
+++ b/eng/WpfArcadeSdk/tools/pre-commit.githook
@@ -28,7 +28,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel | sort)
 TEMP_FILE_FULL_PATH=$REPO_ROOT/$TEMP_FILE_NAME
 
 # Create the temporary file containing a list of staged files(always overwrite)
-echo "$STAGED_FILES" > "$TEMP_FILE_FULL_PATH"
+echo "$STAGED_FILES" | sort > "$TEMP_FILE_FULL_PATH"
 
 # Find any staged files that intersect with the generated file list
 STAGED_GENERATED_FILES=$(comm -12 $TEMP_FILE_FULL_PATH $GENERATED_FILE_LIST) 


### PR DESCRIPTION
Fixes Issue <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Improvements to the hook that deters users from changing generated files:

1. The hook calls a file-comparison tool that expects its inputs to be sorted, but doesn't sort the inputs ("comm: file 1 is not in sorted order").  Fixed that by (a) sorting the dynamic list of staged files, and (b) pre-sorting the fixed list of generated files.
2. Revised the error output to give a better suggestion about what to do next.

To get the full benefit of this change, copy `eng\WpfArcadeSdk\tools\pre-commit.githook` to `.git\hooks\pre-commit`, overwriting the existing file (both paths are relative to your repo's root).  There's probably some way to cause this to happen automatically, but I couldn't find it.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
No change to product code.  Developer experience is improved.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No.

## Testing

<!-- What kind of testing has been done with the fix. -->
It works for me.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
No risk.
