### PR TITLE
Fix the comment in DefaultRestoreFocusMode property

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -105,7 +105,7 @@ namespace System.Windows.Input
 
         /// <summary>
         ///     The default mode for restoring focus.
-        /// <summary>
+        /// </summary>
         public RestoreFocusMode DefaultRestoreFocusMode {get; set;}
 
         /// <summary>


### PR DESCRIPTION


## Description

The XML element is not closed. I found this while reading the code, so I fixed it.

## Customer Impact

None.

## Regression



## Testing

None.

## Risk

Low. I just changed the comment.
