### PR TITLE
Port touch activation fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -1215,20 +1215,7 @@ namespace System.Windows.Input
                             actionsArgs.RoutedEvent=InputManager.PreviewInputReportEvent;
                             e.PushInput(actionsArgs, null);
 
-                            // Create a new RawMouseInputReport for the activate.
-                            RawMouseInputReport reportActivate = new RawMouseInputReport(rawMouseInputReport.Mode,
-                                                                                         rawMouseInputReport.Timestamp,
-                                                                                         rawMouseInputReport.InputSource,
-                                                                                         RawMouseActions.Activate,
-                                                                                         rawMouseInputReport.X,
-                                                                                         rawMouseInputReport.Y,
-                                                                                         rawMouseInputReport.Wheel,
-                                                                                         rawMouseInputReport.ExtraInformation);
-
-                            // Push a new RawMouseInputReport for the activate.
-                            InputReportEventArgs activateArgs = new InputReportEventArgs(inputReportEventArgs.Device, reportActivate);
-                            activateArgs.RoutedEvent=InputManager.PreviewInputReportEvent;
-                            e.PushInput(activateArgs, null);
+                            PushActivateInputReport(e, inputReportEventArgs, rawMouseInputReport, clearExtraInformation:false);
                         }
                     }
                     // Only process mouse input that is from our active PresentationSource.
@@ -1387,6 +1374,30 @@ namespace System.Windows.Input
                 }
             }
 }
+
+        /// <summary>
+        /// Push an Activate input report, on behalf of the given RawMouseInputReport.
+        /// Common logic used by MouseDevice.PreProcessInput and PointerDevice.PreProcessMouseInput
+        /// </summary>
+        internal static void PushActivateInputReport(PreProcessInputEventArgs e, InputReportEventArgs inputReportEventArgs, RawMouseInputReport rawMouseInputReport, bool clearExtraInformation)
+        {
+            IntPtr extraInformation = clearExtraInformation ? IntPtr.Zero : rawMouseInputReport.ExtraInformation;
+
+            // Create a new RawMouseInputReport for the activate.
+            RawMouseInputReport reportActivate = new RawMouseInputReport(rawMouseInputReport.Mode,
+                                                                         rawMouseInputReport.Timestamp,
+                                                                         rawMouseInputReport.InputSource,
+                                                                         RawMouseActions.Activate,
+                                                                         rawMouseInputReport.X,
+                                                                         rawMouseInputReport.Y,
+                                                                         rawMouseInputReport.Wheel,
+                                                                         extraInformation);
+
+            // Push a new RawMouseInputReport for the activate.
+            InputReportEventArgs activateArgs = new InputReportEventArgs(inputReportEventArgs.Device, reportActivate);
+            activateArgs.RoutedEvent=InputManager.PreviewInputReportEvent;
+            e.PushInput(activateArgs, null);
+        }
 
         private void PreNotifyInput(object sender, NotifyInputEventArgs e)
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -232,6 +232,15 @@ namespace System.Windows.Input.StylusPointer
                 && !(CurrentStylusDevice?.As<PointerStylusDevice>()?.TouchDevice?.PromotingToOther ?? false)
                 && (CurrentStylusDevice?.As<PointerStylusDevice>()?.TouchDevice?.PromotingToManipulation ?? false))
             {
+                // If the promoted event contains Activate, push a new Activate event to
+                // replace the event we're dropping.  Otherwise the MouseDevice never activates,
+                // which disables all touch and mouse input.
+                if ((rawMouseInputReport.Actions & RawMouseActions.Activate) == RawMouseActions.Activate)
+                {
+                    // don't copy the extra information, so that the new event isn't treated as a promoted event
+                    MouseDevice.PushActivateInputReport(e, input, rawMouseInputReport, clearExtraInformation:true);
+                }
+
                 input.Handled = true;
                 e.Cancel();
             }


### PR DESCRIPTION
Addresses #5440
This is a port of a servicing fix in .NET 4.7-4.8.

## Description

During a manipulation (e.g. swipe), WPF's Pointer stack discards all promoted mouse events.   In the given scenario, this includes the Activation event.  But this means the MouseDevice never gets the Activation event, and thus stays inactive (unresponsive) even after the manipulation ends, until it gets another Activation event, i.e. until the user activates another window then returns to the WPF app.

Fixed by detecting a "promoted" Activation event and explicitly pushing a non-promoted Activation event in its place.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Touch is broken

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No

## Testing

Ad-hoc around customer scenario.
Standard regression testing.

## Risk

Low. Port of a .NETFx servicing fix released earlier this year.
