### PR TITLE
Change most non-generic sorts to be generic

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -1535,7 +1535,7 @@ namespace System.Windows.Controls
                         double sizeToDistribute;
                         int i;
 
-                        Array.Sort(tempDefinitions, 0, count, s_spanPreferredDistributionOrderComparer);
+                        tempDefinitions.AsSpan(0, count).Sort(s_spanPreferredDistributionOrderComparer);
                         for (i = 0, sizeToDistribute = requestedSize; i < autoDefinitionsCount; ++i)
                         {
                             //  sanity check: only auto definitions allowed in this loop
@@ -1572,7 +1572,7 @@ namespace System.Windows.Controls
                         double sizeToDistribute;
                         int i;
 
-                        Array.Sort(tempDefinitions, 0, count, s_spanMaxDistributionOrderComparer);
+                        tempDefinitions.AsSpan(0, count).Sort(s_spanMaxDistributionOrderComparer);
                         for (i = 0, sizeToDistribute = requestedSize - rangePreferredSize; i < count - autoDefinitionsCount; ++i)
                         {
                             //  sanity check: no auto definitions allowed in this loop
@@ -1717,7 +1717,7 @@ namespace System.Windows.Controls
 
             if (starDefinitionsCount > 0)
             {
-                Array.Sort(tempDefinitions, 0, starDefinitionsCount, s_starDistributionOrderComparer);
+                tempDefinitions.AsSpan(0, starDefinitionsCount).Sort(s_starDistributionOrderComparer);
 
                 //  the 'do {} while' loop below calculates sum of star weights in order to avoid fp overflow...
                 //  partial sum value is stored in each definition's SizeCache member.
@@ -1876,8 +1876,8 @@ namespace System.Windows.Controls
                 double takenStarWeight = 0.0;
                 double remainingAvailableSize = availableSize - takenSize;
                 double remainingStarWeight = totalStarWeight - takenStarWeight;
-                Array.Sort(tempDefinitions, 0, minCount, s_minRatioComparer);
-                Array.Sort(tempDefinitions, defCount, maxCount, s_maxRatioComparer);
+                tempDefinitions.AsSpan(0, minCount).Sort(s_minRatioComparer);
+                tempDefinitions.AsSpan(defCount, maxCount).Sort(s_maxRatioComparer);
 
                 while (minCount + maxCount > 0 && remainingAvailableSize > 0.0)
                 {
@@ -2033,7 +2033,7 @@ namespace System.Windows.Controls
 
             if (starCount > 0)
             {
-                Array.Sort(tempDefinitions, 0, starCount, s_starWeightComparer);
+                tempDefinitions.AsSpan(0, starCount).Sort(s_starWeightComparer);
 
                 // compute the partial sums of *-weight, in increasing order of weight
                 // for minimal loss of precision.
@@ -2204,8 +2204,7 @@ namespace System.Windows.Controls
 
             if (starDefinitionsCount > 0)
             {
-                StarDistributionOrderIndexComparer starDistributionOrderIndexComparer = new StarDistributionOrderIndexComparer(definitions);
-                Array.Sort(definitionIndices, 0, starDefinitionsCount, starDistributionOrderIndexComparer);
+                Array.Sort(definitionIndices, 0, starDefinitionsCount, new StarDistributionOrderIndexComparer(definitions));
 
                 //  the 'do {} while' loop below calculates sum of star weights in order to avoid fp overflow...
                 //  partial sum value is stored in each definition's SizeCache member.
@@ -2252,8 +2251,7 @@ namespace System.Windows.Controls
             if (    allPreferredArrangeSize > finalSize
                 &&  !_AreClose(allPreferredArrangeSize, finalSize)  )
             {
-                DistributionOrderIndexComparer distributionOrderIndexComparer = new DistributionOrderIndexComparer(definitions);
-                Array.Sort(definitionIndices, 0, definitions.Length, distributionOrderIndexComparer);
+                Array.Sort(definitionIndices, 0, definitions.Length, new DistributionOrderIndexComparer(definitions));
                 double sizeToDistribute = finalSize - allPreferredArrangeSize;
 
                 for (int i = 0; i < definitions.Length; ++i)
@@ -2291,8 +2289,7 @@ namespace System.Windows.Controls
                     }
 
                     // Sort rounding errors
-                    RoundingErrorIndexComparer roundingErrorIndexComparer = new RoundingErrorIndexComparer(roundingErrors);
-                    Array.Sort(definitionIndices, 0, definitions.Length, roundingErrorIndexComparer);
+                    Array.Sort(definitionIndices, 0, definitions.Length, new RoundingErrorIndexComparer(roundingErrors));
                     double adjustedSize = allPreferredArrangeSize;
                     double dpiIncrement = UIElement.RoundLayoutValue(1.0, dpi);
 
@@ -2487,10 +2484,8 @@ namespace System.Windows.Controls
                 double remainingAvailableSize = finalSize - takenSize;
                 double remainingStarWeight = totalStarWeight - takenStarWeight;
 
-                MinRatioIndexComparer minRatioIndexComparer = new MinRatioIndexComparer(definitions);
-                Array.Sort(definitionIndices, 0, minCount, minRatioIndexComparer);
-                MaxRatioIndexComparer maxRatioIndexComparer = new MaxRatioIndexComparer(definitions);
-                Array.Sort(definitionIndices, defCount, maxCount, maxRatioIndexComparer);
+                Array.Sort(definitionIndices, 0, minCount, new MinRatioIndexComparer(definitions));
+                Array.Sort(definitionIndices, defCount, maxCount, new MaxRatioIndexComparer(definitions));
 
                 while (minCount + maxCount > 0 && remainingAvailableSize > 0.0)
                 {
@@ -2649,8 +2644,7 @@ namespace System.Windows.Controls
 
             if (starCount > 0)
             {
-                StarWeightIndexComparer starWeightIndexComparer = new StarWeightIndexComparer(definitions);
-                Array.Sort(definitionIndices, 0, starCount, starWeightIndexComparer);
+                Array.Sort(definitionIndices, 0, starCount, new StarWeightIndexComparer(definitions));
 
                 // compute the partial sums of *-weight, in increasing order of weight
                 // for minimal loss of precision.
@@ -2750,8 +2744,7 @@ namespace System.Windows.Controls
                     }
 
                     // Sort rounding errors
-                    RoundingErrorIndexComparer roundingErrorIndexComparer = new RoundingErrorIndexComparer(roundingErrors);
-                    Array.Sort(definitionIndices, 0, definitions.Length, roundingErrorIndexComparer);
+                    Array.Sort(definitionIndices, 0, definitions.Length, new RoundingErrorIndexComparer(roundingErrors));
                     double adjustedSize = roundedTakenSize;
                     double dpiIncrement = 1.0/dpi;
 
@@ -3321,13 +3314,12 @@ namespace System.Windows.Controls
         private const double c_starClip = 1e298;                //  used as maximum for clipping star values during normalization
         private const int c_layoutLoopMaxCount = 5;             // 5 is an arbitrary constant chosen to end the measure loop
         private static readonly LocalDataStoreSlot s_tempDefinitionsDataSlot = Thread.AllocateDataSlot();
-        private static readonly IComparer s_spanPreferredDistributionOrderComparer = new SpanPreferredDistributionOrderComparer();
-        private static readonly IComparer s_spanMaxDistributionOrderComparer = new SpanMaxDistributionOrderComparer();
-        private static readonly IComparer s_starDistributionOrderComparer = new StarDistributionOrderComparer();
-        private static readonly IComparer s_distributionOrderComparer = new DistributionOrderComparer();
-        private static readonly IComparer s_minRatioComparer = new MinRatioComparer();
-        private static readonly IComparer s_maxRatioComparer = new MaxRatioComparer();
-        private static readonly IComparer s_starWeightComparer = new StarWeightComparer();
+        private static readonly Comparison<DefinitionBase> s_spanPreferredDistributionOrderComparer = SpanPreferredDistributionOrderComparer;
+        private static readonly Comparison<DefinitionBase> s_spanMaxDistributionOrderComparer = SpanMaxDistributionOrderComparer;
+        private static readonly Comparison<DefinitionBase> s_starDistributionOrderComparer = StarDistributionOrderComparer;
+        private static readonly Comparison<DefinitionBase> s_minRatioComparer = MinRatioComparer;
+        private static readonly Comparison<DefinitionBase> s_maxRatioComparer = MaxRatioComparer;
+        private static readonly Comparison<DefinitionBase> s_starWeightComparer = StarWeightComparer;
 
         #endregion Static Fields
 
@@ -3632,139 +3624,85 @@ namespace System.Windows.Controls
             private bool _u;
         }
 
-        /// <summary>
-        /// SpanPreferredDistributionOrderComparer.
-        /// </summary>
-        private class SpanPreferredDistributionOrderComparer : IComparer
+        private static int SpanPreferredDistributionOrderComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(x, y, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
+                if (x.UserSize.IsAuto)
                 {
-                    if (definitionX.UserSize.IsAuto)
+                    if (y.UserSize.IsAuto)
                     {
-                        if (definitionY.UserSize.IsAuto)
-                        {
-                            result = definitionX.MinSize.CompareTo(definitionY.MinSize);
-                        }
-                        else
-                        {
-                            result = -1;
-                        }
+                        result = x.MinSize.CompareTo(y.MinSize);
                     }
                     else
                     {
-                        if (definitionY.UserSize.IsAuto)
-                        {
-                            result = +1;
-                        }
-                        else
-                        {
-                            result = definitionX.PreferredSize.CompareTo(definitionY.PreferredSize);
-                        }
+                        result = -1;
                     }
                 }
-
-                return result;
-            }
-        }
-
-        /// <summary>
-        /// SpanMaxDistributionOrderComparer.
-        /// </summary>
-        private class SpanMaxDistributionOrderComparer : IComparer
-        {
-            public int Compare(object x, object y)
-            {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
+                else
                 {
-                    if (definitionX.UserSize.IsAuto)
+                    if (y.UserSize.IsAuto)
                     {
-                        if (definitionY.UserSize.IsAuto)
-                        {
-                            result = definitionX.SizeCache.CompareTo(definitionY.SizeCache);
-                        }
-                        else
-                        {
-                            result = +1;
-                        }
+                        result = +1;
                     }
                     else
                     {
-                        if (definitionY.UserSize.IsAuto)
-                        {
-                            result = -1;
-                        }
-                        else
-                        {
-                            result = definitionX.SizeCache.CompareTo(definitionY.SizeCache);
-                        }
+                        result = x.PreferredSize.CompareTo(y.PreferredSize);
                     }
                 }
-
-                return result;
             }
+
+            return result;
         }
 
-        /// <summary>
-        /// StarDistributionOrderComparer.
-        /// </summary>
-        private class StarDistributionOrderComparer : IComparer
+        private static int SpanMaxDistributionOrderComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(x, y, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
+                if (x.UserSize.IsAuto)
                 {
-                    result = definitionX.SizeCache.CompareTo(definitionY.SizeCache);
+                    if (y.UserSize.IsAuto)
+                    {
+                        result = x.SizeCache.CompareTo(y.SizeCache);
+                    }
+                    else
+                    {
+                        result = +1;
+                    }
                 }
-
-                return result;
+                else
+                {
+                    if (y.UserSize.IsAuto)
+                    {
+                        result = -1;
+                    }
+                    else
+                    {
+                        result = x.SizeCache.CompareTo(y.SizeCache);
+                    }
+                }
             }
+
+            return result;
         }
 
-        /// <summary>
-        /// DistributionOrderComparer.
-        /// </summary>
-        private class DistributionOrderComparer: IComparer
+        private static int StarDistributionOrderComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(x, y, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
-                {
-                    double xprime = definitionX.SizeCache - definitionX.MinSizeForArrange;
-                    double yprime = definitionY.SizeCache - definitionY.MinSizeForArrange;
-                    result = xprime.CompareTo(yprime);
-                }
-
-                return result;
+                result = x.SizeCache.CompareTo(y.SizeCache);
             }
+
+            return result;
         }
 
-
-        /// <summary>
-        /// StarDistributionOrderIndexComparer.
-        /// </summary>
-        private class StarDistributionOrderIndexComparer : IComparer
+        private sealed class StarDistributionOrderIndexComparer : IComparer<int>
         {
             private readonly DefinitionBase[] definitions;
 
@@ -3774,22 +3712,10 @@ namespace System.Windows.Controls
                 this.definitions = definitions;
             }
 
-            public int Compare(object x, object y)
+            public int Compare(int x, int y)
             {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                DefinitionBase definitionX = null;
-                DefinitionBase definitionY = null;
-
-                if (indexX != null)
-                {
-                    definitionX = definitions[indexX.Value];
-                }
-                if (indexY != null)
-                {
-                    definitionY = definitions[indexY.Value];
-                }
+                DefinitionBase definitionX = definitions[x];
+                DefinitionBase definitionY = definitions[y];
 
                 int result;
 
@@ -3802,10 +3728,7 @@ namespace System.Windows.Controls
             }
         }
 
-        /// <summary>
-        /// DistributionOrderComparer.
-        /// </summary>
-        private class DistributionOrderIndexComparer : IComparer
+        private sealed class DistributionOrderIndexComparer : IComparer<int>
         {
             private readonly DefinitionBase[] definitions;
 
@@ -3815,22 +3738,10 @@ namespace System.Windows.Controls
                 this.definitions = definitions;
             }
 
-            public int Compare(object x, object y)
+            public int Compare(int x, int y)
             {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                DefinitionBase definitionX = null;
-                DefinitionBase definitionY = null;
-
-                if (indexX != null)
-                {
-                    definitionX = definitions[indexX.Value];
-                }
-                if (indexY != null)
-                {
-                    definitionY = definitions[indexY.Value];
-                }
+                DefinitionBase definitionX = definitions[x];
+                DefinitionBase definitionY = definitions[y];
 
                 int result;
 
@@ -3845,10 +3756,7 @@ namespace System.Windows.Controls
             }
         }
 
-        /// <summary>
-        /// RoundingErrorIndexComparer.
-        /// </summary>
-        private class RoundingErrorIndexComparer : IComparer
+        private sealed class RoundingErrorIndexComparer : IComparer<int>
         {
             private readonly double[] errors;
 
@@ -3858,96 +3766,57 @@ namespace System.Windows.Controls
                 this.errors = errors;
             }
 
-            public int Compare(object x, object y)
-            {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                int result;
-
-                if (!CompareNullRefs(indexX, indexY, out result))
-                {
-                    double errorX = errors[indexX.Value];
-                    double errorY = errors[indexY.Value];
-                    result = errorX.CompareTo(errorY);
-                }
-
-                return result;
-            }
+            public int Compare(int x, int y) => errors[x].CompareTo(errors[y]);
         }
 
         /// <summary>
-        /// MinRatioComparer.
         /// Sort by w/min (stored in MeasureSize), descending.
         /// We query the list from the back, i.e. in ascending order of w/min.
         /// </summary>
-        private class MinRatioComparer : IComparer
+        private static int MinRatioComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(y, x, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionY, definitionX, out result))
-                {
-                    result = definitionY.MeasureSize.CompareTo(definitionX.MeasureSize);
-                }
-
-                return result;
+                result = y.MeasureSize.CompareTo(x.MeasureSize);
             }
+
+            return result;
         }
 
         /// <summary>
-        /// MaxRatioComparer.
         /// Sort by w/max (stored in SizeCache), ascending.
         /// We query the list from the back, i.e. in descending order of w/max.
         /// </summary>
-        private class MaxRatioComparer : IComparer
+        private static int MaxRatioComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(x, y, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
-                {
-                    result = definitionX.SizeCache.CompareTo(definitionY.SizeCache);
-                }
-
-                return result;
+                result = x.SizeCache.CompareTo(y.SizeCache);
             }
+
+            return result;
         }
 
         /// <summary>
-        /// StarWeightComparer.
         /// Sort by *-weight (stored in MeasureSize), ascending.
         /// </summary>
-        private class StarWeightComparer : IComparer
+        private static int StarWeightComparer(DefinitionBase x, DefinitionBase y)
         {
-            public int Compare(object x, object y)
+            int result;
+
+            if (!CompareNullRefs(x, y, out result))
             {
-                DefinitionBase definitionX = x as DefinitionBase;
-                DefinitionBase definitionY = y as DefinitionBase;
-
-                int result;
-
-                if (!CompareNullRefs(definitionX, definitionY, out result))
-                {
-                    result = definitionX.MeasureSize.CompareTo(definitionY.MeasureSize);
-                }
-
-                return result;
+                result = x.MeasureSize.CompareTo(y.MeasureSize);
             }
+
+            return result;
         }
 
-        /// <summary>
-        /// MinRatioIndexComparer.
-        /// </summary>
-        private class MinRatioIndexComparer : IComparer
+        private sealed class MinRatioIndexComparer : IComparer<int>
         {
             private readonly DefinitionBase[] definitions;
 
@@ -3957,22 +3826,10 @@ namespace System.Windows.Controls
                 this.definitions = definitions;
             }
 
-            public int Compare(object x, object y)
+            public int Compare(int x, int y)
             {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                DefinitionBase definitionX = null;
-                DefinitionBase definitionY = null;
-
-                if (indexX != null)
-                {
-                    definitionX = definitions[indexX.Value];
-                }
-                if (indexY != null)
-                {
-                    definitionY = definitions[indexY.Value];
-                }
+                DefinitionBase definitionX = definitions[x];
+                DefinitionBase definitionY = definitions[y];
 
                 int result;
 
@@ -3985,10 +3842,7 @@ namespace System.Windows.Controls
             }
         }
 
-        /// <summary>
-        /// MaxRatioIndexComparer.
-        /// </summary>
-        private class MaxRatioIndexComparer : IComparer
+        private sealed class MaxRatioIndexComparer : IComparer<int>
         {
             private readonly DefinitionBase[] definitions;
 
@@ -3998,22 +3852,10 @@ namespace System.Windows.Controls
                 this.definitions = definitions;
             }
 
-            public int Compare(object x, object y)
+            public int Compare(int x, int y)
             {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                DefinitionBase definitionX = null;
-                DefinitionBase definitionY = null;
-
-                if (indexX != null)
-                {
-                    definitionX = definitions[indexX.Value];
-                }
-                if (indexY != null)
-                {
-                    definitionY = definitions[indexY.Value];
-                }
+                DefinitionBase definitionX = definitions[x];
+                DefinitionBase definitionY = definitions[y];
 
                 int result;
 
@@ -4026,10 +3868,7 @@ namespace System.Windows.Controls
             }
         }
 
-        /// <summary>
-        /// MaxRatioIndexComparer.
-        /// </summary>
-        private class StarWeightIndexComparer : IComparer
+        private sealed class StarWeightIndexComparer : IComparer<int>
         {
             private readonly DefinitionBase[] definitions;
 
@@ -4039,22 +3878,10 @@ namespace System.Windows.Controls
                 this.definitions = definitions;
             }
 
-            public int Compare(object x, object y)
+            public int Compare(int x, int y)
             {
-                int? indexX = x as int?;
-                int? indexY = y as int?;
-
-                DefinitionBase definitionX = null;
-                DefinitionBase definitionY = null;
-
-                if (indexX != null)
-                {
-                    definitionX = definitions[indexX.Value];
-                }
-                if (indexY != null)
-                {
-                    definitionY = definitions[indexY.Value];
-                }
+                DefinitionBase definitionX = definitions[x];
+                DefinitionBase definitionY = definitions[y];
 
                 int result;
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/SegmentTree.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/AlphaFlattener/SegmentTree.cs
@@ -27,17 +27,6 @@ namespace Microsoft.Internal.AlphaFlattener
         }
     }
 
-    internal class CoordinateComparer : IComparer
-    {
-        int IComparer.Compare(Object x, Object y)
-        {
-            double vx = ((Coordinate)x).value;
-            double vy = ((Coordinate)y).value;
-
-            return vx.CompareTo(vy);
-        }
-    }
-
     internal class CoordinateSearcher : IComparer
     {
         int IComparer.Compare(Object x, Object y)
@@ -237,10 +226,10 @@ namespace Microsoft.Internal.AlphaFlattener
 
             AddPoint(p, count + 1, Double.MaxValue, Double.MaxValue);
 
-            Array.Sort(_xCoord, new CoordinateComparer());
+            Array.Sort(_xCoord, (x, y) => x.value.CompareTo(y.value));
             _xCount = _xCoord.Length;
 
-            Array.Sort(_yCoord, new CoordinateComparer());
+            Array.Sort(_yCoord, (x, y) => x.value.CompareTo(y.value));
             _yCount = _yCoord.Length;
         }
 


### PR DESCRIPTION
## Description

Especially for the sorts based on int[], this avoids boxing potentially huge numbers of ints.  Even for classes, it avoids unnecessary casting and expensive Array.Get/SetValue calls, and switching to a delegate avoids a top-level allocation for the comparer inside the current Array.Sort implementation.

## Customer Impact

Unnecessary allocation, interface dispatch, expensive Array.Get/SetValue calls, etc.

## Regression

No

## Testing

CI

## Risk

Minimal