### PR TITLE
Replace IsAssignableFrom with is in converters

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/BorderGapMaskConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/BorderGapMaskConverter.cs
@@ -36,24 +36,17 @@ namespace System.Windows.Controls
             //
             // Parameter Validation
             //
-
-            Type doubleType = typeof(double);
-
             if (parameter == null ||
                 values == null ||
                 values.Length != 3 ||
-                values[0] == null ||
-                values[1] == null ||
-                values[2] == null ||
-                !doubleType.IsAssignableFrom(values[0].GetType()) ||
-                !doubleType.IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()) )
+                values[0] is not double ||
+                values[1] is not double ||
+                values[2] is not double)
             {
                 return DependencyProperty.UnsetValue;
             }
 
-            Type paramType = parameter.GetType();
-            if (!(doubleType.IsAssignableFrom(paramType) || typeof(string).IsAssignableFrom(paramType)))
+            if (parameter is not double && parameter is not string)
             {
                 return DependencyProperty.UnsetValue;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuScrollingVisibilityConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuScrollingVisibilityConverter.cs
@@ -45,25 +45,18 @@ namespace System.Windows.Controls
             //
             // Parameter Validation
             //
-
-            Type doubleType = typeof(double);
             if (parameter == null ||
                 values == null ||
                 values.Length != 4 ||
-                values[0] == null ||
-                values[1] == null ||
-                values[2] == null ||
-                values[3] == null ||
-                !typeof(Visibility).IsAssignableFrom(values[0].GetType()) ||
-                !doubleType.IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()) ||
-                !doubleType.IsAssignableFrom(values[3].GetType()) )
+                values[0] is not Visibility ||
+                values[1] is not double ||
+                values[2] is not double ||
+                values[3] is not double)
             {
                 return DependencyProperty.UnsetValue;
             }
 
-            Type paramType = parameter.GetType();
-            if (!(doubleType.IsAssignableFrom(paramType) || typeof(string).IsAssignableFrom(paramType)))
+            if (parameter is not double && parameter is not string)
             {
                 return DependencyProperty.UnsetValue;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonScrollButtonVisibilityConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonScrollButtonVisibilityConverter.cs
@@ -45,25 +45,18 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
             //
             // Parameter Validation
             //
-
-            Type doubleType = typeof(double);
             if (parameter == null ||
                 values == null ||
                 values.Length != 4 ||
-                values[0] == null ||
-                values[1] == null ||
-                values[2] == null ||
-                values[3] == null ||
-                !typeof(Visibility).IsAssignableFrom(values[0].GetType()) ||
-                !doubleType.IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()) ||
-                !doubleType.IsAssignableFrom(values[3].GetType()) )
+                values[0] is not Visibility ||
+                values[1] is not double ||
+                values[2] is not double ||
+                values[3] is not double)
             {
                 return DependencyProperty.UnsetValue;
             }
 
-            Type paramType = parameter.GetType();
-            if (!(doubleType.IsAssignableFrom(paramType) || typeof(string).IsAssignableFrom(paramType)))
+            if (parameter is not double && parameter is not string)
             {
                 return DependencyProperty.UnsetValue;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/Microsoft/Windows/Themes/ProgressBarHighlightConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/Microsoft/Windows/Themes/ProgressBarHighlightConverter.cs
@@ -32,15 +32,11 @@ namespace Microsoft.Windows.Themes
             //
             // Parameter Validation
             //
-            Type doubleType = typeof(double);
             if (values == null ||
-                (values.Length != 3) ||
-                (values[0] == null)  ||
-                (values[1] == null)  ||
-                (values[2] == null)  ||
-                !typeof(Brush).IsAssignableFrom(values[0].GetType()) || 
-                !doubleType.IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()))
+                values.Length != 3 ||
+                values[0] is not Brush ||
+                values[1] is not double ||
+                values[2] is not double)
             {
                 return null;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Microsoft/Windows/Themes/ProgressBarHighlightConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Microsoft/Windows/Themes/ProgressBarHighlightConverter.cs
@@ -32,15 +32,11 @@ namespace Microsoft.Windows.Themes
             //
             // Parameter Validation
             //
-            Type doubleType = typeof(double);
             if (values == null ||
-                (values.Length != 3) ||
-                (values[0] == null)  ||
-                (values[1] == null)  ||
-                (values[2] == null)  ||
-                !typeof(Brush).IsAssignableFrom(values[0].GetType()) || 
-                !doubleType.IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()))
+                values.Length != 3 ||
+                values[0] is not Brush ||
+                values[1] is not double ||
+                values[2] is not double)
             {
                 return null;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/Shared/Microsoft/Windows/Themes/ProgressBarBrushConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Shared/Microsoft/Windows/Themes/ProgressBarBrushConverter.cs
@@ -32,19 +32,13 @@ namespace Microsoft.Windows.Themes
             //
             // Parameter Validation
             //
-            Type doubleType = typeof(double);
             if (values == null ||
-                (values.Length != 5) ||
-                (values[0] == null)  ||
-                (values[1] == null)  ||
-                (values[2] == null)  ||
-                (values[3] == null) ||
-                (values[4] == null) ||
-                !typeof(Brush).IsAssignableFrom(values[0].GetType()) || 
-                !typeof(bool).IsAssignableFrom(values[1].GetType()) ||
-                !doubleType.IsAssignableFrom(values[2].GetType()) ||
-                !doubleType.IsAssignableFrom(values[3].GetType()) ||
-                !doubleType.IsAssignableFrom(values[4].GetType()))
+                values.Length != 5 ||
+                values[0] is not Brush ||
+                values[1] is not bool ||
+                values[2] is not double ||
+                values[3] is not double ||
+                values[4] is not double)
             {
                 return null;
             }


### PR DESCRIPTION
## Description
Replace IsAssignableFrom with is in converters. It is faster, has smaller IL and smaller JIT code.

I used [this benchmark](https://gist.github.com/ThomasGoulet73/86043718584c119dc746b1df108ca871) to ensure that it is in fact faster with `MenuScrollingVisibilityConverter` as an example.

Here is the result:
```
| Method |    values | parameter |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Code Size | Allocated |
|------- |---------- |---------- |---------:|---------:|---------:|------:|-------:|----------:|----------:|
|    Old | Object[4] |         0 | 41.75 ns | 0.623 ns | 0.552 ns |  1.00 | 0.0076 |   1,037 B |      24 B |
|    New | Object[4] |         0 | 14.18 ns | 0.175 ns | 0.146 ns |  0.34 | 0.0076 |     936 B |      24 B |
```

## Customer Impact
None.

## Regression
No.

## Testing
Tested a few converters locally.

## Risk
None.
