### PR TITLE
Avoid unnecessary `List<>` wrapper in GetTextRunSpans

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FullTextLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FullTextLine.cs
@@ -2080,7 +2080,7 @@ namespace MS.Internal.TextFormatting
                     return Array.Empty<TextSpan<TextRun>>();
                 }
 
-                IList<TextSpan<TextRun>> lsrunList = new List<TextSpan<TextRun>>(2);
+                List<TextSpan<TextRun>> lsrunList = new List<TextSpan<TextRun>>(2);
 
                 TextRun lastTextRun = null;
                 int cchAcc = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextRunCacheImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextRunCacheImp.cs
@@ -329,13 +329,13 @@ namespace MS.Internal.TextFormatting
         /// </summary>
         internal IList<TextSpan<TextRun>> GetTextRunSpans()
         {
-            IList<TextSpan<TextRun>> textRunList = new List<TextSpan<TextRun>>(_textRunVector.Count);
+            TextSpan<TextRun>[] textRunList = new TextSpan<TextRun>[_textRunVector.Count];
 
-            for (int i = 0; i < _textRunVector.Count; i++)
+            for (int i = 0; i < textRunList.Length; i++)
             {
-                Span currentSpan = _textRunVector[i];                
-                textRunList.Add(new TextSpan<TextRun>(currentSpan.length, currentSpan.element as TextRun));
-            }            
+                Span currentSpan = _textRunVector[i];
+                textRunList[i] = new TextSpan<TextRun>(currentSpan.length, currentSpan.element as TextRun);
+            }
 
             return textRunList;
         }


### PR DESCRIPTION
## Description

We know exactly how big the resulting list needs to be.  As is done in other variants of this method, just allocate the array to be used as an IList.  Also in one place where we do continue using a `List<T>`, strongly-type the local as such to avoid unnecessarily going through the interface.

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal.  Other implementations already return arrays, so callers can't be expecting it'll always be a `List<>`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6516)