### PR TITLE
PickFolders option for OpenFileDialog

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -1838,6 +1838,16 @@ namespace Microsoft.Win32
             // Force no mini mode for the SaveFileDialog.
             // Only accept physically backed locations.
             FOS options = (FOS)VistaOptions | FOS.DEFAULTNOMINIMODE | FOS.FORCEFILESYSTEM;
+
+            // FILEMUSTEXIST is set by default by OpenFileDialog.
+            // While the combination of PICKFOLDERS and FILEMUSTEXIST is valid,
+            // it currently does not let users select anything in the dialog.
+            // We therefore disable FILEMUSTEXIST for folder selection.
+            if ((options & FOS.PICKFOLDERS) != 0)
+            {
+                options &= ~FOS.FILEMUSTEXIST;
+            }
+
             dialog.SetOptions(options);
 
             COMDLG_FILTERSPEC[] filterItems = GetFilterItems(Filter);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -1363,8 +1363,8 @@ namespace Microsoft.Win32
                                         // here and then call SetOption to get _dialogOptions
                                         // into the default state.
 
-            _vistaDialogOptions.Value = 0; // Similarly _vistaDialogOption is an uint containing a set of
-                                           // bit flags used to initialize the Vista dialog.
+            _vistaDialogOptions.Value = 0; // Similarly _vistaDialogOption is an int containing
+                                           // a set of bit flags used to initialize the Vista dialog.
                                            // It is used directly to set the dialog options.
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
@@ -211,14 +211,6 @@ namespace Microsoft.Win32
             set
             {
                 SetVistaOption(FOS.PICKFOLDERS, value);
-
-                if (value)
-                {
-                    // FILEMUSTEXIST is set by default in Initialize
-                    // the combination with PICKFOLDERS is valid
-                    // but does not allow user to pick any folder
-                    SetVistaOption(FOS.FILEMUSTEXIST, false);
-                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
@@ -447,6 +447,8 @@ namespace Microsoft.Win32
             // message box.   Implies OFN_PATHMUSTEXIST.
             SetOption(NativeMethods.OFN_FILEMUSTEXIST, true);
             SetVistaOption(FOS.FILEMUSTEXIST, true);
+
+            // FOS_PICKFOLDERS is reset in the base
         }
 
         #endregion Private Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
@@ -190,6 +190,35 @@ namespace Microsoft.Win32
             set
             {
                 SetOption(NativeMethods.OFN_ALLOWMULTISELECT, value);
+                SetVistaOption(FOS.ALLOWMULTISELECT, value);
+            }
+        }
+
+        //   FOS_PICKFOLDERS
+        //   Present an Open dialog that offers a choice of folders
+        //   rather than files.
+        //
+        /// <summary>
+        /// Gets or sets an option flag indicating whether the
+        /// dialog offers a choice of folders rather than files.
+        /// </summary>
+        public bool PickFolders
+        {
+            get
+            {
+                return GetVistaOption(FOS.PICKFOLDERS);
+            }
+            set
+            {
+                SetVistaOption(FOS.PICKFOLDERS, value);
+
+                if (value)
+                {
+                    // FILEMUSTEXIST is set by default in Initialize
+                    // the combination with PICKFOLDERS is valid
+                    // but does not allow user to pick any folder
+                    SetVistaOption(FOS.FILEMUSTEXIST, false);
+                }
             }
         }
 
@@ -212,6 +241,7 @@ namespace Microsoft.Win32
             set
             {
                 SetOption(NativeMethods.OFN_READONLY, value);
+                // not available in Vista dialogs
             }
         }
 
@@ -238,6 +268,7 @@ namespace Microsoft.Win32
             {
                 // ... and SetOption.
                 SetOption(NativeMethods.OFN_HIDEREADONLY, !value);
+                // not available in Vista dialogs
             }
         }
 
@@ -415,6 +446,7 @@ namespace Microsoft.Win32
             // the user enters an invalid name, we display a warning in a 
             // message box.   Implies OFN_PATHMUSTEXIST.
             SetOption(NativeMethods.OFN_FILEMUSTEXIST, true);
+            SetVistaOption(FOS.FILEMUSTEXIST, true);
         }
 
         #endregion Private Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/SaveFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/SaveFileDialog.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Win32
             {
 
                 SetOption(NativeMethods.OFN_CREATEPROMPT, value);
+                SetVistaOption(FOS.CREATEPROMPT, value);
             }
         }
 
@@ -169,6 +170,7 @@ namespace Microsoft.Win32
             {
 
                 SetOption(NativeMethods.OFN_OVERWRITEPROMPT, value);
+                SetVistaOption(FOS.OVERWRITEPROMPT, value);
             }
         }
 
@@ -378,6 +380,7 @@ namespace Microsoft.Win32
             // the selected file already exists. The user must confirm 
             // whether to overwrite the file.  Default is true.
             SetOption(NativeMethods.OFN_OVERWRITEPROMPT, true);
+            SetVistaOption(FOS.OVERWRITEPROMPT, true);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Win32
         public int FilterIndex { get { throw null; } set { } }
         public string InitialDirectory { get { throw null; } set { } }
         protected int Options { get { throw null; } }
+        protected int VistaOptions { get { throw null; } }
         public bool RestoreDirectory { get { throw null; } set { } }
         public string SafeFileName { get { throw null; } }
         public string[] SafeFileNames { get { throw null; } }
@@ -69,6 +70,7 @@ namespace Microsoft.Win32
     {
         public OpenFileDialog() { }
         public bool Multiselect { get { throw null; } set { } }
+        public bool PickFolders { get { throw null; } set { } }
         public bool ReadOnlyChecked { get { throw null; } set { } }
         public bool ShowReadOnly { get { throw null; } set { } }
         protected override void CheckPermissionsToShowDialog() { }


### PR DESCRIPTION
For discussion. Fixes #438. Further discussion in #4039.

## Description

Allows developers to ask the user to select a folder, a feature known as `FolderBrowserDialog` in WinForms.

This PR is the least invasive way of introducing the feature. It closely reflects the underlying API design, i.e. the ability to specify `FOS_PICKFOLDERS` on the `IOpenFileDialog`. This is a backwards compatible solution - no public API has been moved or removed and no existing behavior has changed.

### Tracking the flags

There is, however, an unfortunate implementation detail - the original authors of the code decided to use a single variable to store legacy OFN_ options, Vista FOS_ options and their own custom options. These options diverged and conflict with each other:

| Value | OFN_ | FOS_ | OPTION_ |
|---|---|---|---|
| 0x0000_0001 | READONLY * | | |
| 0x0000_0002 | OVERWRITEPROMPT | OVERWRITEPROMPT * | |
| 0x0000_0004 | **HIDEREADONLY** * | **STRICTFILETYPES** | |
| 0x0000_0008 | NOCHANGEDIR * | NOCHANGEDIR * | |
| 0x0000_0010 | SHOWHELP | | |
| 0x0000_0020 | **ENABLEHOOK** | **PICKFOLDERS** * | |
| 0x0000_0040 | **ENABLETEMPLATE** | **FORCEFILESYSTEM** | |
| 0x0000_0080 | **ENABLETEMPLATEHANDLE** | **ALLNONSTORAGEITEMS** | |
| 0x0000_0100 | NOVALIDATE * | NOVALIDATE * | |
| 0x0000_0200 | ALLOWMULTISELECT * | ALLOWMULTISELECT * | |
| 0x0000_0400 | EXTENSIONDIFFERENT | | |
| 0x0000_0800 | PATHMUSTEXIST * | PATHMUSTEXIST * | |
| 0x0000_1000 | FILEMUSTEXIST | FILEMUSTEXIST * | |
| 0x0000_2000 | CREATEPROMPT | CREATEPROMPT * | |
| 0x0000_4000 | SHAREAWARE | SHAREAWARE | |
| 0x0000_8000 | NOREADONLYRETURN | NOREADONLYRETURN | |
| 0x0001_0000 | NOTESTFILECREATE | NOTESTFILECREATE | |
| 0x0002_0000 | **NONETWORKBUTTON** | **HIDEMRUPLACES** | |
| 0x0004_0000 | **NOLONGNAMES** | **HIDEPINNEDPLACES** | |
| 0x0008_0000 | EXPLORER | | |
| 0x0010_0000 | NODEREFERENCELINKS * | NODEREFERENCELINKS * | |
| 0x0020_0000 | **LONGNAMES** | **OKBUTTONNEEDSINTERACTION** | |
| 0x0040_0000 | ENABLEINCLUDENOTIFY | | |
| 0x0080_0000 | ENABLESIZING | | |
| 0x0100_0000 | USESHELLITEM | | |
| 0x0200_0000 | DONTADDTORECENT | DONTADDTORECENT | |
| 0x0400_0000 | | | |
| 0x0800_0000 | | | |
| 0x1000_0000 | FORCESHOWHIDDEN | FORCESHOWHIDDEN | |
| 0x2000_0000 | | DEFAULTNOMINIMODE | |
| 0x4000_0000 | | FORCEPREVIEWPANEON | |
| 0x8000_0000 | | **SUPPORTSTREAMABLEITEMS** | **ADDEXTENSION** |

\* allowed to set in code as flags (i.e. preserved by masking)

Most notably `FOS_PICKFOLDERS` conflicts with `OFN_ENABLEHOOK`. The existing code sort of supports only the flags having the same value in both API and passes the combination directly to the APIs. Few conflicting ones are enforced at call time and developers cannot disable them:

For legacy dialogs, that is:
* `OFN_EXPLORER`
* `OFN_ENABLEHOOK`
* `OFN_ENABLESIZING`

For Vista dialogs, that is:
* `FOS_DEFAULTNOMINIMODE`
* `FOS_FORCEFILESYSTEM`

Using the existing infrastructure would mean either
1) using `OFN_EXPLORER` bit to also mean `FOS_PICKFOLDERS`, or;
2) adding a new custom `OPTION_PICKFOLDERS`, preferably as one of the unoccupied bits. 

The former is messy (either requires casting from FOS or declaring fake OFN constant) and creates confusing code. The latter is in danger that new conflicting flags will be introduced, like it already happened with `OPTION_ADDEXTENSION`.

I therefore decided for a potentially controversial solution - I split the backing field and track legacy and Vista options separately. The custom option stays in the legacy field, as no new flags are expected in the legacy API. I am willing to implement options 1) or 2) instead if that was preferred.

### New visible members

In `OpenFileDialog`:
* `public bool PickFolders { get; set; }`

In `FileDialog`:
* `protected int VistaOptions { get; }`

### CheckFileExists behavior

The `OpenFileDialog` turns on `CheckFileExists` by default. The property works as advertised, meaning users cannot confirm anything if only folders are available to pick. For convenience, setting the `PickFolders` option has a side effect of unsetting the `CheckFileExists` option.

### Existing properties on folder dialog

(excerpt from discussion in #4039)

These are the current public properties on the `FileDialog`.

Applicable to folder selection:
* `CustomPlaces`
* `DereferenceLinks` - whether links to folders are followed or not allowed
* `FileName` - e.g. _C:\Users\Thomas_
* `FileNames` - always has 1 item at the moment
* `InitialDirectory`
* `SafeFileName` - e.g. _Thomas_
* `SafeFileNames` - always has 1 item at the moment
* `Tag`
* `Title`

Doing something, but wouldn't be necessary for folders:
* `AddExtension` - internal WPF flag to ensure the file/folder name ends with an extension
* `CheckFileExists` - makes it unable to select a folder, see above
* `DefaultExt` - the extension to add by default
* `ValidateNames` - this one is a red flag, the WPF documentation says "indicating whether the dialog box accepts only valid Win32 file names." which is how the `OFN_NOVALIDATE` flag [works](https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea) in the legacy file dialogs. However, for the Vista dialogs, the `FOS_NOVALIDATE` flag [means](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions) "check for situations that would prevent an application from opening the selected file, such as sharing violations or access denied errors."). In addition to the dialog behavior, WPF uses the flag for adding extensions and prompting for overwriting existing files.

Note that `DefaultExt` with `AddExtensions` are already available for _open_ file dialog which doesn't make much sense, but they work the same when folders are selected.

Valid but currently without any effect:
* `CheckPathExists` - only existing folders are available for selection currently
* `RestoreDirectory` - applicable to legacy dialogs only, [not used](http://web.archive.org/web/20131017051601/http://msdn.microsoft.com/en-us/library/bb761832(VS.85).aspx) in Vista dialogs

Invalid (the native call returns an error):
* `Filter`
* `FilterIndex`

### Existing methods on folder dialog

* `OpenFile` and `OpenFiles` throw `UnauthorisedAccessException` on folders. The existing code should already expect this type of exception when opening files.

### Legacy behavior

The code currently throws `PlatformNotSupported` exception on Windows XP. If that is acceptable, exception message needs to be added. If not, support for `SHBrowseForFolder` API needs to be implemented, which carries non-trivial number of native types (or WinForms version called instead).

## Customer Impact

Without this fix, users have to either use WinForms' `FolderBrowserDialog`, resort to 3rd party libraries or re-implement the whole `IFileDialog` API. #438 is currently the top voted issue in the repository.

## Regression

No.

## Testing

Compiled custom _PresentationFramework.dll_ and tested in 6.0.2 x86 app that both folder browsing and file browsing works as expected.

## Risk

One public and one protected member are added. Existing behavior is not affected. Existing members (even private) still carry the same data. Minimal performance impact (most properties now change two fields) and minimal memory impact (one integer with corresponding generic type). 

User code that processes "used" file dialogs could now be handed an instance that unexpectedly contains folders in the `FileName(s)` properties. This, however, would have to be explicitly caused using new code. Unexpected file operations on folders (i.e. trying to open them) yield IO exceptions that the existing code should be already handling.

/cc @Symbai @ThomasGoulet73 @fabiant3 