### PR TITLE
Fix dlls not generated in native directory

### DIFF
--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -80,7 +80,7 @@ $(PreparePackageAssetsDependsOn):
           Condition="'$(PackageName)'!=''">
 
     <PropertyGroup>
-      <DestinationSubFolder Condition="'$(DestinationSubFolder)'=='' and '$(TargetFramework)'!=''">$(LibFolder)\$(TargetFramework)\</DestinationSubFolder>
+      <DestinationSubFolder Condition="'$(DestinationSubFolder)'=='' and '$(TargetFramework)'!='' and '$(MSBuildProjectExtension)'!='.vcxproj'">$(LibFolder)\$(TargetFramework)\</DestinationSubFolder>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(DestinationSubFolder)'==''">

--- a/eng/WpfArcadeSdk/tools/Packaging.targets
+++ b/eng/WpfArcadeSdk/tools/Packaging.targets
@@ -80,7 +80,7 @@ $(PreparePackageAssetsDependsOn):
           Condition="'$(PackageName)'!=''">
 
     <PropertyGroup>
-      <DestinationSubFolder Condition="'$(DestinationSubFolder)'=='' and '$(TargetFramework)'!='' and '$(MSBuildProjectExtension)'!='.vcxproj'">$(LibFolder)\$(TargetFramework)\</DestinationSubFolder>
+      <DestinationSubFolder Condition="'$(DestinationSubFolder)'=='' and '$(TargetFramework)'!='' and !('$(MSBuildProjectExtension)'=='.vcxproj' and '$(UseDestinationLibFolder)' == '')">$(LibFolder)\$(TargetFramework)\</DestinationSubFolder>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(MSBuildProjectExtension)'=='.vcxproj' and '$(DestinationSubFolder)'==''">

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
@@ -27,7 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>
-    
+    <UseDestinationLibFolder>true</UseDestinationLibFolder>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <RestoreProjectStyle>Unknown</RestoreProjectStyle>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -27,7 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup>
-    
+    <UseDestinationLibFolder>true</UseDestinationLibFolder>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <RestoreProjectStyle>Unknown</RestoreProjectStyle>


### PR DESCRIPTION
Fixes # [PR Failing Test](https://github.com/dotnet/installer/pull/13073)

Main PR <!-- Link to PR if any that fixed this in the main branch. -->
https://github.com/dotnet/installer/pull/13073
## Description
PresentationNative and some more native dls weren't getting created in the native folder, instead were going inside the lib folder.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Some dlls won't be created in their respective locations.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
This was a regression of the PR https://github.com/dotnet/wpf/pull/5901
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local build, CI
<!-- What kind of testing has been done with the fix. -->

## Risk
None
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
