### PR TITLE
Disable Indeterminate animation when hiding ProgressBar

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ProgressBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ProgressBar.cs
@@ -59,7 +59,15 @@ namespace System.Windows.Controls
             // Hook a change handler for IsVisible so we can start/stop animating.
             // Ideally we would do this by overriding metadata, but it's a read-only
             // property so we can't.
-            IsVisibleChanged += (s, e) => { UpdateAnimation(); };
+            IsVisibleChanged += (s, e) =>
+            {
+                UpdateAnimation();
+
+                // Update the visual state when IsVisible changes for performance reasons.
+                // See comment in ChangeVisualState for an explanation.
+                if (_glow == null)
+                    UpdateVisualState();
+            };
         }
 
         #endregion Constructors
@@ -270,7 +278,9 @@ namespace System.Windows.Controls
 
         internal override void ChangeVisualState(bool useTransitions)
         {
-            if (!IsIndeterminate)
+            // We change the visual state to determinate when not IsVisible for performance reasons.
+            // By default, the animation for the Indeterminate state will continue even when the progress bar is not visible.
+            if (!IsIndeterminate || !IsVisible)
             {
                 VisualStateManager.GoToState(this, VisualStates.StateDeterminate, useTransitions);
             }


### PR DESCRIPTION
Fixes dotnet/wpf#6264

## Description
Disable Indeterminate animation when hiding ProgressBar. Fixes a performance regression introduced in Aero2 theme (Windows 8 or newer)

## Customer Impact
Better performance when hiding an indeterminate progress bar with the theme Aero2.

## Regression
Performance regression introduced in Aero2 theme (Windows 8 or newer).

## Testing
Tested with the sample in #6264 and a combination of Visibility and Indeterminate to validate that this PR does not break existing behavior.

## Risk
Low.