### PR TITLE
Fix System.OverflowException in WindowChromeWorker._HandleNCHitTest

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/Utilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/Utilities.cs
@@ -48,13 +48,15 @@ namespace Standard
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static int GET_X_LPARAM(IntPtr lParam)
         {
-            return LOWORD(lParam.ToInt32());
+            // ToInt64 to fix https://github.com/dotnet/wpf/issues/6777
+            return LOWORD((int) lParam.ToInt64());
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static int GET_Y_LPARAM(IntPtr lParam)
         {
-            return HIWORD(lParam.ToInt32());
+            // ToInt64 to fix https://github.com/dotnet/wpf/issues/6777
+            return HIWORD((int) lParam.ToInt64());
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]


### PR DESCRIPTION

Fixes https://github.com/dotnet/wpf/issues/6777



## Description

The lParam may be the int 64 value which will throw OverflowException when cast to int 32. We only use the int32 part inside the int64, so it's safe for us to use ToInt64 first and then cast to int32.

## Customer Impact

See https://github.com/dotnet/wpf/issues/6777

## Regression

None.

## Testing

Just the CI.

## Risk

Low. It is safe for us to use IntPtr.ToInt64 and cast the long to int.
