### PR TITLE
Update XmlnsCache.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -172,7 +172,7 @@ namespace System.Windows.Markup
                         // try to get the mapping from those assemblies.
                         //
 
-                        string[] asmNameList = _uriToAssemblyNameTable[xmlns] as string[];
+                        string[] asmNameList = (string[])_uriToAssemblyNameTable[xmlns];
 
                         Assembly[] asmList = new Assembly[asmNameList.Length];
                         for (int i = 0; i < asmNameList.Length; i++)
@@ -318,7 +318,7 @@ namespace System.Windows.Markup
 
                     GetNamespacesFromDefinitionAttr(attributes[attrIdx], out xmlns, out clrns);
 
-                    if (String.IsNullOrEmpty(xmlns) || String.IsNullOrEmpty(clrns) )
+                    if (string.IsNullOrEmpty(xmlns) || string.IsNullOrEmpty(clrns) )
                     {
                         throw new ArgumentException(SR.Get(SRID.ParserAttributeArgsLow, "XmlnsDefinitionAttribute"));
                     }
@@ -327,7 +327,7 @@ namespace System.Windows.Markup
                     {
                         _cacheTable[xmlns] = new List<ClrNamespaceAssemblyPair>();
                     }
-                    pairList = _cacheTable[xmlns] as List<ClrNamespaceAssemblyPair>;
+                    pairList = (List<ClrNamespaceAssemblyPair>)_cacheTable[xmlns];
                     pairList.Add(new ClrNamespaceAssemblyPair(clrns, assemblyName));
                 }
             }
@@ -357,7 +357,7 @@ namespace System.Windows.Markup
 
                     GetNamespacesFromDefinitionAttr(attributes[attrIdx], out xmlns, out clrns);
 
-                    if (String.IsNullOrEmpty(xmlns) || String.IsNullOrEmpty(clrns) )
+                    if (string.IsNullOrEmpty(xmlns) || string.IsNullOrEmpty(clrns) )
                     {
                         throw new ArgumentException(SR.Get(SRID.ParserAttributeArgsLow, "XmlnsDefinitionAttribute"));
                     }


### PR DESCRIPTION
 as casts

Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Fixes unnecessary as castings to direct castings, making it a bit faster. Changes String to string notation.

## Customer Impact

very small performance update (direct cast is faster instead of as).

## Regression

The as-castings happen in almost the complete solution since a long time.

## Testing

None

## Risk

low


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6558)