### PR TITLE
honor UIA_WindowVisibilityOverridden property (#5839)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -574,7 +574,7 @@ namespace MS.Internal.Automation
 
         WindowInteractionState IWindowProvider.InteractionState
         {
-            // Note: we should consider Implementing InteractionState by finding the gui thread of the 
+            // Note: we should consider Implementing InteractionState by finding the gui thread of the
             // process and mapping ThreadState and WaitReason to a WindowInteractionState
             get
             {
@@ -1457,6 +1457,21 @@ namespace MS.Internal.Automation
         // Check that a window is visible, and has a non-empty rect
         private static bool IsWindowReallyVisible( NativeMethods.HWND hwnd )
         {
+            // check for visibility overrides
+            // The UIA team says:
+            //      * UIA_WindowVisibilityOverridden property was added in 2011 for Win8.1
+            //      * "I'm not actually sure it is documented publicly."
+            //      * "It's a window property that if its handle value is 1 it's ForceVisible, and if it's 2 it's ForceHidden."
+            IntPtr visibilityOverride = UnsafeNativeMethods.GetProp(hwnd, "UIA_WindowVisibilityOverridden");
+            if (visibilityOverride == new IntPtr(1))
+            {
+                return true;
+            }
+            else if (visibilityOverride == new IntPtr(2))
+            {
+                return false;
+            }
+
             if(!SafeNativeMethods.IsWindowVisible(hwnd))
             {
                 return false;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Win32/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Win32/UnsafeNativeMethods.cs
@@ -365,5 +365,12 @@ namespace MS.Win32
         [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern bool DeleteObject(IntPtr hrgn);
 
+        //
+        // Window Property Functions
+        //
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        internal static extern IntPtr GetProp(IntPtr hwnd, string name);
+
     }
 }


### PR DESCRIPTION
Addresses #5443
This is a port of a servicing fix in .NET 4.7-4.8.

### Description
This bug is about "anomalous" windows, where the UIA_WindowVisibilityOverridden property is set to 1 (ForceVisible), but window's rect is empty. The .NET automation code doesn't recognize this property, and thus treats the window as "not visible" because it's empty. This means an automation search won't find any windows below the anomalous window.

Fixed by recognizing the property, and overriding the hwnd's visibility to automation accordingly.

### Customer Impact
Automation searches cannot find descendants of anomalous windows (e.g. the Windows 11 Start button).

### Regression
No.

### Testing
Ad-hoc around customer scenario.
Standard regression testing.

### Risk
Low. Port of a .NETFx servicing fix released earlier this year.