### PR TITLE
Pin assembly versions to prevent revving those in servicing releases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,32 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <MajorVersion>7</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
-    <SystemIOPackagingVersion>7.0.0-preview.2.22113.2</SystemIOPackagingVersion>
-    <SystemResourcesExtensionsVersion>7.0.0-preview.2.22113.2</SystemResourcesExtensionsVersion>
+
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+
+    <!--
+      Set assembly version to align with major and minor version, as for the patches and revisions should be manually
+      updated per assembly if it is serviced.
+
+      Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
+      so that they can exist SxS, as the compiler relies on different version to change assembly version for caching purposes.
+
+      NOTE: WPF does not currently have any public analyzers or source generators. When these are added please check how
+            dotnet/winforms is handling versions for the analyzers.
+      -->
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
   </PropertyGroup>
-  <!-- NuGet Package Versions -->
+
+  <!-- Packages that come from https://github.com/dotnet/winforms -->
   <PropertyGroup>
     <MicrosoftPrivateWinformsVersion>7.0.0-preview.2.22114.4</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
-  <!-- Packages that come from https://github.com/dotnet/core-setup -->
+  <!-- Packages that come from https://github.com/dotnet/runtime -->
   <PropertyGroup>
     <VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion>7.0.0-preview.2.22113.2</VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion>
     <MicrosoftNETCoreAppRefVersion>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreAppRuntimewinx64Version>7.0.0-preview.2.22113.2</MicrosoftNETCoreAppRuntimewinx64Version>
     <MicrosoftNETCorePlatformsVersion>7.0.0-preview.2.22113.2</MicrosoftNETCorePlatformsVersion>
-    <SystemDrawingCommonVersion>7.0.0-preview.2.22113.2</SystemDrawingCommonVersion>
-    <SystemDirectoryServicesVersion>7.0.0-preview.2.22113.2</SystemDirectoryServicesVersion>
-    <SystemReflectionMetadataLoadContextVersion>7.0.0-preview.2.22113.2</SystemReflectionMetadataLoadContextVersion>
-  </PropertyGroup>
-  <!-- Packages that come from https://github.com/dotnet/corefx via core-setup coherency parent dependency -->
-  <PropertyGroup>
     <SystemCodeDomPackageVersion>7.0.0-preview.2.22113.2</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>7.0.0-preview.2.22113.2</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>7.0.0-preview.2.22113.2</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDrawingCommonVersion>7.0.0-preview.2.22113.2</SystemDrawingCommonVersion>
+    <SystemDirectoryServicesVersion>7.0.0-preview.2.22113.2</SystemDirectoryServicesVersion>
+    <SystemIOPackagingVersion>7.0.0-preview.2.22113.2</SystemIOPackagingVersion>
+    <SystemReflectionMetadataLoadContextVersion>7.0.0-preview.2.22113.2</SystemReflectionMetadataLoadContextVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview4.19176.11</SystemReflectionTypeExtensionsPackageVersion>
+    <SystemResourcesExtensionsVersion>7.0.0-preview.2.22113.2</SystemResourcesExtensionsVersion>
     <SystemSecurityCryptographyXmlPackageVersion>7.0.0-preview.2.22113.2</SystemSecurityCryptographyXmlPackageVersion>
     <SystemSecurityPermissionsPackageVersion>7.0.0-preview.2.22113.2</SystemSecurityPermissionsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>7.0.0-preview.2.22113.2</SystemWindowsExtensionsPackageVersion>

--- a/packaging/Microsoft.DotNet.Wpf.GitHub/Check-AssemblyVersions.ps1
+++ b/packaging/Microsoft.DotNet.Wpf.GitHub/Check-AssemblyVersions.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [Parameter(Mandatory=$True, Position=1)]
+  [string] $NuspecFile,
+  [Parameter(Mandatory=$True, Position=2)]
+  [string] $ExpectedAssemblyVersion,
+  [Parameter(Mandatory=$True, Position=3)]
+  [string] $IsServicingRelease,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]] $properties
+)
+
+$servicingRelease = $null;
+[bool]::TryParse($IsServicingRelease, [ref]$servicingRelease) | Out-Null;
+
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# 
+# Verify that components that are exposed as references in the targeting packs don't have their versions revved.
+# See https://github.com/dotnet/core/issues/7172#issuecomment-1034105137 for more details.
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# Iterate over files that MUST NOT have their versions revved with every release
+$nonRevAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\')) `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$nonRevAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if (![string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. Expected: '$ExpectedAssemblyVersion', found: '$version'."
+            exit -1;
+        }
+    }
+
+# Iterate over files that MUST have their versions revved with every release
+$revAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            $_.target.StartsWith('sdk\analyzers\') `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$revAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if ($servicingRelease -and [string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. '$version' is not expected."
+            exit -1;
+        }
+    }

--- a/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
+++ b/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
+    <_ScriptLocation Condition="'$(_ScriptLocation)' == ''">$(MSBuildProjectDirectory)\Check-AssemblyVersions.ps1</_ScriptLocation>
+    <_IsServicingRelease>false</_IsServicingRelease>
+    <_IsServicingRelease Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</_IsServicingRelease>
+  </PropertyGroup>
+
+  <!-- 
+    Inspect the following NuSpecs and validate the assembly versions
+        * .\artifacts\packages\Release\NonShipping\Microsoft.DotNet.Wpf.GitHub.<version>.nuspec produced by Microsoft.DotNet.Wpf.GitHub.ArchNeutral.csproj
+        * .\artifacts\packages\Release\NonShipping\runtime.<arch>.Microsoft.DotNet.Wpf.GitHub.<version>.nuspec produced by Microsoft.DotNet.Wpf.GitHub.csproj
+    -->
+  <Target Name="ValidateTransportPackage"
+          AfterTargets="GenerateNuspec"
+          DependsOnTargets="GenerateNuspec"
+          Condition="'$(IsPackable)' == 'true'">
+    <ItemGroup>
+      <_NuspecFile Include="@(NuGetPackOutput)" Condition="'%(Extension)' == '.nuspec'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NuspecFilePath>@(_NuspecFile)</_NuspecFilePath>
+      <!--
+          When we build Microsoft.DotNet.Wpf.GitHub.csproj GenerateNuspec task creates an arch-specific NuSpec, and
+          NuSpec declared in NuGetPackOutput does not exist.
+          Look for the arch-specific NuSpec
+       -->
+      <_NuspecFilePath Condition="'$(_NuspecFilePath)' == '' or !Exists('$(_NuspecFilePath)')">$(NuspecOutputPath)\$(PackageId).$(PackageVersion).nuspec</_NuspecFilePath>
+    </PropertyGroup>
+
+    <Error Text="'$(_ScriptLocation)' is missing." Condition="!Exists('$(_ScriptLocation)')" />
+    <Error Text="'$(_NuspecFilePath)' is missing." Condition="!Exists('$(_NuspecFilePath)')" />
+
+    <Exec
+        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;$(_NuspecFilePath)&apos; &apos;$(AssemblyVersion)&apos; $(_IsServicingRelease) } &quot;"
+        ContinueOnError="False" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
Relates to https://github.com/dotnet/core/issues/7172#issuecomment-1034105137 and https://github.com/dotnet/core/issues/7176