### PR TITLE
Stop allocating unnecessary StringBuilders in ParsePropertyComments

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
@@ -103,7 +103,7 @@ namespace MS.Internal.Globalization
                         {
                             // terminate the PropertyName by an unesacped whitespace
                             currentPair.PropertyName = tokenBuffer.ToString();
-                            tokenBuffer = new StringBuilder();
+                            tokenBuffer.Clear();
                         }
 
                         // else ignore whitespace at the beginning of the PropertyName name
@@ -116,7 +116,7 @@ namespace MS.Internal.Globalization
                             {
                                 // terminate the PropertyName by an unescaped CommentStart char
                                 currentPair.PropertyName = tokenBuffer.ToString();
-                                tokenBuffer = new StringBuilder();
+                                tokenBuffer.Clear();
                                 i--; // put back this char and continue
                             }
                             else
@@ -161,9 +161,9 @@ namespace MS.Internal.Globalization
                             if (!escaped)
                             {
                                 // terminated by unescaped Comment
-                                currentPair.Value = tokenBuffer.ToString().Substring(1);
+                                currentPair.Value = tokenBuffer.ToString(1, tokenBuffer.Length - 1);
                                 tokens.Add(currentPair);
-                                tokenBuffer = new StringBuilder();
+                                tokenBuffer.Clear();
                                 currentPair = new PropertyComment();
                             }
                             else


### PR DESCRIPTION
## Description

When we already have a StringBuilder, just clear it rather than allocating a replacement.  Also don't ToString() only to then create a new string without the first character; use StringBuilder's ToString that takes an offset and length.

## Customer Impact

Unnecessary allocation.

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6508)