### PR TITLE
[DevDiv VSO: 1425279] WPF should ignore transitory/ignorable DWM error

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/rendertargetmanager.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/uce/rendertargetmanager.h
@@ -153,6 +153,8 @@ private:
         __in              QPC_TIME qpcCurrentTime
         );
 
+    bool ShouldIgnoreDwmFlushErrors();
+
 private:
     // The owning compositor. Note that we do not add-ref it 
     // to avoid cyclical dependencies.


### PR DESCRIPTION

Fixes #5688
[DevDiv VSO: 1425279] WPF should ignore transitory/ignorable DWM error

Main PR <!-- Link to PR if any that fixed this in the main branch. -->
None
## Description
[DevDiv VSO: 1425279] WPF should ignore transitory/ignorable DWM error code (STATUS_MESSAGE_LOST) from DwmFlush

An app can opt-in to the behavior of ignoring all DwmFlush errors by setting a regkey in
HKCU\Software\Microsoft\Avalon.Graphics\IgnoreDwmFlushErrors
or
HKLM\Software\Microsoft\Avalon.Graphics\IgnoreDwmFlushErrors
whose name is the full path to the .exe that wants to opt-in, and whose DWORD value is 1.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Tested on .NET framework and Core both with internal test passes.
<!-- What kind of testing has been done with the fix. -->

## Risk
None
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
