### PR TITLE
Port IME/databinding fix from 4.8.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -1174,7 +1174,7 @@ namespace System.Windows.Data
             ValidationError oldValidationError = GetValidationErrors(validationStep);
 
             // ignore an error from the implicit DataError rule - this is checked
-            // separately (in BindingExpression.Validate). 
+            // separately (in BindingExpression.Validate).
             if (oldValidationError != null &&
                 oldValidationError.RuleInError == DataErrorValidationRule.Instance)
             {
@@ -1484,6 +1484,15 @@ namespace System.Windows.Data
         {
             if (IsUpdateOnPropertyChanged)
             {
+                // cancel a pending UpdateTarget, so that it doesn't negate
+                // the effect of this change to the target value
+                DispatcherOperation op = (DispatcherOperation)GetValue(Feature.UpdateTargetOperation, null);
+                if (op != null)
+                {
+                    ClearValue(Feature.UpdateTargetOperation);
+                    op.Abort();
+                }
+
                 if (Helper.IsComposing(Target, TargetProperty))
                 {
                     // wait for the IME composition to complete


### PR DESCRIPTION
Addresses #5444
This is a port of a servicing fix in .NET 4.7-4.8.

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
A binding on TextBox.Text defers two kinds of work when an IME composition is in progress on the TextBox:
1. When the text changes (and UpdateTrigger=PropertyChanged), write a new value into the source property.
2. After writing a value into the source property, read the property's new value (which might be different), apply the customary conversions, and write the result into the TextBox.

The bug occurs when the IME starts a new composition before the previous composition's type 2 work happens.  This yields a situation where two tasks are deferred:  the older composition's type 2 task and the newer composition's type 1 task.  The type 2 task happens first, overwriting the text change that the type 1 task is supposed to handle.  This confusion of state leads to exceptions (caught and hidden from the IME, but visible in the debugger), and unexpected content entered into the TextBox.

Fixed by cancelling any pending type 2 work when new type 1 work is needed.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Input with certain IMEs (e.g. MS Quick) is broken.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No.

## Testing

<!-- What kind of testing has been done with the fix. -->
Ad-hoc around customer scenario.
Standard regression testing.

## Risk
Low. Port of a .NETFx servicing fix released earlier this year.


<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
