### PR TITLE
Fix build when using source generators

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -441,6 +441,7 @@
                 MSBuildBinPath="$(MSBuildBinPath)"
                 ReferencePathTypeName="ReferencePath"
                 CompileTypeName="Compile"
+                AnalyzerTypeName="Analyzer"
                 GeneratedCodeFiles="@(_GeneratedCodeFiles)"
                 ReferencePath="@(ReferencePath)"
                 BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
@@ -449,7 +450,7 @@
                 CompileTargetName="$(_CompileTargetNameForLocalType)"
                 GenerateTemporaryTargetAssemblyDebuggingInformation="$(GenerateTemporaryTargetAssemblyDebuggingInformation)"
                 IncludePackageReferencesDuringMarkupCompilation="$(IncludePackageReferencesDuringMarkupCompilation)"
-                Analyzers="$(Analyzers)"
+                Analyzers="@(Analyzer)"
                 TemporaryTargetAssemblyProjectName="$(_TemporaryTargetAssemblyProjectName)"
                 MSBuildProjectExtensionsPath="$(MSBuildProjectExtensionsPath)"
                  >

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -263,6 +263,9 @@ namespace Microsoft.Build.Tasks.Windows
                 // Add GeneratedCodeFiles to Compile item list.
                 AddNewItems(xmlProjectDoc, CompileTypeName, GeneratedCodeFiles);
 
+                // Add Analyzers to Analyzer item list.
+                AddNewItems(xmlProjectDoc, AnalyzerTypeName, Analyzers);
+
                 // Replace implicit SDK imports with explicit SDK imports
                 ReplaceImplicitImports(xmlProjectDoc); 
 
@@ -274,7 +277,6 @@ namespace Microsoft.Build.Tasks.Windows
                     ( nameof(BaseIntermediateOutputPath), BaseIntermediateOutputPath ),
                     ( nameof(MSBuildProjectExtensionsPath), MSBuildProjectExtensionsPath ),
                     ( "_TargetAssemblyProjectName", Path.GetFileNameWithoutExtension(CurrentProject) ),
-                    ( nameof(Analyzers), Analyzers )
                 };
 
                 AddNewProperties(xmlProjectDoc, properties);
@@ -481,8 +483,19 @@ namespace Microsoft.Build.Tasks.Windows
         /// Required for Source Generator support. May be null.
         /// 
         /// </summary>
-        public string Analyzers 
+        public ITaskItem[] Analyzers 
         { get; set; }
+
+        /// <summary>
+        /// AnalyzerTypeName
+        ///   The appropriate item name which can be accepted by managed compiler task.
+        ///   It is "Analyzer" for now.
+        ///   
+        ///   Adding this property is to make the type name configurable, if it is changed, 
+        ///   No code is required to change in this task, but set a new type name in project file.
+        /// </summary>
+        [Required]
+        public string AnalyzerTypeName { get; set; }
 
         /// <summary>
         /// BaseIntermediateOutputPath


### PR DESCRIPTION
Fixes dotnet/wpf#6522
Fixes https://github.com/dotnet/roslyn/issues/60257

## Description
Fixes the build when using source generators.

## Customer Impact
Without this PR, customers cannot build a WPF application with source generators.

## Regression
No. To my knowledge, it never worked.

## Testing
Tested by building a blank WPF application that uses the Regex source generator. This PR fixed the build.

## Risk
Low.

/cc @RussKie (It looks like your hunch about the `Analyzers` property was right)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6534)