### PR TITLE
Public the Menu Parameters set API

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -1018,6 +1018,14 @@ namespace System.Windows
                 }
                 return _menuDropAlignment;
             }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuDropAlignment] = true;
+                    _menuDropAlignment = value;
+                }
+            }
         }
 
         /// <summary>
@@ -1045,6 +1053,14 @@ namespace System.Windows
                 }
 
                 return _menuFade;
+            }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuFade] = true;
+                    _menuFade = value;
+                }
             }
         }
 
@@ -1074,6 +1090,14 @@ namespace System.Windows
                 }
 
                 return _menuShowDelay;
+            }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuShowDelay] = true;
+                    _menuShowDelay = value;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1563,15 +1563,15 @@ namespace System.Windows
         public static System.Windows.ResourceKey MenuCheckmarkHeightKey { get { throw null; } }
         public static double MenuCheckmarkWidth { get { throw null; } }
         public static System.Windows.ResourceKey MenuCheckmarkWidthKey { get { throw null; } }
-        public static bool MenuDropAlignment { get { throw null; } }
+        public static bool MenuDropAlignment { get { throw null; } set {} }
         public static System.Windows.ResourceKey MenuDropAlignmentKey { get { throw null; } }
-        public static bool MenuFade { get { throw null; } }
+        public static bool MenuFade { get { throw null; } set { } }
         public static System.Windows.ResourceKey MenuFadeKey { get { throw null; } }
         public static double MenuHeight { get { throw null; } }
         public static System.Windows.ResourceKey MenuHeightKey { get { throw null; } }
         public static System.Windows.Controls.Primitives.PopupAnimation MenuPopupAnimation { get { throw null; } }
         public static System.Windows.ResourceKey MenuPopupAnimationKey { get { throw null; } }
-        public static int MenuShowDelay { get { throw null; } }
+        public static int MenuShowDelay { get { throw null; } set { } }
         public static System.Windows.ResourceKey MenuShowDelayKey { get { throw null; } }
         public static double MenuWidth { get { throw null; } }
         public static System.Windows.ResourceKey MenuWidthKey { get { throw null; } }


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/5944 https://github.com/dotnet/wpf/issues/4641



## Description

We can ignore the System settings by the code:

            SystemParameters.StaticPropertyChanged += (sender, eventArgs) =>
            {
                SystemParameters.MenuDropAlignment = false;
            };

cc @miloush

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

CI and My demo

## Risk

Low.
