### PR TITLE
Stop boxing WeakReferenceListEnumerator in PresentationSource use

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -654,11 +654,11 @@ namespace System.Windows
         ///   over a ReadOnly SnapShot of the List of sources.  The Enumerator
         ///   skips over the any dead weak references in the list.
         /// </summary>
-        internal static IEnumerable CriticalCurrentSources
+        internal static WeakReferenceList CriticalCurrentSources
         {
             get
             {
-                return (IEnumerable)_sources;
+                return _sources;
             }
         }
 


### PR DESCRIPTION
## Description

PresentationSource.CriticalCurrentSources is internal and is only ever foreach'd by consumers.  It's strongly-typed to return IEnumerable, but the actual WeakReferenceList it returns has a struct-based enumerator, which means each foreach boxes that enumerator.  By changing CriticalCurrentSources to return `WeakReferenceList` rather than `IEnumerable`, those foreach's can bind directly to the struct, with all the benefits that brings.

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6502)