### PR TITLE
Reduce allocations when tracing routed events

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -193,7 +193,8 @@ namespace System.Windows
                     
                     // Invoke listeners
 
-                    if( TraceRoutedEvent.IsEnabled )
+                    var traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
+                    if ( traceRoutedEventIsEnabled )
                     {
                         _traceArguments ??= new object[3];
                         _traceArguments[0] = _routeItemList[i].Target;
@@ -207,11 +208,8 @@ namespace System.Windows
                     
                     _routeItemList[i].InvokeHandler(args);
 
-                    if( TraceRoutedEvent.IsEnabled )
+                    if( traceRoutedEventIsEnabled )
                     {
-                        _traceArguments ??= new object[3];
-                        _traceArguments[0] = _routeItemList[i].Target;
-                        _traceArguments[1] = args;
                         _traceArguments[2] = args.Handled ? _true : _false;
                         TraceRoutedEvent.Trace(
                             TraceEventType.Stop,
@@ -267,7 +265,8 @@ namespace System.Windows
                         }
                         
                         
-                        if( TraceRoutedEvent.IsEnabled )
+                        var traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
+                        if ( traceRoutedEventIsEnabled )
                         {
                             _traceArguments ??= new object[3];
                             _traceArguments[0] = _routeItemList[i].Target;
@@ -282,11 +281,8 @@ namespace System.Windows
                         // Invoke listeners
                         _routeItemList[i].InvokeHandler(args);
 
-                        if( TraceRoutedEvent.IsEnabled )
+                        if (traceRoutedEventIsEnabled)
                         {
-                            _traceArguments ??= new object[3];
-                            _traceArguments[0] = _routeItemList[i].Target;
-                            _traceArguments[1] = args;
                             _traceArguments[2] = args.Handled ? _true : _false;
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Stop,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -11,6 +11,7 @@ using MS.Utility;
 using SR=MS.Internal.PresentationCore.SR;
 using SRID=MS.Internal.PresentationCore.SRID;
 using MS.Internal;
+using MS.Internal.KnownBoxes;
 
 namespace System.Windows
 {
@@ -199,7 +200,7 @@ namespace System.Windows
                         _traceArguments ??= new object[3];
                         _traceArguments[0] = _routeItemList[i].Target;
                         _traceArguments[1] = args;
-                        _traceArguments[2] = args.Handled ? _true : _false;
+                        _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                         TraceRoutedEvent.Trace(
                             TraceEventType.Start,
                             TraceRoutedEvent.InvokeHandlers,
@@ -210,7 +211,7 @@ namespace System.Windows
 
                     if( traceRoutedEventIsEnabled )
                     {
-                        _traceArguments[2] = args.Handled ? _true : _false;
+                        _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                         TraceRoutedEvent.Trace(
                             TraceEventType.Stop,
                             TraceRoutedEvent.InvokeHandlers,
@@ -271,7 +272,7 @@ namespace System.Windows
                             _traceArguments ??= new object[3];
                             _traceArguments[0] = _routeItemList[i].Target;
                             _traceArguments[1] = args;
-                            _traceArguments[2] = args.Handled ? _true : _false;
+                            _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Start,
                                 TraceRoutedEvent.InvokeHandlers,
@@ -283,7 +284,7 @@ namespace System.Windows
 
                         if (traceRoutedEventIsEnabled)
                         {
-                            _traceArguments[2] = args.Handled ? _true : _false;
+                            _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Stop,
                                 TraceRoutedEvent.InvokeHandlers,
@@ -557,8 +558,6 @@ namespace System.Windows
 
         // Stores arguments that are passed to TraceRoutedEvent.Trace (to reduce allocations)
         private object[] _traceArguments;
-        private static readonly object _true = true;
-        private static readonly object _false = false;
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -195,25 +195,28 @@ namespace System.Windows
 
                     if( TraceRoutedEvent.IsEnabled )
                     {
+                        _traceArguments ??= new object[3];
+                        _traceArguments[0] = _routeItemList[i].Target;
+                        _traceArguments[1] = args;
+                        _traceArguments[2] = args.Handled ? _true : _false;
                         TraceRoutedEvent.Trace(
                             TraceEventType.Start,
-                            TraceRoutedEvent.InvokeHandlers,  
-                            _routeItemList[i].Target,
-                            args,
-                            args.Handled );
-
+                            TraceRoutedEvent.InvokeHandlers,
+                            _traceArguments);
                     }
                     
                     _routeItemList[i].InvokeHandler(args);
 
                     if( TraceRoutedEvent.IsEnabled )
                     {
+                        _traceArguments ??= new object[3];
+                        _traceArguments[0] = _routeItemList[i].Target;
+                        _traceArguments[1] = args;
+                        _traceArguments[2] = args.Handled ? _true : _false;
                         TraceRoutedEvent.Trace(
                             TraceEventType.Stop,
-                            TraceRoutedEvent.InvokeHandlers,  
-                            _routeItemList[i].Target,
-                            args,
-                            args.Handled );
+                            TraceRoutedEvent.InvokeHandlers,
+                            _traceArguments);
                     }
 
 
@@ -266,12 +269,14 @@ namespace System.Windows
                         
                         if( TraceRoutedEvent.IsEnabled )
                         {
+                            _traceArguments ??= new object[3];
+                            _traceArguments[0] = _routeItemList[i].Target;
+                            _traceArguments[1] = args;
+                            _traceArguments[2] = args.Handled ? _true : _false;
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Start,
-                                TraceRoutedEvent.InvokeHandlers,  
-                                _routeItemList[i].Target,
-                                args,
-                                args.Handled );
+                                TraceRoutedEvent.InvokeHandlers,
+                                _traceArguments);
                         }
 
                         // Invoke listeners
@@ -279,12 +284,14 @@ namespace System.Windows
 
                         if( TraceRoutedEvent.IsEnabled )
                         {
+                            _traceArguments ??= new object[3];
+                            _traceArguments[0] = _routeItemList[i].Target;
+                            _traceArguments[1] = args;
+                            _traceArguments[2] = args.Handled ? _true : _false;
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Stop,
-                                TraceRoutedEvent.InvokeHandlers,  
-                                _routeItemList[i].Target,
-                                args,
-                                args.Handled );
+                                TraceRoutedEvent.InvokeHandlers,
+                                _traceArguments);
                         }
 
                     }
@@ -551,6 +558,11 @@ namespace System.Windows
 
         // Stores Source Items for separated trees
         private FrugalStructList<SourceItem> _sourceItemList;
+
+        // Stores arguments that are passed to TraceRoutedEvent.Trace (to reduce allocations)
+        private object[] _traceArguments;
+        private static readonly object _true = true;
+        private static readonly object _false = false;
 
         #endregion Data
     }


### PR DESCRIPTION
## Description

I was tracing an application with dotMemory and noticed a huge amount of temporary `object[]` being allocated by `EventRoute.InvokeHandlersImpl`.

![image](https://user-images.githubusercontent.com/188129/174408238-1004def8-9555-4107-b9ad-bf4fdf8d9fb2.png)

This particular application had attached a listener to `PresentationTraceSources.RoutedEventSource` to trace some diagnostic information. While it's expected that doing so will add some overhead, it shouldn't be this great.

## Customer Impact

Merging this PR will greatly reduce allocations for customers whose applications add a listener to `PresentationTraceSources.RoutedEventSource.Listeners`. 

## Regression

No.

## Testing

Tested with dotMemory after shipping this fix in https://github.com/Faithlife/wpf.

## Risk

Minimal.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6700)