### PR TITLE
DynamicResource support for app resource changes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1702,7 +1702,11 @@ namespace System.Windows
             // modifying the collection while we iterate over it
             InvalidateResourceReferenceOnWindowCollection(WindowsInternal.Clone(), info);
             InvalidateResourceReferenceOnWindowCollection(NonAppWindowsInternal.Clone(), info);
+            
+            ResourcesChanged?.Invoke(this, new ResourcesChangedEventArgs(info));
         }
+
+        internal event EventHandler ResourcesChanged;
 
         // Creates and returns a NavigationWindow for standalone cases
         // For browser hosted cases, returns the existing RootBrowserWindow which

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceExpression.cs
@@ -153,6 +153,14 @@ namespace System.Windows
                                                                         false, // disableThrowOnResourceFailure
                                                                         true,  // allowDeferredResourceReference
                                                                         false  /* mustReturnDeferredResourceReference*/);
+
+                // If there is no mentor, changes to the App and Theme resources will not propagate
+                // to the target object, and we need to subscribe to notifications directly.
+                Application app = Application.Current;
+                if (app != null)
+                {
+                    app.ResourcesChanged += new EventHandler(InvalidateExpressionValue);
+                }
             }
 
             if (resource == null)
@@ -327,6 +335,14 @@ namespace System.Windows
 
                     // Drop the mentor cache
                     _mentorCache = null;
+                }
+                else
+                {
+                    Application app = Application.Current;
+                    if (app != null)
+                    {
+                        app.ResourcesChanged -= new EventHandler(InvalidateExpressionValue);
+                    }
                 }
 
                 // Mark the cache invalid


### PR DESCRIPTION
Fixes #6302

## Description

Changes in application resources are not picked up by `DynamicResource` extension if the target object is not in the visual tree (i.e. has no mentor). It already has code to access App/System resources in the absence of mentor which suggests this was meant to be a supported scenario.

This PR introduces internal `ResourcesChanged` instance event on the `Application` object and subscribes the `ResourceReferenceExpression` to the changes when the target element does not have a mentor.

## Customer Impact

`DynamicResource` extension on `DependencyObject`s such as `DataGridColumn`s or other user types will not track the changes to the application resources. However, the extension reads them correct the first time, making this issue difficult to diagnose.

## Regression

No.

## Testing

Built an updated _PresentationFramework.dll_ and tested with the repro project in #6302 on 6.0.2 x86 app.

## Risk

No changes to public API. No changes to behavior when the resource does not come from App/System resources, or when the target object has a mentor. At runtime, each instance of `ResourceReferenceExpression` will create a strong reference to the Application instance, but only in the affected case.