### PR TITLE
Stop boxing in Visual.SetDpiScaleVisualFlags

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DpiScale.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DpiScale.cs
@@ -77,6 +77,8 @@ namespace System.Windows
             get { return DpiUtil.DefaultPixelsPerInch * _dpiScaleY; }
         }
 
+        internal bool Equals(DpiScale other) => _dpiScaleX == other._dpiScaleX && _dpiScaleY == other._dpiScaleY;
+
         private readonly double _dpiScaleX;
         private readonly double _dpiScaleY;
     }


### PR DESCRIPTION
## Description

This uses DpiScale.Equals(DpiScale), but there's no such strongly-typed overload, so it falls back to using ValueType.Equals(object), which not only boxes the DpiScale but also both doubles that end up being compared.  This just adds an internal Equals method to DpiScale to bind to that Equals instead; ideally in the future DpiScale would implement `IEquatable<T>` and this `Equals` would be made public.

## Customer Impact

Unnecessary allocation / overhead

## Regression

No

## Testing

CI

## Risk

Minimal