### PR TITLE
Mismatch of PBT version between WinFX Targets and PBT csproj

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">net6.0</_PresentationBuildTasksTfm>
+    <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">net7.0</_PresentationBuildTasksTfm>
     <_PresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_PresentationBuildTasksTfm>
     <_PresentationBuildTasksAssembly Condition="'$(_PresentationBuildTasksAssembly)'==''">$([MSBuild]::Unescape($([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\$(_PresentationBuildTasksTfm)\PresentationBuildTasks.dll'))))</_PresentationBuildTasksAssembly>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -60,7 +60,7 @@
     <PackagingAssemblyContent Include="System.Reflection.MetadataLoadContext.dll" />
     <PackagingAssemblyContent Include="System.Runtime.CompilerServices.Unsafe.dll" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
     <PackagingAssemblyContent Include="PresentationBuildTasks.dll" />
     <PackagingAssemblyContent Include="System.Reflection.MetadataLoadContext.dll" />
   </ItemGroup>


### PR DESCRIPTION
Fixes # 
https://github.com/dotnet/sdk/pull/23293

Main PR <!-- Link to PR if any that fixed this in the main branch. -->
https://github.com/dotnet/sdk/pull/23293

## Description
Mismatch of the TargetFramework used to create the package and to locate the task DLL.
PBT csproj has net7.0 while winfx targets had net6.0
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
None
<!-- What is the impact to customers of not taking this fix? -->

## Regression
None
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Build CI and SDK Tests
<!-- What kind of testing has been done with the fix. -->

## Risk
None
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
