### PR TITLE
optimistic TrackValue check, supporting not anymore connected columns

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -6886,17 +6886,20 @@ namespace System.Windows.Controls
                     if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
                     {
                         DataGridColumn column = (_cell != null) ? _cell.Column : _column;
-                        DataGridAutomationPeer peer = DataGridAutomationPeer.FromElement(column.DataGridOwner) as DataGridAutomationPeer;
-                        if (peer != null)
+                        if (column.DataGridOwner != null)
                         {
-                            object item = (_cell != null) ? _cell.DataContext : _item;
-                            DataGridItemAutomationPeer dataGridItemAutomationPeer = peer.FindOrCreateItemAutomationPeer(item) as DataGridItemAutomationPeer;
-                            if (dataGridItemAutomationPeer != null)
+                            DataGridAutomationPeer peer = DataGridAutomationPeer.FromElement(column.DataGridOwner) as DataGridAutomationPeer;
+                            if (peer != null)
                             {
-                                DataGridCellItemAutomationPeer cellPeer = dataGridItemAutomationPeer.GetOrCreateCellItemPeer(column);
-                                if (cellPeer != null)
+                                object item = (_cell != null) ? _cell.DataContext : _item;
+                                DataGridItemAutomationPeer dataGridItemAutomationPeer = peer.FindOrCreateItemAutomationPeer(item) as DataGridItemAutomationPeer;
+                                if (dataGridItemAutomationPeer != null)
                                 {
-                                    cellPeer.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, _value, newValue);
+                                    DataGridCellItemAutomationPeer cellPeer = dataGridItemAutomationPeer.GetOrCreateCellItemPeer(column);
+                                    if (cellPeer != null)
+                                    {
+                                        cellPeer.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, _value, newValue);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## User Story
I had an issue where I manipulated the `Columns` property of a DataGrid by removing a column. This resulted in a null-reference issue because the `TrackValue` method of the internal class `CellAutomationValueHolder` references to `column.DataGridOwner` which was not set anymore for the DataGridColumn since it was removed.

This is not a default (and maybe not wanted) behavior, but I think WPF should use here an optimistic check.

## Description
Adding a optimistic check by ignoring all `TrackValue` calls where the `DataGridOwner` property of the column is not set.


## Customer Impact

Might throw a null-reference-exception from `System.Windows.Automation.Peers.UIElementAutomationPeer.FromElement(UIElement element)` which is called within the `CellAutomationValueHolder.TrackValue` method.


## Testing

CI

## Risk

None

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6553)