### PR TITLE
Fix for Bug 1493635: MenuItems with IsCheckable and StaysOpenOnClick set to true do not announce to Narrator when IsChecked is changed 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/MenuItemAutomationPeer.cs
@@ -316,6 +316,7 @@ namespace System.Windows.Automation.Peers
                 newValue ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed);
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         internal void RaiseToggleStatePropertyChangedEvent(bool oldValue, bool newValue)
         {
             RaisePropertyChangedEvent(TogglePatternIdentifiers.ToggleStateProperty,


### PR DESCRIPTION
Fixes #5237

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
Added NoInLining attribute

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->


## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Fixes a regression.

## Testing

<!-- What kind of testing has been done with the fix. -->
NA

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6750)