### PR TITLE
Port dirty-rectangle opt-out from 4.8 (#5837)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/exports.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/exports.cs
@@ -245,7 +245,7 @@ namespace System.Windows.Media.Composition
                 IntPtr pChannel,
                 DUCE.ResourceHandle hResource,
                 out uint refCount
-                );                
+                );
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace System.Windows.Media.Composition
 
                 if (EventTrace.IsEnabled(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW))
                 {
-                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.CreateOrAddResourceOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, PerfService.GetPerfElementID(instance), _hChannel, (uint) handle, (uint) resourceType); 
+                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.CreateOrAddResourceOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, PerfService.GetPerfElementID(instance), _hChannel, (uint) handle, (uint) resourceType);
                 }
 
                 return handleNeedsCreation;
@@ -553,14 +553,14 @@ namespace System.Windows.Media.Composition
 
                 if ((releasedOnChannel != 0) && EventTrace.IsEnabled(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW))
                 {
-                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.ReleaseOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, _hChannel, (uint) handle); 
+                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.ReleaseOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, _hChannel, (uint) handle);
                 }
 
                 return (releasedOnChannel != 0);
             }
 
             /// <summary>
-            /// Internal only: GetRefCount returns the reference count of a resource 
+            /// Internal only: GetRefCount returns the reference count of a resource
             /// corresponding to the specified handle on the channel.
             /// </summary>
             /// <return>
@@ -972,7 +972,7 @@ namespace System.Windows.Media.Composition
 
 
             /// <summary>
-            /// Returns the real UInt32 handle. 
+            /// Returns the real UInt32 handle.
             /// </summary>
             /// <remarks>
             /// Consider moving to an abstract handle type in the future.
@@ -1522,7 +1522,7 @@ namespace System.Windows.Media.Composition
                 bool inmap = _map.Get(channel, out handle);
 
                 bool created = channel.CreateOrAddRefOnChannel(instance, ref handle, type);
-                
+
                 if (!inmap)
                 {
                     _map.Set(channel, handle);
@@ -1690,7 +1690,7 @@ namespace System.Windows.Media.Composition
                 DUCE.ResourceHandle hEffect,
                 Channel channel)
             {
-                DUCE.MILCMD_VISUAL_SETEFFECT command;               
+                DUCE.MILCMD_VISUAL_SETEFFECT command;
 
                 command.Type = MILCMD.MilCmdVisualSetEffect;
                 command.Handle = hCompositionNode;
@@ -1704,14 +1704,14 @@ namespace System.Windows.Media.Composition
                         );
                 }
             }
-            
+
 
             internal static void SetCacheMode(
                 DUCE.ResourceHandle hCompositionNode,
                 DUCE.ResourceHandle hCacheMode,
                 Channel channel)
             {
-                DUCE.MILCMD_VISUAL_SETCACHEMODE command;               
+                DUCE.MILCMD_VISUAL_SETCACHEMODE command;
 
                 command.Type = MILCMD.MilCmdVisualSetCacheMode;
                 command.Handle = hCompositionNode;
@@ -1834,7 +1834,7 @@ namespace System.Windows.Media.Composition
                         sizeof(DUCE.MILCMD_VISUAL_SETSCROLLABLEAREACLIP)
                         );
                 }
-            }            
+            }
 
             internal static void SetClip(
                 DUCE.ResourceHandle hCompositionNode,
@@ -2239,7 +2239,7 @@ namespace System.Windows.Media.Composition
                     command.flags |= (UInt32)MILRTInitializationFlags.MIL_RT_SOFTWARE_ONLY;
                 }
 
-                bool? enableMultiMonitorDisplayClipping = 
+                bool? enableMultiMonitorDisplayClipping =
                     System.Windows.CoreCompatibilityPreferences.EnableMultiMonitorDisplayClipping;
 
                 if (enableMultiMonitorDisplayClipping != null)
@@ -2251,6 +2251,11 @@ namespace System.Windows.Media.Composition
                     {
                         command.flags |= (UInt32) MILRTInitializationFlags.MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING;
                     }
+                }
+
+                if (CoreAppContextSwitches.DisableDirtyRectangles)
+                {
+                    command.flags |= (UInt32)MILRTInitializationFlags.MIL_RT_DISABLE_DIRTY_RECTANGLES;
                 }
 
                 command.hBitmap = DUCE.ResourceHandle.Null;
@@ -2465,11 +2470,11 @@ namespace System.Windows.Media.Composition
         }
 
         /// <summary>
-        /// See <see cref="MediaContext.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> for 
+        /// See <see cref="MediaContext.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> for
         /// details.
         /// </summary>
         internal static void NotifyPolicyChangeForNonInteractiveMode(
-            bool forceRender, 
+            bool forceRender,
             Channel channel
             )
         {
@@ -2482,8 +2487,8 @@ namespace System.Windows.Media.Composition
             unsafe
             {
                 channel.SendCommand(
-                    (byte*)&command, 
-                    sizeof(DUCE.MILCMD_PARTITION_NOTIFYPOLICYCHANGEFORNONINTERACTIVEMODE), 
+                    (byte*)&command,
+                    sizeof(DUCE.MILCMD_PARTITION_NOTIFYPOLICYCHANGEFORNONINTERACTIVEMODE),
                     sendInSeparateBatch: false
                     );
             }

--- a/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/Graphics/wgx_core_types.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Media.Composition
         MilSegmentPolyLine,
         MilSegmentPolyBezier,
         MilSegmentPolyQuadraticBezier,
-    
+
         MIL_SEGMENT_TYPE_FORCE_DWORD = unchecked((int)0xffffffff)
     };
 
@@ -27,121 +27,121 @@ namespace System.Windows.Media.Composition
         SegTypeLine                  = 0x00000001,
         SegTypeBezier                = 0x00000002,
         SegTypeMask                  = 0x00000003,
-    
+
         // When this bit is set then this segment is not to be stroked
         SegIsAGap                    = 0x00000004,
-    
+
         // When this bit is set then the join between this segment and the PREVIOUS segment
         // will be rounded upon widening, regardless of the pen line join property.
         SegSmoothJoin                = 0x00000008,
-    
+
         // When this bit is set on the first type then the figure should be closed.
         SegClosed                    = 0x00000010,
-    
+
         // This bit indicates whether the segment is curved.
         SegIsCurved                  = 0x00000020,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MIL_PEN_CAP    {
         MilPenCapFlat = 0,
         MilPenCapSquare = 1,
         MilPenCapRound = 2,
         MilPenCapTriangle = 3,
-    
+
         MIL_PEN_CAP_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MIL_PEN_JOIN    {
         MilPenJoinMiter = 0,
         MilPenJoinBevel = 1,
         MilPenJoinRound = 2,
-    
+
         MIL_PEN_JOIN_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     [System.Flags]
     internal enum MILRTInitializationFlags
     {
         // Default initialization flags (0) imply hardware with software fallback,
         // synchronized to reduce tearing for hw RTs, and no retention of contents
         // between scenes.
-    
+
         MIL_RT_INITIALIZE_DEFAULT       = 0x00000000,
-    
+
         // This flag disables the hardware accelerated RT. Use only software.
-    
+
         MIL_RT_SOFTWARE_ONLY            = 0x00000001,
-    
+
         // This flag disables the software RT. Use only hardware.
-    
+
         MIL_RT_HARDWARE_ONLY            = 0x00000002,
-    
+
         // Creates a dummy render target that consumes all calls
-    
+
         MIL_RT_NULL                     = 0x00000003,
-    
+
         // Mask for choice of render target
-    
+
         MIL_RT_TYPE_MASK                = 0x00000003,
-    
+
         // This flag indicates that presentation should not wait for any specific
         // time to promote the results to the display. This may result in display
         // tearing.
-    
+
         MIL_RT_PRESENT_IMMEDIATELY      = 0x00000004,
-    
+
         // This flag makes the RT reatin the contents from one frame to the next.
         // Retaining the contents has performance implications.  For scene changes
         // with little to update retaining contents may help, but if most of the
         // scene will be repainted anyway, retention may hurt some hw scenarios.
-    
+
         MIL_RT_PRESENT_RETAIN_CONTENTS  = 0x00000008,
-    
+
         // This flag indicates that we should create a full screen RT.
-    
+
         MIL_RT_FULLSCREEN               = 0x00000010,
-    
+
         // This flag indicates that the render target backbuffer will have
         // linear gamma.
-    
+
         MIL_RT_LINEAR_GAMMA             = 0x00000020,
-    
+
         // This flag indicates that the render target backbuffer will have
         // an alpha channel that is at least 8 bits wide.
-    
+
         MIL_RT_NEED_DESTINATION_ALPHA   = 0x00000040,
-    
+
         // This flag allows the render target backbuffer to contain
         // 10 bits per channel rather than 32. This flag only has
         // meaning when linear gamma is also present.
-    
+
         MIL_RT_ALLOW_LOW_PRECISION      = 0x00000080,
-    
+
         // This flag assumes that all resources (such as bitmaps and render
         // targets) are released on the same thread as the rendering device.  This
         // flag enables us to use a single threaded dx device instead of a
         // multi-threaded one.
-    
+
         MIL_RT_SINGLE_THREADED_USAGE    = 0x00000100,
-    
+
         // This flag directs the render target to extend its presentation area
         // to include the non-client area.  The origin of the render target space
         // will be equal to the origin of the window.
-    
+
         MIL_RT_RENDER_NONCLIENT         = 0x00000200,
-    
+
         // This flag enables tear free composition by using the SWAPEFFECT D3D_FLIP.
-    
+
         MIL_RT_PRESENT_FLIP             = 0x00000400,
-    
+
         // Setting this flag results in the DX device instructing the driver not to
         // autorotate if the monitor is in a rotated mode.  Only makes sense for
         // fullscreen RTs
-    
+
         MIL_RT_FULLSCREEN_NO_AUTOROTATE = 0x00000800,
-    
+
         // This flag directed the render target not to restrict its rendering and
         // presentation to the visible portion of window on the desktop.  This is
         // useful for when the window position may be faked or the system may try
@@ -149,62 +149,68 @@ namespace System.Windows.Media.Composition
         // example DWM thumbnails expect a fully rendered and presented window.
         //
         // Note: This does not guarantee that some clipping will not be used.  See
-    
+
         MIL_RT_DISABLE_DISPLAY_CLIPPING = 0x00001000,
 
         //
-        // This flag is the same as MIL_RT_DISABLE_DISPLAY_CLIPPING except that it disables 
-        // display clipping on multi-monitor configurations in all OS'. This flag is automatically 
-        // set on Windows 8 and newer systems. If WPF decides to unset 
+        // This flag is the same as MIL_RT_DISABLE_DISPLAY_CLIPPING except that it disables
+        // display clipping on multi-monitor configurations in all OS'. This flag is automatically
+        // set on Windows 8 and newer systems. If WPF decides to unset
         // MIL_RT_DISABLE_DISPLAY_CLIPPING, then MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING flag
         // will not be respected even if set by an applicaiton via its manifest
         //
         MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING = 0x00004000,
 
         //
-        // This flag is passed down by PresentationCore to tell wpfgfx that 
-        // the DisableMultimonDisplayClipping compatibity flag is set by the user. This 
+        // This flag is passed down by PresentationCore to tell wpfgfx that
+        // the DisableMultimonDisplayClipping compatibity flag is set by the user. This
         // allows us to distinguish between when DisableMultimonDisplayClipping == 0 means
-        // that the user set it to false explicitly, versus when the user didn't set it 
+        // that the user set it to false explicitly, versus when the user didn't set it
         // and the DisableMultimonDisplayClipping bit happens to be implicitly set to 0
         //
         MIL_RT_IS_DISABLE_MULTIMON_DISPLAY_CLIPPING_VALID = 0x00008000,
 
-        // 
+        //
+        // This flag directs the render target to render the full scene,
+        // bypassing D3D's dirty-rectangle optimizations.
+        //
+        MIL_RT_DISABLE_DIRTY_RECTANGLES = 0x00010000,
+
+        //
         // UCE only flags
         //
-    
+
         // This flag directs the composition rendertarget to enable the occlusion
         // culling optimization.
         MIL_UCE_RT_ENABLE_OCCLUSION     = 0x00010000,
-    
-    
+
+
         //
         // Test only / internal flags
         //
-    
+
         // This flag forces the render target to use the d3d9 reference raster
         // when using d3d. (Should be combined with MIL_RT_INITIALIZE_DEFAULT or
         // MIL_RT_HARDWARE_ONLY)
         // This is designed for test apps only
-    
+
         MIL_RT_USE_REF_RAST             = 0x01000000,
-    
+
         // This flag forces the render target to use the rgb reference raster
         // when using d3d.( Should be combined with MIL_RT_INITIALIZE_DEFAULT or
         // MIL_RT_HARDWARE_ONLY )
         // This is designed for test apps only
-    
+
         MIL_RT_USE_RGB_RAST             = 0x02000000,
-    
-    
+
+
         // MIL Core Rendering Internal flag (=Do NOT pass to RT Create methods)
         // This flag enables the buffer to be set up in a transposed mode
         // in order to manage our own rotation for 90 and 270 degree rotations.
-    
+
         MIL_RT_FULLSCREEN_TRANSPOSE_XY  = unchecked((int)0x10000000),
-    
-    
+
+
         // We support 4 primary present modes:
         //
         // 1) Present using D3D
@@ -217,11 +223,11 @@ namespace System.Windows.Media.Composition
         MIL_RT_PRESENT_USING_BITBLT     = unchecked((int)0x40000000),
         MIL_RT_PRESENT_USING_ALPHABLEND = unchecked((int)0x80000000),
         MIL_RT_PRESENT_USING_ULW        = unchecked((int)0xC0000000),
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
-    
+
+
     internal enum MIL_PRESENTATION_RESULTS    {
         MIL_PRESENTATION_VSYNC,
         MIL_PRESENTATION_NOPRESENT,
@@ -229,7 +235,7 @@ namespace System.Windows.Media.Composition
         MIL_PRESENTATION_DWM,
         MIL_PRESENTATION_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     internal struct MIL_PEN_DATA    {
         internal double Thickness;
@@ -241,7 +247,7 @@ namespace System.Windows.Media.Composition
         internal MIL_PEN_JOIN LineJoin;
         internal UInt32 DashArraySize;
     };
-    
+
     [System.Flags]
     internal enum MILTransparencyFlags
     {
@@ -249,34 +255,34 @@ namespace System.Windows.Media.Composition
         ConstantAlpha = 0x1,
         PerPixelAlpha = 0x2,
         ColorKey = 0x4,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MILWindowLayerType
     {
         NotLayered = 0,
         SystemManagedLayer = 1,
         ApplicationManagedLayer = 2,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
 //
-// Enum which describes whether certain values should be considered as absolute 
-// local coordinates or whether they should be considered multiples of a bounding 
+// Enum which describes whether certain values should be considered as absolute
+// local coordinates or whether they should be considered multiples of a bounding
 // box's size.
 //
 internal enum MilBrushMappingMode
 {
     //
-    // Absolute means that the values in question will be interpreted directly in 
+    // Absolute means that the values in question will be interpreted directly in
     // local space.
     //
     Absolute = 0,
 
     //
-    // RelativeToBoundingBox means that the values will be interpreted as a multiples 
+    // RelativeToBoundingBox means that the values will be interpreted as a multiples
     // of a bounding box, where 1.0 is considered 100% of the bounding box measure.
     //
     RelativeToBoundingBox = 1,
@@ -285,7 +291,7 @@ internal enum MilBrushMappingMode
 }
 
 //
-// The AlignmentX enum is used to describe how content is positioned horizontally 
+// The AlignmentX enum is used to describe how content is positioned horizontally
 // within a container.
 //
 internal enum MilHorizontalAlignment
@@ -309,7 +315,7 @@ internal enum MilHorizontalAlignment
 }
 
 //
-// The AlignmentY enum is used to describe how content is positioned vertically 
+// The AlignmentY enum is used to describe how content is positioned vertically
 // within a container.
 //
 internal enum MilVerticalAlignment
@@ -374,7 +380,7 @@ internal enum MilMessageClass
 
 
     //
-    // Not a real message. This value is one more than message with the greatest 
+    // Not a real message. This value is one more than message with the greatest
     // numerical value.
     //
     Last,
@@ -555,8 +561,8 @@ internal struct MilGraphicsAccelerationCaps
 
 /// <summary>
 ///     MilGraphicsAccelerationAssessment
-///     Assessment of the video memory bandwidth and total video memory as set by 
-///     WinSAT. Used by the DWM to determine glass and opaque glass capability of the 
+///     Assessment of the video memory bandwidth and total video memory as set by
+///     WinSAT. Used by the DWM to determine glass and opaque glass capability of the
 ///     display machine.
 /// </summary>
 [StructLayout(LayoutKind.Sequential, Pack=1)]
@@ -595,7 +601,7 @@ internal struct MilMatrix3x2D
     internal double DY;
 };
 internal enum MILCMD
-{                                   
+{
     /* 0x00 */ MilCmdInvalid                                 = 0x00,
 
     //--------------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -337,6 +337,49 @@ namespace MS.Internal
 
         #endregion
 
+        #region DisableDirtyRectangles
+
+        internal const string DisableDirtyRectanglesSwitchName = "Switch.System.Windows.Media.MediaContext.DisableDirtyRectangles";
+        private static int _DisableDirtyRectangles;
+        public static bool DisableDirtyRectangles
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                /// <summary>
+                /// Due to a limitation of D3D's implementation of
+                /// dirty-rectangle processing, images occasionally render incorrectly.
+                /// An app can disable dirty-rectangle processing by setting this switch to true.
+                /// This will cause more work for the GPU, but the results will be better.
+                /// </summary>
+                if (EnableDynamicDirtyRectangles)
+                {
+                    bool disableDirtyRectangles;
+                    AppContext.TryGetSwitch(DisableDirtyRectanglesSwitchName, out disableDirtyRectangles);
+                    return disableDirtyRectangles;
+                }
+
+                return LocalAppContext.GetCachedSwitchValue(DisableDirtyRectanglesSwitchName, ref _DisableDirtyRectangles);
+            }
+        }
+
+        internal const string EnableDynamicDirtyRectanglesSwitchName = "Switch.System.Windows.Media.MediaContext.EnableDynamicDirtyRectangles";
+        private static int _EnableDynamicDirtyRectangles;
+        public static bool EnableDynamicDirtyRectangles
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                /// <summary>
+                /// Setting this switch to true causes the DisableDirtyRectangles
+                /// switch to be re-evaluated before each render.
+                /// </summary>
+                return LocalAppContext.GetCachedSwitchValue(EnableDynamicDirtyRectanglesSwitchName, ref _EnableDynamicDirtyRectangles);
+            }
+        }
+
+        #endregion
+
     }
 #pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -48,6 +48,7 @@ namespace System.Windows.Interop
         HardwareReference = MILRTInitializationFlags.MIL_RT_HARDWARE_ONLY | MILRTInitializationFlags.MIL_RT_USE_REF_RAST,
         DisableMultimonDisplayClipping = MILRTInitializationFlags.MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING,
         IsDisableMultimonDisplayClippingValid = MILRTInitializationFlags.MIL_RT_IS_DISABLE_MULTIMON_DISPLAY_CLIPPING_VALID,
+        DisableDirtyRectangles = MILRTInitializationFlags.MIL_RT_DISABLE_DIRTY_RECTANGLES,
     }
 
     // This is the public, more limited, enum exposed for use with the RenderMode property.
@@ -621,6 +622,11 @@ namespace System.Windows.Interop
                 }
             }
 
+            if (MediaSystem.DisableDirtyRectangles)
+            {
+                mode |= RenderingMode.DisableDirtyRectangles;
+            }
+
             // Select the render target initialization flags based on the requested
             // rendering mode.
 
@@ -1075,8 +1081,8 @@ namespace System.Windows.Interop
                     // pollute the measure data based on the Minized window size.
                     if (NativeMethods.IntPtrToInt32(wparam) != NativeMethods.SIZE_MINIMIZED)
                     {
-                        // Rendering sometimes does not refresh propertly,and results in 
-                        // rendering artifacts that look like a patchwork of black unpainted squares. 
+                        // Rendering sometimes does not refresh propertly,and results in
+                        // rendering artifacts that look like a patchwork of black unpainted squares.
                         // This is is caused by a race condition in Windows 7 (and possibly
                         // Windows Vista, though we haven't observed the effect there).
                         // Sometimes when we restore from minimized, when we present into the newly
@@ -1122,7 +1128,7 @@ namespace System.Windows.Interop
                     bool enableRenderTarget = (wparam != IntPtr.Zero);
                     OnShowWindow(enableRenderTarget);
                     //
-                    //  
+                    //
                     //      When locked on downlevel, MIL stops rendering and invalidates the
                     //      window causing WM_PAINT. When the window is layered and hidden
                     //      before the lock, it won't get the WM_PAINT on unlock and the MIL will
@@ -2018,7 +2024,7 @@ namespace System.Windows.Interop
         private DpiAwarenessContextValue DpiAwarenessContext { get; set; }
 
         internal DpiScale2 CurrentDpiScale { get; private set; }
-        
+
         internal static bool IsPerMonitorDpiScalingSupportedOnCurrentPlatform
         {
             get
@@ -2311,7 +2317,7 @@ namespace System.Windows.Interop
 
                     // UIAutomation listens for the EventObjectUIFragmentCreate WinEvent to
                     // understand when UI that natively implements UIAutomation comes up
-                    
+
                     // Need to figure out how to handle when _rootVisual is replaced above (is there some
                     // event when this happens?); MS.Internal.Automation.NativeEventListener may have a context
                     // monitor that is holding onto the old _rootVisual and that would need to be cleaned up.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
@@ -146,56 +146,56 @@ namespace System.Windows.Media
         #region Compat support for rendering in a Non-interactive Window Station
 
         /// <summary>
-        /// General case: 
-        ///     True if our window station is interactive (WinSta0), otherwise false. 
-        ///     In addition to this, two compatibility switches are provided to opt-in 
+        /// General case:
+        ///     True if our window station is interactive (WinSta0), otherwise false.
+        ///     In addition to this, two compatibility switches are provided to opt-in
         ///     or opt-out of this behavior
-        ///     
+        ///
         /// Compatibility switches
-        ///     i. <see cref=" MS.Internal.CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> 
+        ///     i. <see cref=" MS.Internal.CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/>
         ///     ii. <see cref="MS.Internal.CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation"/>
-        /// 
+        ///
         /// How this will work:
         ///     Desktop/Interactive Window Stations:
-        ///         Rendering will be throttled back/stopped when no display devices are available. For e.g., when a TS 
+        ///         Rendering will be throttled back/stopped when no display devices are available. For e.g., when a TS
         ///         session is in WTSDisconnected state, the OS may not provide any display devices in response to our enumeration.
-        ///         If an application would like to continue rendering in the absence of display devices (accepting that 
-        ///         it can lead to a CPU spike), it can set <see cref=" MS.Internal.CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> 
+        ///         If an application would like to continue rendering in the absence of display devices (accepting that
+        ///         it can lead to a CPU spike), it can set <see cref=" MS.Internal.CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/>
         ///         to true.
         ///     Service/Non-interactive Window Stations
         ///         Rendering will continue by default, irrespective of the presence of display devices.Unless the WPF
-        ///         API's being used are shortlived (like rendering to a bitmap), it can lead to a CPU spike. 
-        ///         If an application running inside a service would like to receive the 'default' WPF behavior, 
+        ///         API's being used are shortlived (like rendering to a bitmap), it can lead to a CPU spike.
+        ///         If an application running inside a service would like to receive the 'default' WPF behavior,
         ///         i.e., no rendering in the absence of display devices, then it should set
         ///         <see cref="MS.Internal.CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation"/> to true
-        ///     In pseudocode, 
+        ///     In pseudocode,
         ///         IsNonInteractiveWindowStation = !Environment.UserInteractive
         ///         IF DisplayDevicesNotFound() THEN
-        ///             IF IsNonInteractiveWindowStation THEN 
+        ///             IF IsNonInteractiveWindowStation THEN
         ///                 // We are inside a SCM service
         ///                 // Default = True, AppContext switch can override it to False
         ///                 ShouldRender = !CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation
-        ///             ELSE 
+        ///             ELSE
         ///                 // Desktop/interactive mode, including WTSDisconnected scenarios
         ///                 // Default = False, AppContext switch can override it to True
         ///                 ShouldRender = CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable
         ///             END IF
         ///         END IF
-        ///     
+        ///
         /// </summary>
         /// <remarks>
         /// i. <see cref=">Environment.UserInteractive"/> calls into Window Station related
-        /// Win32 API's to identify whether the current Window Station has WSF_VISIBLE 
-        /// flag set. 
-        /// 
+        /// Win32 API's to identify whether the current Window Station has WSF_VISIBLE
+        /// flag set.
+        ///
         /// ii. Field is internal to allow <see cref="HwndTarget"/> to consume its value
-        /// 
-        /// iii. This field is named to reflect the general use-case, namely to force rendering 
-        /// when inside a SCM service. 
+        ///
+        /// iii. This field is named to reflect the general use-case, namely to force rendering
+        /// when inside a SCM service.
         /// </remarks>
         internal static bool ShouldRenderEvenWhenNoDisplayDevicesAreAvailable { get; } =
-            !Environment.UserInteractive ? // IF DisplayDevicesNotAvailable && IsNonInteractiveWindowStation/IsService...  
-                !CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation :      // THEN render by default, allow ShouldNotRender AppContext override 
+            !Environment.UserInteractive ? // IF DisplayDevicesNotAvailable && IsNonInteractiveWindowStation/IsService...
+                !CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStation :      // THEN render by default, allow ShouldNotRender AppContext override
                 CoreAppContextSwitches.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable;   // ELSE do not render by default, allow ShouldRender AppContext override
 
 
@@ -353,7 +353,7 @@ namespace System.Windows.Media
             }
         }
 
-        // MediaSystem is per-AppDomain and so it uses this to ensure that InvalidateRenderMode() 
+        // MediaSystem is per-AppDomain and so it uses this to ensure that InvalidateRenderMode()
         // is called by the right thread.
         internal void PostInvalidateRenderMode()
         {
@@ -366,7 +366,7 @@ namespace System.Windows.Media
         private object InvalidateRenderMode(object dontCare)
         {
             Debug.Assert(CheckAccess());
-            
+
             foreach (ICompositionTarget target in _registeredICompositionTargets)
             {
                 HwndTarget hwndTarget = target as HwndTarget;
@@ -518,7 +518,7 @@ namespace System.Windows.Media
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Internal event which is raised when the Tier changes on this MediaContext.
         /// </summary>
@@ -1000,7 +1000,7 @@ namespace System.Windows.Media
                         {
                             CommittingBatch(Channel, new EventArgs());
                         }
-                        
+
                         Channel.SyncFlush();
                     }
                 }
@@ -1217,12 +1217,12 @@ namespace System.Windows.Media
         {
             _channelManager.CreateChannels();
 
-            // Notify renderer how it should behave when no valid displays are available, 
-            // or when this process is running in a non-interactive Window Station, or when 
+            // Notify renderer how it should behave when no valid displays are available,
+            // or when this process is running in a non-interactive Window Station, or when
             // an application has opted into behavior that requests WPF to continue rendering
             // even when no valid displays are detected.
-            // 
-            // Do this immediately after creating channels. 
+            //
+            // Do this immediately after creating channels.
             DUCE.NotifyPolicyChangeForNonInteractiveMode(
                     ShouldRenderEvenWhenNoDisplayDevicesAreAvailable,
                     Channel);
@@ -1860,6 +1860,8 @@ namespace System.Windows.Media
 
                 _timeManager.UnlockTickTime();
 
+                MediaSystem.PropagateDirtyRectangleSettings();
+
                 // Invalidate the input devices on the InputManager
                 InputManager.UnsecureCurrent.InvalidateInputDevices();
 
@@ -1921,7 +1923,7 @@ namespace System.Windows.Media
                 // Reset current operation so it can be re-queued by layout
                 // This is needed when exception happens in the midst of layout/TemplateExpansion
                 // and it unwinds from the stack. If we don't clean this field here, the subsequent
-                // PostRender won't queue new render operation and the window gets stuck. 
+                // PostRender won't queue new render operation and the window gets stuck.
                 if (gotException
                     && _currentRenderOp != null)
                 {
@@ -2268,7 +2270,7 @@ namespace System.Windows.Media
                             {
                                 CommittingBatch(Channel, new EventArgs());
                             }
-                            
+
                             Channel.WaitForNextMessage();
                             NotifyChannelMessage();
                         } while (_interlockState == InterlockState.WaitingForResponse);
@@ -2311,7 +2313,7 @@ namespace System.Windows.Media
                     {
                         CommittingBatch(Channel, new EventArgs());
                     }
-                    
+
                     //
                     // Issue a sync flush, which will only return after
                     // the last frame is presented

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -1475,6 +1475,44 @@ namespace System.Windows.Controls
                 }
             }
 
+            // Test whether the current mouse point lies within the convex hull
+            internal bool ContainsMousePoint()
+            {
+                IInputElement rootElement = _source.RootVisual as IInputElement;
+                if (rootElement != null)
+                {
+                    // get the coordinates of the current mouse point, relative to our PresentationSource
+                    System.Windows.Point pt = Mouse.PrimaryDevice.GetPosition(rootElement);
+
+                    // check whether the point lies within the hull
+                    return ContainsPoint(_source, (int)pt.X, (int)pt.Y);
+
+                    // NOTE: GetPosition doesn't actually return the position of the current mouse point,
+                    // but rather the last recorded position.  (See MouseDevice.GetScreenPositionFromSystem,
+                    // which says that "Win32 has issues reliably returning where the mouse is".)
+                    // This causes a small problem when (a) the PresentationSource has capture, e.g.
+                    // the popup of a ComboBox, and (b) the mouse moves to a position that lies outside both the
+                    // capturing PresentationSource (popup window) and the input-providing PresentationSource
+                    // (main window).  The MouseDevice only records positions within the input-providing
+                    // PresentationSource, so we'll test the position where the mouse left the main window,
+                    // rather than the current position.
+                    //      This means we may leave a tooltip open even when the mouse leaves its SafeArea,
+                    // but only when the tooltip belongs to a capturing source, and the "leaving the SafeArea"
+                    // action occurs outside the surrounding main window.  For our example, it can happen
+                    // when the ComboBox is close to the edge of the main window so that a tooltip from its
+                    // popup content extends beyond the main window.
+                    //      This can only be fixed by changing MouseDevice.GetScreenPositionFromSystem to
+                    // use a "better way" to find the current mouse position, which allegedly needs work from the OS.
+                    // But we can live with this behavior, because
+                    //  * this is a corner case - tooltips from popup content that extend beyond the main window
+                    //  * the effect is transient - the tooltip will close when the user dismisses the popup
+                    //  * there's no accessibility issue - WCAG 2.1 only requires that the tooltip stays open under
+                    //      proscribed conditions, not that it has to close when the conditions cease to apply
+                }
+                else
+                    return false;
+            }
+
             // Test whether a given mouse point (x,y) lies within the convex hull
             internal bool ContainsPoint(PresentationSource source, int x, int y)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/xml/Resource.xml
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/codegen/mcg/xml/Resource.xml
@@ -351,7 +351,7 @@
             <Field Name="Enabled" Value="1"
                    Comment="Rendering engine will enable ClearType for this element subtree.  Where an intermediate render target is introduced in this subtree, ClearType will once again be disabled." />
             <Field Name="Last" UnmanagedOnly="true" />
-        </Enum>        
+        </Enum>
 
         <Enum Name="CachingHint" UnmanagedName="MilCachingHint" NeedsValidateValueCallback="true"
               Comment="Enum used for hinting the rendering engine that rendered content can be cached">
@@ -373,7 +373,7 @@
             <Field Name="ClearType" Value="3"
                    Comment="Rendering engine will render text with ClearType filtering when possible" />
             <Field Name="Last" UnmanagedOnly="true" />
-        </Enum>        
+        </Enum>
 
         <Enum Name="TextHintingMode" UnmanagedName="MilTextHintingMode" NeedsValidateValueCallback="true"
               Comment="Enum used for specifying how text should be rendered with respect to animated or static text">
@@ -384,7 +384,7 @@
             <Field Name="Animated" Value="2"
                    Comment="Rendering engine will render text for highest animated quality" />
              <Field Name="Last" UnmanagedOnly="true" />
-        </Enum>        
+        </Enum>
 
 <!--
         <Enum Name="PixelFormatEnum"
@@ -458,7 +458,7 @@
             <Field Name="BulgedUp" Value="3" Comment="Use a bulged up edge profile" />
         </Enum>
 
-        <Enum Name="ShaderRenderMode" UnmanagedName="ShaderEffectShaderRenderMode" 
+        <Enum Name="ShaderRenderMode" UnmanagedName="ShaderEffectShaderRenderMode"
                 Comment="Policy for rendering the shader in software.">
             <Field Name="Auto" Value="0" Comment="Allow hardware and software" />
             <Field Name="SoftwareOnly" Value="1" Comment="Force software rendering" />
@@ -470,7 +470,7 @@
             <Field Name="Performance" Value="0" Comment="Bias towards performance" />
             <Field Name="Quality" Value="1" Comment="Bias towards quality" />
         </Enum>
-        
+
     </Enums>
 
     <Enums ManagedNamespace="System.Windows">
@@ -635,25 +635,29 @@
             <Field Name="ForceCompatible" Value="0x00002000"
                     Comment="This flag forces the creation of a render target bitmap to match its
                              parent's type, so a software surface only creates software RTs and a
-                             hardware surface only creates hardware RTs.  This is necessary for the 
+                             hardware surface only creates hardware RTs.  This is necessary for the
                              hardware-accelerated bitmap effects pipeline to guarantee that we do
-                             not encounter a situation where we're trying to run shaders sampling 
+                             not encounter a situation where we're trying to run shaders sampling
                              from a hardware texture to render into a software intermediate." />
-          
+
             <Field Name="DisableMultimonDisplayClipping" Value="0x00004000"
-                   Comment="This flag is the same as DisableDisplayClipping except that it disables 
-                   display clipping on multi-monitor configurations in all OS'. This flag is automatically 
-                   set on Windows 8 and newer systems. If WPF decides to unset 
-                   DisableDisplayClipping, then DisableMultimonDisplayClipping flag will not be 
+                   Comment="This flag is the same as DisableDisplayClipping except that it disables
+                   display clipping on multi-monitor configurations in all OS'. This flag is automatically
+                   set on Windows 8 and newer systems. If WPF decides to unset
+                   DisableDisplayClipping, then DisableMultimonDisplayClipping flag will not be
                    respected even if set by an applicaiton via its manifest" />
 
             <Field Name="IsDisableMultimonDisplayClippingValid" Value="0x00008000"
-                   Comment ="This flag is passed down by PresentationCore to tell wpfgfx that 
-                   the DisableMultimonDisplayClipping compatibity flag is set by the user. This 
+                   Comment ="This flag is passed down by PresentationCore to tell wpfgfx that
+                   the DisableMultimonDisplayClipping compatibity flag is set by the user. This
                    allows us to distinguish between when DisableMultimonDisplayClipping == 0 means
-                   that the user set it to false explicitly, versus when the user didn't set it 
+                   that the user set it to false explicitly, versus when the user didn't set it
                    and the DisableMultimonDisplayClipping bit happens to be implicitly set to 0" />
-          
+
+            <Field Name="DisableDirtyRectangles" Value="0x00010000"
+                   Comment ="This flag directs the render target to render the full scene,
+                   bypassing D3D's dirty-rectangle optimizations." />
+
             <BlockCommentedFields Comment="Test only / internal flags">
                 <Field Name="UseRefRast" Value="0x01000000"
                        Comment="This flag forces the render target to use the d3d9 reference raster
@@ -2740,7 +2744,7 @@
 
         <Resource Name="ImplicitInputBrush" Extends="Brush" SkipToString="true" CanIntroduceCycles="false">
         </Resource>
-        
+
 
         <Resource Name="Effect" SkipToString="true" IsAbstract="true">
         </Resource>
@@ -2764,7 +2768,7 @@
             </Fields>
         </Resource>
 
-        <Resource Name="ShaderEffect" Extends="Effect" LeaveUnsealed="true" SkipUpdate="true" UseProcessUpdateWrapper="true" SkipToString="true" 
+        <Resource Name="ShaderEffect" Extends="Effect" LeaveUnsealed="true" SkipUpdate="true" UseProcessUpdateWrapper="true" SkipToString="true"
                                       UseOnChannelCoreWrapper="true" CreateInstanceCoreViaActivator="true" CanIntroduceCycles="false">
             <Fields>
                 <Field Name="PixelShader"                     Type="PixelShader"      IsProtected="true" PropertyChangedHook="true"/>
@@ -3358,7 +3362,7 @@
                        Comment="If true, this Brush wrap its Target visual in a ContainerVisual, which will allow the brush to support rendering all properties on the visual above the cache to match VisualBrush's behavior."/>
             </Fields>
         </Resource>
-        
+
         <Resource Name="DashStyle" SkipToString="true" CanIntroduceCycles="false">
             <Fields>
                 <Field Name="Offset" Type="Double" Default="0.0" Animate="true" />
@@ -3398,7 +3402,7 @@
                        Comment="The glyph or codepoint count, based on the graunularity" />
             </Fields>
         </Resource>
-        
+
         <!--
             Drawing Classes
         -->
@@ -3466,7 +3470,7 @@
                 <Field Name="IsDynamic" Type="Boolean" Default="false" IsInternal="true"/>
             </Fields>
         </Resource>
-        
+
         <!-- Caching -->
         <Resource Name="CacheMode" SkipToString="true" IsAbstract="true" />
         <Resource Name="BitmapCache" Extends="CacheMode" SkipToString="true" CanIntroduceCycles="false">
@@ -3686,7 +3690,7 @@
             <Namespace Name="System.Windows.Media.Media3D"/>
             <Namespace Name="System.Diagnostics"/>
         </Namespaces>
-        
+
         <Resource Name="D3DImage" Extends="ImageSource" LeaveUnsealed="true" IsAnimatable="true" SkipToString="true" CanIntroduceCycles="false" />
     </Resources>
 
@@ -4082,7 +4086,7 @@
         ManagedSharedDestinationDir="src\Shared\Ms\Internal\Generated">
 
         <Generate Name="BlurBitmapEffect" ManagedClass="true"/>
-        <Generate Name="DropShadowBitmapEffect" ManagedClass="true"/>  
+        <Generate Name="DropShadowBitmapEffect" ManagedClass="true"/>
         <Generate Name="EmbossBitmapEffect" ManagedClass="true"/>
         <Generate Name="OuterGlowBitmapEffect" ManagedClass="true"/>
         <Generate Name="BevelBitmapEffect" ManagedClass="true"/>
@@ -4621,7 +4625,7 @@
             <TemplateInstance ModuleName="Core\CSharp" TypeName="Vector3D"  />
             <TemplateInstance ModuleName="Framework" TypeName="Thickness" />
         </Template>
-        
+
         <Template Name="MS.Internal.MilCodeGen.ResourceModel.EasingKeyFrameTemplate">
             <TemplateInstance ModuleName="Core\CSharp" TypeName="Byte"/>
             <TemplateInstance ModuleName="Core\CSharp" TypeName="Color"/>

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/api/api_utils.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/api/api_utils.cpp
@@ -70,6 +70,7 @@ HRESULT HrValidateInitializeCall(
         MilRTInitialization::DisableDisplayClipping |
         MilRTInitialization::DisableMultimonDisplayClipping |
         MilRTInitialization::IsDisableMultimonDisplayClippingValid |
+        MilRTInitialization::DisableDirtyRectangles |
         MilRTInitialization::UseRefRast |
         MilRTInitialization::UseRgbRast |
         MilRTInitialization::PresentUsingMask

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/hwdisplayrt.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/hwdisplayrt.h
@@ -147,7 +147,7 @@ public:
         THIS_
         __in_ecount(1) const RECT *prcSource,
         __in_ecount(1) const RECT *prcDest
-        ) PURE;    
+        ) PURE;
 
     STDMETHOD(InvalidateRect)(
         __in_ecount(1) CMILSurfaceRect const *pRect
@@ -158,7 +158,7 @@ public:
     {
         return CBaseSurfaceRenderTarget<CHwRenderTargetLayerData>::ClearInvalidatedRects();
     }
-    
+
     STDMETHOD(WaitForVBlank)();
 
     STDMETHOD_(VOID, AdvanceFrame)(
@@ -186,6 +186,7 @@ protected:
 
 protected:
     BOOL    m_fEnableRendering; // Rendering is disabled during resize
+    BOOL    m_fDisableDirtyRectangles;  // app wants to skip D3D dirty-rect optimization
     CD3DSwapChain *m_pD3DSwapChain;
     D3DPRESENT_PARAMETERS m_D3DPresentParams;
     UINT const m_AdapterOrdinalInGroup;
@@ -230,7 +231,7 @@ private:
         __in_ecount(1) IWGXBitmapSource *pBitmap,
         __deref_out_ecount(1) CD3DSurface **ppD3DSurface
         );
-        
+
     BOOL m_fDbgClearOnPresent;
 #endif DBG_STEP_RENDERING
 };

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/sw/swhwndrt.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/sw/swhwndrt.h
@@ -35,13 +35,13 @@ MtExtern(CSwPresenter32bppGDI);
 **************************************************************************/
 
 //
-// There is only one presenter, CSwPresenter32bppGDI. Having a separate 
+// There is only one presenter, CSwPresenter32bppGDI. Having a separate
 // CSwPresenterBase is probably redundant and unnecessary
 //
 
 class CSwPresenterBase :
     //  This needs to be an IWGXBitmap so it can be used in SetSurface but
-    //  a lock operates on it and our lock implementation, CWGXBitmapLock, 
+    //  a lock operates on it and our lock implementation, CWGXBitmapLock,
     //  requires a CWGXBitmap because of the Unlock() method
     public CWGXBitmap
 {
@@ -166,7 +166,7 @@ public:
         THIS_
         __in_ecount(1) const RECT *prcSource,
         __in_ecount(1) const RECT *prcDest
-        );    
+        );
 
     STDMETHOD(InvalidateRect)(
         __in_ecount(1) CMILSurfaceRect const *prc
@@ -180,7 +180,7 @@ public:
     {
         RRETURN(CBaseSurfaceRenderTarget<CSwRenderTargetLayerData>::ClearInvalidatedRects());
     }
-    
+
     STDMETHOD(Resize)(
         UINT uWidth,
         UINT uHeight
@@ -219,6 +219,7 @@ private:
     HWND m_hwnd;
 
     CSwPresenter32bppGDI *m_pPresenter;
+    BOOL    m_fDisableDirtyRectangles;  // app wants to skip dirty-rect optimization
 };
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/sw/swlib/swhwndrt.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/sw/swlib/swhwndrt.cpp
@@ -60,7 +60,7 @@ HRESULT CSwPresenterBase::GetSize(
 {
     *puiWidth = m_nWidth;
     *puiHeight = m_nHeight;
-    
+
     return S_OK;
 }
 
@@ -75,7 +75,7 @@ HRESULT CSwPresenterBase::GetSize(
 HRESULT CSwPresenterBase::GetPixelFormat(
     __out_ecount(1) MilPixelFormat::Enum *pPixelFormat
     )
-{   
+{
     *pPixelFormat = m_RenderPixelFormat;
 
     return S_OK;
@@ -97,7 +97,7 @@ HRESULT CSwPresenterBase::GetResolution(
 
     *pDpiX = primaryDisplayDpi.DpiScaleX;
     *pDpiY = primaryDisplayDpi.DpiScaleY;
-    
+
     return S_OK;
 }
 
@@ -336,6 +336,7 @@ HRESULT CSwRenderTargetHWND::Init(
         );
 
     m_hwnd = hwnd;
+    m_fDisableDirtyRectangles = (nFlags & MilRTInitialization::DisableDirtyRectangles) != 0;
 
 #if DBG_STEP_RENDERING
     m_fDbgClearOnPresent = !(nFlags & MilRTInitialization::PresentRetainContents);
@@ -368,8 +369,14 @@ STDMETHODIMP CSwRenderTargetHWND::Present(
     CMILSurfaceRect presentRect;
 
     bool fPresent = false;
-    
+
     RGNDATA *pDirtyRegion = NULL;
+
+    if (m_fDisableDirtyRectangles)
+    {
+        // invalidating the empty rect tells ShouldPresent to present everything
+        InvalidateRect(reinterpret_cast<const CMILSurfaceRect *>(&CMILSurfaceRect::sc_rcEmpty));
+    }
 
     IFC(ShouldPresent(
         pRect,
@@ -377,7 +384,7 @@ STDMETHODIMP CSwRenderTargetHWND::Present(
         &pDirtyRegion,
         &fPresent
         ));
-    
+
     if (fPresent)
     {
         IFC(m_pPresenter->Present(
@@ -441,7 +448,7 @@ CSwRenderTargetHWND::ScrollBlt (
     IFC(m_pPresenter->ScrollBlt(&source, &dest, true, true));
 
 Cleanup:
-    RRETURN(hr);    
+    RRETURN(hr);
 }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/hwndtarget.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/hwndtarget.cpp
@@ -20,31 +20,31 @@ MtDefine(CSlaveHWndRenderTarget, MILRender, "CSlaveHWndRenderTarget");
 
 //------------------------------------------------------------------
 // CSlaveHwndRenderTarget::ctor
-// 
+//
 // Note:
-//      It is important that m_disableCookie start at zero to 
-//      allow an initial UpdateWindowSettings(enable) command to 
-//      enable the render target without a preceeding 
+//      It is important that m_disableCookie start at zero to
+//      allow an initial UpdateWindowSettings(enable) command to
+//      enable the render target without a preceeding
 //      UpdateWindowSettings(disable) command.
 //
 //      This is a good place to force sw fallback by initializing
 //      m_fSoftwareFallback = true
-//  
+//
 //      Everything else not initialized here is initialized to zero
 //      by DECLARE_METERHEAP_CLEAR
 //
 //      DpiProvider is a CDelegatingUnknown, which requires the correct
 //      version of IUnknown to delegate AddRef/Release/QueryInterface
-//      calls to. This is accomplished by passing the CMILCOMBase* 
-//      version of the IUnknown to it. 
+//      calls to. This is accomplished by passing the CMILCOMBase*
+//      version of the IUnknown to it.
 //------------------------------------------------------------------
 
-CSlaveHWndRenderTarget::CSlaveHWndRenderTarget(CComposition *pComposition) : 
-    CRenderTarget(pComposition), 
-    m_DisplayDevicesAvailabilityChangedWindowMessage(RegisterWindowMessage(L"DisplayDevicesAvailabilityChanged")), 
-    m_LastKnownDisplayDevicesAvailabilityChangedWParam(-1), 
-    m_WindowLayerType(MilWindowLayerType::NotLayered), 
-    m_WindowTransparency(MilTransparency::Opaque), 
+CSlaveHWndRenderTarget::CSlaveHWndRenderTarget(CComposition *pComposition) :
+    CRenderTarget(pComposition),
+    m_DisplayDevicesAvailabilityChangedWindowMessage(RegisterWindowMessage(L"DisplayDevicesAvailabilityChanged")),
+    m_LastKnownDisplayDevicesAvailabilityChangedWParam(-1),
+    m_WindowLayerType(MilWindowLayerType::NotLayered),
+    m_WindowTransparency(MilTransparency::Opaque),
     m_hWnd(nullptr),                                // Will be changed during ProcessCreate
     m_UCETargetFlags(MilRTInitialization::Null),    // Will be changed during ProcessCreate
     m_RenderTargetFlags(MilRTInitialization::Null), // Will be changed during ProcessCreate
@@ -89,10 +89,10 @@ CSlaveHWndRenderTarget::Render(
 
     CDrawingContext *pDrawingContext = NULL;
     IFC(GetDrawingContext(&pDrawingContext));
-    
+
     if (m_pRenderTarget
         && m_fRenderingEnabled
-        && !m_fNoScreenAccess  // If we don't have screen access we don't need to render. 
+        && !m_fNoScreenAccess  // If we don't have screen access we don't need to render.
         && !m_fIsZombie)       // The hwnd target is going away and therefore we don't need to render.
     {
         UINT uNumInvalidTargetRegions = 0;
@@ -103,13 +103,13 @@ CSlaveHWndRenderTarget::Render(
         if (m_hWnd)
         {
             //
-            // Get list of areas of target that don't have valid contents. 
+            // Get list of areas of target that don't have valid contents.
             // Later add the list to the dirty areas.
             // This happens when SetPosition() has been called on the render target
             // to change the window size.
             //
             bool fWholeTargetInvalid = false;
-            
+
             IFC(m_pRenderTarget->GetInvalidRegions(
                 &rgInvalidTargetRegions,
                 &uNumInvalidTargetRegions,
@@ -159,7 +159,7 @@ CSlaveHWndRenderTarget::Render(
             //   the layered window is opaque, I just tried it and artifacts appeared everywhere,
             //   and since it's not a goal to make it work, I haven't debugged it).
             //
-            bool fCanAccelerateScroll =    !m_fNeedsFullRender 
+            bool fCanAccelerateScroll =    !m_fNeedsFullRender
                                         && (uNumInvalidTargetRegions == 0)
                                         && (m_WindowLayerType == MilWindowLayerType::NotLayered);
 
@@ -191,7 +191,7 @@ CSlaveHWndRenderTarget::Render(
                     uNumInvalidTargetRegions,
                     rgInvalidTargetRegions,
                     fCanAccelerateScroll,
-                    &fNeedsFullPresent                    
+                    &fNeedsFullPresent
                     ));
 
                 pDrawingContext->EndFrame();
@@ -220,11 +220,11 @@ CSlaveHWndRenderTarget::Render(
         //
         // If we have no invalid regions for this frame, we will
         // not present and will keep the previous frames invalid regions
-        // because we did not copy them in CDrawingContext::Render. We 
+        // because we did not copy them in CDrawingContext::Render. We
         // will copy them on the next frame that actually does get presented.
         //
         if (m_fHasInvalidRegions)
-        {   
+        {
             IFC(SendInvalidRegions());
         }
 
@@ -266,13 +266,13 @@ CSlaveHWndRenderTarget::Present()
     if (m_fNeedsPresent)
     {
         m_fNeedsPresent = false;
-        
+
         if (   m_pRenderTarget
             && m_fRenderingEnabled
             && !m_fNoScreenAccess  // If we don't have screen access; so no need to present.
             && !m_fIsZombie)
         {
-            
+
             IFC(m_pRenderTarget->Present());
             if (g_uMilPerfInstrumentationFlags & MilPerfInstrumentation_SignalPresent)
             {
@@ -295,7 +295,7 @@ Cleanup:
     // HandleWindowErrors also handles some success codes (e.g. S_PRESENT_OCCLUDED). Hence calling it
     // outside of the if-FAILED block.
     hr = HandleWindowErrors(hr);
-    
+
     RRETURN1(hr, S_PRESENT_OCCLUDED);
 }
 
@@ -303,11 +303,11 @@ Cleanup:
 //
 //  Member: CSlaveHWndRenderTarget::PostDisplayAvailabilityMessage
 //
-//  Synopsis:  Sends m_DisplayDevicesAvailabilityChangedWindowMessage to the 
-//             HWND. 
+//  Synopsis:  Sends m_DisplayDevicesAvailabilityChangedWindowMessage to the
+//             HWND.
 //
-//             wParam for this message is set to 0 if no displays are available, 
-//             and it is set to 1 when > 0 displays are available. 
+//             wParam for this message is set to 0 if no displays are available,
+//             and it is set to 1 when > 0 displays are available.
 //
 //             lParam is unused.
 //  Parameters:
@@ -320,11 +320,11 @@ Cleanup:
 BOOL CSlaveHWndRenderTarget::PostDisplayAvailabilityMessage(int displayCount)
 {
     m_LastKnownDisplayDevicesAvailabilityChangedWParam = (displayCount > 0) ? 1 : 0;
-    return 
+    return
         PostMessage(
-            m_hWnd, 
-            m_DisplayDevicesAvailabilityChangedWindowMessage, 
-            m_LastKnownDisplayDevicesAvailabilityChangedWParam, 
+            m_hWnd,
+            m_DisplayDevicesAvailabilityChangedWindowMessage,
+            m_LastKnownDisplayDevicesAvailabilityChangedWParam,
             0);
 }
 
@@ -332,11 +332,11 @@ BOOL CSlaveHWndRenderTarget::PostDisplayAvailabilityMessage(int displayCount)
 //
 //  Member: CSlaveHWndRenderTarget::NotifyInvalidDisplaySet
 //
-//  Synopsis:  Invalidates this particulare HWND render target if it isn't 
-//             a full-screen render target (typically used by the DWM) 
+//  Synopsis:  Invalidates this particulare HWND render target if it isn't
+//             a full-screen render target (typically used by the DWM)
 //  Parameters:
-//                  invalid:  When true, indicates that the new display set 
-//                            obtained after the recent mode-change is invalid. 
+//                  invalid:  When true, indicates that the new display set
+//                            obtained after the recent mode-change is invalid.
 //           oldDisplayCount: The number of valid displays available before this
 //                            change.
 //              displayCount: Indicates the number of valid displays available
@@ -360,7 +360,7 @@ CSlaveHWndRenderTarget::NotifyDisplaySetChange(bool invalid , int oldDisplayCoun
         // Let the UI thread know that the display-set has changed in a meaningful way.
         // This helps in ensuring that the UI thread does not repeatedly attempt to process
         // WM_PAINT or invalidate itself when the render-thread is unable to render.
-        if ((invalid || (displayCount == 0)) && 
+        if ((invalid || (displayCount == 0)) &&
             (oldDisplayCount != displayCount))
         {
             PostDisplayAvailabilityMessage(displayCount); // ignore return value
@@ -403,9 +403,9 @@ CSlaveHWndRenderTarget::ProcessCreate(
     HRESULT hr = S_OK;
 
     RtlCopyMemory(&m_clearColor, &pCmd->clearColor, sizeof(m_clearColor));
-    
+
     m_hWnd = (HWND)pCmd->hwnd;
-    
+
     DpiProvider::UpdateDpi(DpiScale(pCmd->DpiX, pCmd->DpiY));
     DpiProvider::SetDpiAwarenessContext(pCmd->DpiAwarenessContext);
 
@@ -418,7 +418,7 @@ Cleanup:
     RRETURN(hr);
 }
 
-HRESULT 
+HRESULT
 CSlaveHWndRenderTarget::ProcessSuppressLayered(
     __in_ecount(1) CMilSlaveHandleTable* pHandleTable,
     __in_ecount(1) const MILCMD_HWNDTARGET_SUPPRESSLAYERED* pCmd
@@ -427,7 +427,7 @@ CSlaveHWndRenderTarget::ProcessSuppressLayered(
     RRETURN(S_OK);
 }
 
-HRESULT 
+HRESULT
 CSlaveHWndRenderTarget::ProcessDpiChanged(
     __in_ecount(1) CMilSlaveHandleTable* pHandleTable,
     __in_ecount(1) const MILCMD_HWNDTARGET_DPICHANGED* pCmd
@@ -443,7 +443,7 @@ CSlaveHWndRenderTarget::ProcessDpiChanged(
 //      CSlaveHWndRenderTarget::CalculateWindowRect
 //
 //  Synopsis:
-//      A helper method that obtains the window rect. 
+//      A helper method that obtains the window rect.
 //
 //----------------------------------------------------------------------------
 
@@ -487,19 +487,19 @@ CSlaveHWndRenderTarget::CalculateWindowRect()
 Cleanup:
     if (FAILED(hr))
     {
-        // 
-        // Since there appear to be random multiple errors being 
+        //
+        // Since there appear to be random multiple errors being
         // returned here, and we can't rely on WIN32 error codes being
         // accurate, for the time being we are dying silently on the ones
         // below by returning a WGXERR_GENERIC_IGNORE.
         //
-        TraceTag((tagMILWarning, 
-                     "CSlaveHWndRenderTarget::GetWindowRect: Failure occurred, converting to WGXERR_GENERIC_IGNORE"));        
+        TraceTag((tagMILWarning,
+                     "CSlaveHWndRenderTarget::GetWindowRect: Failure occurred, converting to WGXERR_GENERIC_IGNORE"));
 
         MIL_THR(WGXERR_GENERIC_IGNORE);
     }
 
-    RRETURN(hr);    
+    RRETURN(hr);
 }
 
 
@@ -509,7 +509,7 @@ Cleanup:
 
 HRESULT
 CSlaveHWndRenderTarget::ProcessUpdateWindowSettings(
-    __in_ecount(1) CMilSlaveHandleTable* pHandleTable, 
+    __in_ecount(1) CMilSlaveHandleTable* pHandleTable,
     __in_ecount(1) const MILCMD_TARGET_UPDATEWINDOWSETTINGS* pCmd
     )
 {
@@ -569,7 +569,7 @@ CSlaveHWndRenderTarget::ProcessUpdateWindowSettings(
         {
             // Remember the lastest cookie.
             m_disableCookie = pCmd->disableCookie;
-        
+
             m_fRenderingEnabled = false;
         }
     }
@@ -645,7 +645,7 @@ CSlaveHWndRenderTarget::ProcessUpdateWindowSettings(
     IFC(UpdateRenderTargetFlags(
         m_UCETargetFlags
         ));
-    
+
 
 Cleanup:
     RRETURN(hr);
@@ -694,7 +694,7 @@ CSlaveHWndRenderTarget::ProcessSetFlags(
     HRESULT hr = S_OK;
 
     const MilRTInitialization::Flags c_dwAllowedFlags =
-        (MilRTInitialization::TypeMask | MilRTInitialization::UseRefRast | MilRTInitialization::UseRgbRast);
+        (MilRTInitialization::TypeMask | MilRTInitialization::UseRefRast | MilRTInitialization::UseRgbRast | MilRTInitialization::DisableDirtyRectangles);
 
     MilRTInitialization::Flags dwNewInitializationFlags;
 
@@ -725,8 +725,8 @@ CSlaveHWndRenderTarget::ProcessInvalidate(
     UINT cbPayload
     )
 {
-    HRESULT hr = S_OK; 
-    
+    HRESULT hr = S_OK;
+
     // We get a WM_PAINT when the screen is unlocked.... or immediately after
     // invalidation if the window is layered or running in the DWM.
 
@@ -734,7 +734,7 @@ CSlaveHWndRenderTarget::ProcessInvalidate(
     // non-layered windows on XPDM. Other scenarios will still render when the
     // screen is locked but those scenarios are not as bad. See comment in
     // HandleWindowErrors for more information.
-    
+
     m_fNoScreenAccess = false;
 
     if (   (pCmd->rc.right > pCmd->rc.left)
@@ -754,7 +754,7 @@ CSlaveHWndRenderTarget::ProcessInvalidate(
 Cleanup:
     RRETURN(hr);
 }
-  
+
 
 //-----------------------------------------------------------------------------
 // CSlaveHWndRenderTarget::SetNewRenderTargetFlags
@@ -788,10 +788,10 @@ HRESULT
 CSlaveHWndRenderTarget::UpdateRenderTargetFlags()
 {
     // We want to update the render flags to possibly include software
-    // based upon RenderOptions and the requested flags. We don't want to 
-    // overwrite the current flags requested by the client so we don't call 
+    // based upon RenderOptions and the requested flags. We don't want to
+    // overwrite the current flags requested by the client so we don't call
     // SetNewUCETargetFlags().
-    RRETURN(UpdateRenderTargetFlags(m_UCETargetFlags));   
+    RRETURN(UpdateRenderTargetFlags(m_UCETargetFlags));
 }
 
 //-----------------------------------------------------------------------------
@@ -891,7 +891,7 @@ CSlaveHWndRenderTarget::EnsureRenderTargetInternal()
         EventWriteWClientDesktopRTCreateEnd((UINT64)m_hWnd);
 
         m_fNeedsFullRender = true;
-        m_fTransparencyDirty = true;        
+        m_fTransparencyDirty = true;
     }
 
     Assert(m_pRenderTarget != NULL);
@@ -924,7 +924,7 @@ CSlaveHWndRenderTarget::UpdateWindowSettingsInternal()
     // commands to update their size and location.  So we have to query
     // it all the time.
     //
-    
+
     if (m_fChild)
     {
         IFC(CalculateWindowRect());
@@ -981,7 +981,7 @@ CSlaveHWndRenderTarget::InvalidateInternal(
     {
         IFC(m_invalidRegions.Add(*pRect));
     }
-    
+
     m_fHasInvalidRegions = true;
 
 Cleanup:
@@ -1054,10 +1054,10 @@ CSlaveHWndRenderTarget::HandleWindowErrors(HRESULT hr)
                 {
                     // Setting the flag will force us to create a software render target on the next render.
                     // This will never allow us to get back into hw mode. To enable resetting the render target
-                    // using the SetFlags command simply set 
+                    // using the SetFlags command simply set
                     //     m_UCETargetFlags = m_UCETargetFlags | MilRTInitialization::SoftwareOnly;
-                    // This feature intentionally not enabled becuase we do not have any API exposure for it and 
-                    // there is no test plan. 
+                    // This feature intentionally not enabled becuase we do not have any API exposure for it and
+                    // there is no test plan.
                     Assert((m_UCETargetFlags & MilRTInitialization::TypeMask) != MilRTInitialization::HardwareOnly);
                     Assert((m_RenderTargetFlags & MilRTInitialization::TypeMask) != MilRTInitialization::HardwareOnly);
                     m_fSoftwareFallback = true;
@@ -1072,11 +1072,11 @@ CSlaveHWndRenderTarget::HandleWindowErrors(HRESULT hr)
                 ReleaseResources();
                 SetScreenAccessDenied();
 
-                // If m_LastKnownDisplayDevicesAvailabilityChangedWParam == 0, it means that the 
-                // UI thread will eventually call InvalidateRect(HWND) when it receives an updated 
-                // m_DisplayDevicesAvailabilityChanged Window Message with wParam = 1. 
-                // Until then, we do not need to continue invalidating the window - doing so will 
-                // simply generate a series of WM_PAINT messages that would be handled and ignroed by 
+                // If m_LastKnownDisplayDevicesAvailabilityChangedWParam == 0, it means that the
+                // UI thread will eventually call InvalidateRect(HWND) when it receives an updated
+                // m_DisplayDevicesAvailabilityChanged Window Message with wParam = 1.
+                // Until then, we do not need to continue invalidating the window - doing so will
+                // simply generate a series of WM_PAINT messages that would be handled and ignroed by
                 // the UI thread
                 if ((hr == WGXERR_NEED_RECREATE_AND_PRESENT) ||
                     ((hr == WGXERR_DISPLAYSTATEINVALID) && (m_LastKnownDisplayDevicesAvailabilityChangedWParam != 0)))
@@ -1085,11 +1085,11 @@ CSlaveHWndRenderTarget::HandleWindowErrors(HRESULT hr)
                 }
 
                 // The composition object needs to know when the underlying render targets
-                // are being recreated; therefore we bubble WGXERR_DISPLAYSTATEINVALID 
-                // up. 
+                // are being recreated; therefore we bubble WGXERR_DISPLAYSTATEINVALID
+                // up.
                 hrReturn = WGXERR_DISPLAYSTATEINVALID;
                 break;
-                
+
             case WGXERR_SCREENACCESSDENIED:     // Display is locked right now
                 SetScreenAccessDenied();
                 __fallthrough;
@@ -1100,7 +1100,7 @@ CSlaveHWndRenderTarget::HandleWindowErrors(HRESULT hr)
 
                 hrReturn = S_OK;
                 break;
-                
+
             case __HRESULT_FROM_WIN32(ERROR_INVALID_WINDOW_HANDLE): // FALL THROUGH Window has been asynchronously destroyed
                 m_fIsZombie = TRUE;
                 __fallthrough;
@@ -1121,8 +1121,8 @@ CSlaveHWndRenderTarget::HandleWindowErrors(HRESULT hr)
     }
 
     //
-    // Somewhat special case for S_PRESENT_OCCLUDED.  In this case nothing is 
-    // wrong with the render target, we just need to do a full present when we 
+    // Somewhat special case for S_PRESENT_OCCLUDED.  In this case nothing is
+    // wrong with the render target, we just need to do a full present when we
     // become un-occluded.
     //
     if (hrReturn == S_PRESENT_OCCLUDED)
@@ -1150,7 +1150,7 @@ CSlaveHWndRenderTarget::SetScreenAccessDenied()
     // is locked for software render targets or for hardware
     // render targets that present to GDI. For hardware render
     // targets that  do not present to GDI we get
-    // WGXERR_DISPLAYSTATEINVALID.   
+    // WGXERR_DISPLAYSTATEINVALID.
     //
     // On Vista WDDM, D3D Presents return S_PRESENT_OCCLUDED,
     // but lower levels of the code eat this error. GDI
@@ -1182,7 +1182,7 @@ CSlaveHWndRenderTarget::SetScreenAccessDenied()
     // will come to us immediately. This *could* cause us to
     // loop, producing a WM_PAINT "storm", *if* we fail with
     // one of the above error codes in these cases when the
-    // screen is (still) locked. 
+    // screen is (still) locked.
     //
     // Fortunately for us, the cases
     // which do not hold back WM_PAINTs also do not return
@@ -1194,14 +1194,14 @@ CSlaveHWndRenderTarget::SetScreenAccessDenied()
     // through here.
     //
     // 2009/09/23 BedeJ - Unfortunately for us, this last paragraph
-    // is not entirely true. If the monitor is powered off, but the 
+    // is not entirely true. If the monitor is powered off, but the
     // display is not locked, a D3D present can fail with
     // S_PRESENT_OCCLUDED (see CD3DDeviceLevel1::PresentWithD3D). When
-    // I tried to work around this by invalidating the window before 
+    // I tried to work around this by invalidating the window before
     // silently eating the error, I ended up in the WM_PAINT storm
-    // situation described here. The fix I developed instead was to 
+    // situation described here. The fix I developed instead was to
     // continue to ignore the failure, but have the UI thread register
-    // for and listen to power broadcast events for monitor power on/off, 
+    // for and listen to power broadcast events for monitor power on/off,
     // and to invalidate the entire window when the monitor is powered
     // back on if a failure . To avoid unnecessary invalidation of windows that
     // haven't had a failed present, we send a window message to the UI
@@ -1209,8 +1209,8 @@ CSlaveHWndRenderTarget::SetScreenAccessDenied()
     // that the invalidation is necessary.
     //
 
-    m_fNoScreenAccess = true;  
-}               
+    m_fNoScreenAccess = true;
+}
 
 //+-----------------------------------------------------------------------
 //
@@ -1240,46 +1240,46 @@ HRESULT CSlaveHWndRenderTarget::WaitForVBlank()
     {
         MIL_THR(WGXERR_NO_HARDWARE_DEVICE);
     }
-    
+
     RRETURN(hr);
 }
 
 //------------------------------------------------------------------
 // CSlaveHWndRenderTarget::ReleaseResources
-// 
+//
 // Wrapper function for releasing all render targets and cleaning
 // up dependent member variables
 //------------------------------------------------------------------
 void
 CSlaveHWndRenderTarget::ReleaseResources()
-{      
+{
     ReleaseInterface(m_pRenderTarget);
     ReleaseDrawingContext();
 }
-    
+
 //+------------------------------------------------------------------------
 //
 //  Function:  CSlaveHWndRenderTarget::Advance
 //
 //  Synopsis:  Advances frame count and inserts a gpu marker.
-//             
+//
 //-------------------------------------------------------------------------
 void
 CSlaveHWndRenderTarget::AdvanceFrame(UINT uFrameNumber)
 {
-    if (m_fRenderingEnabled && !m_fIsZombie && m_pRenderTarget)        
+    if (m_fRenderingEnabled && !m_fIsZombie && m_pRenderTarget)
     {
         m_pRenderTarget->AdvanceFrame(uFrameNumber);
     }
 }
-    
+
 //+------------------------------------------------------------------------
 //
 //  Function:  CSlaveHWndRenderTarget::GetNumQueuedPresents
 //
-//  Synopsis:  Forwards to the rendertarget if it's valid, otherwise 
+//  Synopsis:  Forwards to the rendertarget if it's valid, otherwise
 //             returns 0.
-//             
+//
 //-------------------------------------------------------------------------
 HRESULT
 CSlaveHWndRenderTarget::GetNumQueuedPresents(
@@ -1288,8 +1288,8 @@ CSlaveHWndRenderTarget::GetNumQueuedPresents(
 {
     HRESULT hr = S_OK;
 
-    if (m_fRenderingEnabled 
-        && !m_fIsZombie 
+    if (m_fRenderingEnabled
+        && !m_fIsZombie
         &&  m_pRenderTarget
         )
     {
@@ -1311,7 +1311,7 @@ Cleanup:
 //  Synopsis:  Returns the underlying render target internal.
 //
 //------------------------------------------------------------------------
-HRESULT 
+HRESULT
 CSlaveHWndRenderTarget::GetBaseRenderTargetInternal(
     __deref_out_opt IRenderTargetInternal **ppIRT
     )

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_misc.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/Generated/wgx_misc.h
@@ -745,31 +745,37 @@ BEGIN_MILFLAGENUM( MilRTInitialization )
     //
     // This flag forces the creation of a render target bitmap to match its
     // parent's type, so a software surface only creates software RTs and a
-    // hardware surface only creates hardware RTs.  This is necessary for the 
+    // hardware surface only creates hardware RTs.  This is necessary for the
     // hardware-accelerated bitmap effects pipeline to guarantee that we do
-    // not encounter a situation where we're trying to run shaders sampling 
+    // not encounter a situation where we're trying to run shaders sampling
     // from a hardware texture to render into a software intermediate.
     //
     ForceCompatible = 0x00002000,
 
     //
-    // This flag is the same as DisableDisplayClipping except that it disables 
+    // This flag is the same as DisableDisplayClipping except that it disables
     // display clipping on multi-monitor configurations in all OS'. This flag is 
-    // automatically 
-    // set on Windows 8 and newer systems. If WPF decides to unset 
-    // DisableDisplayClipping, then DisableMultimonDisplayClipping flag will not be 
+    // automatically
+    // set on Windows 8 and newer systems. If WPF decides to unset
+    // DisableDisplayClipping, then DisableMultimonDisplayClipping flag will not be
     // respected even if set by an applicaiton via its manifest
     //
     DisableMultimonDisplayClipping = 0x00004000,
 
     //
-    // This flag is passed down by PresentationCore to tell wpfgfx that 
-    // the DisableMultimonDisplayClipping compatibity flag is set by the user. This 
+    // This flag is passed down by PresentationCore to tell wpfgfx that
+    // the DisableMultimonDisplayClipping compatibity flag is set by the user. This
     // allows us to distinguish between when DisableMultimonDisplayClipping == 0 means
-    // that the user set it to false explicitly, versus when the user didn't set it 
+    // that the user set it to false explicitly, versus when the user didn't set it
     // and the DisableMultimonDisplayClipping bit happens to be implicitly set to 0
     //
     IsDisableMultimonDisplayClippingValid = 0x00008000,
+
+    //
+    // This flag directs the render target to render the full scene,
+    // bypassing D3D's dirty-rectangle optimizations.
+    //
+    DisableDirtyRectangles = 0x00010000,
 
 
     //

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/exports.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/exports.cs
@@ -273,7 +273,7 @@ namespace System.Windows.Media.Composition
                 IntPtr pChannel,
                 DUCE.ResourceHandle hResource,
                 out uint refCount
-                );                
+                );
         }
 
         /// <summary>
@@ -452,7 +452,7 @@ namespace System.Windows.Media.Composition
             /// </summary>
             /// <SecurityNote>
             ///    Critical: This code calls into MilConnection_CloseBatch which causes an elevation
-            ///    TreatAsSafe: Closing a batch is safe and nothing is exposed. Batches are in the 
+            ///    TreatAsSafe: Closing a batch is safe and nothing is exposed. Batches are in the
             ///                 render thread, and can only be written to from the UI thread while
             ///                 they're open using other SC/STAS methods on DUCE.Channel. Once closed,
             ///                 the only operation that can be done on a batch is Channel.Commit.
@@ -574,7 +574,7 @@ namespace System.Windows.Media.Composition
 
                 if (EventTrace.IsEnabled(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW))
                 {
-                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.CreateOrAddResourceOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, PerfService.GetPerfElementID(instance), _hChannel, (uint) handle, (uint) resourceType); 
+                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.CreateOrAddResourceOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, PerfService.GetPerfElementID(instance), _hChannel, (uint) handle, (uint) resourceType);
                 }
 
                 return handleNeedsCreation;
@@ -650,14 +650,14 @@ namespace System.Windows.Media.Composition
 
                 if ((releasedOnChannel != 0) && EventTrace.IsEnabled(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW))
                 {
-                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.ReleaseOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, _hChannel, (uint) handle); 
+                    EventTrace.EventProvider.TraceEvent(EventTrace.Event.ReleaseOnChannel, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.PERF_LOW, _hChannel, (uint) handle);
                 }
 
                 return (releasedOnChannel != 0);
             }
 
             /// <summary>
-            /// Internal only: GetRefCount returns the reference count of a resource 
+            /// Internal only: GetRefCount returns the reference count of a resource
             /// corresponding to the specified handle on the channel.
             /// </summary>
             /// <return>
@@ -1152,7 +1152,7 @@ namespace System.Windows.Media.Composition
 
 
             /// <summary>
-            /// Returns the real UInt32 handle. 
+            /// Returns the real UInt32 handle.
             /// </summary>
             public DUCE.ResourceHandle Handle { get { return _handle; } }
         }
@@ -1702,7 +1702,7 @@ namespace System.Windows.Media.Composition
                 bool inmap = _map.Get(channel, out handle);
 
                 bool created = channel.CreateOrAddRefOnChannel(instance, ref handle, type);
-                
+
                 if (!inmap)
                 {
                     _map.Set(channel, handle);
@@ -1880,7 +1880,7 @@ namespace System.Windows.Media.Composition
                 DUCE.ResourceHandle hEffect,
                 Channel channel)
             {
-                DUCE.MILCMD_VISUAL_SETEFFECT command;               
+                DUCE.MILCMD_VISUAL_SETEFFECT command;
 
                 command.Type = MILCMD.MilCmdVisualSetEffect;
                 command.Handle = hCompositionNode;
@@ -1894,7 +1894,7 @@ namespace System.Windows.Media.Composition
                         );
                 }
             }
-            
+
 
             /// <SecurityNote>
             ///     Critical: This code accesses an unsafe code block
@@ -1906,7 +1906,7 @@ namespace System.Windows.Media.Composition
                 DUCE.ResourceHandle hCacheMode,
                 Channel channel)
             {
-                DUCE.MILCMD_VISUAL_SETCACHEMODE command;               
+                DUCE.MILCMD_VISUAL_SETCACHEMODE command;
 
                 command.Type = MILCMD.MilCmdVisualSetCacheMode;
                 command.Handle = hCompositionNode;
@@ -2054,7 +2054,7 @@ namespace System.Windows.Media.Composition
                         sizeof(DUCE.MILCMD_VISUAL_SETSCROLLABLEAREACLIP)
                         );
                 }
-            }            
+            }
 
             /// <SecurityNote>
             ///     Critical: This code accesses an unsafe code block
@@ -2534,7 +2534,7 @@ namespace System.Windows.Media.Composition
                     command.flags |= (UInt32)MILRTInitializationFlags.MIL_RT_SOFTWARE_ONLY;
                 }
 
-                bool? enableMultiMonitorDisplayClipping = 
+                bool? enableMultiMonitorDisplayClipping =
                     System.Windows.CoreCompatibilityPreferences.EnableMultiMonitorDisplayClipping;
 
                 if (enableMultiMonitorDisplayClipping != null)
@@ -2546,6 +2546,11 @@ namespace System.Windows.Media.Composition
                     {
                         command.flags |= (UInt32) MILRTInitializationFlags.MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING;
                     }
+                }
+
+                if (CoreAppContextSwitches.DisableDirtyRectangles)
+                {
+                    command.flags |= (UInt32)MILRTInitializationFlags.MIL_RT_DISABLE_DIRTY_RECTANGLES;
                 }
 
                 command.hBitmap = DUCE.ResourceHandle.Null;
@@ -2791,17 +2796,17 @@ namespace System.Windows.Media.Composition
         }
 
         /// <summary>
-        /// See <see cref="MediaContext.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> for 
+        /// See <see cref="MediaContext.ShouldRenderEvenWhenNoDisplayDevicesAreAvailable"/> for
         /// details.
         /// </summary>
         /// <SecurityNote>
         ///     Critical: This code accesses an unsafe code block
-        ///     Safe:     Operation is ok to call, sending a pointer to a channel is safe, 
+        ///     Safe:     Operation is ok to call, sending a pointer to a channel is safe,
         ///               and this does not return any Critical data to the caller
         /// </SecurityNote>
         [SecuritySafeCritical]
         internal static void NotifyPolicyChangeForNonInteractiveMode(
-            bool forceRender, 
+            bool forceRender,
             Channel channel
             )
         {
@@ -2814,8 +2819,8 @@ namespace System.Windows.Media.Composition
             unsafe
             {
                 channel.SendCommand(
-                    (byte*)&command, 
-                    sizeof(DUCE.MILCMD_PARTITION_NOTIFYPOLICYCHANGEFORNONINTERACTIVEMODE), 
+                    (byte*)&command,
+                    sizeof(DUCE.MILCMD_PARTITION_NOTIFYPOLICYCHANGEFORNONINTERACTIVEMODE),
                     sendInSeparateBatch: false
                     );
             }

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/processed/wgx_core_types.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/processed/wgx_core_types.h
@@ -858,6 +858,12 @@ BEGIN_MILFLAGENUM( MilRTInitialization )
     //
     IsDisableMultimonDisplayClippingValid = 0x00008000,
 
+    //
+    // This flag directs the render target to render the full scene,
+    // bypassing D3D's dirty-rectangle optimizations.
+    //
+    DisableDirtyRectangles = 0x00010000,
+
 
     //
     // Test only / internal flags

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/wgx_core_types_compat.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/include/wgx_core_types_compat.cs
@@ -25,133 +25,133 @@
         MilSegmentPolyLine,
         MilSegmentPolyBezier,
         MilSegmentPolyQuadraticBezier,
-    
+
         MIL_SEGMENT_TYPE_FORCE_DWORD = unchecked((int)0xffffffff)
     };
 
     [System.Flags]
     internal enum MILCoreSegFlags
     {
-    
+
         SegTypeLine                  = 0x00000001,
         SegTypeBezier                = 0x00000002,
         SegTypeMask                  = 0x00000003,
-    
+
         // When this bit is set then this segment is not to be stroked
         SegIsAGap                    = 0x00000004,
-    
+
         // When this bit is set then the join between this segment and the PREVIOUS segment
         // will be rounded upon widening, regardless of the pen line join property.
         SegSmoothJoin                = 0x00000008,
-    
+
         // When this bit is set on the first type then the figure should be closed.
         SegClosed                    = 0x00000010,
-    
+
         // This bit indicates whether the segment is curved.
         SegIsCurved                  = 0x00000020,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MIL_PEN_CAP    {
         MilPenCapFlat = 0,
         MilPenCapSquare = 1,
         MilPenCapRound = 2,
         MilPenCapTriangle = 3,
-    
+
         MIL_PEN_CAP_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MIL_PEN_JOIN    {
         MilPenJoinMiter = 0,
         MilPenJoinBevel = 1,
         MilPenJoinRound = 2,
-    
+
         MIL_PEN_JOIN_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     [System.Flags]
     internal enum MILRTInitializationFlags
     {
-    
+
         // Default initialization flags (0) imply hardware with software fallback,
         // synchronized to reduce tearing for hw RTs, and no retention of contents
         // between scenes.
-    
+
         MIL_RT_INITIALIZE_DEFAULT       = 0x00000000,
-    
+
         // This flag disables the hardware accelerated RT. Use only software.
-    
+
         MIL_RT_SOFTWARE_ONLY            = 0x00000001,
-    
+
         // This flag disables the software RT. Use only hardware.
-    
+
         MIL_RT_HARDWARE_ONLY            = 0x00000002,
-    
+
         // Creates a dummy render target that consumes all calls
-    
+
         MIL_RT_NULL                     = 0x00000003,
-    
+
         // Mask for choice of render target
-    
+
         MIL_RT_TYPE_MASK                = 0x00000003,
-    
+
         // This flag indicates that presentation should not wait for any specific
         // time to promote the results to the display. This may result in display
         // tearing.
-    
+
         MIL_RT_PRESENT_IMMEDIATELY      = 0x00000004,
-    
+
         // This flag makes the RT reatin the contents from one frame to the next.
         // Retaining the contents has performance implications.  For scene changes
         // with little to update retaining contents may help, but if most of the
         // scene will be repainted anyway, retention may hurt some hw scenarios.
-    
+
         MIL_RT_PRESENT_RETAIN_CONTENTS  = 0x00000008,
-    
+
         // This flag indicates that we should create a full screen RT.
-    
+
         MIL_RT_FULLSCREEN               = 0x00000010,
-    
+
         // This flag indicates that the render target backbuffer will have
         // linear gamma.
-    
+
         MIL_RT_LINEAR_GAMMA             = 0x00000020,
-    
+
         // This flag indicates that the render target backbuffer will have
         // an alpha channel that is at least 8 bits wide.
-    
+
         MIL_RT_NEED_DESTINATION_ALPHA   = 0x00000040,
-    
+
         // This flag allows the render target backbuffer to contain
         // 10 bits per channel rather than 32. This flag only has
         // meaning when linear gamma is also present.
-    
+
         MIL_RT_ALLOW_LOW_PRECISION      = 0x00000080,
-    
+
         // This flag assumes that all resources (such as bitmaps and render
         // targets) are released on the same thread as the rendering device.  This
         // flag enables us to use a single threaded dx device instead of a
         // multi-threaded one.
-    
+
         MIL_RT_SINGLE_THREADED_USAGE    = 0x00000100,
-    
+
         // This flag directs the render target to extend its presentation area
         // to include the non-client area.  The origin of the render target space
         // will be equal to the origin of the window.
-    
+
         MIL_RT_RENDER_NONCLIENT         = 0x00000200,
-    
+
         // This flag enables tear free composition by using the SWAPEFFECT D3D_FLIP.
-    
+
         MIL_RT_PRESENT_FLIP             = 0x00000400,
-    
+
         // Setting this flag results in the DX device instructing the driver not to
         // autorotate if the monitor is in a rotated mode.  Only makes sense for
         // fullscreen RTs
-    
+
         MIL_RT_FULLSCREEN_NO_AUTOROTATE = 0x00000800,
-    
+
         // This flag directed the render target not to restrict its rendering and
         // presentation to the visible portion of window on the desktop.  This is
         // useful for when the window position may be faked or the system may try
@@ -163,58 +163,64 @@
         MIL_RT_DISABLE_DISPLAY_CLIPPING = 0x00001000,
 
         //
-        // This flag is the same as MIL_RT_DISABLE_DISPLAY_CLIPPING except that it disables 
-        // display clipping on multi-monitor configurations in all OS'. This flag is automatically 
-        // set on Windows 8 and newer systems. If WPF decides to unset 
+        // This flag is the same as MIL_RT_DISABLE_DISPLAY_CLIPPING except that it disables
+        // display clipping on multi-monitor configurations in all OS'. This flag is automatically
+        // set on Windows 8 and newer systems. If WPF decides to unset
         // MIL_RT_DISABLE_DISPLAY_CLIPPING, then MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING flag
         // will not be respected even if set by an applicaiton via its manifest
         //
         MIL_RT_DISABLE_MULTIMON_DISPLAY_CLIPPING = 0x00004000,
 
         //
-        // This flag is passed down by PresentationCore to tell wpfgfx that 
-        // the DisableMultimonDisplayClipping compatibity flag is set by the user. This 
+        // This flag is passed down by PresentationCore to tell wpfgfx that
+        // the DisableMultimonDisplayClipping compatibity flag is set by the user. This
         // allows us to distinguish between when DisableMultimonDisplayClipping == 0 means
-        // that the user set it to false explicitly, versus when the user didn't set it 
+        // that the user set it to false explicitly, versus when the user didn't set it
         // and the DisableMultimonDisplayClipping bit happens to be implicitly set to 0
         //
         MIL_RT_IS_DISABLE_MULTIMON_DISPLAY_CLIPPING_VALID = 0x00008000,
 
-        // 
+        //
+        // This flag directs the render target to render the full scene,
+        // bypassing D3D's dirty-rectangle optimizations.
+        //
+        MIL_RT_DISABLE_DIRTY_RECTANGLES = 0x00010000,
+
+        //
         // UCE only flags
         //
-    
+
         // This flag directs the composition rendertarget to enable the occlusion
         // culling optimization.
         MIL_UCE_RT_ENABLE_OCCLUSION     = 0x00010000,
-    
-    
+
+
         //
         // Test only / internal flags
         //
-    
+
         // This flag forces the render target to use the d3d9 reference raster
         // when using d3d. (Should be combined with MIL_RT_INITIALIZE_DEFAULT or
         // MIL_RT_HARDWARE_ONLY)
         // This is designed for test apps only
-    
+
         MIL_RT_USE_REF_RAST             = 0x01000000,
-    
+
         // This flag forces the render target to use the rgb reference raster
         // when using d3d.( Should be combined with MIL_RT_INITIALIZE_DEFAULT or
         // MIL_RT_HARDWARE_ONLY )
         // This is designed for test apps only
-    
+
         MIL_RT_USE_RGB_RAST             = 0x02000000,
-    
-    
+
+
         // MIL Core Rendering Internal flag (=Do NOT pass to RT Create methods)
         // This flag enables the buffer to be set up in a transposed mode
         // in order to manage our own rotation for 90 and 270 degree rotations.
-    
+
         MIL_RT_FULLSCREEN_TRANSPOSE_XY  = unchecked((int)0x10000000),
-    
-    
+
+
         // We support 4 primary present modes:
         //
         // 1) Present using D3D
@@ -227,11 +233,11 @@
         MIL_RT_PRESENT_USING_BITBLT     = unchecked((int)0x40000000),
         MIL_RT_PRESENT_USING_ALPHABLEND = unchecked((int)0x80000000),
         MIL_RT_PRESENT_USING_ULW        = unchecked((int)0xC0000000),
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
-    
+
+
     internal enum MIL_PRESENTATION_RESULTS    {
         MIL_PRESENTATION_VSYNC,
         MIL_PRESENTATION_NOPRESENT,
@@ -239,7 +245,7 @@
         MIL_PRESENTATION_DWM,
         MIL_PRESENTATION_FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     internal struct MIL_PEN_DATA    {
         internal double Thickness;
@@ -251,29 +257,28 @@
         internal MIL_PEN_JOIN LineJoin;
         internal UInt32 DashArraySize;
     };
-    
+
     [System.Flags]
     internal enum MILTransparencyFlags
     {
-    
+
         Opaque = 0x0,
         ConstantAlpha = 0x1,
         PerPixelAlpha = 0x2,
         ColorKey = 0x4,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
+
     internal enum MILWindowLayerType
     {
-    
+
         NotLayered = 0,
         SystemManagedLayer = 1,
         ApplicationManagedLayer = 2,
-    
+
         FORCE_DWORD = unchecked((int)0xffffffff)
     };
-    
 
 
 


### PR DESCRIPTION
Addresses #5441
This is a port of a servicing fix in .NET 4.7-4.8.

## Description

The problem is due to a limitation of D3D - the content it presents via dirty-rectangles can be out of sync with the rest of the content, if the timing of the presents and fills is unfortunate.  WPF cannot fix this, but we can mitigate it by giving the app a way to disable the dirty-rectangle optimization.  This impacts the graphics performance;  by opting-in the app accepts the tradeoff of performance vs. fidelity.

The mitigation takes the form of two AppContext switches:
* Switch.System.Windows.Media.MediaContext.DisableDirtyRectangles
* Switch.System.Windows.Media.MediaContext.EnableDynamicDirtyRectangles

These can be set using one of the techniques listed [here](https://docs.microsoft.com/en-us/dotnet/api/system.appcontext?view=net-5.0#remarks) under the subheading "AppContext for library consumers".   Setting the first switch to 'true' disables the dirty-rectangle optimization.  Setting the second switch to 'true' causes WPF to re-query the first switch before each render, so that it honors changes the app makes at runtime by calling AppContext.SetSwitch.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
No way to get rapidly updating images to display faithfully.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
No

## Testing

Ad-hoc around customer scenario.
Standard regression testing.

## Risk

Low. Port of a .NETFx servicing fix released earlier this year.
