### PR TITLE
Fix for Bug 1493635: MenuItems with IsCheckable and StaysOpenOnClick set to true do not announce to Narrator when IsChecked is changed

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -318,10 +318,9 @@ namespace System.Windows.Automation.Peers
 
         internal void RaiseToggleStatePropertyChangedEvent(bool oldValue, bool newValue)
         {
-            if (oldValue != newValue)
-            {
-                RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(oldValue), ConvertToToggleState(newValue));
-            }
+            RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty,
+                oldValue ? ConvertToToggleState(oldValue) : ConvertToToggleState(newValue),
+                newValue ? ConvertToToggleState(oldValue) : ConvertToToggleState(newValue));
         }
 
         private static ToggleState ConvertToToggleState(bool value) => value ? ToggleState.On : ToggleState.Off;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -316,6 +316,27 @@ namespace System.Windows.Automation.Peers
                 newValue ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed);
         }
 
+        internal void RaiseToggleStatePropertyChangedEvent(bool oldValue, bool newValue)
+        {
+            if (oldValue != newValue)
+            {
+                RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty, ConvertToToggleState(oldValue), ConvertToToggleState(newValue));
+            }
+        }
+
+        private static ToggleState ConvertToToggleState(bool? value)
+        {
+            switch (value)
+            {
+                case (true):
+                    return ToggleState.On;
+                case (false):
+                    return ToggleState.Off;
+                default:
+                    return ToggleState.Indeterminate;
+            }
+        }
+
         // Return the base without the AccessKey character
         ///
         override protected string GetNameCore()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -324,18 +324,7 @@ namespace System.Windows.Automation.Peers
             }
         }
 
-        private static ToggleState ConvertToToggleState(bool? value)
-        {
-            switch (value)
-            {
-                case (true):
-                    return ToggleState.On;
-                case (false):
-                    return ToggleState.Off;
-                default:
-                    return ToggleState.Indeterminate;
-            }
-        }
+        private static ToggleState ConvertToToggleState(bool value) => value ? ToggleState.On : ToggleState.Off;
 
         // Return the base without the AccessKey character
         ///

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -949,12 +949,6 @@ namespace System.Windows.Controls
             bool oldValue = (bool)e.OldValue;
             bool newValue = (bool)e.NewValue;
 
-            MenuItemAutomationPeer peer = UIElementAutomationPeer.FromElement(menuItem) as MenuItemAutomationPeer;
-            if (peer != null)
-            {
-                peer.RaiseToggleStatePropertyChangedEvent(oldValue, newValue);
-            }
-
             if (newValue)
             {
                 menuItem.OnChecked(new RoutedEventArgs(CheckedEvent));
@@ -962,6 +956,12 @@ namespace System.Windows.Controls
             else
             {
                 menuItem.OnUnchecked(new RoutedEventArgs(UncheckedEvent));
+            }
+            
+            MenuItemAutomationPeer peer = UIElementAutomationPeer.FromElement(menuItem) as MenuItemAutomationPeer;
+            if (peer != null)
+            {
+                peer.RaiseToggleStatePropertyChangedEvent(oldValue, newValue);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MenuItem.cs
@@ -946,7 +946,16 @@ namespace System.Windows.Controls
         {
             MenuItem menuItem = (MenuItem) d;
 
-            if ((bool) e.NewValue)
+            bool oldValue = (bool)e.OldValue;
+            bool newValue = (bool)e.NewValue;
+
+            MenuItemAutomationPeer peer = UIElementAutomationPeer.FromElement(menuItem) as MenuItemAutomationPeer;
+            if (peer != null)
+            {
+                peer.RaiseToggleStatePropertyChangedEvent(oldValue, newValue);
+            }
+
+            if (newValue)
             {
                 menuItem.OnChecked(new RoutedEventArgs(CheckedEvent));
             }


### PR DESCRIPTION
Fixes #5237

## Description
Provided a fix for the problem when windows Narrator was not announcing anything when IsChecked is changed (e.g. the item is clicked on or the user types "Enter" while focusing it).

## Customer Impact
Fixes a regression.

## Regression
Yes

## Testing
NA

## Risk
Low


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6706)