### PR TITLE
Fix issue number in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fixes Issue <!-- Issue Number -->
+Fixes # <!-- Issue Number -->
 
 Main PR <!-- Link to PR if any that fixed this in the main branch. -->
 


### PR DESCRIPTION
## Description
Fix issue number to allow GitHub to link a PR with an issue. This also allows GitHub to automatically close the linked issue when the pull request is merged.

GitHub does not recognize "Fixes Issue #..."
GitHub recognizes "Fixes #..."

I also moved "PULL_REQUEST_TEMPLATE" to ".github/PULL_REQUEST_TEMPLATE.md", the same path as the template in the Windows Forms repo.

## Customer Impact
None.

## Regression
No.

## Testing
I don't really know how to test it without merging this PR.

## Risk
None.
