### PR TITLE
Expose the `Window` Handle property

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -1693,23 +1693,15 @@ namespace System.Windows
         //
         //----------------------------------------------
         #region Protected properties
-        
+
         /// <summary>
-        /// Exposes the hWnd of the window. This property is used by the WindowInteropHandler
-        /// class.
+        /// Get the Handle of the window
         /// </summary>
-        protected IntPtr CriticalHandle
+        protected IntPtr Handle
         {
             get
             {
-                VerifyContextAndObjectState();
-                
-                if (_swh != null)
-                {
-                    return _swh.CriticalHandle;
-                }
-
-                return IntPtr.Zero;
+                return CriticalHandle;
             }
         }
 
@@ -3074,13 +3066,21 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Get the Handle of the window.
+        /// Exposes the hWnd of the window. This property is used by the WindowInteropHandler
+        /// class.
         /// </summary>
-        protected IntPtr Handle
+        internal IntPtr CriticalHandle
         {
             get
             {
-                return CriticalHandle;
+                VerifyContextAndObjectState();
+                
+                if (_swh != null)
+                {
+                    return _swh.CriticalHandle;
+                }
+
+                return IntPtr.Zero;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3091,7 +3091,7 @@ namespace System.Windows
         ///<remarks>
         ///     This API is currently not available for use in Internet Zone.
         ///</remarks>
-        protected IntPtr OwnerHandle
+        internal IntPtr OwnerHandle
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3076,7 +3076,7 @@ namespace System.Windows
         /// <summary>
         /// Get the Handle of the window.
         /// </summary>
-        protected IntPtr Handle
+        internal IntPtr Handle
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -1687,6 +1687,34 @@ namespace System.Windows
 
         #endregion
 
+        //----------------------------------------------
+        //
+        // Protected properties
+        //
+        //----------------------------------------------
+        #region Protected properties
+        
+        /// <summary>
+        /// Exposes the hWnd of the window. This property is used by the WindowInteropHandler
+        /// class.
+        /// </summary>
+        protected IntPtr CriticalHandle
+        {
+            get
+            {
+                VerifyContextAndObjectState();
+                
+                if (_swh != null)
+                {
+                    return _swh.CriticalHandle;
+                }
+
+                return IntPtr.Zero;
+            }
+        }
+
+        #endregion Protected properties
+
         //---------------------------------------------------
         //
         // Protected Methods
@@ -3042,24 +3070,6 @@ namespace System.Windows
             {
                 VerifyContextAndObjectState();
                 return _isVisibilitySet;
-            }
-        }
-
-        /// <summary>
-        ///     Exposes the hwnd of the window. This property is used by the WindowInteropHandler
-        ///     class
-        /// </summary>
-        internal IntPtr CriticalHandle
-        {
-            get
-            {
-                VerifyContextAndObjectState();
-                if (_swh != null)
-                {
-                    return _swh.CriticalHandle;
-                }
-                else
-                return IntPtr.Zero;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3074,6 +3074,17 @@ namespace System.Windows
         }
 
         /// <summary>
+        /// Get the Handle of the window.
+        /// </summary>
+        protected IntPtr Handle
+        {
+            get
+            {
+                return CriticalHandle;
+            }
+        }
+
+        /// <summary>
         ///     Enables to get/set the owner handle for this window. This property is used by
         ///     the WindowInteropHelper class
         /// </summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3076,7 +3076,7 @@ namespace System.Windows
         /// <summary>
         /// Get the Handle of the window.
         /// </summary>
-        internal IntPtr Handle
+        protected IntPtr Handle
         {
             get
             {
@@ -3091,7 +3091,7 @@ namespace System.Windows
         ///<remarks>
         ///     This API is currently not available for use in Internet Zone.
         ///</remarks>
-        internal IntPtr OwnerHandle
+        protected IntPtr OwnerHandle
         {
             get
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1981,7 +1981,7 @@ namespace System.Windows
         [System.ComponentModel.TypeConverterAttribute("System.Windows.LengthConverter, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, Custom=null")]
         public double Left { get { throw null; } set { } }
         protected internal override System.Collections.IEnumerator LogicalChildren { get { throw null; } }
-        protected IntPtr CriticalHandle { get { throw null; } }
+        protected IntPtr Handle { get { throw null; } }
         public System.Windows.WindowCollection OwnedWindows { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(null)]
         public System.Windows.Window Owner { get { throw null; } set { } }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1981,6 +1981,7 @@ namespace System.Windows
         [System.ComponentModel.TypeConverterAttribute("System.Windows.LengthConverter, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, Custom=null")]
         public double Left { get { throw null; } set { } }
         protected internal override System.Collections.IEnumerator LogicalChildren { get { throw null; } }
+        protected IntPtr CriticalHandle { get { throw null; } }
         public System.Windows.WindowCollection OwnedWindows { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(null)]
         public System.Windows.Window Owner { get { throw null; } set { } }


### PR DESCRIPTION
## Description

This PR exposes the **Handle** property. Thus, it allows classes that inherit from the `Window` class to gain direct access to the window hWnd that presents the WPF view. A developer creating advanced apps based on WPF one way or another can access this pointer anyway, and at the moment it is ***difficult*** which only slows things down.

A `Window` class, by design, should and is extendable, so I believe that accessing the window handle is a fundamental part of extending this class. `WindowInteropHelper` is just adding extra steps for inherited class.

Example of use, could be:
```c#
protected override void OnSourceInitialized(EventArgs e)
{
  if (Handle == IntPtr.Zero)
    return;

  var pvAttribute = Interop.Dwmapi.DWM_WINDOW_CORNER_PREFERENCE.ROUND;

  UnsafeNativeMethods.DwmSetWindowAttribute(
    Handle,
    Interop.Dwmapi.DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE,
    ref pvAttribute,
    Marshal.SizeOf(typeof(int)));
}
```
## Customer Impact

The end customer does not feel the change. A programmer can directly and easily modify window properties if he deems it necessary. More comfortable.

## Testing

The CI of this PR should build the project correctly.

## Risk

We add a new property - Handle, which should not collide with others. Property also does not become public, so we reduce the risk of accidental use.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6611)