### PR TITLE
Fix build failing when using multiple SDK

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 using System.Globalization;
 using System.Diagnostics;
@@ -752,7 +753,7 @@ namespace Microsoft.Build.Tasks.Windows
         //
         // Replace implicit SDK imports with explicit imports 
         //
-        static private void ReplaceImplicitImports(XmlDocument xmlProjectDoc)
+        private static void ReplaceImplicitImports(XmlDocument xmlProjectDoc)
         {
             if (xmlProjectDoc == null)
             {
@@ -764,45 +765,70 @@ namespace Microsoft.Build.Tasks.Windows
 
             for (int i = 0; i < root.Attributes.Count; i++)
             {
-                XmlAttribute xmlAttribute = root.Attributes[i] as XmlAttribute;
+                XmlAttribute xmlAttribute = root.Attributes[i];
 
                 if (xmlAttribute.Name.Equals("Sdk", StringComparison.OrdinalIgnoreCase))
                 {
-                    //  <Project Sdk="Microsoft.NET.Sdk">
-                    //  <Project Sdk="My.Custom.Sdk/1.0.0">
-                    //  <Project Sdk="My.Custom.Sdk/min=1.0.0">
+                    string sdks = xmlAttribute.Value;
 
-                    string sdkValue = xmlAttribute.Value;
+                    bool removedSdkAttribute = false;
+                    XmlNode previousNodeImportProps = null;
+                    XmlNode previousNodeImportTargets = null;
 
-                    if (!SdkReference.TryParse(sdkValue, out SdkReference sdkReference))
-                        return;
+                    foreach (string sdk in sdks.Split(_semicolonChar).Select(i => i.Trim()))
+                    {
+                        //  <Project Sdk="Microsoft.NET.Sdk">
+                        //  <Project Sdk="My.Custom.Sdk/1.0.0">
+                        //  <Project Sdk="My.Custom.Sdk/min=1.0.0">
+                        if (!SdkReference.TryParse(sdk, out SdkReference sdkReference))
+                            break;
 
-                    // Remove Sdk attribute
-                    root.Attributes.Remove(xmlAttribute);
+                        // Remove Sdk attribute
+                        if (!removedSdkAttribute)
+                        {
+                            root.Attributes.Remove(xmlAttribute);
 
-                    //
-                    // Add explicit top import
-                    //
-                    //  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-                    //  <Import Project="Sdk.props" Sdk="My.Custom.Sdk" Version="1.0.0" />
-                    //  <Import Project="Sdk.props" Sdk="My.Custom.Sdk" MinimumVersion="1.0.0" />
-                    //
-                    XmlNode nodeImportProps = CreateImportProjectSdkNode(xmlProjectDoc, "Sdk.props", sdkReference);
+                            removedSdkAttribute = true;
+                        }
 
-                    // Prepend this Import to the root of the XML document
-                    root.PrependChild(nodeImportProps);
+                        //
+                        // Add explicit top import
+                        //
+                        //  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+                        //  <Import Project="Sdk.props" Sdk="My.Custom.Sdk" Version="1.0.0" />
+                        //  <Import Project="Sdk.props" Sdk="My.Custom.Sdk" MinimumVersion="1.0.0" />
+                        //
+                        XmlNode nodeImportProps = CreateImportProjectSdkNode(xmlProjectDoc, "Sdk.props", sdkReference);
 
-                    //
-                    // Add explicit bottom import
-                    //
-                    //  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-                    //  <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" Version="1.0.0" />
-                    //  <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" MinimumVersion="1.0.0" />
-                    //
-                    XmlNode nodeImportTargets = CreateImportProjectSdkNode(xmlProjectDoc, "Sdk.targets", sdkReference);
+                        // Prepend this Import to the root of the XML document
+                        if (previousNodeImportProps == null)
+                        {
+                            previousNodeImportProps = root.PrependChild(nodeImportProps);
+                        }
+                        else
+                        {
+                            previousNodeImportProps = root.InsertAfter(nodeImportProps, previousNodeImportProps);
+                        }
 
-                    // Append this Import to the end of the XML document
-                    root.AppendChild(nodeImportTargets);
+                        //
+                        // Add explicit bottom import
+                        //
+                        //  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+                        //  <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" Version="1.0.0" />
+                        //  <Import Project="Sdk.targets" Sdk="My.Custom.Sdk" MinimumVersion="1.0.0" />
+                        //
+                        XmlNode nodeImportTargets = CreateImportProjectSdkNode(xmlProjectDoc, "Sdk.targets", sdkReference);
+
+                        // Append this Import to the end of the XML document
+                        if (previousNodeImportTargets == null)
+                        {
+                            previousNodeImportTargets = root.AppendChild(nodeImportTargets);
+                        }
+                        else
+                        {
+                            previousNodeImportTargets = root.InsertAfter(nodeImportTargets, previousNodeImportTargets);
+                        }
+                    }
                 }
             }
         }
@@ -879,6 +905,8 @@ namespace Microsoft.Build.Tasks.Windows
         private const string INCLUDE_ATTR_NAME = "Include";
 
         private const string WPFTMP = "wpftmp";
+
+        private static readonly char[] _semicolonChar = new char[] { ';' };
 
         #endregion Private Fields
 


### PR DESCRIPTION
Fixes #5921

## Description
Fixes a build error when using multiple SDKs in the SDK attribute when `IncludePackageReferencesDuringMarkupCompilation` is set to true. Loops through every SDKs in the SDK attribute and adds them to the generated project separately.

I used this code from the MSBuild repo to split the SDKs: https://github.com/dotnet/msbuild/blob/main/src/Build/Construction/ProjectRootElement.cs#L1907.

## Customer Impact
Developers cannot build projects with multiple SDKs.

## Regression
This is an accidental regression introduced in the .Net 6 SDK when `IncludePackageReferencesDuringMarkupCompilation` was changed to true by default. The same bug is happening in the .Net 5 SDK when overriding `IncludePackageReferencesDuringMarkupCompilation` to true.

## Testing
Tested build of a project with multiple SDKs.

## Risk
Low.

Note to reviewer: I recommend reviewing this PR using the diff without whitespace because the indentation changed a lot: https://github.com/dotnet/wpf/pull/5922/files?diff=unified&w=1.
