### PR TITLE
Fix setting DPI awareness

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ModuleInitializer.cs
@@ -25,11 +25,18 @@ internal static class ModuleInitializer
 
     private static void IsProcessDpiAware()
     {
+        bool disableDpiAware = false;
+
         // By default, Application is DPIAware.
         Assembly assemblyApp = Assembly.GetEntryAssembly();
 
         // Check if the Application has explicitly set DisableDpiAwareness attribute.
         if (assemblyApp != null && Attribute.IsDefined(assemblyApp, typeof(System.Windows.Media.DisableDpiAwarenessAttribute)))
+        {
+            disableDpiAware = true;
+        }
+
+        if (!disableDpiAware)
         {
             // DpiAware composition is enabled for this application.
             SetProcessDPIAware_Internal();


### PR DESCRIPTION
## Description

Currently DPI awareness will be enabled *only if* a `DisableDpiAwarenessAttribute` attribute is applied to the entry assembly. Which does not make a lot of sense. This also does not match the behavior of .NET 6.

This PR changes the logic to always enable DPI awareness *unless* a `DisableDpiAwarenessAttribute` attribute is applied to the entry assembly.

## Customer Impact

WPF applications are not DPI aware. This can be seen by:

```
dotnet new wpf
dotnet run
```

And then checking the DPI Awareness column in Task Manager. On .NET 6 the DPI awareness is "System". In .NET 7 preview 1, it is "Unaware".

## Regression

This regression was introduced by #5765, which migrated the DPI awareness enablement code from C++ to C#.

## Testing

```
dotnet new wpf
```

Then replace the contents of `MainWindow.xml.cs` with:

```csharp
using System.Windows;
using System.Runtime.InteropServices;

namespace test
{
    /// <summary>
    /// Interaction logic for MainWindow.xaml
    /// </summary>
    public partial class MainWindow : Window
    {
        [DllImport("User32", EntryPoint = "IsProcessDPIAware", CharSet = CharSet.Auto, SetLastError = true)]
        internal static extern bool IsProcessDPIAware();

        public MainWindow()
        {
            InitializeComponent();
            this.Title = IsProcessDPIAware().ToString();
        }
    }
}
```

Results of running this program on different versions of WPF:

|.NET Version|title|
|--|--|
|6.0.3|True|
|7 Preview 1|False|
|This PR|True|

## Risk

Low.