### PR TITLE
Better fix build when using source generators coming from NuGet package

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -435,11 +435,6 @@
           <_IntermediateOutputPathNoTargetFrameworkOrRID>$([System.Text.RegularExpressions.Regex]::Replace($(_IntermediateOutputPathNoTargetFrameworkOrRID), "$(TargetFramework)\\$",, System.Text.RegularExpressions.RegexOptions.IgnoreCase))</_IntermediateOutputPathNoTargetFrameworkOrRID>
       </PropertyGroup>
 
-      <ItemGroup>
-          <!-- Include analyzers that are coming from a FrameworkReference in the temporary target assembly project. -->
-          <_TemporaryTargetAssemblyAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.FrameworkReferenceName)' != ''" />
-      </ItemGroup>
-
        <!--  Use the legacy .NET Framework/.NET Core 3.0 GenerateTemporaryTargetAssembly path if 'IncludePackageReferencesDuringMarkupCompilation' is 'false',. -->
        <GenerateTemporaryTargetAssembly
                 CurrentProject="$(MSBuildProjectFullPath)"
@@ -455,7 +450,7 @@
                 CompileTargetName="$(_CompileTargetNameForLocalType)"
                 GenerateTemporaryTargetAssemblyDebuggingInformation="$(GenerateTemporaryTargetAssemblyDebuggingInformation)"
                 IncludePackageReferencesDuringMarkupCompilation="$(IncludePackageReferencesDuringMarkupCompilation)"
-                Analyzers="@(_TemporaryTargetAssemblyAnalyzer)"
+                Analyzers="@(Analyzer)"
                 TemporaryTargetAssemblyProjectName="$(_TemporaryTargetAssemblyProjectName)"
                 MSBuildProjectExtensionsPath="$(MSBuildProjectExtensionsPath)"
                  >
@@ -491,6 +486,20 @@
                      Condition="Exists('%(Fullpath)')" />
   </Target>
 
+  <!--
+                 ===========================================
+                          RemoveDuplicateAnalyzers
+                 ===========================================
+
+                Name : RemoveDuplicateAnalyzers
+  -->
+  <Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
+    <ItemGroup>
+        <FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+        <Analyzer Remove="@(Analyzer)" />
+        <Analyzer Include="@(FilteredAnalyzer)" />
+    </ItemGroup>
+</Target>
 
 <!--
     ================================================================


### PR DESCRIPTION
Fixes dotnet/wpf#6792

Description
Fixes build of project using source generators coming from NuGet packages. I fixed this by only including analyzers that are coming from a FrameworkReference in the temporary target assembly project. Those analyzers are the ones that are not automatically added in the temporary target assembly project because ResolveTargetingPackAssets is never called (We could investigate calling this target in the future but, to me, it seemed riskier than the changes in this PR).

[Added a target to de-duplicate the list of analyzers ](https://github.com/dotnet/wpf/issues/6792#issuecomment-1183633402)

Customer Impact
Fixes build.

Regression
This is a regression introduced in .Net 6.0.7 by https://github.com/dotnet/wpf/pull/6534 which was backported by https://github.com/dotnet/wpf/pull/6680. Those were changes from me, sorry about the regression.

Testing
Tested locally by building a project which uses Regex source generator, WinForms source generator and [CommunityToolkit.Mvvm 7.1.2](https://www.nuget.org/packages/CommunityToolkit.Mvvm/7.1.2) source generator (This is an example of a source generator that currently fails on .Net 6.0.7 SDK).

Risk
Low.