### PR TITLE
Remove duplicate PackageReference Microsoft.Private.Winforms

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -216,7 +216,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="$(SystemDirectoryServicesPackage)" Version="$(SystemDirectoryServicesVersion)" />


### PR DESCRIPTION
Contributes to #6647

## Description
Removes duplicate PackageReference for Microsoft.Private.Winforms, it is already added here:
https://github.com/dotnet/wpf/blob/42a8bbe349253e71d53e0d24ec18363dcb20655d/eng/WpfArcadeSdk/tools/SdkReferences.targets#L3-L10

Duplicate PackageReference is a build error in VS 2022 Preview (I have the error on 17.3.0 Preview 1.1).

## Customer Impact
None.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low.