### PR TITLE
Remove unused item metadata after copy/paste in Visual Studio

### DIFF
--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -1,14 +1,16 @@
 <Project>
 
-  <ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition=" '$(_EnableWindowsDesktopGlobbing)' == 'true' ">
     <ApplicationDefinition>
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+      <SubType>Designer</SubType>
     </ApplicationDefinition>
 
     <Page>
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+      <SubType>Designer</SubType>
     </Page>
   </ItemDefinitionGroup>
 

--- a/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
+++ b/packaging/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props
@@ -1,23 +1,26 @@
 <Project>
 
-  <ItemGroup Condition=" '$(_EnableWindowsDesktopGlobbing)' == 'true' ">
-    <ApplicationDefinition Include="App.xaml"
-                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'">
-      <Generator>MSBuild:Compile</Generator>
-      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
-    </ApplicationDefinition>
-    <ApplicationDefinition Include="Application.xaml"
-                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/Application.xaml') And '$(MSBuildProjectExtension)' == '.vbproj'">
+  <ItemDefinitionGroup>
+    <ApplicationDefinition>
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </ApplicationDefinition>
 
-    <Page Include="**/*.xaml"
-          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(ApplicationDefinition)"
-          Condition="'$(EnableDefaultPageItems)' != 'false'" >
+    <Page>
       <Generator>MSBuild:Compile</Generator>
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
+  </ItemDefinitionGroup>
+
+  <ItemGroup Condition=" '$(_EnableWindowsDesktopGlobbing)' == 'true' ">
+    <ApplicationDefinition Include="App.xaml"
+                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/App.xaml') And '$(MSBuildProjectExtension)' == '.csproj'" />
+    <ApplicationDefinition Include="Application.xaml"
+                           Condition="'$(EnableDefaultApplicationDefinition)' != 'false' And Exists('$(MSBuildProjectDirectory)/Application.xaml') And '$(MSBuildProjectExtension)' == '.vbproj'" />
+
+    <Page Include="**/*.xaml"
+          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(ApplicationDefinition)"
+          Condition="'$(EnableDefaultPageItems)' != 'false'" />
 
 
     <!--


### PR DESCRIPTION
Fixes #5461

## Description
Removes unused item metadata that are automatically added to the project after copy/pasting a xaml file in Visual Studio.

## Customer Impact
None.

## Regression
No.

## Testing
Tested locally by modifying my installed SDK to apply the changes in this PR. It fixed the addition of `<XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>` on copy/paste.

## Risk
This PR will add `<Generator>MSBuild:Compile</Generator>` and `<XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>` to any `Page` or `ApplicationDefinition` item even if globbing is disabled or if they are added manually.