### PR TITLE
fix IME vs. property-changed Binding battle (#5840)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -1170,7 +1170,7 @@ namespace System.Windows.Data
             ValidationError oldValidationError = GetValidationErrors(validationStep);
 
             // ignore an error from the implicit DataError rule - this is checked
-            // separately (in BindingExpression.Validate). 
+            // separately (in BindingExpression.Validate).
             if (oldValidationError != null &&
                 oldValidationError.RuleInError == DataErrorValidationRule.Instance)
             {
@@ -1478,6 +1478,15 @@ namespace System.Windows.Data
         {
             if (IsUpdateOnPropertyChanged)
             {
+                // cancel a pending UpdateTarget, so that it doesn't negate
+                // the effect of this change to the target value
+                DispatcherOperation op = (DispatcherOperation)GetValue(Feature.UpdateTargetOperation, null);
+                if (op != null)
+                {
+                    ClearValue(Feature.UpdateTargetOperation);
+                    op.Abort();
+                }
+
                 if (Helper.IsComposing(Target, TargetProperty))
                 {
                     // wait for the IME composition to complete


### PR DESCRIPTION
Addresses #5444
This is a port of a servicing fix in .NET 4.7-4.8.

### Description
A binding on TextBox.Text defers two kinds of work when an IME composition is in progress on the TextBox:

When the text changes (and UpdateTrigger=PropertyChanged), write a new value into the source property.
After writing a value into the source property, read the property's new value (which might be different), apply the customary conversions, and write the result into the TextBox.
The bug occurs when the IME starts a new composition before the previous composition's type 2 work happens. This yields a situation where two tasks are deferred: the older composition's type 2 task and the newer composition's type 1 task. The type 2 task happens first, overwriting the text change that the type 1 task is supposed to handle. This confusion of state leads to exceptions (caught and hidden from the IME, but visible in the debugger), and unexpected content entered into the TextBox.

Fixed by cancelling any pending type 2 work when new type 1 work is needed.

### Customer Impact
Input with certain IMEs (e.g. MS Quick) is broken.

### Regression
No.

### Testing
Ad-hoc around customer scenario.
Standard regression testing.

### Risk
Low. Port of a .NETFx servicing fix released earlier this year.