### PR TITLE
Enable template localization on dotnet CLI

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -3,6 +3,7 @@
     <ProjectGuid>{BFF6C118-3369-43B5-ACA6-D65ED00EEBE0}</ProjectGuid>
     
     <Platforms>AnyCPU;x64;arm64</Platforms>
+    <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>    
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikace WPF",
   "description": "Projekt pro vytvoření aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "symbols/Nullable/description": "Určuje, zda se mají pro tento projekt povolit odkazové typy s možnou hodnotou null.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF-Anwendung",
   "description": "Ein Projekt zum Erstellen einer .NET WPF-Anwendung",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Nullable/description": "Gibt an, ob Nullable-Verweistypen für dieses Projekt aktiviert werden sollen.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicación WPF",
   "description": "Proyecto para crear una aplicación WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "symbols/Nullable/description": "Indica si se deben habilitar tipos de referencia que aceptan valores NULL para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Application WPF",
   "description": "Projet de création d'une application WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "symbols/Nullable/description": "Indique s’il faut activer les types référence Nullable pour ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Applicazione WPF",
   "description": "Progetto per la creazione di un'applicazione WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "symbols/Nullable/description": "Indica se abilitare i tipi di riferimento che ammettono i valori Null per questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF アプリケーション",
   "description": ".NET WPF アプリケーションを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "symbols/Nullable/description": "このプロジェクトの null 許容参照型を有効にするかどうか。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 애플리케이션",
   "description": ".NET WPF 애플리케이션 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "symbols/Nullable/description": "이 프로젝트에 대해 nullable 참조 형식을 사용할지 여부를 지정합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,17 +1,18 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikacja WPF",
-  "description": "Projekt służący do tworzenia aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/Nullable/description": "Określa, czy w przypadku tego projektu mają być włączane typy pustych referencji.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik MainWindow.xaml w edytorze"
+  "postActions/editor/description": "Otwiera plik MainWindow.xaml w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicativo WPF",
   "description": "Um projeto para a criação de um aplicativo .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "symbols/Nullable/description": "Se permitir tipos de referência anuláveis para este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Приложение WPF",
   "description": "Проект для создания приложения WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "symbols/Nullable/description": "Следует ли включить ссылочные типы, допускающие значение null, для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Uygulaması",
   "description": ".NET WPF Uygulaması oluşturmaya yönelik proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "symbols/Nullable/description": "Bu proje için null atanabilir başvuru türlerinin etkinleştirilip etkinleştirilmeyeceğini belirtir.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 应用程序",
   "description": "用于创建 .NET WPF 应用程序的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "symbols/Nullable/description": "是否为此项目启用可为 null 的引用类型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 應用程式",
   "description": "此專案可用於建立 .NET WPF 應用程式",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "symbols/Nullable/description": "是否要啟用此專案的可 null 參考類型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikace WPF",
   "description": "Projekt pro vytvoření aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF-Anwendung",
   "description": "Ein Projekt zum Erstellen einer .NET WPF-Anwendung",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicación WPF",
   "description": "Proyecto para crear una aplicación WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Application WPF",
   "description": "Projet de création d'une application WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Applicazione WPF",
   "description": "Progetto per la creazione di un'applicazione WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF アプリケーション",
   "description": ".NET WPF アプリケーションを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 애플리케이션",
   "description": ".NET WPF 애플리케이션 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,16 +1,17 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikacja WPF",
-  "description": "Projekt służący do tworzenia aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik MainWindow.xaml w edytorze"
+  "postActions/editor/description": "Otwiera plik MainWindow.xaml w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicativo WPF",
   "description": "Um projeto para a criação de um aplicativo .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaura os pacotes do NuGet exigidos por este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Приложение WPF",
   "description": "Проект для создания приложения WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Uygulaması",
   "description": ".NET WPF Uygulaması oluşturmaya yönelik proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 应用程序",
   "description": "用于创建 .NET WPF 应用程序的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 應用程式",
   "description": "此專案可用於建立 .NET WPF 應用程式",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna tříd WPF",
   "description": "Projekt pro vytvoření knihovny tříd určené pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "symbols/Nullable/description": "Určuje, zda se mají pro tento projekt povolit odkazové typy s možnou hodnotou null.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF-Klassenbibliothek",
   "description": "Ein Projekt zum Erstellen einer Klassenbibliothek für eine .NET WPF-Anwendung",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Nullable/description": "Gibt an, ob Nullable-Verweistypen für dieses Projekt aktiviert werden sollen.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de clases de WPF",
   "description": "Proyecto para crear una biblioteca de clases destinada a una aplicación WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "symbols/Nullable/description": "Indica si se deben habilitar tipos de referencia que aceptan valores NULL para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de classes WPF",
   "description": "Projet de création d'une bibliothèque de classes qui cible une application WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "symbols/Nullable/description": "Indique s’il faut activer les types référence Nullable pour ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di classi WPF",
   "description": "Progetto per la creazione di una libreria di classi destinata a un'applicazione WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "symbols/Nullable/description": "Indica se abilitare i tipi di riferimento che ammettono i valori Null per questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF クラス ライブラリ",
   "description": ".NET WPF アプリケーションを対象とするクラス ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "symbols/Nullable/description": "このプロジェクトの null 許容参照型を有効にするかどうか。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 클래스 라이브러리",
   "description": ".NET Core WPF 애플리케이션을 대상으로 하는 클래스 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "symbols/Nullable/description": "이 프로젝트에 대해 nullable 참조 형식을 사용할지 여부를 지정합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,17 +1,18 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka klas WPF",
-  "description": "Projekt służący do tworzenia biblioteki klas przeznaczonej dla aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia biblioteki klas przeznaczonej dla aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/Nullable/description": "Określa, czy w przypadku tego projektu mają być włączane typy pustych referencji.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik Class1.cs w edytorze"
+  "postActions/editor/description": "Otwiera plik Class1.cs w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Classes WPF",
   "description": "Um projeto para a criação de uma biblioteca de classes voltada para um aplicativo .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "symbols/Nullable/description": "Se permitir tipos de referência anuláveis para este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека классов WPF",
   "description": "Проект для создания библиотеки классов, использующей приложение WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "symbols/Nullable/description": "Следует ли включить ссылочные типы, допускающие значение null, для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Sınıf Kitaplığı",
   "description": "Bir .NET WPF Uygulamasını hedefleyen bir sınıf kitaplığı oluşturmaya yönelik bir proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "symbols/Nullable/description": "Bu proje için null atanabilir başvuru türlerinin etkinleştirilip etkinleştirilmeyeceğini belirtir.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 类库",
   "description": "用于创建目标为 .NET WPF 应用程序的类库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "symbols/Nullable/description": "是否为此项目启用可为 null 的引用类型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 類別庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的類別庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "symbols/Nullable/description": "是否要啟用此專案的可 null 參考類型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna tříd WPF",
   "description": "Projekt pro vytvoření knihovny tříd určené pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF-Klassenbibliothek",
   "description": "Ein Projekt zum Erstellen einer Klassenbibliothek für eine .NET WPF-Anwendung",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de clases de WPF",
   "description": "Proyecto para crear una biblioteca de clases destinada a una aplicación WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de classes WPF",
   "description": "Projet de création d'une bibliothèque de classes qui cible une application WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di classi WPF",
   "description": "Progetto per la creazione di una libreria di classi destinata a un'applicazione WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF クラス ライブラリ",
   "description": ".NET WPF アプリケーションを対象とするクラス ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 클래스 라이브러리",
   "description": ".NET Core WPF 애플리케이션을 대상으로 하는 클래스 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,16 +1,17 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka klas WPF",
-  "description": "Projekt służący do tworzenia biblioteki klas przeznaczonej dla aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia biblioteki klas przeznaczonej dla aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik Class1.vb w edytorze"
+  "postActions/editor/description": "Otwiera plik Class1.vb w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Classes WPF",
   "description": "Um projeto para a criação de uma biblioteca de classes voltada para um aplicativo .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaura os pacotes do NuGet exigidos por este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека классов WPF",
   "description": "Проект для создания библиотеки классов, использующей приложение WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Sınıf Kitaplığı",
   "description": "Bir .NET WPF Uygulamasını hedefleyen bir sınıf kitaplığı oluşturmaya yönelik bir proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 类库",
   "description": "用于创建目标为 .NET WPF 应用程序的类库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 類別庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的類別庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna vlastních ovládacích prvků WPF",
   "description": "Projekt pro vytvoření knihovny vlastních ovládacích prvků pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "symbols/Nullable/description": "Určuje, zda se mají pro tento projekt povolit odkazové typy s možnou hodnotou null.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothek benutzerdefinierter WPF-Steuerelemente",
   "description": "Ein Projekt zum Erstellen einer Bibliothek benutzerdefinierter Steuerelemente für .NET WPF-Anwendungen",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Nullable/description": "Gibt an, ob Nullable-Verweistypen für dieses Projekt aktiviert werden sollen.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de control personalizada de WPF",
   "description": "Proyecto para crear una biblioteca de control personalizada para aplicaciones WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "symbols/Nullable/description": "Indica si se deben habilitar tipos de referencia que aceptan valores NULL para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles personnalisés WPF",
   "description": "Projet de création d'une bibliothèque de contrôles personnalisés pour les applications WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "symbols/Nullable/description": "Indique s’il faut activer les types référence Nullable pour ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli personalizzati WPF",
   "description": "Progetto per la creazione di una libreria di controlli personalizzati per applicazioni WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "symbols/Nullable/description": "Indica se abilitare i tipi di riferimento che ammettono i valori Null per questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF カスタム コントロール ライブラリ",
   "description": ".NET WPF アプリケーション用のカスタム コントロール ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "symbols/Nullable/description": "このプロジェクトの null 許容参照型を有効にするかどうか。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 사용자 지정 컨트롤 라이브러리",
   "description": ".NET Core WPF 애플리케이션용 사용자 지정 컨트롤 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "symbols/Nullable/description": "이 프로젝트에 대해 nullable 참조 형식을 사용할지 여부를 지정합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,17 +1,18 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka niestandardowych kontrolek WPF",
-  "description": "Projekt służący do tworzenia niestandardowej biblioteki kontrolek na potrzeby aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia niestandardowej biblioteki kontrolek na potrzeby aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/Nullable/description": "Określa, czy w przypadku tego projektu mają być włączane typy pustych referencji.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik CustomControl1.cs w edytorze"
+  "postActions/editor/description": "Otwiera plik CustomControl1.cs w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles Personalizados do WPF",
   "description": "Um projeto para a criação de uma biblioteca de controles personalizada para aplicativos .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "symbols/Nullable/description": "Se permitir tipos de referência anuláveis para este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека настраиваемых элементов управления WPF",
   "description": "Проект для создания библиотеки настраиваемых элементов управления для приложений WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "symbols/Nullable/description": "Следует ли включить ссылочные типы, допускающие значение null, для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Özel Denetim Kitaplığı",
   "description": ".NET WPF Uygulamaları için özel bir denetim kitaplığı oluşturmaya yönelik bir proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "symbols/Nullable/description": "Bu proje için null atanabilir başvuru türlerinin etkinleştirilip etkinleştirilmeyeceğini belirtir.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 自定义控件库",
   "description": "用于为 .NET WPF 应用程序创建自定义控件库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "symbols/Nullable/description": "是否为此项目启用可为 null 的引用类型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 自訂控制項程式庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的自訂控制項程式庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "symbols/Nullable/description": "是否要啟用此專案的可 null 參考類型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna vlastních ovládacích prvků WPF",
   "description": "Projekt pro vytvoření knihovny vlastních ovládacích prvků pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothek benutzerdefinierter WPF-Steuerelemente",
   "description": "Ein Projekt zum Erstellen einer Bibliothek benutzerdefinierter Steuerelemente für .NET WPF-Anwendungen",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de control personalizada de WPF",
   "description": "Proyecto para crear una biblioteca de control personalizada para aplicaciones WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles personnalisés WPF",
   "description": "Projet de création d'une bibliothèque de contrôles personnalisés pour les applications WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli personalizzati WPF",
   "description": "Progetto per la creazione di una libreria di controlli personalizzati per applicazioni WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF カスタム コントロール ライブラリ",
   "description": ".NET WPF アプリケーション用のカスタム コントロール ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 사용자 지정 컨트롤 라이브러리",
   "description": ".NET Core WPF 애플리케이션용 사용자 지정 컨트롤 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,16 +1,17 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka niestandardowych kontrolek WPF",
-  "description": "Projekt służący do tworzenia niestandardowej biblioteki kontrolek na potrzeby aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia niestandardowej biblioteki kontrolek na potrzeby aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik CustomControl1.vb w edytorze"
+  "postActions/editor/description": "Otwiera plik CustomControl1.vb w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles Personalizados do WPF",
   "description": "Um projeto para a criação de uma biblioteca de controles personalizada para aplicativos .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaura os pacotes do NuGet exigidos por este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека настраиваемых элементов управления WPF",
   "description": "Проект для создания библиотеки настраиваемых элементов управления для приложений WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Özel Denetim Kitaplığı",
   "description": ".NET WPF Uygulamaları için özel bir denetim kitaplığı oluşturmaya yönelik bir proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 自定义控件库",
   "description": "用于为 .NET WPF 应用程序创建自定义控件库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 自訂控制項程式庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的自訂控制項程式庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna uživatelských ovládacích prvků WPF",
   "description": "Projekt pro vytvoření knihovny uživatelských ovládacích prvků pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "symbols/Nullable/description": "Určuje, zda se mají pro tento projekt povolit odkazové typy s možnou hodnotou null.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothek von WPF-Benutzersteuerelementen",
   "description": "Ein Projekt zum Erstellen einer Bibliothek von Benutzersteuerelementen für .NET WPF-Anwendungen",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Nullable/description": "Gibt an, ob Nullable-Verweistypen für dieses Projekt aktiviert werden sollen.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/Nullable/description": "Whether to enable nullable reference types for this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de controles de usuario de WPF",
   "description": "Proyecto para crear una biblioteca de controles de usuario para aplicaciones WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "symbols/Nullable/description": "Indica si se deben habilitar tipos de referencia que aceptan valores NULL para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles utilisateur WPF",
   "description": "Projet de création d'une bibliothèque de contrôles utilisateur pour les applications WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "symbols/Nullable/description": "Indique s’il faut activer les types référence Nullable pour ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli utente WPF",
   "description": "Progetto per la creazione di una libreria di controlli utente per applicazioni WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "symbols/Nullable/description": "Indica se abilitare i tipi di riferimento che ammettono i valori Null per questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF ユーザー コントロール ライブラリ",
   "description": ".NET Core WPF アプリケーション用のユーザー コントロール ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "symbols/Nullable/description": "このプロジェクトの null 許容参照型を有効にするかどうか。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 사용자 정의 컨트롤 라이브러리",
   "description": ".NET WPF 애플리케이션용 사용자 정의 컨트롤 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "symbols/Nullable/description": "이 프로젝트에 대해 nullable 참조 형식을 사용할지 여부를 지정합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,17 +1,18 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka kontrolek użytkownika WPF",
-  "description": "Projekt służący do tworzenia biblioteki kontrolek użytkownika na potrzeby aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia biblioteki kontrolek użytkownika na potrzeby aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/Nullable/description": "Określa, czy w przypadku tego projektu mają być włączane typy pustych referencji.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik UserControl1.xaml w edytorze"
+  "postActions/editor/description": "Otwiera plik UserControl1.xaml w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles de Usuário do WPF",
   "description": "Um projeto para criar uma biblioteca de controles de usuário para aplicativos .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "symbols/Nullable/description": "Se permitir tipos de referência anuláveis para este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека пользовательских элементов управления WPF",
   "description": "Проект для создания библиотеки пользовательских элементов управления для приложений WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "symbols/Nullable/description": "Следует ли включить ссылочные типы, допускающие значение null, для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Kullanıcı Denetimi Kitaplığı",
   "description": ".NET WPF Uygulamaları için kullanıcı kontrolü kitaplığı oluşturmaya yönelik proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "symbols/Nullable/description": "Bu proje için null atanabilir başvuru türlerinin etkinleştirilip etkinleştirilmeyeceğini belirtir.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 用户控件库",
   "description": "用于为 .NET WPF 应用程序创建用户控件库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "symbols/Nullable/description": "是否为此项目启用可为 null 的引用类型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 使用者控制項程式庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的使用者控制項程式庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "symbols/Nullable/description": "是否要啟用此專案的可 null 參考類型。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna uživatelských ovládacích prvků WPF",
   "description": "Projekt pro vytvoření knihovny uživatelských ovládacích prvků pro aplikace WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Cílit na netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Cílit na net5.0",
   "symbols/Framework/choices/net6.0/description": "Cílit na net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Nastaví langVersion ve vytvořeném souboru projektu.",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothek von WPF-Benutzersteuerelementen",
   "description": "Ein Projekt zum Erstellen einer Bibliothek von Benutzersteuerelementen für .NET WPF-Anwendungen",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Auf „netcoreapp3.1“ abzielen",
   "symbols/Framework/choices/net5.0/description": "Auf „net5.0“ abzielen",
   "symbols/Framework/choices/net6.0/description": "Auf „net6.0“ abzielen",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Legt „langVersion“ in der erstellten Projektdatei fest",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Target netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Target net5.0",
   "symbols/Framework/choices/net6.0/description": "Target net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Sets langVersion in the created project file",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de controles de usuario de WPF",
   "description": "Proyecto para crear una biblioteca de controles de usuario para aplicaciones WPF de .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Establece langVersion en el archivo de proyecto creado.",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles utilisateur WPF",
   "description": "Projet de création d'une bibliothèque de contrôles utilisateur pour les applications WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli utente WPF",
   "description": "Progetto per la creazione di una libreria di controlli utente per applicazioni WPF .NET",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 di destinazione",
   "symbols/Framework/choices/net5.0/description": "Net5.0 di destinazione",
   "symbols/Framework/choices/net6.0/description": "Net6.0 di destinazione",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Imposta langVersion nel file di progetto creato",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF ユーザー コントロール ライブラリ",
   "description": ".NET Core WPF アプリケーション用のユーザー コントロール ライブラリを作成するためのプロジェクト",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "ターゲット netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "ターゲット net5.0",
   "symbols/Framework/choices/net6.0/description": "ターゲット net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "作成されたプロジェクト ファイルで langVersion を設定します",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 사용자 정의 컨트롤 라이브러리",
   "description": ".NET WPF 애플리케이션용 사용자 정의 컨트롤 라이브러리 만들기 프로젝트",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "대상 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "대상 net5.0",
   "symbols/Framework/choices/net6.0/description": "대상 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "만든 프로젝트 파일의 langVersion를 설정합니다",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,16 +1,17 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka kontrolek użytkownika WPF",
-  "description": "Projekt służący do tworzenia biblioteki kontrolek użytkownika na potrzeby aplikacji WPF w środowisku .NET",
+  "description": "Projekt służący do tworzenia biblioteki kontrolek użytkownika na potrzeby aplikacji WPF w\u00A0środowisku .NET",
   "symbols/TargetFrameworkOverride/description": "Zastępuje platformę docelową",
   "symbols/Framework/description": "Platforma docelowa dla tego projektu.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Docelowy netcoreapp3.0",
   "symbols/Framework/choices/netcoreapp3.1/description": "Docelowy netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Docelowy net5.0",
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/editor/description": "Otwiera plik UserControl1.xaml w edytorze"
+  "postActions/editor/description": "Otwiera plik UserControl1.xaml w\u00A0edytorze"
 }

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,13 +1,14 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles de Usuário do WPF",
   "description": "Um projeto para criar uma biblioteca de controles de usuário para aplicativos .NET WPF",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.0/description": "Netcoreapp3.0 de destino",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",
   "symbols/Framework/choices/net5.0/description": "Net5.0 de destino",
   "symbols/Framework/choices/net6.0/description": "Net6.0 de destino",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Define a langVersion no arquivo do projeto criado",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "postActions/restore/description": "Restaura os pacotes do NuGet exigidos por este projeto.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека пользовательских элементов управления WPF",
   "description": "Проект для создания библиотеки пользовательских элементов управления для приложений WPF .NET.",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF Kullanıcı Denetimi Kitaplığı",
   "description": ".NET WPF Uygulamaları için kullanıcı kontrolü kitaplığı oluşturmaya yönelik proje",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "Hedef netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "Hedef net5.0",
   "symbols/Framework/choices/net6.0/description": "Hedef net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "Oluşturulan proje dosyasında langVersion'ı ayarlar",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 用户控件库",
   "description": "用于为 .NET WPF 应用程序创建用户控件库的项目",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目标 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目标 net5.0",
   "symbols/Framework/choices/net6.0/description": "目标 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在创建的项目文件中设置 langVersion",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "WPF 使用者控制項程式庫",
   "description": "此專案可用於建立適用於 .NET WPF 應用程式的使用者控制項程式庫",
@@ -8,6 +8,7 @@
   "symbols/Framework/choices/netcoreapp3.1/description": "目標 netcoreapp3.1",
   "symbols/Framework/choices/net5.0/description": "目標 net5.0",
   "symbols/Framework/choices/net6.0/description": "目標 net6.0",
+  "symbols/Framework/choices/net7.0/description": "Target net7.0",
   "symbols/langVersion/description": "在建立的專案檔中設定 langVersion",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",


### PR DESCRIPTION
Fixes # 
related to https://github.com/dotnet/templating/issues/4308

## Description
Template engine (`dotnet new`) added support for template localizations in .NET 6.0. This new system replaces the old way of localizing templates that only worked on Visual Studio and works on both .NET CLI as well as VS.

This PR introduces changes to switch to the new template localization system.

### Summary of the changes
- Adds `<UsingToolTemplateLocalizer>true</>` to projects containing templates.
- Generates localization files to be translated by loc team

### What to expect after merging
Every time there is a change to one of the templates:
- The dev making the change should build (at the very least) the modified template project. This will update the loc files on the local working copy,
- Push the loc files together with the template modifications. Review & merge.
- OneLocBuild integration will automatically pick up the changes and will send them for translation.
- You will receive a PR containing the translated template loc files when they are ready. Review & merge.

## Customer Impact

## Regression

## Testing

## Risk