### PR TITLE
Added correct WPFArtifactsPath for x64

### DIFF
--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -13,7 +13,10 @@
   <PropertyGroup>
     <WpfConfig Condition="'$(WpfConfig)'==''">Debug</WpfConfig>
     <RuntimeIdentifier>win-$(PlatformTarget)</RuntimeIdentifier>
-    <WPFArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
+    
+    <WpfPackagesCommonPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging</WpfPackagesCommonPath>
+    <WPFArtifactsPath Condition="'$(PlatformTarget)'=='x86'">$(WpfPackagesCommonPath)\$(WpfConfig)\Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
+    <WPFArtifactsPath Condition="'$(PlatformTarget)'=='x64'">$(WpfPackagesCommonPath)\$(WpfConfig)\x64\Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Earlier the wpf-debug.targets did not work with applications built on x64. In this fix, when the PlatformTarget is set to x64, correct WPF artifacts path is being pointed for loading the modules.

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Tested the loaded modules in both scenarios ( x86, x64 )
<!-- What kind of testing has been done with the fix. -->

## Risk
None
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
