### PR TITLE
GridSplitter should not exclusively rely on its logical parent

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridSplitter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridSplitter.cs
@@ -490,7 +490,7 @@ namespace System.Windows.Controls
         // Initialize the data needed for resizing
         private void InitializeData(bool ShowsPreview)
         {
-            Grid grid = VisualTreeHelper.GetParent(this) as Grid;
+            Grid grid = FindParentGrid();
 
             // If not in a grid or can't resize, do nothing
             if (grid != null)
@@ -729,13 +729,13 @@ namespace System.Windows.Controls
                     break;
             }
         }
+        
+        private Grid FindParentGrid() => Parent as Grid ?? VisualTreeHelper.GetParent(this) as Grid;
 
         // Cancels the Resize when the user hits Escape
         private void CancelResize()
         {
             // Restore original column/row lengths
-            Grid grid = VisualTreeHelper.GetParent(this) as Grid;
-
             if (_resizeData.ShowsPreview)
             {
                 RemovePreviewAdorner();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridSplitter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridSplitter.cs
@@ -490,7 +490,7 @@ namespace System.Windows.Controls
         // Initialize the data needed for resizing
         private void InitializeData(bool ShowsPreview)
         {
-            Grid grid = Parent as Grid;
+            Grid grid = VisualTreeHelper.GetParent(this) as Grid;
 
             // If not in a grid or can't resize, do nothing
             if (grid != null)
@@ -734,7 +734,7 @@ namespace System.Windows.Controls
         private void CancelResize()
         {
             // Restore original column/row lengths
-            Grid grid = Parent as Grid;
+            Grid grid = VisualTreeHelper.GetParent(this) as Grid;
 
             if (_resizeData.ShowsPreview)
             {


### PR DESCRIPTION
`GridSplitter` should rely on its `VisualParent` not it's `LogicalParent`

Fixes #6490

## Description
`GridSplitter` needs to interact with it's parent, this however should not exclusively be the LogicalParent.

## Customer Impact

GridSplitters do not work in `IsItemsHost` scenarios.


## Testing

I copied the modified code since I havent managed to build WPF yet.

## Risk

I dont think it is possible to use a `ControlTemplate` for a `Grid`, so `VisualParent` should generally be the more suitable solution

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6550)