### PR TITLE
Eliminate allocation in `StreamAsIStream.Read`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/StreamAsIStream.cs
@@ -10,6 +10,7 @@ using System.Security;
 using System;
 using MS.Internal;
 using MS.Win32;
+using System.Buffers;
 using System.Reflection;
 using System.Collections;
 using System.Diagnostics;
@@ -28,7 +29,7 @@ namespace System.Windows.Media
     internal struct StreamDescriptor
     {
         internal delegate void Dispose(ref StreamDescriptor pSD);
-        internal delegate int Read(ref StreamDescriptor pSD, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), Out]byte[] buffer, uint cb, out uint cbRead);
+        internal delegate int Read(ref StreamDescriptor pSD, IntPtr buffer, uint cb, out uint cbRead);
 
         internal unsafe delegate int Seek(ref StreamDescriptor pSD, long offset, uint origin, long* plibNewPostion);
         internal delegate int Stat(ref StreamDescriptor pSD, out System.Runtime.InteropServices.ComTypes.STATSTG statstg, uint grfStatFlag);
@@ -237,7 +238,7 @@ namespace System.Windows.Media
 
                     uint read = 0;
 
-                    hr = Read(buffer, toRead, out read);
+                    hr = Read(buffer.AsSpan(0, (int) toRead), out read);
 
                     if (read == 0)
                     {
@@ -290,7 +291,7 @@ namespace System.Windows.Media
             return NativeMethods.E_NOTIMPL;
         }
 
-        public int Read(byte[] buffer, uint cb, out uint cbRead)
+        public int Read(Span<byte> buffer, out uint cbRead)
         {
             cbRead = 0;
 
@@ -301,7 +302,7 @@ namespace System.Windows.Media
                 Verify();
                 ActualizeVirtualPosition();
 
-                cbRead = (uint) dataStream.Read(buffer, 0, (int) cb);
+                cbRead = (uint) dataStream.Read(buffer);
             }
             catch (Exception e)
             {
@@ -597,9 +598,10 @@ namespace System.Windows.Media
             return (StreamAsIStream.FromSD(ref pSD)).LockRegion(libOffset, cb, dwLockType);
         }
 
-        internal static int Read(ref StreamDescriptor pSD, byte[] buffer, uint cb, out uint cbRead)
+        internal static unsafe int Read(ref StreamDescriptor pSD, IntPtr buffer, uint cb, out uint cbRead)
         {
-            return (StreamAsIStream.FromSD(ref pSD)).Read(buffer, cb, out cbRead);
+            var span = new Span<byte>(buffer.ToPointer(), (int) cb);
+            return (StreamAsIStream.FromSD(ref pSD)).Read(span, out cbRead);
         }
 
         internal static int Revert(ref StreamDescriptor pSD)


### PR DESCRIPTION
## Description

The native/managed interop layer will allocate a byte array to marshal a native buffer to the `StreamDescriptor.Read` delegate. By using `Span<byte>` and the corresponding overload of `Stream.Read`, we can read directly into the caller's buffer when `CManagedStream::Read` calls this delegate.

Sample improvement by running a benchmark to create a `BitmapImage` with a `MemoryStream` `StreamSource` containing a 79KB PNG:

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1706 (21H2)
Intel Core i7-10875H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100-preview.4.22252.9
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT
  Job-FFRIND : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT

Runtime=.NET 6.0  Toolchain=net6.0-windows
```

|     Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|----------- |---------:|----------:|----------:|---------:|---------:|---------:|----------:|
| Before | 3.623 ms | 0.0702 ms | 0.0656 ms | 984.3750 | 984.3750 | 984.3750 |     82 KB |
| After | 3.619 ms | 0.1386 ms | 0.4088 ms | 960.9375 | 960.9375 | 960.9375 |      3 KB |

## Customer Impact

Unnecessary allocation and memory copy between native/managed buffers.

## Regression

No

## Testing

Tested in real-world application via incorporation into [Faithlife.Wpf](https://www.nuget.org/packages/Faithlife.Wpf/).

## Risk

Minimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6632)