### PR TITLE
Eliminate memory copy when reading font data

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFileStream.h
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/CPP/DWriteWrapper/FontFileStream.h
@@ -20,9 +20,9 @@ namespace MS { namespace Internal { namespace Text { namespace TextInterface
     private ref class FontFileStream : public IDWriteFontFileStreamMirror
     {  
         private:
-            Stream^                            _fontSourceStream;
+            UnmanagedMemoryStream^             _fontSourceStream;
+            Byte*                              _fontSourcePointer;
             INT64                              _lastWriteTime;
-            Object^                            _fontSourceStreamLock;
 
         public:
 


### PR DESCRIPTION
Fixes #6236

## Description

Using a `<Resource>` font in WPF currently causes a lot of allocation, GC pinning, and memory copying. This is entirely avoidable by returning a pointer to the already-loaded font data to DWrite.

## Customer Impact

Without this fix, customers are forced to hook DWrite APIs and supply their own font-loading implementation; e.g., https://faithlife.codes/blog/2019/06/improving-wpf-text-display-performance/.

## Regression

Not a regression.

## Testing

Manual testing using a test app: https://github.com/bgrainger/EmbeddedFontPerformance

## Risk

Risk is low. This fix has been prototyped in a commercial WPF application that's been shipping for 5 years (see blog post above). Since the font source is an `UnmanagedMemoryStream`, we can rely on its data being present in memory at least as long as we hold a reference to the stream. (And since, practically speaking, the font data is backed by the assembly that contains it being mmap'ed into the process' address space, it's going to be safe to dereference it for the lifetime of the application.)
