### PR TITLE
Remove the unnecessary fields in DpiHelper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/DpiHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/DpiHelper.cs
@@ -13,11 +13,6 @@ namespace Standard
 
     internal static class DpiHelper
     {
-        [ThreadStatic]
-        private static Matrix _transformToDevice;
-        [ThreadStatic]
-        private static Matrix _transformToDip;
-
         /// <summary>
         /// Convert a point in device independent pixels (1/96") to a point in the system coordinates.
         /// </summary>
@@ -25,9 +20,9 @@ namespace Standard
         /// <returns>Returns the parameter converted to the system's coordinates.</returns>
         public static Point LogicalPixelsToDevice(Point logicalPoint, double dpiScaleX, double dpiScaleY)
         {
-            _transformToDevice = Matrix.Identity;
-            _transformToDevice.Scale(dpiScaleX, dpiScaleY);
-            return _transformToDevice.Transform(logicalPoint);
+            Matrix transformToDevice = Matrix.Identity;
+            transformToDevice.Scale(dpiScaleX, dpiScaleY);
+            return transformToDevice.Transform(logicalPoint);
         }
 
         /// <summary>
@@ -37,9 +32,9 @@ namespace Standard
         /// <returns>Returns the parameter converted to the device independent coordinate system.</returns>
         public static Point DevicePixelsToLogical(Point devicePoint, double dpiScaleX, double dpiScaleY)
         {
-            _transformToDip = Matrix.Identity;
-            _transformToDip.Scale(1d / dpiScaleX, 1d / dpiScaleY);
-            return _transformToDip.Transform(devicePoint);
+            Matrix transformToDip = Matrix.Identity;
+            transformToDip.Scale(1d / dpiScaleX, 1d / dpiScaleY);
+            return transformToDip.Transform(devicePoint);
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]


### PR DESCRIPTION
## Description

We can merge the `_transformToDevice` and `_transformToDip` fields to local variable. Why we define the  `_transformToDevice` and `_transformToDip` fields? Because we use the two fields to store the DPI in the previous version, and the code is:

```csharp
        private static Matrix _transformToDevice;
        private static Matrix _transformToDip;

        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
        static DpiHelper()
        {
            using (SafeDC desktop = SafeDC.GetDesktop())
            {
                int deviceCaps1 = NativeMethods.GetDeviceCaps(desktop, DeviceCap.LOGPIXELSX);
                int deviceCaps2 = NativeMethods.GetDeviceCaps(desktop, DeviceCap.LOGPIXELSY);
                DpiHelper._transformToDip = Matrix.Identity;
                DpiHelper._transformToDip.Scale(96.0 / (double)deviceCaps1, 96.0 / (double)deviceCaps2);
                DpiHelper._transformToDevice = Matrix.Identity;
                DpiHelper._transformToDevice.Scale((double)deviceCaps1 / 96.0, (double)deviceCaps2 / 96.0);
            }
        }
```

In order to support Per-Moniter v2, we will use the DPI in per window and we do not get the dpi from desktop once. It is means that we do not need these two fields anymore.

## Customer Impact

None.

## Regression

None.

## Testing

Just CI.

## Risk

Low. Unless some developers rely on using reflection to get fields.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6851)