### PR TITLE
Avoid Hashtable-related allocations in AccessorTable

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingOperations.cs
@@ -491,6 +491,7 @@ namespace System.Windows.Data
         }
 
         // Print various interesting statistics
+        [Conditional("DEBUG")]
         internal static void PrintStats()
         {
             DataBindEngine.CurrentDataBindEngine.AccessorTable.PrintStats();


### PR DESCRIPTION
## Description

Use a strongly-typed Dictionary instead.

- The key is a struct.  Every time an item is added to the table or a lookup into the table is performed, the key is getting boxed. Using Dictionary avoids all this boxing.
- The struct key lacks a strongly-typed Equals.  Every comparison results in a boxing.  Gave the key a strongly-typed Equals.
- Every cleanup operation is allocating an enumerator.  Dictionary has a struct-based enumerator.
- Every cleanup operation is allocating an array to store the items to be removed (even if there aren't any to be removed).  Dictionary supports removal during enumeration, so this can be removed entirely.

## Customer Impact

Unnecessary allocations

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6500)