### PR TITLE
Replace resource constants with properties in UIAutomationProvider

### DIFF
--- a/eng/WpfArcadeSdk/tools/SystemResources.props
+++ b/eng/WpfArcadeSdk/tools/SystemResources.props
@@ -12,6 +12,7 @@
 
     <_GenerateResourcesCodeAsConstants>true</_GenerateResourcesCodeAsConstants>
 
+    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='UIAutomationProvider'">false</_GenerateResourcesCodeAsConstants>
     <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='System.Xaml'">false</_GenerateResourcesCodeAsConstants>
     <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='WindowsBase'">false</_GenerateResourcesCodeAsConstants>
     <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='WindowsFormsIntegration'">false</_GenerateResourcesCodeAsConstants>
@@ -29,7 +30,7 @@
       <GenerateResourcesCodeAsConstants>$(_GenerateResourcesCodeAsConstants)</GenerateResourcesCodeAsConstants>
 
       <ClassName Condition="'$(AssemblyName)'=='PresentationBuildTasks'">MS.Utility.SRID</ClassName>
-      <ClassName Condition="'$(AssemblyName)'=='UIAutomationProvider'">System.SR</ClassName>
+      <ClassName Condition="'$(AssemblyName)'=='UIAutomationProvider'">MS.Internal.Automation.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='UIAutomationTypes'">System.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='WindowsBase'">MS.Internal.WindowsBase.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='System.Windows.Controls.Ribbon'">Microsoft.Windows.Controls.SRID</ClassName>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Automation.Provider
         /// <returns>base raw element for specified window</returns>
         public static IRawElementProviderSimple HostProviderFromHandle ( IntPtr hwnd )
         {
-            ValidateArgument(hwnd != IntPtr.Zero, nameof(SRID.HwndMustBeNonNULL));
+            ValidateArgument(hwnd != IntPtr.Zero, nameof(SR.HwndMustBeNonNULL));
             return UiaCoreProviderApi.UiaHostProviderFromHwnd(hwnd);
         }
     
@@ -75,7 +75,7 @@ namespace System.Windows.Automation.Provider
         /// <returns>Server should return the return value as the lresult return value to the WM_GETOBJECT windows message</returns>
         public static IntPtr ReturnRawElementProvider (IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el )
         {
-            ValidateArgument( hwnd != IntPtr.Zero, nameof(SRID.HwndMustBeNonNULL));
+            ValidateArgument( hwnd != IntPtr.Zero, nameof(SR.HwndMustBeNonNULL));
             ValidateArgumentNonNull(el, "el" );
             
             return UiaCoreProviderApi.UiaReturnRawElementProvider(hwnd, wParam, lParam, el);
@@ -215,7 +215,7 @@ namespace System.Windows.Automation.Provider
         // Throw an argument Exception with a generic error
         private static void ThrowInvalidArgument(string argName)
         {
-            throw new ArgumentException(SR.Format(SRID.GenericInvalidArgument, argName));
+            throw new ArgumentException(SR.Format(SR.GenericInvalidArgument, argName));
         }
 
         // Check that specified condition is true; if not, throw exception

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/UIAutomationProvider.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/UIAutomationProvider.csproj
@@ -3,8 +3,6 @@
     <NoWarn>$(NoWarn);0618</NoWarn>
     <DefineConstants>$(DefineConstants);AUTOMATION</DefineConstants>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
-    <GenerateResourcesSRNamespace>MS.Internal.Automation</GenerateResourcesSRNamespace>
-    <GenerateResourcesResourcesClassName>SRID</GenerateResourcesResourcesClassName>
     <Platforms>AnyCPU;x64;arm64</Platforms>
   </PropertyGroup>
 
@@ -14,9 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\Strings.resx">
-      <ClassName>$(GenerateResourcesSRNamespace).$(GenerateResourcesResourcesClassName)</ClassName>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Resources\Strings.resx" />
     <Compile Include="$(WpfCommonDir)src\System\SR.cs">
         <Link>Common\System\SR.cs</Link>
     </Compile>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/ref/UIAutomationProvider-ref.csproj
@@ -6,8 +6,6 @@
     <NoWarn>$(NoWarn);0618</NoWarn>
     <DefineConstants>$(DefineConstants);AUTOMATION</DefineConstants>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
-    <GenerateResourcesSRNamespace>MS.Internal.Automation</GenerateResourcesSRNamespace>
-    <GenerateResourcesResourcesClassName>SRID</GenerateResourcesResourcesClassName>
     <Platforms>AnyCPU;x64;arm64</Platforms>
     
   </PropertyGroup>


### PR DESCRIPTION
Contributes to dotnet/wpf#1

## Description
Replace the use of resource constants with properties in UIAutomationProvider. This follows the standard of other .Net projects, like [dotnet/runtime](https://github.com/dotnet/runtime).

## Customer Impact
None.

## Regression
No.

## Testing
Local build + CI.

## Risk
None.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6619)