### PR TITLE
Enable h/w acceleration in RDP

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/display.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/display.cpp
@@ -2125,7 +2125,7 @@ CDisplaySet::GetGraphicsAccelerationCaps(
         *pulDisplayUniqueness = m_ulDisplayUniquenessLoader;
     }
 
-    if (m_rgpDisplays.GetCount() == 0 || m_fNonLocalDevicePresent)
+    if (m_rgpDisplays.GetCount() == 0)
     {
         //
         // No display - no acceleration


### PR DESCRIPTION
Fixes  https://github.com/dotnet/wpf/issues/3215

## Description

Enable h/w acceleration in RDP. See https://github.com/dotnet/wpf/issues/3215

cc @vatsan-madhavan

## Customer Impact

The application can use the h/w acceleration in RDP

## Regression

None.

## Testing

Just CI.

## Risk

Medium. This will change some rendering behavior.
