### PR TITLE
[release/6.0] Remove duplicate reference

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/PresentationUI.csproj
@@ -216,7 +216,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Private.Winforms" Version="$(MicrosoftPrivateWinformsVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
     <PackageReference Include="$(SystemDirectoryServicesPackage)" Version="$(SystemDirectoryServicesVersion)" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/wpf/pull/6648, should fix build errors in 6.0