### PR TITLE
Avoid unnecessary enumerator allocations in XamlDirective.GetHashCode

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlLanguage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlLanguage.cs
@@ -444,15 +444,13 @@ namespace System.Xaml
         private static XamlDirective GetXamlDirective(string name, XamlType xamlType,
             XamlValueConverter<TypeConverter> typeConverter, AllowedMemberLocations allowedLocation)
         {
-            XamlDirective result = new XamlDirective(s_xamlNamespaces, name, xamlType,
-                typeConverter, allowedLocation);
+            XamlDirective result = new XamlDirective(s_xamlNamespaces, name, allowedLocation, new MemberReflector(xamlType, typeConverter));
             return result;
         }
 
         private static XamlDirective GetXmlDirective(string name)
         {
-            XamlDirective result = new XamlDirective(s_xmlNamespaces, name, String,
-                BuiltInValueConverter.String, AllowedMemberLocations.Attribute);
+            XamlDirective result = new XamlDirective(s_xmlNamespaces, name, AllowedMemberLocations.Attribute, new MemberReflector(String, BuiltInValueConverter.String));
             return result;
         }
 


### PR DESCRIPTION
## Description

We can just index into the ReadOnlyCollection rather than iterating it via IEnumerator.  We can also avoid unnecessary collection allocations when all of our internal usage that already has an immutable ReadOnlyCollection goes through the internal constructor.

## Customer Impact

These XamlDirective instances are frequently stored in Dictionary's, resulting in every GetHashCode call by the dictionary allocating an enumerator.

## Regression

No

## Testing

CI

## Risk

Minimal.