### PR TITLE
Supress CA1420 Temporarily to fix build errors

### DIFF
--- a/src/Microsoft.DotNet.Wpf/Directory.Build.Props
+++ b/src/Microsoft.DotNet.Wpf/Directory.Build.Props
@@ -1,3 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1420</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Supress CA1420 Temporarily to fix build errors

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/6952)