### PR TITLE
Fix build when using Razor source generator

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -454,6 +454,7 @@
                 Analyzers="@(Analyzer)"
                 TemporaryTargetAssemblyProjectName="$(_TemporaryTargetAssemblyProjectName)"
                 MSBuildProjectExtensionsPath="$(MSBuildProjectExtensionsPath)"
+                RootNamespace="$(RootNamespace)"
                  >
 
           <Output TaskParameter="TemporaryAssemblyForLocalTypeReference" PropertyName="_AssemblyForLocalTypeReference" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -277,6 +277,7 @@ namespace Microsoft.Build.Tasks.Windows
                     ( nameof(BaseIntermediateOutputPath), BaseIntermediateOutputPath ),
                     ( nameof(MSBuildProjectExtensionsPath), MSBuildProjectExtensionsPath ),
                     ( "_TargetAssemblyProjectName", Path.GetFileNameWithoutExtension(CurrentProject) ),
+                    ( nameof(RootNamespace), RootNamespace ),
                 };
 
                 AddNewProperties(xmlProjectDoc, properties);
@@ -496,6 +497,14 @@ namespace Microsoft.Build.Tasks.Windows
         /// </summary>
         [Required]
         public string AnalyzerTypeName { get; set; }
+
+        /// <summary>
+        /// RootNamespace 
+        /// 
+        /// Required for Source Generator support. May be null.
+        /// 
+        /// </summary>
+        public string RootNamespace { get; set; }
 
         /// <summary>
         /// BaseIntermediateOutputPath


### PR DESCRIPTION
Fixes dotnet/wpf#4421
Fixes dotnet/wpf#5697

## Description
Fixes build when using Razor source generator by adding RootNamespace to the list of property added to the generated project.

Without this PR, the Razor source generator would generate files in the wrong namespace (`WpfBlazorRepro_5s0cnboz_wpftmp ` instead of `WpfBlazorRepro`).

Fixes incremental build where the RootNamespace is changing on each build and therefore is recognized as a fresh build (Not incremental).

## Customer Impact
Without this PR, customers cannot build a WPF application with the Razor source generator (Maybe others?).

## Regression
No. To my knowledge, it never worked.

## Testing
Tested by building the repro project in the issue (https://github.com/Eilon/WPFXamlRazorGeneratorBug). This PR fixed the build.

Tested the repro here: https://github.com/dotnet/wpf/issues/5697#issuecomment-1458411584. This PR makes the repro build incrementally.

## Risk
Low.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6535)