### PR TITLE
Update versions of .NET and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,25 @@ Windows Presentation Foundation (WPF) is a UI framework for building Windows des
 
 WPF applications are based on a vector graphics architecture. This enables applications to look great on high DPI monitors, as they can be infinitely scaled. WPF also includes a flexible hosting model, which makes it straightforward to host a video in a button, for example. The visual designer provided in Visual Studio makes it easy to build WPF application, with drag-in-drop and/or direct editing of XAML markup.
 
+As of .NET 6.0 WPF supports ARM64. 
+
 See the [WPF Roadmap](roadmap.md) to learn about project priorities, status and ship dates.
 
 [WinForms](https://github.com/dotnet/winforms) is another UI framework for building Windows desktop applications that is supported on .NET (6.0.x/5.0.x/3.1.x). WPF and WinForms applications only run on Windows. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use the most recent version of [Visual Studio](https://visualstudio.microsoft.com/downloads/) to develop WPF and WinForms applications for .NET.  
 
-WPF for ARM64 is new for .NET 6.0 and is supported by NET 6.0 Preview 1 and later. 
-
-To build the WPF repo and contribute features and fixes for .NET 6.0, the most recent [Visual Studio Preview](https://visualstudio.microsoft.com/vs/preview/) is required.  
+To build the WPF repo and contribute features and fixes for .NET 6.0, please read our [contributing guide](Documentation/contributing.md).  
 
 ## Getting started
 
-* [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
-* [.NET Preview SDKs (6.0 Preview 1, 5.0 servicing, and 3.1 servicing)](https://github.com/dotnet/installer)
+* [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
+* [.NET Preview SDKs (7.0 daily, 6.0 servicing, and 3.1 servicing)](https://github.com/dotnet/installer)
 * [Getting started instructions](Documentation/getting-started.md)
 * [Contributing guide](Documentation/contributing.md)
 * [Migrating .NET Framework WPF Apps to .NET Core](https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework)
 
 ## Status
 
-- We are currently developing WPF for .NET 6. 
+- We are currently developing WPF for .NET 7. 
 - We have completed publishing WPF sources. You can learn more about this at https://github.com/dotnet/wpf/issues/2554. 
 - We have completed porting WPF to .NET Core as part of .NET Core 3.0, you can learn more about what was done [here](https://github.com/dotnet/wpf/issues/1936).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [WPF Roadmap](roadmap.md) to learn about project priorities, status and 
 
 [WinForms](https://github.com/dotnet/winforms) is another UI framework for building Windows desktop applications that is supported on .NET (6.0.x/5.0.x/3.1.x). WPF and WinForms applications only run on Windows. They are part of the `Microsoft.NET.Sdk.WindowsDesktop` SDK. You are recommended to use the most recent version of [Visual Studio](https://visualstudio.microsoft.com/downloads/) to develop WPF and WinForms applications for .NET.  
 
-To build the WPF repo and contribute features and fixes for .NET 6.0, please read our [contributing guide](Documentation/contributing.md).  
+To build the WPF repo and contribute features and fixes for .NET 7.0,  [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) is required.
 
 ## Getting started
 


### PR DESCRIPTION
Update stale information. Make sure that current development targets .NET 7, because otherwise README get's impression of being state. Redirect to contribution guide instead of mentioning that VS version is required. No need for preview right now, I suspect later in .NET 7 cycle that can be requirement again. Overall I think that's not for main page.