### PR TITLE
fix hang when margin is not a multiple of DPI rounding quantum (#5841)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -3078,6 +3078,38 @@ namespace System.Windows.Controls
             return ElementViewportPosition.None;
         }
 
+        // this version also returns the element's layout rectangle (in viewport's coordinates).
+        // VirtualizingStackPanel needs this, to determine the element's scroll offset.
+        internal static ElementViewportPosition GetElementViewportPosition(FrameworkElement viewPort,
+            UIElement element,
+            FocusNavigationDirection axis,
+            bool fullyVisible,
+            bool ignorePerpendicularAxis,
+            out Rect elementRect,
+            out Rect layoutRect)
+        {
+            ElementViewportPosition position = GetElementViewportPosition(
+                viewPort,
+                element,
+                axis,
+                fullyVisible,
+                false,
+                out elementRect);
+
+            if (position == ElementViewportPosition.None)
+            {
+                layoutRect = Rect.Empty;
+            }
+            else
+            {
+                Visual parent = VisualTreeHelper.GetParent(element) as Visual;
+                Debug.Assert(element != viewPort && element.IsArrangeValid && parent != null, "GetElementViewportPosition called in unsupported situation");
+                layoutRect = CorrectCatastrophicCancellation(parent.TransformToAncestor(viewPort)).TransformBounds(element.PreviousArrangeRect);
+            }
+
+            return position;
+        }
+
         // in large virtualized hierarchical lists (TreeView or grouping), the transform
         // returned by element.TransformToAncestor(viewport) is vulnerable to catastrophic
         // cancellation.  If element is at the top of the viewport, but embedded in


### PR DESCRIPTION
Addresses #4834
This is a port of a servicing fix in .NET 4.7-4.8.

### Description
This hang arises when UseLayoutRounding is set, and the container's top margin is not a multiple of the rounding quantum. VSP uses two offsets from the viewport to the container, one that includes the margin and one that doesn't. It was computing the second and subtracting the margin to obtain the first, but that can give the wrong answer in the situation above. This can lead to infinite re-measures in anchored scrolls.

Fixed by computing the first offset directly from layout information. The two offsets will differ by an amount that is close to the margin size, and rounded to a quantum, but there's no way to know which of the nearby candidates is the right one.

### Customer Impact
Hang while scrolling an ItemsControl.

### Regression
no

### Testing
Ad-hoc around customer scenario.
Standard regression testing.

### Risk
Low. Port of a .NETFx servicing fix released earlier this year.