### PR TITLE
Remove closure/delegate allocation in ItemContainerGenerator

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemsControl.cs
@@ -3690,9 +3690,8 @@ namespace System.Windows.Controls
                             // otherwise see if an unclaimed container matches the item
                             object item = info.Item;
                             ItemContainerGenerator.FindItem(
-                                delegate(object o, DependencyObject d)
-                                    { return ItemsControl.EqualsEx(o, item) &&
-                                        !claimedContainers.Contains(d); },
+                                static (state, o, d) => ItemsControl.EqualsEx(o, state.item) && !state.claimedContainers.Contains(d),
+                                (item, claimedContainers),
                                 out container, out index);
                         }
 


### PR DESCRIPTION
## Description

Calls to ItemContainerGenerator.DoLinearSearch are capturing locals to use for comparison, resulting in closure/delegate allocations on each call.  We can instead pass the extra state through as a state argument.

## Customer Impact

Unnecessary allocation/overhead.

## Regression

No

## Testing

CI

## Risk

Minimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6396)