### PR TITLE
Avoid exceptional string allocation in StaticExtension.ProvideValue

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
@@ -53,17 +53,15 @@ namespace System.Windows.Markup
 
             object value;
             Type type = MemberType;
-            string fieldString = null;
-            string memberFullName = null;
+            string fieldString;
+            string typeNameForError = null;
             if (type != null)
             {
                 fieldString = _member;
-                memberFullName = type.FullName + "." + _member;
+                typeNameForError = type.FullName;
             }
             else
             {
-                memberFullName = _member;
-
                 // Validate the _member
 
                 int dotIndex = _member.IndexOf('.');
@@ -120,7 +118,7 @@ namespace System.Windows.Markup
             }
             else
             {
-                throw new ArgumentException(SR.Get(SRID.MarkupExtensionBadStatic, memberFullName));
+                throw new ArgumentException(SR.Get(SRID.MarkupExtensionBadStatic, typeNameForError is not null ? $"{typeNameForError}.{_member}" : _member));
             }
         }
 


### PR DESCRIPTION
## Description

ProvideValue is frequently creating a string that only ends up being used to populate an exception.  We can just delay creating the string until the exception is thrown so that we don't create it in success cases.

## Customer Impact

Unnecessary allocations meant only for an exceptional path showing up in success paths.

## Regression

No

## Testing

CI

## Risk

Minimal