### PR TITLE
Some improvements to FrugalList

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -1346,7 +1346,11 @@ namespace MS.Utility
             return FrugalListStoreState.Success;
         }
 
-        public override void Clear() => _entries.AsSpan(0, _count).Clear();
+        public override void Clear()
+        {
+            _entries.AsSpan(0, _count).Clear();
+            _count = 0;
+        }
 
         public override bool Contains(T value) => IndexOf(value) >= 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -397,6 +397,7 @@
     <NetCoreReference Include="System.Linq" />
     <NetCoreReference Include="System.ObjectModel" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
+    <NetCoreReference Include="System.Memory" />
     <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />


### PR DESCRIPTION
## Description

- FrugalStructList's `ICollection<T>`-based constructor uses foreach to enumerate the contents of the collection.  If it's an `IList<T>`, we can instead index and avoid allocating the enumerator.
- Avoid multiple interface calls to `ICollection<T>.Count` in FrugalStructList's ctor
- Delete a dead ctor on `ArrayItemList<T>`.  That ctor was the only reason an array field may have been left null, so we can also remove subsequent null checks when accessing that array.
- Use Span/Array in ArrayItemList for Clear, Contains, IndexOf, ToArray, and CopyTo rather than open-coding them

## Customer Impact

Unnecessary allocation and interface dispatch

## Regression

No

## Testing

CI

## Risk

Minimal