### PR TITLE
WPF DataGrid/GridView  column width can be changed using the keyboard shortcut ALT+left or right arrow key

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -964,6 +964,28 @@ namespace System.Windows.Controls
         /// </summary>
         protected override void OnKeyDown(KeyEventArgs e)
         {
+            if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
+            {
+                DataGridLength updatedWidth = new DataGridLength();
+
+                if (e.Key == Key.Right)
+                {
+                    updatedWidth = new DataGridLength(this.Column.ActualWidth + _columnWidthStepSize);
+                }
+                else if (e.Key == Key.Left)
+                {
+                    updatedWidth = new DataGridLength(this.Column.ActualWidth - _columnWidthStepSize);
+                }
+
+                if (Column.CanColumnResize(updatedWidth))
+                {
+                    this.Column.SetCurrentValue(DataGridColumn.WidthProperty, updatedWidth);
+                }
+
+                e.Handled = true;
+                return;
+            }
+            
             SendInputToColumn(e);
         }
 
@@ -1100,6 +1122,7 @@ namespace System.Windows.Controls
         private DataGridRow _owner;
         private ContainerTracking<DataGridCell> _tracker;
         private bool _syncingIsSelected;                    // Used to prevent unnecessary notifications
+        private const double _columnWidthStepSize = 10d;
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -970,11 +970,11 @@ namespace System.Windows.Controls
 
                 if (e.Key == Key.Right)
                 {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth + _columnWidthStepSize);
+                    updatedWidth = new DataGridLength(this.Column.ActualWidth + ColumnWidthStepSize);
                 }
                 else if (e.Key == Key.Left)
                 {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth - _columnWidthStepSize);
+                    updatedWidth = new DataGridLength(this.Column.ActualWidth - ColumnWidthStepSize);
                 }
 
                 if (Column.CanColumnResize(updatedWidth))
@@ -1122,7 +1122,7 @@ namespace System.Windows.Controls
         private DataGridRow _owner;
         private ContainerTracking<DataGridCell> _tracker;
         private bool _syncingIsSelected;                    // Used to prevent unnecessary notifications
-        private const double _columnWidthStepSize = 10d;
+        private const double ColumnWidthStepSize = 10d;
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -964,7 +964,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
+            if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
             {
                 DataGridLength updatedWidth = new DataGridLength();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
@@ -1491,7 +1491,17 @@ namespace System.Windows.Controls
                 column.DataGridOwner,
                 DataGrid.CanUserResizeColumnsProperty);
         }
+        
+        internal bool CanColumnResize(DataGridLength width)
+        {
+            if (!CanUserResize)
+            {
+                return false;
+            }
 
+            return width.DisplayValue >= this.MinWidth && width.DisplayValue <= this.MaxWidth;
+        }
+        
         #endregion
 
         #region Hidden Columns

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
@@ -789,7 +789,7 @@ namespace System.Windows.Controls
         }
 
         // Set column header width and associated column width
-        private void UpdateColumnHeaderWidth(double width)
+        internal void UpdateColumnHeaderWidth(double width)
         {
             if (Column != null)
             {
@@ -979,7 +979,7 @@ namespace System.Windows.Controls
             // Define a Style with ContentTemplate and assign it to GridViewColumn.HeaderContainerStyle property. GridViewColumnHeader.OnPropertyChagned method will be called twice.
             // The first call is for ContentTemplate property. In this call, IgnoreContentTemplate is false.
             // The second call is for Style property. In this call, IgnoreStyle is true.
-            // One flag can’t distinguish them.
+            // One flag canÂ’t distinguish them.
             None                                = 0,
             StyleSetByUser                      = 0x00000001,
             IgnoreStyle                         = 0x00000002,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -350,7 +350,7 @@ namespace System.Windows.Controls
                 case Key.Down:
                 case Key.Right:
                     {
-                    if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
+                    if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
                         {
                             if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -350,6 +350,30 @@ namespace System.Windows.Controls
                 case Key.Down:
                 case Key.Right:
                     {
+                    if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt)
+                        {
+                            if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader)
+                            {
+                                if (key == Key.Left)
+                                {
+                                    if(gridViewColumnHeader.Column.ActualWidth > 0)
+                                    {
+                                        gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth - ColumnWidthStepSize;
+                                        gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
+                                    }
+                                    
+                                    handled = true;
+                                }
+                                else if (key == Key.Right)
+                                {
+                                    gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth + ColumnWidthStepSize;
+                                    gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
+                                    handled = true;
+                                }
+                                break;
+                            }
+                        }
+                    
                         KeyboardNavigation.ShowFocusVisual();
 
                         // Depend on logical orientation we decide to move focus or just scroll
@@ -1011,6 +1035,8 @@ namespace System.Windows.Controls
         private WeakReference _lastActionItem;
 
         private DispatcherTimer _autoScrollTimer;
+        
+        private const double ColumnWidthStepSize = 10d;
 
         private static RoutedUICommand SelectAllCommand =
             new RoutedUICommand(SR.Get(SRID.ListBoxSelectAllText), "SelectAll", typeof(ListBox));


### PR DESCRIPTION
Fixes # <!-- Issue Number --> #5880 

Main PR <!-- Link to PR if any that fixed this in the main branch. --> #6054 

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->
Issue related to WPF DataGrid column width can now be changed using the keyboard shortcut "ALT + left arrow key" and "ALT + right arrow key".

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Fixes a regression.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Yes.

## Testing

<!-- What kind of testing has been done with the fix. -->
Integration tests are in progress.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low. Add ability to adjust column width using keyboard for WPF DataGrid.
