### PR TITLE
Use Dictionary instead of Hashtable in WeakEventTable

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
@@ -108,7 +108,11 @@ namespace MS.Internal
         /// </summary>
         internal WeakEventManager this[Type managerType]
         {
-            get { return (WeakEventManager)_managerTable[managerType]; }
+            get
+            {
+                _managerTable.TryGetValue(managerType, out WeakEventManager result);
+                return result;
+            }
             set { _managerTable[managerType] = value; }
         }
 
@@ -120,7 +124,8 @@ namespace MS.Internal
             get
             {
                 EventNameKey key = new EventNameKey(eventSourceType, eventName);
-                return (WeakEventManager)_eventNameTable[key];
+                _eventNameTable.TryGetValue(key, out WeakEventManager result);
+                return result;
             }
 
             set
@@ -138,7 +143,7 @@ namespace MS.Internal
             get
             {
                 EventKey key = new EventKey(manager, source);
-                object result = _dataTable[key];
+                _dataTable.TryGetValue(key, out object result);
                 return result;
             }
 
@@ -297,7 +302,7 @@ namespace MS.Internal
                 {
                     // copy the keys into a separate array, so that later on
                     // we can change the table while iterating over the keys
-                    ICollection ic = _dataTable.Keys;
+                    ICollection<EventKey> ic = _dataTable.Keys;
                     EventKey[] keys = new EventKey[ic.Count];
                     ic.CopyTo(keys, 0);
 
@@ -331,14 +336,11 @@ namespace MS.Internal
                     Debug.Assert(_toRemove.Count == 0, "to-remove list should be empty");
                     _inPurge = true;
 
-                    // enumerate the dictionary using IDE explicitly rather than
-                    // foreach, to avoid allocating temporary DictionaryEntry objects
-                    IDictionaryEnumerator ide = _dataTable.GetEnumerator() as IDictionaryEnumerator;
-                    while (ide.MoveNext())
+                    foreach (KeyValuePair<EventKey, object> kvp in _dataTable)
                     {
-                        EventKey key = (EventKey)ide.Key;
+                        EventKey key = kvp.Key;
                         object source = key.Source;
-                        foundDirt |= key.Manager.PurgeInternal(source, ide.Value, purgeAll);
+                        foundDirt |= key.Manager.PurgeInternal(source, kvp.Value, purgeAll);
 
                         // if source has been GC'd, remove its data
                         if (!purgeAll && source == null)
@@ -347,9 +349,6 @@ namespace MS.Internal
                         }
                     }
 
-#if WeakEventTelemetry
-                    LogAllocation(ide.GetType(), 1, 36);                    // Hashtable+HashtableEnumerator
-#endif
                     _inPurge = false;
                 }
 
@@ -449,9 +448,9 @@ namespace MS.Internal
         //  Private Fields
         //
 
-        private Hashtable _managerTable = new Hashtable();  // maps manager type -> instance
-        private Hashtable _dataTable = new Hashtable();     // maps EventKey -> data
-        private Hashtable _eventNameTable = new Hashtable(); // maps <Type,name> -> manager
+        private Dictionary<Type, WeakEventManager> _managerTable = new Dictionary<Type, WeakEventManager>();                   // maps manager type -> instance
+        private Dictionary<EventKey, object> _dataTable = new Dictionary<EventKey, object>();                                  // maps EventKey -> data
+        private Dictionary<EventNameKey, WeakEventManager> _eventNameTable = new Dictionary<EventNameKey, WeakEventManager>(); // maps <Type,name> -> manager
 
         ReaderWriterLockWrapper     _lock = new ReaderWriterLockWrapper();
         private int                 _cleanupRequests;


### PR DESCRIPTION
## Description

It's currently using a Hashtable with struct keys (except the _managerTable, but better to change all of them), which means every operation on the Hashtable boxes the struct. Switching to a Dictionary removes those costs.
The Hashtable indexer returns null when key not exists, so in this case TryGetValue should be used on the Dictionary object.

## Customer Impact

Less unnecessary boxing means less pauses due to GC.

## Regression

No

## Testing

Just CI

## Risk

Similar as in #4731
