### PR TITLE
Use builtin MSBuild functions to compare versions

### DIFF
--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64Version)'!='' And 
                                         '$(NoTargets)'!='true' And 
-                                         '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And 
-                                         ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0')">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimeFrameworkVersion>
+                                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And 
+                                        $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->

--- a/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
+++ b/eng/WpfArcadeSdk/tools/RuntimeFrameworkReference.targets
@@ -16,7 +16,7 @@
                       Condition="'$(MicrosoftNETCoreAppRefVersion)'!='' 
                              And '$(NoTargets)'!='true' 
                              And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
-                             And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0') 
+                             And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
                              And '$(MSBuildProjectExtension)'!='.vcxproj'">
       <TargetingPackVersion>$(MicrosoftNETCoreAppRefVersion)</TargetingPackVersion>
     </FrameworkReference>
@@ -30,6 +30,6 @@
 
   <PropertyGroup>
     <!-- If TargetFramework is not one of the supported .NET Core versions, then reset RuntimeFrameworkVersion -->
-    <RuntimeFrameworkVersion Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp') Or ('$(TargetFrameworkVersion)' != 'v3.0' And '$(TargetFrameworkVersion)' != 'v3.1' And '$(TargetFrameworkVersion)' == 'v6.0')" />
+    <RuntimeFrameworkVersion Condition="('$(TargetFrameworkIdentifier)' != '.NETCoreApp') Or $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))" />
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/SdkReferences.targets
+++ b/eng/WpfArcadeSdk/tools/SdkReferences.targets
@@ -6,7 +6,7 @@
                       GeneratePathProperty="True"
                       Condition="'$(MSBuildProjectExtension)'!='.vcxproj'
                               And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                              And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0')
+                              And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
                               And '$(NoAutoMicrosoftPrivateWinformsReference)'!='true'"/>
 
     <!--
@@ -122,7 +122,7 @@
     Condition="'@(MicrosoftDotNetWpfGitHubReference)'!=''
            And '$(MSBuildProjectExtension)' != '.vcxproj'
            And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-           And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0')
+           And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
            and '$(DoNotLimitMicrosoftDotNetWpfGitHubReferences)'!='true'">
     <!--
     In your project, Add a references to WPF GitHub transport package like this:
@@ -196,7 +196,7 @@
   <Target Name="ResolveWinFormsReferences"
           Condition="'@(MicrosoftPrivateWinFormsReference)'!=''
                  And '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                 And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0') ">
+                 And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0')) ">
     <ItemGroup>
       <Reference Include="$(PkgMicrosoft_Private_Winforms)\ref\$(TargetFramework)\%(MicrosoftPrivateWinFormsReference.Identity).dll"
                  Condition="Exists('$(PkgMicrosoft_Private_Winforms)\ref\$(TargetFramework)\%(MicrosoftPrivateWinFormsReference.Identity).dll')">

--- a/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
+++ b/eng/WpfArcadeSdk/tools/WpfProjectReference.targets
@@ -6,7 +6,7 @@
                       GeneratePathProperty="True"
                       Condition="'$(MSBuildProjectExtension)'!='.vcxproj' 
                              And '$(TargetFrameworkIdentifier)' == '.NETCoreApp' 
-                             And ('$(TargetFrameworkVersion)' == 'v3.0' Or '$(TargetFrameworkVersion)' == 'v3.1' Or '$(TargetFrameworkVersion)' == 'v6.0')
+                             And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0'))
                              And '$(NoAutoMicrosoftDotNetWpfGitHubPackageReference)'!='true'
                              And '$(MicrosoftDotNetWpfGitHubPackage)'!=''"/>
 


### PR DESCRIPTION
## Description
Future-proofs target framework version increments by using builtin MSBuild functions to compare target framework versions.

Reduces the number of place to update when incrementing the target framework version.

This PR could be merged before #5901 to reduce diff or after to reduce diff of future target framework version increments.

The changes in this PR requires MSBuild 16.5 since `VersionGreaterThanOrEquals` was added in this version.

## Customer Impact
Build only.

## Regression
No.

## Testing
Local build + CI.

## Risk
None.

/cc @singhashish-wpf @RussKie