### PR TITLE
WPF DataGrid/GridView column width can be changed using the keyboard shortcut ALT+left or right arrow key

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -964,28 +964,36 @@ namespace System.Windows.Controls
         /// </summary>
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
+            if (!e.Handled)
             {
-                DataGridLength updatedWidth = new DataGridLength();
+                const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
+                ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
 
-                if (e.Key == Key.Right)
+                if (((e.SystemKey == Key.Right) || (e.SystemKey == Key.Left)) && (modifierKeys == ModifierKeys.Alt))
                 {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth + ColumnWidthStepSize);
-                }
-                else if (e.Key == Key.Left)
-                {
-                    updatedWidth = new DataGridLength(this.Column.ActualWidth - ColumnWidthStepSize);
-                }
+                    DataGridLength updatedWidth = new DataGridLength();
 
-                if (Column.CanColumnResize(updatedWidth))
-                {
-                    this.Column.SetCurrentValue(DataGridColumn.WidthProperty, updatedWidth);
-                }
+                    if (e.SystemKey == Key.Right)
+                    {
+                        updatedWidth = new DataGridLength(Column.ActualWidth + ColumnWidthStepSize);
+                    }
+                    else if (e.SystemKey == Key.Left)
+                    {
+                        updatedWidth = new DataGridLength(Column.ActualWidth - ColumnWidthStepSize);
+                    }
 
-                e.Handled = true;
-                return;
+                    if (Column != null)
+                    {
+                        if (Column.CanColumnResize(updatedWidth))
+                        {
+                            Column.SetCurrentValueInternal(DataGridColumn.WidthProperty, updatedWidth);
+                        }
+                        e.Handled = true;
+                    }
+                    return;
+                }
             }
-            
+
             SendInputToColumn(e);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumn.cs
@@ -1491,7 +1491,7 @@ namespace System.Windows.Controls
                 column.DataGridOwner,
                 DataGrid.CanUserResizeColumnsProperty);
         }
-        
+
         internal bool CanColumnResize(DataGridLength width)
         {
             if (!CanUserResize)
@@ -1501,7 +1501,7 @@ namespace System.Windows.Controls
 
             return width.DisplayValue >= this.MinWidth && width.DisplayValue <= this.MaxWidth;
         }
-        
+
         #endregion
 
         #region Hidden Columns

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnHeader.cs
@@ -452,6 +452,19 @@ namespace System.Windows.Controls
             SetFlag(ignoreFlag, false);
         }
 
+        // Set column header width and associated column width
+        internal void UpdateColumnHeaderWidth(double width)
+        {
+            if (Column != null)
+            {
+                Column.Width = width;
+            }
+            else
+            {
+                Width = width;
+            }
+        }
+
         #endregion Internal Methods
 
         //-------------------------------------------------------------------
@@ -785,19 +798,6 @@ namespace System.Windows.Controls
                 {
                     _headerGripper.Cursor = gripperCursor;
                 }
-            }
-        }
-
-        // Set column header width and associated column width
-        internal void UpdateColumnHeaderWidth(double width)
-        {
-            if (Column != null)
-            {
-                Column.Width = width;
-            }
-            else
-            {
-                Width = width;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -349,31 +349,7 @@ namespace System.Windows.Controls
                 case Key.Left:
                 case Key.Down:
                 case Key.Right:
-                    {
-                    if ((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt && (e.Key == Key.Left || e.Key == Key.Right))
-                        {
-                            if(e.OriginalSource is GridViewColumnHeader gridViewColumnHeader)
-                            {
-                                if (key == Key.Left)
-                                {
-                                    if(gridViewColumnHeader.Column.ActualWidth > 0)
-                                    {
-                                        gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth - ColumnWidthStepSize;
-                                        gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
-                                    }
-                                    
-                                    handled = true;
-                                }
-                                else if (key == Key.Right)
-                                {
-                                    gridViewColumnHeader.Width = gridViewColumnHeader.Column.ActualWidth + ColumnWidthStepSize;
-                                    gridViewColumnHeader.UpdateColumnHeaderWidth(gridViewColumnHeader.Width);
-                                    handled = true;
-                                }
-                                break;
-                            }
-                        }
-                    
+                    {                   
                         KeyboardNavigation.ShowFocusVisual();
 
                         // Depend on logical orientation we decide to move focus or just scroll
@@ -508,6 +484,45 @@ namespace System.Windows.Controls
                 case Key.PageDown:
                     NavigateByPage(FocusNavigationDirection.Down, new ItemNavigateArgs(e.Device, Keyboard.Modifiers));
                     break;
+
+                case Key.System:
+                    Key skey = e.SystemKey;
+                    switch (skey)
+                    {
+                        case Key.Right:
+                        case Key.Left:
+                            const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
+                            ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
+
+                            if (modifierKeys == ModifierKeys.Alt)
+                            {
+                                if (e.OriginalSource is GridViewColumnHeader gridViewColumnHeader && gridViewColumnHeader.Column != null)
+                                {
+                                    double width = 0;
+                                    if (e.SystemKey == Key.Left)
+                                    {
+                                        width = gridViewColumnHeader.Column.ActualWidth - ColumnWidthStepSize;
+                                    }
+                                    else if (e.SystemKey == Key.Right)
+                                    {
+                                        width = gridViewColumnHeader.Column.ActualWidth + ColumnWidthStepSize;
+                                    }
+
+                                    if (width > 0)
+                                    {
+                                        gridViewColumnHeader.UpdateColumnHeaderWidth(width);
+                                    }
+                                }
+                            }
+                            break;
+
+                        default:
+                            handled = false;
+                            break;
+                    }
+
+                    break;
+
 
                 default:
                     handled = false;


### PR DESCRIPTION
Fixes #5880

Main PR #6054

## Description
Issue related to WPF DataGrid column width can now be changed using the keyboard shortcut "ALT + left arrow key" and "ALT + right arrow key".

## Customer Impact
Adds a requirement.

## Regression
NO

## Risk
Low. Add ability to adjust column width using keyboard for WPF DataGrid.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6812)