### PR TITLE
Avoid delegate allocation to call ListCollectionView.PrepareComparer

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
@@ -87,11 +87,11 @@ namespace MS.Internal.Data
                     ListCollectionView.PrepareComparer(
                         _groupBy.CustomSort,
                         _groupBy.SortDescriptionsInternal,
-                        () =>
+                        static state =>
                         {
-                            for (CollectionViewGroupInternal group = this;
-                                    group != null;
-                                    group = group.Parent)
+                            for (CollectionViewGroupInternal group = (CollectionViewGroupInternal)state;
+                                 group != null;
+                                 group = group.Parent)
                             {
                                 CollectionViewGroupRoot root = group as CollectionViewGroupRoot;
                                 if (root != null)
@@ -100,7 +100,7 @@ namespace MS.Internal.Data
                                 }
                             }
                             return null;    // this should never happen - root should always be present
-                        });
+                        }, this);
 
                 if (oldIsBottomLevel != IsBottomLevel)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -2447,7 +2447,7 @@ namespace System.Windows.Data
 
         // return an appropriate comparer.   Common logic used by ListCollectionView
         // and by CollectionViewGroupInternal.
-        internal static IComparer PrepareComparer(IComparer customSort, SortDescriptionCollection sort, Func<CollectionView> lazyGetCollectionView)
+        internal static IComparer PrepareComparer(IComparer customSort, SortDescriptionCollection sort, Func<object, CollectionView> lazyGetCollectionView, object state)
         {
             if (customSort != null)
             {
@@ -2456,7 +2456,7 @@ namespace System.Windows.Data
 
             if (sort != null && sort.Count > 0)
             {
-                CollectionView view = lazyGetCollectionView();
+                CollectionView view = lazyGetCollectionView(state);
                 Debug.Assert(view != null, "lazyGetCollectionView should not return null");
 
                 if (view.SourceCollection != null)
@@ -2895,7 +2895,7 @@ namespace System.Windows.Data
         private void PrepareShaping()
         {
             // sort:  prepare the comparer
-            ActiveComparer = ListCollectionView.PrepareComparer(_customSort, _sort, () => { return this; });
+            ActiveComparer = PrepareComparer(_customSort, _sort, static state => (ListCollectionView)state, this);
 
             // filter:  prepare the Predicate<object> filter
             ActiveFilter = Filter;


### PR DESCRIPTION
## Description

Pass the required state in as a state object to be passed on to the delegate invocation.

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6511)