### PR TITLE
adding support for Nullable

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -666,7 +666,7 @@ namespace MS.Internal
                     {
                         _ccRoot.CodeClass.IsPartial = true;
                     }
-                    addDirectiveToFile(codeStreamWriter, NULLABLE_RESTORE_DIRECTIVE);
+                    AddDirectiveToFile(codeStreamWriter, NULLABLE_RESTORE_DIRECTIVE);
                     codeProvider.GenerateCodeFromCompileUnit(ccu, codeStreamWriter, o);
 
                     codeStreamWriter.Flush();
@@ -686,7 +686,7 @@ namespace MS.Internal
         }
 
         // adds directrive to top of the file.
-        private static void addDirectiveToFile(StreamWriter streamWriter, string directive) {
+        private static void AddDirectiveToFile(StreamWriter streamWriter, string directive) {
             streamWriter.WriteLine(directive);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -686,7 +686,8 @@ namespace MS.Internal
         }
 
         // adds directrive to top of the file.
-        private static void AddDirectiveToFile(StreamWriter streamWriter, string directive) {
+        private static void AddDirectiveToFile(StreamWriter streamWriter, string directive) 
+        {
             streamWriter.WriteLine(directive);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -666,7 +666,7 @@ namespace MS.Internal
                     {
                         _ccRoot.CodeClass.IsPartial = true;
                     }
-
+                    addDirectiveToFile(codeStreamWriter, NULLABLE_RESTORE_DIRECTIVE);
                     codeProvider.GenerateCodeFromCompileUnit(ccu, codeStreamWriter, o);
 
                     codeStreamWriter.Flush();
@@ -683,6 +683,11 @@ namespace MS.Internal
             // or a friend assembly and it is generated only when any such internals are actually
             // encountered in any of the xaml files in the project.
             GenerateInternalTypeHelperImplementation();
+        }
+
+        // adds directrive to top of the file.
+        private static void addDirectiveToFile(StreamWriter streamWriter, string directive) {
+            streamWriter.WriteLine(directive);
         }
 
         //
@@ -1643,6 +1648,7 @@ namespace MS.Internal
 
         private void AddLinePragma(CodeTypeMember ctm, int lineNumber)
         {
+
             CodeLinePragma clp = new CodeLinePragma(ParentFolderPrefix + SourceFileInfo.RelativeSourceFilePath + XAML, lineNumber);
             ctm.LinePragma = clp;
         }
@@ -3608,6 +3614,9 @@ namespace MS.Internal
 
         private static string s_generatedCode_ToolName;
         private static string s_generatedCode_ToolVersion;
+
+        // For enabling nullable in the project
+        private static string NULLABLE_RESTORE_DIRECTIVE = "#nullable restore";
 
 #endregion Private Data
     }


### PR DESCRIPTION
Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
Create a C# "WPF Application" project targeting .NET 5 or .NET 6
Add a "Page Function (WPF)" item to the project.
Build Solution
Expected: No errors
Actual: CS0263 -- Partial declarations of 'PageFunction1' must not specify different base classes

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
