### PR TITLE
Fix wpf-debug.targets

### DIFF
--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -16,7 +16,8 @@
     
     <WpfArtifactsPackagesCommonPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging</WpfArtifactsPackagesCommonPath>
     <WpfPlatformTargetArtifactsDirectory Condition="'$(PlatformTarget)'=='x64'">x64\</WpfPlatformTargetArtifactsDirectory>
-    <WPFArtifactsPath>$(WpfPackagesCommonPath)\$(WpfConfig)\$(WpfPlatformTargetArtifactsDirectory)Microsoft.DotNet.Wpf.GitHub.$(WpfConfig)</WPFArtifactsPath>
+    <WPFArtifactsPathSuffix Condition="'$(WpfConfig)'=='Debug'">.$(WpfConfig)</WPFArtifactsPathSuffix>
+    <WPFArtifactsPath>$(WpfArtifactsPackagesCommonPath)\$(WpfConfig)\$(WpfPlatformTargetArtifactsDirectory)Microsoft.DotNet.Wpf.GitHub$(WPFArtifactsPathSuffix)</WPFArtifactsPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Fixes 2 bug in wpf-debug.targets.

Fixes a bug introduced in #6334: `WPFArtifactsPath` should use `WpfArtifactsPackagesCommonPath` instead of `WpfPackagesCommonPath` which doesn't exist.

Fixes a bug in Release: `WPFArtifactsPath` should only contain suffix `.$(WpfConfig)` in Debug. In release, there are no suffix to `Microsoft.DotNet.Wpf.GitHub`

## Customer Impact
None.

## Regression
No.

## Testing
I built WPF for Debug x86, Debug x64, Release x86 and Release x64. Then I used wpf-debug.targets in a project and made sure that the correct binaries were copied to the output path for the correct combination of Configuration and TargetPlatform.

## Risk
None.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6709)