### PR TITLE
Fix build when using source generators coming from NuGet package

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -513,6 +513,20 @@
 
   </Target>
 
+  <!--
+                 ===========================================
+                          RemoveDuplicateAnalyzers
+                 ===========================================
+
+                Name : RemoveDuplicateAnalyzers
+  -->
+  <Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
+    <ItemGroup>
+        <FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+        <Analyzer Remove="@(Analyzer)" />
+        <Analyzer Include="@(FilteredAnalyzer)" />
+    </ItemGroup>
+  </Target>
 
 
 <!--
@@ -997,4 +1011,3 @@
   <!-- End of the project file, Do not add any more propeties, items, targets etc. -->
 
 </Project>
-


### PR DESCRIPTION
Fixes dotnet/wpf#6792

## Description
Fixes build of project using source generators coming from NuGet packages. Added a new target for de-duplicating the list of analyzers.

[Added a target to de-duplicate the list of analyzers ](https://github.com/dotnet/wpf/issues/6792#issuecomment-1183633402)

### Customer Impact
Fixes build.

### Regression
This is a regression introduced in .Net 6.0.7 by https://github.com/dotnet/wpf/pull/6534 which was backported by https://github.com/dotnet/wpf/pull/6680. 

### Testing
Tested locally by building a project which uses Regex source generator, WinForms source generator and [CommunityToolkit.Mvvm 7.1.2](https://www.nuget.org/packages/CommunityToolkit.Mvvm/7.1.2) source generator (This is an example of a source generator that currently fails on .Net 6.0.7 SDK).

### Risk
Low.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6800)