### PR TITLE
Port extra-info fix from 4.8

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
@@ -187,9 +187,11 @@ namespace MS.Win32
 
 
 #if BASE_NATIVEMETHODS
-
         [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
         internal static extern IntPtr GetMessageExtraInfo();
+
+        [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
+        internal static extern IntPtr SetMessageExtraInfo(IntPtr lParam);
 #endif
 
 #if BASE_NATIVEMETHODS

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -2417,8 +2417,14 @@ namespace System.Windows.Threading
                     }
                     else if (_postedProcessingType == PROCESS_FOREGROUND)
                     {
+                        // Preserve the thread's current "extra message info"
+                        // (PeekMessage overwrites it).
+                        IntPtr extraInformation = UnsafeNativeMethods.GetMessageExtraInfo();
+
                         MSG msg = new MSG();
                         UnsafeNativeMethods.PeekMessage(ref msg, new HandleRef(this, _window.Value.Handle), _msgProcessQueue, _msgProcessQueue, NativeMethods.PM_REMOVE);
+
+                        UnsafeNativeMethods.SetMessageExtraInfo(extraInformation);
                     }
                     _postedProcessingType = PROCESS_NONE;
                 }


### PR DESCRIPTION
Addresses #5442
This is a port of a servicing fix in .NET 4.7-4.8.

## Description

As part of a mitigation for an OS problem (delivering WM_CHAR messages after the related WM_KEYDOWN message has been marked "handled"), WPF reorders the thread's message queue by removing a certain private message, then re-inserting it at the end of the queue.  This happens early while acting on a WM_KEYDOWN, but has the (undocumented) side-effect of overwriting the "extra info" associated with the WM_KEYDOWN.  

This is fixed by preserving the "extra info" across the call that removes the private message.

## Customer Impact

Extra info attached to a WM_KEYDOWN is lost.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No.

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc around customer scenario.
Standard regression testing.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low. Port of a .NETFx servicing fix released earlier this year.