### PR TITLE
Update GenAPI additional parameter usage

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -91,9 +91,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>68a9b6dc9c0f375893fcdab74b7dd2538afb1c4b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="7.0.0-beta.22122.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="7.0.0-beta.22124.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>68a9b6dc9c0f375893fcdab74b7dd2538afb1c4b</Sha>
+      <Sha>f7136626d0109856df867481219eb7366951985d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,7 +46,7 @@
   <PropertyGroup>
     <MicrosoftDotNetApiCompatVersion>7.0.0-beta.22122.3</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>7.0.0-beta.22122.3</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIVersion>7.0.0-beta.22122.3</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenAPIVersion>7.0.0-beta.22124.4</MicrosoftDotNetGenAPIVersion>
   </PropertyGroup>
   <!-- Maintain System.CodeDom PackageVersion at 4.4.0. See https://github.com/Microsoft/msbuild/issues/3627 -->
   <!-- Pin specific versions of S.Memory so that it would supply AssemblyVersion=4.0.1.0. See https://github.com/dotnet/runtime/issues/31672 -->

--- a/eng/WpfArcadeSdk/tools/GenApi.props
+++ b/eng/WpfArcadeSdk/tools/GenApi.props
@@ -26,9 +26,9 @@
     <GlobalApiExclusionsFile Condition="'$(GlobalApiExclusionsFile)'==''">$(WpfArcadeSdkRoot)tools\GenApi\GlobalApiExclusions.txt</GlobalApiExclusionsFile>
     <GlobalAttrExclusionsFile Condition="'$(GlobalAttrExclusionsFile)'==''">$(WpfArcadeSdkRoot)tools\GenApi\GlobalAttrExclusions.txt</GlobalAttrExclusionsFile>
 
-    <GenAPIAdditionalParameters>--exclude-members</GenAPIAdditionalParameters>
-    <GenAPIAdditionalParameters Condition="'$(GlobalApiExclusionsFile)'!=''">$(GenAPIAdditionalParameters) --exclude-api-list "$(GlobalApiExclusionsFile)" </GenAPIAdditionalParameters>
-    <GenAPIAdditionalParameters Condition="'$(GlobalAttrExclusionsFile)'!=''">$(GenAPIAdditionalParameters) --exclude-attributes-list "$(GlobalAttrExclusionsFile)"</GenAPIAdditionalParameters>
+    <GenAPIExcludeMembers>true</GenAPIExcludeMembers>
+    <GenAPIExcludeApiList Condition="'$(GlobalApiExclusionsFile)'!=''">$(GlobalApiExclusionsFile)</GenAPIExcludeApiList>
+    <GenAPIExcludeAttributesList Condition="'$(GlobalAttrExclusionsFile)'!=''">$(GlobalAttrExclusionsFile)</GenAPIExcludeAttributesList>
 
     <!-- 
       GenAPI is run on demand.  Note that making a public API change without the associated reference assembly change will result in an ApiCompat error. 


### PR DESCRIPTION
https://github.com/dotnet/arcade/commit/e44123d2796c8333cf90f90b51dfd9d04d224bea switched GenAPI to run in-proc as an msbuild task. Because of that, the usage is slightly different when additional parameters are passed in to GenAPI.