### PR TITLE
Reuse bool box objects in UncommonField<bool>.SetValue

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using MS.Internal.KnownBoxes;
 using MS.Internal.WindowsBase;  // for FriendAccessAllowed
 
 namespace System.Windows
@@ -56,8 +57,8 @@ namespace System.Windows
 
                     if (typeof(T) == typeof(bool))
                     {
-                        // There are only two possible values. Use shared boxed instances rather than creating new objects for each SetValue call.
-                        valueObject = Unsafe.As<T, bool>(ref value) ? (s_true ??= true) : (s_false ??= false);
+                        // Use shared boxed instances rather than creating new objects for each SetValue call.
+                        valueObject = BooleanBoxes.Box(Unsafe.As<T, bool>(ref value));
                     }
                     else
                     {
@@ -145,11 +146,6 @@ namespace System.Windows
         private T _defaultValue;
         private int _globalIndex;
         private bool _hasBeenSet;
-
-        /// <summary>A lazily boxed false value.</summary>
-        private static object s_false;
-        /// <summary>A lazily boxed true value.</summary>
-        private static object s_true;
 
         #endregion
     }


### PR DESCRIPTION
## Description

In some scenarios, these UncommonField<bool>s end up being set very frequently, and each time the value being passed in gets boxed.  We can avoid that by caching and reusing a box for each of the only two possible values (though it looks like the default value is almost always false and so it mainly only boxes true).

## Customer Impact

Unnecessary allocation

## Regression

No

## Testing

CI

## Risk

Minimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6528)