### PR TITLE
Avoid unnecessary StringBuilder reallocation in LookupAndSetLocalizabilityAttribute

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
@@ -228,7 +228,7 @@ namespace MS.Internal.Globalization
                             attributeGroup
                             );
 
-                        builder = new StringBuilder();
+                        builder.Clear();
                     }
                 }
                 else


### PR DESCRIPTION
## Description

Clear the StringBuilder rather than throwing it away and creating a new one.

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6509)