### PR TITLE
Translation fix for TextBox_ContextMenu_Cut [cs-CZ]

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -5595,7 +5595,7 @@ Chcete ho nahradit?</target>
       </trans-unit>
       <trans-unit id="TextBox_ContextMenu_Cut">
         <source>Cu_t</source>
-        <target state="translated">Od_stranit</target>
+        <target state="translated">V_yjmout</target>
         <note />
       </trans-unit>
       <trans-unit id="TextBox_ContextMenu_Description_DBCSSpace">


### PR DESCRIPTION
Fixes #6603

## Description

Wrong translation for the `TextBox`' context menu for Cut in cs-CZ.

## Customer Impact

Not taking this fix will keep showing the wrong command name to customers (meaning Delete instead of Cut) running with cs-CZ resources. `ApplicationCommands.Cut.Text` has the correct translation.

## Regression

No.

## Testing

Not tested.

## Risk

Low, translation changed. Verified that the second letter is the accelerator in Notepad.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6614)