### PR TITLE
Fixing the C++/CLI projects failing due to NU1504

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -353,6 +353,16 @@ using namespace System::Runtime::Versioning;
        <AdditionalNugetIds Remove="%40(AdditionalNugetIds)" />
        <AdditionalNugetIds Include="%24([System.String]::Copy('%25(_AdditionalPackages.Identity)').Split('+')[0])" />
      </ItemGroup>
+
+     <!-- 
+      Removing the Microsoft.NETCore.Platforms directly and then 
+      adding it again to remove the duplicate reference.
+     -->
+     <ItemGroup>
+        <PackageReference Remove="Microsoft.NETCore.Platforms" />   
+        <PackageReference Include="Microsoft.NETCore.Platforms" 
+                      Version="$(MicrosoftNETCorePlatformsVersion)" />
+     </ItemGroup> 
   </Target>
 
 <Target

--- a/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/DirectWriteForwarder/DirectWriteForwarder.vcxproj
@@ -30,6 +30,11 @@
     <UseDestinationLibFolder>true</UseDestinationLibFolder>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <RestoreProjectStyle>Unknown</RestoreProjectStyle>
+    <!-- 
+      Opting out of this to ensure _WindowsBaseReference is used as 
+      OutputItemsType in the project reference later.
+    -->
+    <LegacyNativeReferenceResolution>true</LegacyNativeReferenceResolution>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -31,6 +31,11 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <RestoreProjectStyle>Unknown</RestoreProjectStyle>
+    <!-- 
+      Opting out of this to ensure _defineReference is used as 
+      OutputItemsType in the project references later. 
+    -->
+    <LegacyNativeReferenceResolution>true</LegacyNativeReferenceResolution>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>


### PR DESCRIPTION
Fixes # <!-- Issue Number --> #6647 

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
Fixed the DuplicatePackageReference build issue in C++/CLI projects.
This PR along with PR #6648 , fixes the build issues is VS 2022 preview.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
None
<!-- What is the impact to customers of not taking this fix? -->

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
CI + Local Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
Low.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6698)