### PR TITLE
Pin assembly versions to prevent revving those in servicing releases

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>6.0.3</VersionPrefix>
+    <MajorVersion>6</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>3</PatchVersion>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+
+    <!--
+      Set assembly version to align with major and minor version, as for the patches and revisions should be manually
+      updated per assembly if it is serviced.
+
+      Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
+      so that they can exist sxs. The compiler relies on different version to change assembly version for caching purposes.
+
+      Because it is possible to build on a lower version and run on a higher version, we're locking the targeting pack and the runtime
+      assembly vesions to 6.0.2.
+      There's still a risk that some customers building on 6.0.2+ and trying to run on 6.0.0 and 6.0.1 will still have issue, but
+      those issues can be mitigated with a workaround described in https://github.com/dotnet/core/issues/7176.
+      -->
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).2.0</AssemblyVersion>
+
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>

--- a/packaging/Microsoft.DotNet.Wpf.GitHub/Check-AssemblyVersions.ps1
+++ b/packaging/Microsoft.DotNet.Wpf.GitHub/Check-AssemblyVersions.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [Parameter(Mandatory=$True, Position=1)]
+  [string] $NuspecFile,
+  [Parameter(Mandatory=$True, Position=2)]
+  [string] $ExpectedAssemblyVersion,
+  [Parameter(Mandatory=$True, Position=3)]
+  [string] $IsServicingRelease,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]] $properties
+)
+
+$servicingRelease = $null;
+[bool]::TryParse($IsServicingRelease, [ref]$servicingRelease) | Out-Null;
+
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# 
+# Verify that components that are exposed as references in the targeting packs don't have their versions revved.
+# See https://github.com/dotnet/core/issues/7172#issuecomment-1034105137 for more details.
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# Iterate over files that MUST NOT have their versions revved with every release
+$nonRevAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\')) `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$nonRevAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if (![string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. Expected: '$ExpectedAssemblyVersion', found: '$version'."
+            exit -1;
+        }
+    }
+
+# Iterate over files that MUST have their versions revved with every release
+$revAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            $_.target.StartsWith('sdk\analyzers\') `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$revAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if ($servicingRelease -and [string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. '$version' is not expected."
+            exit -1;
+        }
+    }

--- a/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
+++ b/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
+    <_ScriptLocation Condition="'$(_ScriptLocation)' == ''">$(MSBuildProjectDirectory)\Check-AssemblyVersions.ps1</_ScriptLocation>
+    <_IsServicingRelease>false</_IsServicingRelease>
+    <_IsServicingRelease Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</_IsServicingRelease>
+  </PropertyGroup>
+
+  <!-- 
+    Inspect the following NuSpecs and validate the assembly versions
+        * .\artifacts\packages\Release\NonShipping\Microsoft.DotNet.Wpf.GitHub.<version>.nuspec produced by Microsoft.DotNet.Wpf.GitHub.ArchNeutral.csproj
+        * .\artifacts\packages\Release\NonShipping\runtime.<arch>.Microsoft.DotNet.Wpf.GitHub.<version>.nuspec produced by Microsoft.DotNet.Wpf.GitHub.csproj
+    -->
+  <Target Name="ValidateTransportPackage"
+          AfterTargets="GenerateNuspec"
+          DependsOnTargets="GenerateNuspec"
+          Condition="'$(IsPackable)' == 'true'">
+    <ItemGroup>
+      <_NuspecFile Include="@(NuGetPackOutput)" Condition="'%(Extension)' == '.nuspec'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_NuspecFilePath>@(_NuspecFile)</_NuspecFilePath>
+      <!--
+          When we build Microsoft.DotNet.Wpf.GitHub.csproj GenerateNuspec task creates an arch-specific NuSpec, and
+          NuSpec declared in NuGetPackOutput does not exist.
+          Look for the arch-specific NuSpec
+       -->
+      <_NuspecFilePath Condition="'$(_NuspecFilePath)' == '' or !Exists('$(_NuspecFilePath)')">$(NuspecOutputPath)\$(PackageId).$(PackageVersion).nuspec</_NuspecFilePath>
+    </PropertyGroup>
+
+    <Error Text="'$(_ScriptLocation)' is missing." Condition="!Exists('$(_ScriptLocation)')" />
+    <Error Text="'$(_NuspecFilePath)' is missing." Condition="!Exists('$(_NuspecFilePath)')" />
+
+    <Exec
+        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;$(_NuspecFilePath)&apos; &apos;$(AssemblyVersion)&apos; $(_IsServicingRelease) } &quot;"
+        ContinueOnError="False" />
+
+  </Target>
+
+</Project>

--- a/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
+++ b/packaging/Microsoft.DotNet.Wpf.GitHub/Directory.Build.targets
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
+    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
     <_ScriptLocation Condition="'$(_ScriptLocation)' == ''">$(MSBuildProjectDirectory)\Check-AssemblyVersions.ps1</_ScriptLocation>
     <_IsServicingRelease>false</_IsServicingRelease>
     <_IsServicingRelease Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</_IsServicingRelease>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves https://github.com/dotnet/core/issues/7172#issuecomment-1034105137
This is a complimentary work to https://github.com/dotnet/winforms/pull/6667


## Proposed changes

* Lock runtime and targeting pack assemblies at 6.0.2.0 so that any applications, libraries or NuGets built against 6.0.2 or later can work. 
This assembly versions pinning is similar to https://github.com/dotnet/runtime/blob/bbc766a7c65716305919bc691d696b1e46fa6f62/eng/Versions.props#L14 and https://github.com/dotnet/aspnetcore/blob/c0575788ecadd6e5cfeb4eab635c13b5fd433d37/Directory.Build.targets#L88.
* Add a validation step when we run packaging to verify that the assemblies we package into the transport package are correctly versioned, i.e., analyzers/generators are revved for every release for sxs, and those part of the ref pack are pinned to X.Y.2.0.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Currently WPF applications built against 6.0.2 won't run on 6.0 GA or 6.0.1
With the fix applications, libraries or NuGets built against 6.0.2 or later can work. Any applications built on 6.0.2 or later that need to target 6.0.0 or 6.0.1 will need to use the workaround provided in https://github.com/dotnet/core/issues/7176. It is not ideal, but is believed to have a lesser impact than going back to 6.0.0.0 versions, and have 6.0.2 broken.

## Regression? 

- Yes 

## Risk

- Medium. With this fix we'll stop supporting the folks that compiled against 6.0.2 or later and target 6.0.0 or 6.0.1 without the workaround.
In general, since 6.0.1 and 6.0.2 are security releases, customers are encouraged to update to the latest version.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

6.0.1
![image](https://user-images.githubusercontent.com/4403806/153336436-ff2b0f29-9019-44f3-9b62-8b021d4ff676.png)
![image](https://user-images.githubusercontent.com/4403806/153336463-0289b410-d474-46e3-8021-1e0a8b9346b0.png)

6.0.2
![image](https://user-images.githubusercontent.com/4403806/153336273-5bf08a69-b4fa-4834-938f-d55e0d1702be.png)
![image](https://user-images.githubusercontent.com/4403806/153336311-4b350c68-1151-4774-b300-ed5fca3db8b8.png)

### After

A [private build](https://dev.azure.com/dnceng/internal/_artifacts/feed/general-testing-internal/NuGet/runtime.win-x64.Microsoft.DotNet.Wpf.GitHub/6.0.3-servicing.22110.10/) for this fix:

![image](https://user-images.githubusercontent.com/4403806/153538280-c0291dcf-0de1-4a64-b65d-ea8ada3bc300.png)
![image](https://user-images.githubusercontent.com/4403806/153538306-6b97a937-35e2-4dcd-8c65-8c63267a7b28.png)



