### PR TITLE
Fix Popup regression on high DPI

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -1562,7 +1562,8 @@ namespace System.Windows.Controls
                 if (rootElement != null)
                 {
                     // get the coordinates of the current mouse point, relative to our PresentationSource
-                    System.Windows.Point pt = Mouse.PrimaryDevice.GetPosition(rootElement);
+                    Matrix transform = PresentationSource.FromVisual(_source.RootVisual).CompositionTarget.TransformToDevice;
+                    System.Windows.Point pt = transform.Transform(Mouse.PrimaryDevice.GetPosition(rootElement));
 
                     // check whether the point lies within the hull
                     return ContainsPoint(_source, (int)pt.X, (int)pt.Y);


### PR DESCRIPTION
Fixes dotnet/wpf#6289

## Description
Fixes a regression where popups would vanish when using high DPI settings. The current code in .Net 6.0.3 uses the position of the mouse to check if the mouse was inside an array of points. The problem was that the position of the mouse was not DPI aware while the array of points was DPI aware. I fixed this by transforming the position of the mouse to have a point which is DPI aware.

## Customer Impact
Fixes popup vanishing immediately.

## Regression
Regression introduced in .Net 6.0.3 with #6063 which was a backport of #5931.

## Testing
I tested locally using the sample provided here: https://github.com/dotnet/wpf/pull/6063#issuecomment-1064069083. I used two monitors with different DPI settings and after the changes in this PR, the issue was fixed.

## Risk
Low.