### PR TITLE
DataGridColumnBorder caching of Freezable brushes is not actually caching anything at all

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/Shared/Microsoft/Windows/Themes/DataGridHeaderBorder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Shared/Microsoft/Windows/Themes/DataGridHeaderBorder.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Windows.Themes
         /// </summary>
         public static readonly DependencyProperty SeparatorVisibilityProperty =
             DependencyProperty.Register("SeparatorVisibility", typeof(Visibility), typeof(DataGridHeaderBorder), new FrameworkPropertyMetadata(Visibility.Visible));
-        
+
         #endregion
 
         #region Layout
@@ -305,18 +305,18 @@ namespace Microsoft.Windows.Themes
         #region Freezable Cache
 
         /// <summary>
-        ///     Creates a cache of frozen Freezable resources for use 
+        ///     Creates a cache of frozen Freezable resources for use
         ///     across all instances of the border.
         /// </summary>
         private static void EnsureCache(int size)
         {
             // Quick check to avoid locking
-            if (_freezableCache == null) 
+            if (_freezableCache == null)
             {
                 lock (_cacheAccess)
                 {
                     // Re-check in case another thread created the cache
-                    if (_freezableCache == null) 
+                    if (_freezableCache == null)
                     {
                         _freezableCache = new List<Freezable>(size);
                         for (int i = 0; i < size; i++)
@@ -336,7 +336,7 @@ namespace Microsoft.Windows.Themes
         private static void ReleaseCache()
         {
             // Avoid locking if necessary
-            if (_freezableCache != null) 
+            if (_freezableCache != null)
             {
                 lock (_cacheAccess)
                 {
@@ -368,7 +368,7 @@ namespace Microsoft.Windows.Themes
 
             lock (_cacheAccess)
             {
-                if (_freezableCache[index] != null)
+                if (_freezableCache[index] == null)
                 {
                     _freezableCache[index] = freezable;
                 }


### PR DESCRIPTION
Fixes #6713 

## Description

CacheFreezable() logic is incorrect in that it checks if the indexed value is NOT null before caching versus if it IS null. This means that values will never actually be cached and any calls to GetCachedFreezable() will always return null causing the Brush to be regenerated rather than reused on every rendering pass.

## Customer Impact

Unnecessary computation on every rendering pass. Possible memory and brush leak.

## Regression

Does not appear to be a regression.

## Testing

Validated fix locally in private implementation of DataGridColumnBorder

## Risk

This should be minimal. DataGridColumnBorder code was clearly implemented assuming that brushes will be cached but they never actually are. There are various assertions in place already to ensure proper behavior here.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6714)