### PR TITLE
Avoid unnecessary duplication of fields in NullableBooleanBoxes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ToolTipService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ToolTipService.cs
@@ -544,7 +544,7 @@ namespace System.Windows.Controls
             DependencyProperty.RegisterAttached("ShowsToolTipOnKeyboardFocus",     // Name
                                                 typeof(bool?),          // Type
                                                 typeof(ToolTipService), // Owner
-                                                new FrameworkPropertyMetadata(NullableBooleanBoxes.NullBox));   // Default Value
+                                                new FrameworkPropertyMetadata(null));   // Default Value
 
         /// <summary>
         ///     Gets the value of the ShowsToolTipOnKeyboardFocus property.
@@ -573,7 +573,7 @@ namespace System.Windows.Controls
             {
                 throw new ArgumentNullException("element");
             }
-            element.SetValue(ShowsToolTipOnKeyboardFocusProperty, NullableBooleanBoxes.Box(value));
+            element.SetValue(ShowsToolTipOnKeyboardFocusProperty, BooleanBoxes.Box(value));
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/tooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/tooltip.cs
@@ -354,7 +354,7 @@ namespace System.Windows.Controls
         public bool? ShowsToolTipOnKeyboardFocus
         {
             get { return (bool?)GetValue(ShowsToolTipOnKeyboardFocusProperty); }
-            set { SetValue(ShowsToolTipOnKeyboardFocusProperty, NullableBooleanBoxes.Box(value)); }
+            set { SetValue(ShowsToolTipOnKeyboardFocusProperty, BooleanBoxes.Box(value)); }
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/KnownBoxes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/KnownBoxes.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using MS.Internal.WindowsBase;
 
 namespace MS.Internal.KnownBoxes
@@ -10,46 +9,18 @@ namespace MS.Internal.KnownBoxes
     [FriendAccessAllowed] // Built into Base, also used by Core and Framework.
     internal static class BooleanBoxes
     {
-        internal static object TrueBox = true;
-        internal static object FalseBox = false;
+        internal static readonly object TrueBox = true;
+        internal static readonly object FalseBox = false;
 
-        internal static object Box(bool value)
-        {
-            if (value)
-            {
-                return TrueBox;
-            }
-            else
-            {
-                return FalseBox;
-            }
-        }
-    }
+        internal static object Box(bool value) =>
+            value ? TrueBox : FalseBox;
 
-    [FriendAccessAllowed] // Built into Base, also used by Core and Framework.
-    internal static class NullableBooleanBoxes
-    {
-        internal static object TrueBox = (bool?)true;
-        internal static object FalseBox = (bool?)false;
-        internal static object NullBox = (bool?)null;
-
-        internal static object Box(bool? value)
-        {
-            if (value.HasValue)
+        internal static object Box(bool? value) =>
+            value switch
             {
-                if (value == true)
-                {
-                    return TrueBox;
-                }
-                else
-                {
-                    return FalseBox;
-                }
-            }
-            else
-            {
-                return NullBox;
-            }
-        }
+                true => TrueBox,
+                false => FalseBox,
+                null => null,
+            };
     }
 }


### PR DESCRIPTION
## Description

A boxed boolean doesn't know whether it came from a nullable bool or a bool, so there's no need to maintain separate True/FalseBox objects for bool? vs bool, nor do we need to store a NullBox... that field will just be null.

## Customer Impact

Nothing measurable.  This is just unnecessary duplication.

## Regression

No

## Testing

CI

## Risk

Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6529)