### PR TITLE
[Port] Fixes rounding error while glyphrun serialization

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
@@ -64,6 +64,8 @@ namespace System.Windows.Media
             _advances = glyphRun.AdvanceWidths;
             _offsets = glyphRun.GlyphOffsets;
 
+            _advanceWidthRoundingError = 0.0;
+
             // "100,50,,0;".Length is a capacity estimate for an individual glyph
             _glyphStringBuider = new StringBuilder(10);
 
@@ -82,6 +84,8 @@ namespace System.Windows.Media
         /// </summary>
         public void ComputeContentStrings(out string characters, out string indices, out string caretStops)
         {
+            _advanceWidthRoundingError = 0.0;
+
             if (_clusters != null)
             {
                 // the algorithm works by finding (n:m) clusters and appending m glyphs for each cluster
@@ -184,7 +188,9 @@ namespace System.Windows.Media
             _glyphStringBuider.Append(GlyphSubEntrySeparator);
 
             // advance width
-            int normalizedAdvance = (int)Math.Round(_advances[glyph] * _milToEm);
+            double unroundedAdvance = _advances[glyph] * _milToEm;
+            int normalizedAdvance = (int)Math.Round(unroundedAdvance + _advanceWidthRoundingError);
+            _advanceWidthRoundingError += (unroundedAdvance - (double)normalizedAdvance);
             double fontAdvance = _sideways ? _glyphTypeface.AdvanceHeights[fontIndex] : _glyphTypeface.AdvanceWidths[fontIndex];
             if (normalizedAdvance != (int)Math.Round(fontAdvance * EmScaleFactor))
             {
@@ -319,6 +325,8 @@ namespace System.Windows.Media
         private bool _sideways;
 
         private int _glyphClusterInitialOffset;
+
+        private double _advanceWidthRoundingError;
 
         private IList<ushort> _clusters;
 


### PR DESCRIPTION
Fixes # <!-- Issue Number --> #6525 
Port of PR #6295 

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
When we serialize a GlyphRun to an XPS file, the advance widths for each glyph are rounded to an integer separately, thus producing a significant difference between the rendered output in the file and on the screen. This PR fixes the rounding, by taking into account the cumulative rounding error from the previous glyphs while rounding the current glyph.

## Customer Impact
Affects the visual fidelity of WPF Applications.
<!-- What is the impact to customers of not taking this fix? -->

## Regression

No

## Testing

Ad-Hoc testing. Tried with different sample apps.

## Risk
Less
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
