### PR TITLE
Command Base class Added (implements ICommand)

### DIFF
--- a/eng/WpfArcadeSdk/tools/ApiCompat.targets
+++ b/eng/WpfArcadeSdk/tools/ApiCompat.targets
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <!-- Turn off default API Compat targets in favor of WPF ones. -->
-    <RunApiCompat>false</RunApiCompat>
+    <RunApiCompat>true</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -356,6 +356,8 @@
     <Compile Include="System\Windows\IContentHost.cs" />
     <Compile Include="System\Windows\IDataObject.cs" />
     <Compile Include="System\Windows\IInputElement.cs" />
+    <Compile Include="System\Windows\Input\Command\Command.cs" />
+    <Compile Include="System\Windows\Input\Command\LowEventManager.cs" />
     <Compile Include="System\Windows\LayoutManager.cs" />
     <Compile Include="System\Windows\LocalizabilityAttribute.cs" />
     <Compile Include="System\Windows\LocalizationCategory.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/Command.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/Command.cs
@@ -1,0 +1,137 @@
+﻿namespace System.Windows.Input
+{
+    public class Command : ICommand
+    {
+        private readonly Func<object, bool> _canExecute;
+
+        private readonly Action<object> _execute;
+
+        private readonly LowEventManager _weakEventManager = new LowEventManager();
+
+        /// <summary>
+        /// Occurs when the target of the Command should reevaluate whether or not the Command
+        ///     can be executed.
+        /// </summary>
+        /// <remarks>
+        /// To be added.
+        /// </remarks>
+#pragma warning disable CS8612
+        public event EventHandler CanExecuteChanged
+        {
+            add
+            {
+                _weakEventManager.AddEventHandler(value, "CanExecuteChanged");
+            }
+            remove
+            {
+                _weakEventManager.RemoveEventHandler(value, "CanExecuteChanged");
+            }
+        }
+#pragma warning restore CS8612
+
+#pragma warning disable CS8618
+        public Command(Action<object> execute)
+        {
+            if (execute == null)
+            {
+                throw new ArgumentNullException("execute");
+            }
+
+            _execute = execute;
+        }
+#pragma warning restore CS8618
+
+        public Command(Action execute)
+            : this((Action<object>)delegate
+            {
+                execute();
+            })
+        {
+            if (execute == null)
+            {
+                throw new ArgumentNullException("execute");
+            }
+        }
+
+        public Command(Action<object> execute, Func<object, bool> canExecute)
+            : this(execute)
+        {
+            if (canExecute == null)
+            {
+                throw new ArgumentNullException("canExecute");
+            }
+
+            _canExecute = canExecute;
+        }
+
+        public Command(Action execute, Func<bool> canExecute)
+            : this(delegate
+            {
+                execute();
+            }, (object o) => canExecute())
+        {
+            if (execute == null)
+            {
+                throw new ArgumentNullException("execute");
+            }
+
+            if (canExecute == null)
+            {
+                throw new ArgumentNullException("canExecute");
+            }
+        }
+
+        /// <summary>
+        /// Returns a System.Boolean indicating if the Command can be exectued with the given
+        ///     parameter.
+        /// </summary>
+        /// <param name="parameter">
+        /// An System.Object used as parameter to determine if the Command can be executed.
+        /// </param>
+        /// <returns> 
+        /// true if the Command can be executed, false otherwise.
+        /// </returns>
+        /// <remarks>
+        /// If no canExecute parameter was passed to the Command constructor, this method
+        /// always returns true.
+        /// If the Command was created with non-generic execute parameter, the parameter
+        /// of this method is ignored.
+        /// </remarks>
+#pragma warning disable CS8767
+        public bool CanExecute(object parameter)
+        {
+            if (_canExecute != null)
+            {
+                return _canExecute(parameter);
+            }
+
+            return true;
+        }
+#pragma warning restore CS9867
+
+        /// <summary>
+        /// Invokes the execute Action
+        /// </summary>
+        /// <param name="parameter">
+        ///  An System.Object used as parameter for the execute Action.
+        /// </param>
+        /// <remarks>
+        /// If the Command was created with non-generic execute parameter, the parameter
+        //     of this method is ignored.
+        /// </remarks>
+        public void Execute(object parameter)
+        {
+            _execute(parameter);
+        }
+        /// <summary>
+        /// Send a System.Windows.Input.ICommand.CanExecuteChanged
+        /// </summary>
+        /// <remarks>
+        ///     To be added.
+        /// </remarks>
+        public void ChangeCanExecute()
+        {
+            _weakEventManager.HandleEvent(this, EventArgs.Empty, "CanExecuteChanged");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/LowEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/LowEventManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 
 namespace System.Windows.Input
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/LowEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/LowEventManager.cs
@@ -1,0 +1,211 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace System.Windows.Input
+{
+    internal class LowEventManager
+    {
+        private struct Subscription
+        {
+            public readonly WeakReference Subscriber;
+
+            public readonly MethodInfo Handler;
+
+            public Subscription(WeakReference subscriber, MethodInfo handler)
+            {
+                Subscriber = subscriber;
+                Handler = (handler ?? throw new ArgumentNullException("handler"));
+            }
+        }
+
+        private readonly Dictionary<string, List<Subscription>> _eventHandlers = new Dictionary<string, List<Subscription>>();
+
+        /// <summary>
+        /// To be added.
+        /// </summary>
+        /// <typeparam name="TEventArgs">To be added.</typeparam>
+        /// <param name="handler">To be added.</param>
+        /// <param name="eventName">To be added.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <remarks>To be added.</remarks>
+#pragma warning disable CS8604
+        public void AddEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "") where TEventArgs : EventArgs
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException("handler");
+            }
+            AddEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+        }
+
+
+        /// <summary>
+        ///  To be added.
+        /// </summary>
+        /// <param name="handler"> To be added.</param>
+        /// <param name="eventName"> To be added.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <remarks> To be added.</remarks>
+        public void AddEventHandler(EventHandler handler, [CallerMemberName] string eventName = "")
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException("handler");
+            }
+
+            AddEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+        }
+
+        /// <summary>
+        /// To be added.
+        /// </summary>
+        /// <param name="sender">To be added.</param>
+        /// <param name="args">To be added.param>
+        /// <param name="eventName">To be added.</param>
+        /// <remarks>
+        /// To be added.
+        /// </remars>
+#pragma warning disable CS8600
+#pragma warning disable CS8620
+        public void HandleEvent(object sender, object args, string eventName)
+        {
+            List<(object, MethodInfo)> list = new List<(object, MethodInfo)>();
+            List<Subscription> list2 = new List<Subscription>();
+            if (_eventHandlers.TryGetValue(eventName, out List<Subscription> value))
+            {
+                for (int i = 0; i < value.Count; i++)
+                {
+                    Subscription item = value[i];
+                    if (item.Subscriber == null)
+                    {
+                        list.Add((null, item.Handler));
+                        continue;
+                    }
+
+                    object target = item.Subscriber.Target;
+                    if (target == null)
+                    {
+                        list2.Add(item);
+                    }
+                    else
+                    {
+                        list.Add((target, item.Handler));
+                    }
+                }
+
+                for (int j = 0; j < list2.Count; j++)
+                {
+                    Subscription item2 = list2[j];
+                    value.Remove(item2);
+                }
+            }
+
+            for (int k = 0; k < list.Count; k++)
+            {
+                (object, MethodInfo) tuple = list[k];
+                object item3 = tuple.Item1;
+                tuple.Item2.Invoke(item3, new object[2]
+                {
+                    sender,
+                    args
+                });
+            }
+        }
+#pragma warning restore CS8620
+
+        /// <summary>
+        /// To be added.
+        /// </summary>
+        /// <typeparam name="TEventArgs">To be added.</typeparam>
+        /// <param name="handler">To be added.</param>
+        /// <param name="eventName">To be added.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <remarks>To be added.</remarks>
+        public void RemoveEventHandler<TEventArgs>(EventHandler<TEventArgs> handler, [CallerMemberName] string eventName = "") where TEventArgs : EventArgs
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException("handler");
+            }
+
+            RemoveEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+        }
+
+        /// <summary>
+        /// To be added.
+        /// </summary>
+        /// <param name="handler">To be added.</param>
+        /// <param name="eventName">To be added.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <remarks>To be added.</remarks>
+        public void RemoveEventHandler(EventHandler handler, [CallerMemberName] string eventName = "")
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentNullException("eventName");
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException("handler");
+            }
+
+            RemoveEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+        }
+#pragma warning disable CS8625
+        private void AddEventHandler(string eventName, object handlerTarget, MethodInfo methodInfo)
+        {
+            if (!_eventHandlers.TryGetValue(eventName, out List<Subscription> value))
+            {
+                value = new List<Subscription>();
+                _eventHandlers.Add(eventName, value);
+            }
+
+            if (handlerTarget == null)
+            {
+                value.Add(new Subscription(null, methodInfo));
+            }
+            else
+            {
+                value.Add(new Subscription(new WeakReference(handlerTarget), methodInfo));
+            }
+        }
+#pragma warning restore CS8625
+
+
+        private void RemoveEventHandler(string eventName, object handlerTarget, MemberInfo methodInfo)
+        {
+            if (!_eventHandlers.TryGetValue(eventName, out List<Subscription> value))
+            {
+                return;
+            }
+
+            for (int num = value.Count; num > 0; num--)
+            {
+                Subscription item = value[num - 1];
+                if (item.Subscriber?.Target == handlerTarget && !(item.Handler.Name != methodInfo.Name))
+                {
+                    value.Remove(item);
+                    break;
+                }
+            }
+        }
+#pragma warning restore CS8600
+    }
+}
+


### PR DESCRIPTION
Fixes #6151 

## Description
WeakEventManager Class Added to manage Events,
ICommand Interface Implemented with Command Class to be Base Class That takes an Action to Execute 

## Customer Impact

make it easy for developer to use MVVM with Command Binding in WPF

## Regression

## Testing
Tested Successfully on a wpf app

## Risk
Just make sure you don't have a class with "Command" where you Use System.Windows.Input