### PR TITLE
Use generic Marshal.StructureToPtr

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -46,12 +46,6 @@ namespace MS.Win32
 
     internal partial class UnsafeNativeMethods {
 
-        // For some reason "StructureToPtr" requires super high permission.
-        public static void StructureToPtr(object structure, IntPtr ptr, bool fDeleteOld)
-        {
-            Marshal.StructureToPtr(structure, ptr, fDeleteOld);
-        }
-
 #if BASE_NATIVEMETHODS
         [DllImport(ExternDll.Ole32, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int OleGetClipboard(ref IComDataObject data);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
@@ -38,7 +38,8 @@ namespace System.Windows.Automation
         }
 
         // uiaCondition is one of the Uia condition structs - eg UiaCoreApi.UiaAndOrCondition
-        internal static SafeConditionMemoryHandle AllocateConditionHandle(object uiaCondition)
+        internal static SafeConditionMemoryHandle AllocateConditionHandle<T>(T uiaCondition)
+            where T : struct
         {
             // Allocate SafeHandle first to avoid failure later.
             SafeConditionMemoryHandle sh = new SafeConditionMemoryHandle();
@@ -138,7 +139,8 @@ namespace System.Windows.Automation
  
         #region Internal Methods
 
-        internal void SetMarshalData(object uiaCondition)
+        internal void SetMarshalData<T>(T uiaCondition)
+            where T : struct
         {
             // Takes one of the interop UiaCondition classes (from UiaCoreApi.cs), and allocs
             // a SafeHandle with associated unmanaged memory - can then pass that to the UIA APIs.


### PR DESCRIPTION
## Description
Use generic Marshal.StructureToPtr instead of the non-generic. I removed the customs UnsafeNativeMethods.StructureToPtr which justs forwards to Marshal.StructureToPtr because it causes linker warnings because Marshal.StructureToPtr is annotated while UnsafeNativeMethods.StructureToPtr isn't.

Almost every call to Marshal.StructureToPtr were already using the generic overload without the need to change the code.

Contributes to #3811

## Customer Impact
None, same behavior as the non-generic.

## Regression
No

## Testing
I manually tested a few of the generic and non-generic and they gave the same result.

## Risk
None, same behavior as the non-generic.