### PR TITLE
Fix StaticResourceExtension will not find the resources of the ResourceDictionary of the sibling node

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlRecordReader.cs
@@ -5680,7 +5680,15 @@ namespace System.Windows.Markup
 
         internal override DeferredResourceReference PrefetchedValue
         {
-            get { return _prefetchedValue; }
+            get
+            {
+                if (_prefetchedValue == null || _prefetchedValue.Value == DependencyProperty.UnsetValue)
+                {
+                    return null;
+                }
+
+                return _prefetchedValue;
+            }
         }
 
         #endregion Methods


### PR DESCRIPTION
Fixes  https://github.com/dotnet/wpf/issues/6627

## Description

We should call `FindResourceInEnviroment` when the PrefetchedValue is the DependencyProperty.UnsetValue.

https://github.com/dotnet/wpf/blob/71944cc265d69b4cd29d6e7833e6bac06217c505/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StaticResourceExtension.cs#L176-L206

## Customer Impact

We can use this feature to reduce duplicate creation of resources.

## Regression

None.

## Testing

CI and my demo: https://github.com/lindexi/lindexi_gd/tree/cd70c10df4f57fdedd9d2fbee018290e432422cf/GeacejalcurnawLarjearemwhear

And I cherry-pick the commit to build the test version in https://github.com/dotnet-campus/dotnetCampus.CustomWpf/pull/9

## Risk

Changed the resource lookup behavior


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6629)