### PR TITLE
Remove substring allocation from Baml2006Reader.Logic_GetFullXmlns

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -2078,7 +2078,7 @@ namespace System.Windows.Baml2006
                         // We need to append local assembly
 
                         return uriInput + ((_settings.LocalAssembly != null)
-                                                ? ";assembly=" + GetAssemblyNameForNamespace(_settings.LocalAssembly)
+                                                ? string.Concat(";assembly=", GetAssemblyNameForNamespace(_settings.LocalAssembly))
                                                 : String.Empty);
                     }
                     else
@@ -2097,7 +2097,7 @@ namespace System.Windows.Baml2006
                         ReadOnlySpan<char> assemblyName = uriInput.AsSpan(equalIdx + 1);
                         if (assemblyName.TrimStart().IsEmpty)
                         {
-                            return uriInput + GetAssemblyNameForNamespace(_settings.LocalAssembly);
+                            return string.Concat(uriInput, GetAssemblyNameForNamespace(_settings.LocalAssembly));
                         }
                     }
                 }
@@ -2106,14 +2106,13 @@ namespace System.Windows.Baml2006
             return uriInput;
         }
 
-        //  Providing the assembly short name may lead to ambiguity between two versions of the same assembly, but we need to
+        // Providing the assembly short name may lead to ambiguity between two versions of the same assembly, but we need to
         // keep it this way since it is exposed publicly via the Namespace property, Baml2006ReaderInternal provides the full Assembly name.
         // We need to avoid Assembly.GetName() so we run in PartialTrust without asserting.
-        internal virtual string GetAssemblyNameForNamespace(Assembly assembly)
+        internal virtual ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly assembly)
         {
             string assemblyLongName = assembly.FullName;
-            string assemblyShortName = assemblyLongName.Substring(0, assemblyLongName.IndexOf(','));
-            return assemblyShortName;
+            return assemblyLongName.AsSpan(0, assemblyLongName.IndexOf(','));
         }
 
         // (prefix, namespaceUri)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006ReaderInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006ReaderInternal.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Baml2006
         #endregion
 
         // Return the full assembly name, this includes the assembly version
-        internal override string GetAssemblyNameForNamespace(Assembly asm)
+        internal override ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly asm)
         {
             return asm.FullName;
         }


### PR DESCRIPTION
## Description

When getting the assembly name, we can slice out the piece that's needed rather than allocating a substring.

## Customer Impact

Unnecessary string allocations.

## Regression

No

## Testing

CI

## Risk

Minimal