### PR TITLE
Avoid unnecessary `Collection<T>` wrapper in CombineSources

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -2464,7 +2464,7 @@ namespace System.Windows.Data
                 count++;
             }
 
-            Collection<WeakDependencySource> tempList = new Collection<WeakDependencySource>();
+            var tempList = new List<WeakDependencySource>();
 
             if (commonSources != null)
             {
@@ -2502,19 +2502,9 @@ namespace System.Windows.Data
                 }
             }
 
-            WeakDependencySource[] result;
-            if (tempList.Count > 0)
-            {
-                result = new WeakDependencySource[tempList.Count];
-                tempList.CopyTo(result, 0);
-                tempList.Clear();
-            }
-            else
-            {
-                result = null;
-            }
-
-            return result;
+            return result = tempList.Count > 0 ?
+                tempList.ToArray() :
+                null;
         }
 
         internal void ResolvePropertyDefaultSettings(BindingMode mode, UpdateSourceTrigger updateTrigger, FrameworkPropertyMetadata fwMetaData)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingExpressionBase.cs
@@ -2502,7 +2502,7 @@ namespace System.Windows.Data
                 }
             }
 
-            return result = tempList.Count > 0 ?
+            return tempList.Count > 0 ?
                 tempList.ToArray() :
                 null;
         }


### PR DESCRIPTION
## Description

The temporary list is just being used locally.  There's no reason to allocate and go through an extra level of indirection.

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6517)