### PR TITLE
Pull release/6.0 into main

### DIFF
--- a/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
+++ b/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
@@ -46,13 +46,13 @@
           Outputs="$(IntellisenseXmlDir)$(AssemblyName).xml">
     <PropertyGroup>
       <!-- Also in global.json -->
-      <DotNetApiDocsNet50>0.0.0.3</DotNetApiDocsNet50>
+      <DotNetApiDocsNet60>0.0.0.4</DotNetApiDocsNet60>
 
       <!-- 
         This blob lives in Azure storage at https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/dotnet-api-docs_net6.0/
         Instructions for updating these artifacts are at https://github.com/dotnet/wpf/blob/master/docs/intellisense.md
       -->
-      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net5.0\$(DotNetApiDocsNet50)\_intellisense\net-5.0\</IntellisenseXmlDir>
+      <IntellisenseXmlDir>$(CommonLibrary_NativeInstallDir)\bin\dotnet-api-docs_net6.0\$(DotNetApiDocsNet60)\_intellisense\net-6.0\</IntellisenseXmlDir>
     </PropertyGroup>
     
     <Error Condition="!Exists('$(IntellisenseXmlDir)')"

--- a/global.json
+++ b/global.json
@@ -21,6 +21,6 @@
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",
     "net-framework-48-ref-assemblies": "0.0.0.1",
-    "dotnet-api-docs_net5.0": "0.0.0.3"
+    "dotnet-api-docs_net6.0": "0.0.0.4"
   }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -281,15 +281,11 @@ namespace Microsoft.Build.Tasks.Windows
                 // Save the xmlDocument content into the temporary project file.
                 xmlProjectDoc.Save(TemporaryTargetAssemblyProjectName);
 
-                // Disable conflicting Arcade SDK workaround that imports NuGet props/targets
-                Hashtable globalProperties = new Hashtable(1);
-                globalProperties["_WpfTempProjectNuGetFilePathNoExt"] = "";
-
                 //
                 //  Compile the temporary target assembly project
                 //
                 Dictionary<string, ITaskItem[]> targetOutputs = new Dictionary<string, ITaskItem[]>();
-                retValue = BuildEngine.BuildProjectFile(TemporaryTargetAssemblyProjectName, new string[] { CompileTargetName }, globalProperties, targetOutputs);
+                retValue = BuildEngine.BuildProjectFile(TemporaryTargetAssemblyProjectName, new string[] { CompileTargetName }, null, targetOutputs);
 
                 // If the inner build succeeds, retrieve the path to the local type assembly from the task's TargetOutputs.
                 if (retValue)


### PR DESCRIPTION
Contains #5453 and #5329
Fixes #5448
Fixes #4119

## Description
I recently noticed that a couple of changes were made in `release/6.0` and were never pulled back into `main` so I took the liberty of opening a PR targeting `main` with those changes.

I did this by rebasing and squashing `release/6.0` onto `main` and then I removed changes that were specific to `release/6.0`.

## Customer Impact
None.

## Regression
No.

## Testing
Local build + this code is already in `release/6.0`.

## Risk
None.