### PR TITLE
Remove the unnecessary calculate code in ImageSource.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSource.cs
@@ -112,7 +112,7 @@ namespace System.Windows.Media
 
             if (dpif < 0.0F || FloatUtil.IsCloseToDivideByZero(96.0F, dpif))
             {
-                dpif = 96.0F;
+                return pixels;
             }
 
             return (double)(pixels * (96.0F / dpif));


### PR DESCRIPTION


## Description

Should we remove the calculate when dpif equals 96.0F?

    return (double)(pixels * (96.0F / dpif));
    When dpif == 96.0F
    (double)(pixels * (96.0F / dpif)) 
      = (double)(pixels * (96.0F / 96.0F)) 
      = (double)(pixels * 1) 
      = (double)(pixels) 

## Customer Impact

None.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI

## Risk

Low.
