### PR TITLE
Adds System.Windows.DataObject.GetData overload taking an index

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -202,6 +202,37 @@ namespace System.Windows
         /// <summary>
         /// Retrieves the data associated with the specified data
         /// format, using an automated conversion parameter to determine whether to convert
+        /// the data to the format and an index to specify the desired view of the data.
+        /// </summary>
+        public object GetData(string format, bool autoConvert, int index)
+        {
+            if (format == null)
+            {
+                throw new ArgumentNullException("format");
+            }
+
+            if (format == string.Empty)
+            {
+                throw new ArgumentException(SR.Get(SRID.DataObject_EmptyFormatNotAllowed));
+            }
+
+            if (_innerData is OleConverter converter)
+            {
+                return converter.GetData(format, autoConvert, index);
+            }
+
+            if (_innerData is DataStore store)
+            {
+                return store.GetData(format, autoConvert, index);
+            }
+
+            // This should be unreachable (constructor ensures one of the above)
+            return _innerData.GetData(format, autoConvert);
+        }
+
+        /// <summary>
+        /// Retrieves the data associated with the specified data
+        /// format, using an automated conversion parameter to determine whether to convert
         /// the data to the format.
         /// </summary>
         public object GetData(string format, bool autoConvert)
@@ -2507,9 +2538,14 @@ namespace System.Windows
                 return GetData(format.FullName);
             }
 
+            public Object GetData(string format, bool autoConvert, int index)
+            {
+                return GetData(format, autoConvert, DVASPECT.DVASPECT_CONTENT, index);
+            }
+
             public Object GetData(string format, bool autoConvert)
             {
-                return GetData(format, autoConvert, DVASPECT.DVASPECT_CONTENT, -1);
+                return GetData(format, autoConvert, -1);
             }
 
             public bool GetDataPresent(string format)
@@ -3408,7 +3444,12 @@ namespace System.Windows
 
             public Object GetData(string format, bool autoConvert)
             {
-                return GetData(format, autoConvert, DVASPECT.DVASPECT_CONTENT, -1);
+                return GetData(format, autoConvert, -1);
+            }
+
+            public Object GetData(string format, bool autoConvert, int index)
+            {
+                return GetData(format, autoConvert, DVASPECT.DVASPECT_CONTENT, index);
             }
 
             public bool GetDataPresent(string format)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -492,6 +492,7 @@ namespace System.Windows
         public System.IO.Stream GetAudioStream() { throw null; }
         public object GetData(string format) { throw null; }
         public object GetData(string format, bool autoConvert) { throw null; }
+        public object GetData(string format, bool autoConvert, int index) { throw null; }
         public object GetData(System.Type format) { throw null; }
         public bool GetDataPresent(string format) { throw null; }
         public bool GetDataPresent(string format, bool autoConvert) { throw null; }


### PR DESCRIPTION
Fixes #6352

## Description

Applications are unable to access multiple aspects/views of `IDataObject` (for example, when multiple files are pasted or dropped not from a file system).

The functionality already exists internally. This PR makes it accessible via a public API by adding an overload that accepts a value for `FORMATETC.lindex`.

Unfortunately the functionality is only made available on `System.Windows.DataObject` since `IDataObject` is public and introducing a new member would break existing implementations.

An equivalent `SetData` update should be considered.

## Customer Impact

Customers are unable to get data from drop operations or clipboard when `FileContents` format contains multiple files without rewriting the whole `IDataObject` stack.

## Regression

No.

## Testing

Built an updated _PresentationCore.dll_ and tested in 6.0.2 x86 app by dragging and dropping multiple attachments from Outlook onto a WPF window.

## Risk

Adding one new public overload of an existing method. If `DataObject` ever supports any other sources other than `OleConverter` and `DataStore`, the new `GetData` overload would need to be updated. Existing behavior not affected. 