### PR TITLE
WPF DataGrid/GridView column width can be changed using the keyboard shortcut ALT+left or right arrow key

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -973,11 +973,11 @@ namespace System.Windows.Controls
 
                 if (e.Key == Key.Right)
                 {
-                    updatedWidth = new DataGridLength(Column.ActualWidth + _columnWidthStepSize);
+                    updatedWidth = new DataGridLength(Column.ActualWidth + ColumnWidthStepSize);
                 }
                 else if (e.Key == Key.Left)
                 {
-                    updatedWidth = new DataGridLength(Column.ActualWidth - _columnWidthStepSize);
+                    updatedWidth = new DataGridLength(Column.ActualWidth - ColumnWidthStepSize);
                 }
 
                 if(Column != null && Column.CanColumnResize(updatedWidth))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -964,28 +964,35 @@ namespace System.Windows.Controls
         /// </summary>
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
+            const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
+            ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
+
+            if ((modifierKeys == ModifierKeys.Alt) && (e.Key == Key.Left || e.Key == Key.Right))
             {
                 DataGridLength updatedWidth = new DataGridLength();
 
                 if (e.Key == Key.Right)
                 {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth + ColumnWidthStepSize);
+                    updatedWidth = new DataGridLength(Column.ActualWidth + _columnWidthStepSize);
                 }
                 else if (e.Key == Key.Left)
                 {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth - ColumnWidthStepSize);
+                    updatedWidth = new DataGridLength(Column.ActualWidth - _columnWidthStepSize);
                 }
 
-                if (Column.CanColumnResize(updatedWidth))
+                if(Column != null && Column.CanColumnResize(updatedWidth))
                 {
-                    this.Column.SetCurrentValue(DataGridColumn.WidthProperty, updatedWidth);
+                    Column.SetCurrentValueInternal(DataGridColumn.WidthProperty, updatedWidth);
+                    e.Handled = true;
+                }
+                else
+                {
+                    e.Handled = false;
                 }
 
-                e.Handled = true;
                 return;
             }
-            
+
             SendInputToColumn(e);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -967,7 +967,7 @@ namespace System.Windows.Controls
             const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
             ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
 
-            if ((modifierKeys == ModifierKeys.Alt) && (e.Key == Key.Left || e.Key == Key.Right))
+            if ((modifierKeys & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
             {
                 DataGridLength updatedWidth = new DataGridLength();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -353,7 +353,7 @@ namespace System.Windows.Controls
                         const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
                         ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
 
-                        if ((modifierKeys == ModifierKeys.Alt) && (key == Key.Left || key == Key.Right))
+                        if ((modifierKeys & ModifierKeys.Alt) == ModifierKeys.Alt && (key == Key.Left || key == Key.Right))
                         {
                             if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader && gridViewColumnHeader.Column != null)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -350,28 +350,34 @@ namespace System.Windows.Controls
                 case Key.Down:
                 case Key.Right:
                     {
-                    if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
+                        const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
+                        ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
+
+                        if ((modifierKeys == ModifierKeys.Alt) && (key == Key.Left || key == Key.Right))
                         {
-                            if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader)
+                            if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader && gridViewColumnHeader.Column != null)
                             {
+                                double width;
                                 if (key == Key.Left)
                                 {
-                                    if(gridViewColumnHeader.Column.ActualWidth > 0)
+                                    width = gridViewColumnHeader.Column.ActualWidth - ColumnWidthStepSize;
+                                    if (width > 0)
                                     {
-                                        gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth - ColumnWidthStepSize;
-                                        gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
-                                    }
-                                    
-                                    handled = true;
+                                        gridViewColumnHeader.UpdateColumnHeaderWidth(width);
+                                    }                                    
                                 }
                                 else if (key == Key.Right)
                                 {
-                                    gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth + ColumnWidthStepSize;
-                                    gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
-                                    handled = true;
+                                    width = gridViewColumnHeader.Column.ActualWidth + ColumnWidthStepSize;
+                                    gridViewColumnHeader.UpdateColumnHeaderWidth(width);
                                 }
-                                break;
                             }
+                            else
+                            {
+                                handled = false;
+                            }
+
+                            break;
                         }
                     
                         KeyboardNavigation.ShowFocusVisual();


### PR DESCRIPTION
Fixes # https://github.com/dotnet/wpf/issues/5880

Main PR https://github.com/dotnet/wpf/pull/6054

Description
Issue related to WPF DataGrid column width can now be changed using the keyboard shortcut "ALT + left arrow key" and "ALT + right arrow key".

Customer Impact
Fixes a regression.

Regression
Yes.

Testing
Integration tests are in progress.

Risk
Low. Add ability to adjust column width using keyboard for WPF DataGrid.