### PR TITLE
Crash after closing a tooltip's Popup directly (#5932)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -561,7 +561,13 @@ namespace System.Windows.Controls
         /// <param name="tooltip"></param>
         private void ClearServiceProperties(ToolTip tooltip)
         {
-            if (tooltip != null)
+            // This is normally called from OnToolTipClosed, after CloseToolTip has closed the tooltip
+            // and waited for the tooltip's Popup to destroy its window asynchronously.
+            // Apps can close the Popup directly (not easily done, and not recommended), which leads to
+            // a call from OnToolTipClosed while tooltip.IsOpen is still true.  In that case we need to
+            // leave the properties in place - CloseToolTip needs them (as does the popup if it should
+            // re-open).  They will get cleared by OnForceClose, if not earlier.
+            if (tooltip != null && !tooltip.IsOpen)
             {
                 tooltip.ClearValue(OwnerProperty);
                 tooltip.FromKeyboard = false;
@@ -672,6 +678,7 @@ namespace System.Windows.Controls
                 _forceCloseTimer.Stop();
                 ToolTip toolTip = (ToolTip)_forceCloseTimer.Tag;
                 toolTip.ForceClose();
+                ClearServiceProperties(toolTip);    // this handles the case where app closed the Popup directly
                 _forceCloseTimer = null;
             }
         }
@@ -817,6 +824,18 @@ namespace System.Windows.Controls
 
         private bool MouseHasLeftSafeArea()
         {
+            // if there is no SafeArea, the mouse didn't leave it
+            if (SafeArea == null)
+                return false;
+
+            // if the current tooltip's owner is no longer being displayed, the safe area is no longer valid
+            // so the mouse has effectively left it
+            DependencyObject owner = GetOwner(CurrentToolTip);
+            PresentationSource presentationSource = (owner != null) ? PresentationSource.CriticalFromVisual(owner) : null;
+            if (presentationSource == null)
+                return true;
+
+            // if the safe area is valid, see if it still contains the mouse point
             return !(SafeArea?.ContainsMousePoint() ?? true);
         }
 


### PR DESCRIPTION
Fixes #5730

## Description

Closing a tooltip's Popup directly (as opposed to closing the ToolTip and letting WPF close the Popup in response) causes WPF to clear some private state on the ToolTip while leaving its IsOpen=true.  When the ToolTip is eventually closed, WPF uses that state and crashes because it's null.

Fixed by preserving the private state until the ToolTip itself is closed, and adding logic to ensure that the state is cleared even if the Popup was already closed before the ToolTip closed.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
Fixes a regression.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Yes.

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low.  The fix itself is safe.  The customer reports did not include repros, so there's a small risk that there are crashing scenarios that this fix doesn't address.