### PR TITLE
Adds Support for ObservableCollection<T> and Collection<T> Range APIs from dotnet/runtime

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -1681,8 +1681,6 @@ namespace System.Windows.Data
             if (args == null)
                 throw new ArgumentNullException("args");
 
-            ValidateCollectionChangedEventArgs(args);
-
             // adding or replacing an item can change CanAddNew, by providing a
             // non-null representative
             if (!_isItemConstructorValid)
@@ -2517,42 +2515,6 @@ namespace System.Windows.Data
         //------------------------------------------------------
 
         #region Private Methods
-
-        private void ValidateCollectionChangedEventArgs(NotifyCollectionChangedEventArgs e)
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    if (e.NewItems.Count != 1)
-                        throw new NotSupportedException(SR.Get(SRID.RangeActionsNotSupported));
-                    break;
-
-                case NotifyCollectionChangedAction.Remove:
-                    if (e.OldItems.Count != 1)
-                        throw new NotSupportedException(SR.Get(SRID.RangeActionsNotSupported));
-                    break;
-
-                case NotifyCollectionChangedAction.Replace:
-                    if (e.NewItems.Count != 1 || e.OldItems.Count != 1)
-                        throw new NotSupportedException(SR.Get(SRID.RangeActionsNotSupported));
-                    break;
-
-                case NotifyCollectionChangedAction.Move:
-                    if (e.NewItems.Count != 1)
-                        throw new NotSupportedException(SR.Get(SRID.RangeActionsNotSupported));
-                    if (e.NewStartingIndex < 0)
-                        throw new InvalidOperationException(SR.Get(SRID.CannotMoveToUnknownPosition));
-                    break;
-
-                case NotifyCollectionChangedAction.Reset:
-                    break;
-
-                default:
-                    throw new NotSupportedException(SR.Get(SRID.UnexpectedCollectionChangeAction, e.Action));
-            }
-        }
-
-
         /// <summary>
         /// Create, filter and sort the local index array.
         /// called from Refresh(), override in derived classes as needed.


### PR DESCRIPTION
Fixes #1887

## Description
Removes the `CollectionChanged` exceptions from `ListCollectionVIew` when the record count is not equal to 1. This PR is required to support https://github.com/dotnet/runtime/pull/65101. 

The change to dotnet/runtime as originally attempted in 2019 and it was discovered during preview builds that it broke WPF. I have spoken with both the .NET Team and the WPF Team and both teams are ready to accept this change. See https://github.com/dotnet/runtime/pull/65101 for a complete detail of history and API changes.

## Customer Impact
If this change is accepted it will allow developers to use `AddRange()` and `RemoveRange()` APIs on their `ObservableCollection<T>`. This will reduce the call stack from event invocations by N number of items that are being added to the collection. If an application is adding 5000 items to an `ObservableCollection<T>` currently it will invoke 5000 events, with this change it will only invoke 1 event.

If this change is not accepted, then https://github.com/dotnet/runtime/pull/65101 will not be accepted as it will break just about every WPF application that uses `ListCollectionView`.

## Regression
N/A

## Testing
I had problems running the wpf project locally and wasn't able to test as I would have liked to. I wanted to submit this PR and discuss with the community if someone could give me some help testing or instructions. I think the testing is giving me issues because I need a custom build of .NET 7 and the SDK project, then I need a custom build of WPF and finally will be able to test.

## Risk
As far as I understand this PR mitigates the risk of breaking changes from https://github.com/dotnet/runtime/pull/65101. I think it is important once we get a build we can test with to use some large WPF projects as a test solution like the NuGet Package Explorer. That was the project that originally caught the issue from the first attempt in 2019
