### PR TITLE
Remove .net6.0; not required

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <EnablePInvokeAnalyzer>true</EnablePInvokeAnalyzer>
 


### PR DESCRIPTION
Fixes 
[**https://github.com/dotnet/sdk/pull/23293**
](https://github.com/dotnet/sdk/pull/23293)
Main PR <!-- Link to PR if any that fixed this in the main branch. -->
[**https://github.com/dotnet/sdk/pull/23293**
](https://github.com/dotnet/sdk/pull/23293)

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Tests in dotnet SDK failing.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
None
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
CI Build and Run SDK Tests
<!-- What kind of testing has been done with the fix. -->

## Risk
None
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
