### PR TITLE
Enable stage1 source index

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -7,6 +7,7 @@ parameters:
   binlogPath: artifacts/log/Debug/Build.binlog
   condition: ''
   dependsOn: ''
+  pool: ''
 
 jobs:
 - job: SourceIndexStage1
@@ -22,13 +23,17 @@ jobs:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: source-dot-net stage1 variables
 
-  pool:
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
-    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+  ${{ if ne(parameters.pool, '') }}:
+    pool: ${{ parameters.pool }}
+  ${{ if eq(parameters.pool, '') }}:
+    pool:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+
   steps:
   - ${{ each preStep in parameters.preSteps }}:
     - ${{ preStep }}

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -24,6 +24,17 @@ jobs:
     enablePublishBuildAssets: true
     enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
+    enableSourceIndex: true
+    sourceIndexParams:
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+      binlogPath: artifacts/log/Debug/x86/Build.binlog
+      pool:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
     helixRepo: $(repoName)
 
     jobs:


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/discussions/6410

## Description

Wpf isn't showing up on source.dot.net due to a dependency on preview features. This enables the source index "stage1" processing to solve this issue without forcing the preview features on the entire index build.

The changes to eng/common are contained in the next arcade update, but I am including them here so this change works.

## Customer Impact

source.dot.net won't have wpf sources on it.

## Regression

no

## Testing

https://dev.azure.com/dnceng/internal/_build/results?buildId=1727210&view=results

## Risk

Minimal, this job is separate from the parts of the build that build the project.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6484)