### PR TITLE
Close Stream when creating an ImageSource from a Uri

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ImageSourceConverter.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Media
                         uriHolder.OriginalUri,
                         null,
                         BitmapCreateOptions.None,
-                        BitmapCacheOption.Default,
+                        BitmapCacheOption.OnLoad,
                         null
                         );
                 }


### PR DESCRIPTION
Fixes #6842

## Description

During XAML serialization, an `ImageSource` may first be loaded by `ImageSourceConverter.ConvertFrom`. This calls `BitmapDecoder.CreateFromUriOrStream` with a pack URI, opens a `Stream`, and keeps it open. This will eventually be closed by the `BitmapDecoder` finalizer (see comments in that method).

https://github.com/dotnet/wpf/blob/c8742b5c39f72927e8598825291d6cf4e593df10/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs#L215-L221

Subsequently the same pack URI is opened by `ImageSourceTypeConverter.ConvertTo`. This throws an `IOException: 'Entries cannot be opened multiple times in Update mode.'`. This occurs because the same `ZipArchiveEntry` is being opened a second time, while the first stream is still open.

By specifying `BitmapCacheOption.OnLoad` here, `BitmapDecoder.Initialize` will eagerly close the stream, which allows the `ZipArchiveEntry` to be opened a second time.

## Customer Impact

Fixes an exception that prevents certain documents (presumably ones containing images, or ImageBrushes?) from printing.

## Regression

Yes, regression from .NET Framework 4.8.

## Testing

Tested in real-world application by using Faithlife.WPF: https://github.com/Faithlife/wpf/blob/stable/README.md#faithlifewpf

## Risk

Seems low-risk. May improve system resource usage by closing streams early instead of letting them be closed by a finalizer? OTOH, may perform unnecessary image decoding work up-front?
