### PR TITLE
PickFolders option for OpenFileDialog (minimal)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -1792,6 +1792,19 @@ namespace Microsoft.Win32
             // Force no mini mode for the SaveFileDialog.
             // Only accept physically backed locations.
             FOS options = ((FOS)Options & c_VistaFileDialogMask) | FOS.DEFAULTNOMINIMODE | FOS.FORCEFILESYSTEM;
+
+            // FILEMUSTEXIST is set by default in OpenFileDialog.
+            // While the combination of PICKFOLDERS and FILEMUSTEXIST is valid,
+            // it currently does not let users select anything in the dialog.
+            // We therefore disable FILEMUSTEXIST for folder selection.
+            // This needs to be persisted in the options, because ProcessFileNames
+            // and PromptUserIfAppropriate check it when user presses OK.
+            if (GetOption(OPTION_PICKFOLDERS))
+            {
+                options |= FOS.PICKFOLDERS;
+                SetOption(NativeMethods.OFN_FILEMUSTEXIST, false);
+            }
+
             dialog.SetOptions(options);
 
             COMDLG_FILTERSPEC[] filterItems = GetFilterItems(Filter);
@@ -1981,6 +1994,10 @@ namespace Microsoft.Win32
         // OPTION_ADDEXTENSION is our own bit flag that we use to control our
         // own automatic extension appending feature.
         private const int OPTION_ADDEXTENSION = unchecked(unchecked((int)0x80000000));
+
+        // OPTION_PICKFOLDERS is our own bit flag to specify FOS_PICKFOLDERS
+        // which otherwise conflicts with OFN_ENABLEHOOK
+        internal const int OPTION_PICKFOLDERS = unchecked(unchecked((int)0x08000000));
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
@@ -193,6 +193,25 @@ namespace Microsoft.Win32
             }
         }
 
+        //  OPTIONS_PICKFOLDERS
+        //  Causes the Vista dialog to allow picking a folder only.
+        //  This option disables OFN_FILEMUSTEXIST when the dialog is prepared.
+        //
+        /// <summary>
+        ///  Gets or sets whether the dialog box allows to pick a folder.
+        /// </summary>
+        public bool PickFolders
+        {
+            get
+            {
+                return GetOption(OPTION_PICKFOLDERS);
+            }
+            set
+            {
+                SetOption(OPTION_PICKFOLDERS, value);
+            }
+        }
+
         //  OFN_READONLY
         //  Causes the Read Only check box to be selected initially 
         //  when the dialog box is created. This flag indicates the 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Win32
     {
         public OpenFileDialog() { }
         public bool Multiselect { get { throw null; } set { } }
+        public bool PickFolders { get { throw null; } set { } }
         public bool ReadOnlyChecked { get { throw null; } set { } }
         public bool ShowReadOnly { get { throw null; } set { } }
         protected override void CheckPermissionsToShowDialog() { }


### PR DESCRIPTION
For discussion. Fixes #438. Further discussion in #4039. Previous attempt: #6351

## Description

Allows developers to ask the user to select a folder, a feature known as `FolderBrowserDialog` in WinForms.

This PR is the minimal code changes needed to introduce the feature. It closely reflects the underlying API design, i.e. the ability to specify `FOS_PICKFOLDERS` on the `IOpenFileDialog`. This is a backwards compatible solution - no public API has been moved or removed and no existing behavior has changed.

A custom option `OPTION_PICKFOLDERS` is introduced that sets `FOS_PICKFOLDERS` and clears `OFN_FILEMUSTEXIST` when the dialog is prepared.

### New visible members

In `OpenFileDialog`:
* `public bool PickFolders { get; set; }`

### Legacy behavior

Legacy code path (pre-Vista) ignores the flag and shows standard file open dialog.

## Customer Impact

Without this fix, users have to either use WinForms' `FolderBrowserDialog`, resort to 3rd party libraries or re-implement the whole `IFileDialog` API. #438 is currently the top voted issue in the repository.

## Regression

No.

## Testing

Compiled custom _PresentationFramework.dll_ and tested in 6.0.2 x86 app that both folder browsing and file browsing works as expected.

## Risk

Low - existing behavior not affected, minimal code changes. Setting `Filter` on a dialog with `PickFolders` will throw `COMException` on `ShowDialog()`.

The bit used by `OPTION_PICKFOLDERS` is currently unused in both legacy and `IOpenFileDialog` API, but it might get allocated in the future. This would however not break this feature as the bits are masked out (same happened in the past with `OPTION_ADDEXTENSION`).

User code that processes "used" file dialogs could now be handed an instance that unexpectedly contains folders in the `FileName(s)` properties. This, however, would have to be explicitly caused using new code. Unexpected file operations on folders (i.e. trying to open them) yield IO exceptions that the existing code should be already handling.

/cc @ThomasGoulet73 @batzen