### PR TITLE
Adding the lock to keep the WeakEventTable ThreadSafe

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/WeakEventTable.cs
@@ -137,15 +137,21 @@ namespace MS.Internal
         {
             get
             {
-                EventKey key = new EventKey(manager, source);
-                object result = _dataTable[key];
-                return result;
+                using (ReadLock)
+                {
+                    EventKey key = new EventKey(manager, source);
+                    object result = _dataTable[key];
+                    return result;
+                }
             }
 
             set
             {
-                EventKey key = new EventKey(manager, source, true);
-                _dataTable[key] = value;
+                using (WriteLock)
+                {
+                    EventKey key = new EventKey(manager, source, true);
+                    _dataTable[key] = value;
+                }
             }
         }
 
@@ -177,13 +183,16 @@ namespace MS.Internal
         internal void Remove(WeakEventManager manager, object source)
         {
             EventKey key = new EventKey(manager, source);
-            if (!_inPurge)
+            using (WriteLock)
             {
-                _dataTable.Remove(key);
-            }
-            else
-            {
-                _toRemove.Add(key);
+                if (!_inPurge)
+                {
+                    _dataTable.Remove(key);
+                }
+                else
+                {
+                    _toRemove.Add(key);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/6452

## Description

The `_dataTable` is the field in WeakEventTable which will be read and written in a thread-unsafe code. See https://github.com/dotnet/wpf/issues/6452

## Customer Impact

Fix the WeakEventTable thread safe issues.

## Regression

None.

## Testing

Just CI.

## Risk

The lock may cause the performance issues.
