### PR TITLE
Account for optional out parameters in IStream

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/api/exports.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/api/exports.cpp
@@ -759,6 +759,8 @@ CManagedStreamWrapper::Seek(
     __out_ecount(1) ULARGE_INTEGER* newPos
     )
 {
+    ULARGE_INTEGER newPosLocal;
+    if (!newPos) newPos = &newPosLocal;
     RRETURN(m_sd.pfnSeek(&m_sd, offset, origin, newPos));
 }
 
@@ -778,6 +780,8 @@ CManagedStreamWrapper::Write(
     __out_ecount(1) ULONG* cbWritten
     )
 {
+    ULONG cbWrittenLocal;
+    if (!cbWritten) cbWritten = &cbWrittenLocal;
     RRETURN(m_sd.pfnWrite(&m_sd, buf, cb, cbWritten));
 }
 
@@ -789,6 +793,10 @@ CManagedStreamWrapper::CopyTo(
     __out_ecount(1) ULARGE_INTEGER* cbWritten
     )
 {
+    ULARGE_INTEGER cbReadLocal;
+    ULARGE_INTEGER cbWrittenLocal;
+    if (!cbRead) cbRead = &cbReadLocal;
+    if (!cbWritten) cbWritten = &cbWrittenLocal;
     RRETURN(m_sd.pfnCopyTo(&m_sd, stream,cb, cbRead, cbWritten));
 }
 


### PR DESCRIPTION
Fixes #6344 

## Description

`System.Windows.Media.StreamAsIStream.Write(byte[] buffer, uint cb, out uint cbWritten)` throws `NullReferenceException` when trying to set `cbWritten` because the `out int cbWritten` parameter has been passed in as null.

According to the documentation, caller can pass `NULL` as `pcbWritten` to [IStream::Write](https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-isequentialstream-write) when they are not interested in the number of bytes written.

The `CManagedStreamWrapper` does not expect that and [simply passes](https://github.com/dotnet/wpf/blob/89d172db0b7a192de720c6cfba5e28a1e7d46123/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/api/exports.cpp#L775-L782) the pointer to the managed assembly, however, CLR is not happy with writing to null out parameters.

The PR fixes the issue by always passing a valid reference to the managed assembly. If an output argument was omitted, a reference to a local variable on stack is passed instead, and the output value is thrown away.

The same convention applies to `IStream::Seek` and `IStream::CopyTo` methods.

## Customer Impact

Customers are unable to use WIC encoders (and potentially decoders) that call `IStream` without the optional parameters (i.e. passing `NULL`). In the case of #6344, customers cannot save HEIF files using a paid encoder provided by Microsoft (built-in in previous Windows builds).

## Regression

No.

## Testing

Compiled an updated _wpfgfx_cor3.dll_ and tested in .NET 6.0.2 x86 WPF application with the repro code in #6344.

## Risk

I am not aware of any risks, the fix does not affect any currently working scenario.
