### PR TITLE
Fix ZeroForNow parameter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsTextServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsTextServices.cs
@@ -1972,14 +1972,14 @@ namespace MS.Win32
             //                   [out] LONG *pcch,
             //                   [in, unique] const TF_HALTCOND *pHalt);
             /// <summary></summary>
-            void ShiftStart(int ec, int count, out int result, int ZeroForNow); // "ZeroForNow" should be a struct ptr if we ever use this
+            void ShiftStart(int ec, int count, out int result, IntPtr pHalt);
 
             //HRESULT ShiftEnd([in] TfEditCookie ec,
             //                 [in] LONG cchReq,
             //                 [out] LONG *pcch,
             //                 [in, unique] const TF_HALTCOND *pHalt);
             /// <summary></summary>
-            void ShiftEnd(int ec, int count, out int result, int ZeroForNow); // "ZeroForNow" should be a struct ptr if we ever use this
+            void ShiftEnd(int ec, int count, out int result, IntPtr pHalt);
 
             //HRESULT ShiftStartToRange([in] TfEditCookie ec,
             //                          [in] ITfRange *pRange,
@@ -2117,14 +2117,14 @@ namespace MS.Win32
             //                   [out] LONG *pcch,
             //                   [in, unique] const TF_HALTCOND *pHalt);
             /// <summary></summary>
-            void ShiftStart(int ec, int count, out int result, int ZeroForNow); // "ZeroForNow" should be a struct ptr if we ever use this
+            void ShiftStart(int ec, int count, out int result, IntPtr pHalt);
 
             //HRESULT ShiftEnd([in] TfEditCookie ec,
             //                 [in] LONG cchReq,
             //                 [out] LONG *pcch,
             //                 [in, unique] const TF_HALTCOND *pHalt);
             /// <summary></summary>
-            void ShiftEnd(int ec, int count, out int result, int ZeroForNow); // "ZeroForNow" should be a struct ptr if we ever use this
+            void ShiftEnd(int ec, int count, out int result, IntPtr pHalt);
 
             //HRESULT ShiftStartToRange([in] TfEditCookie ec,
             //                          [in] ITfRange *pRange,


### PR DESCRIPTION
`int` is not the same as `const TF_HALTCOND *` on x64 arch


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6657)