### PR TITLE
Fix NullReferenceException in Invariant.get_IsDialogOverrideEnabled

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
@@ -238,8 +238,6 @@ namespace MS.Internal
                 enabled = false;
 
                 //extracting all the data under an elevation.
-                object dbgJITDebugLaunchSettingValue;
-                string dbgManagedDebuggerValue;
                 key = Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\.NETFramework");
                 //
                 // Check for the enable.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
@@ -241,13 +241,14 @@ namespace MS.Internal
                 object dbgJITDebugLaunchSettingValue;
                 string dbgManagedDebuggerValue;
                 key = Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\.NETFramework");
-                dbgJITDebugLaunchSettingValue = key.GetValue("DbgJITDebugLaunchSetting");
-                dbgManagedDebuggerValue = key.GetValue("DbgManagedDebugger") as string;
                 //
                 // Check for the enable.
                 //
                 if (key != null)
                 {
+                    dbgJITDebugLaunchSettingValue = key.GetValue("DbgJITDebugLaunchSetting");
+                    dbgManagedDebuggerValue = key.GetValue("DbgManagedDebugger") as string;
+
                     //
                     // Only count the enable if there's a JIT debugger to launch.
                     //

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Invariant.cs
@@ -246,8 +246,8 @@ namespace MS.Internal
                 //
                 if (key != null)
                 {
-                    dbgJITDebugLaunchSettingValue = key.GetValue("DbgJITDebugLaunchSetting");
-                    dbgManagedDebuggerValue = key.GetValue("DbgManagedDebugger") as string;
+                    object dbgJITDebugLaunchSettingValue = key.GetValue("DbgJITDebugLaunchSetting");
+                    string dbgManagedDebuggerValue = key.GetValue("DbgManagedDebugger") as string;
 
                     //
                     // Only count the enable if there's a JIT debugger to launch.


### PR DESCRIPTION
Fixes #6772

## Description

Fix NullReferenceException in Invariant.get_IsDialogOverrideEnabled when .NET Framework Registry key (HKLM\Software\Microsoft\.NETFramework) is not present on the machine

## Customer Impact

-

## Regression

-

## Testing

-

## Risk

-


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6785)