### PR TITLE
Don't allocate fallback name in XamlNamespace.GetXamlType unless it's needed

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -68,15 +68,15 @@ namespace System.Xaml.Schema
             {
                 return null;
             }
-            string fallbackName = GetTypeExtensionName(typeName);
+
             if (typeArgs == null || typeArgs.Length == 0)
             {
-                return TryGetXamlType(typeName) ?? TryGetXamlType(fallbackName);
+                return TryGetXamlType(typeName) ?? TryGetXamlType(GetTypeExtensionName(typeName));
             }
             else
             {
                 Type[] clrTypeArgs = ConvertArrayOfXamlTypesToTypes(typeArgs);
-                return TryGetXamlType(typeName, clrTypeArgs) ?? TryGetXamlType(fallbackName, clrTypeArgs);
+                return TryGetXamlType(typeName, clrTypeArgs) ?? TryGetXamlType(GetTypeExtensionName(typeName), clrTypeArgs);
             }
         }
 


### PR DESCRIPTION
## Description

XamlNamespace.GetXamlType is always concatenating a string together, but that string is only used on a fallback path.  So only create it on the fallback path.

## Customer Impact

Unnecessary string allocation.

## Regression

No

## Testing

CI

## Risk

Minimal