### PR TITLE
Update pre-release label and add triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ trigger:
     - release/3.*
     - release/5.*
     - release/6.*
+    - release/7.*
     - internal/release/5.*
     - internal/release/6.*
     - experimental/*
@@ -56,6 +57,7 @@ pr:
     - internal/release/3.*
     - release/5.*
     - release/6.*
+    - release/7.*
     - experimental/*
   paths:
     exclude:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>7.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <SystemIOPackagingVersion>7.0.0-preview.2.22074.8</SystemIOPackagingVersion>
     <SystemResourcesExtensionsVersion>7.0.0-preview.2.22074.8</SystemResourcesExtensionsVersion>
   </PropertyGroup>


### PR DESCRIPTION
Updates the pre-release label to 2 and adds triggers for the 7.0 branches.