### PR TITLE
Revert autoConvert for string DataObjects

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorCopyPaste.cs
@@ -92,14 +92,14 @@ namespace System.Windows.Documents
                 // ConfirmDataFormatSetting rasies a public event - could throw recoverable exception.
                 if (ConfirmDataFormatSetting(This.UiScope, dataObject, DataFormats.Text))
                 {
-                    dataObject.SetData(DataFormats.Text, textString, false);
+                    dataObject.SetData(DataFormats.Text, textString, true);
                 }
 
                 // Copy unicode text into data object.
                 // ConfirmDataFormatSetting rasies a public event - could throw recoverable exception.
                 if (ConfirmDataFormatSetting(This.UiScope, dataObject, DataFormats.UnicodeText))
                 {
-                    dataObject.SetData(DataFormats.UnicodeText, textString, false);
+                    dataObject.SetData(DataFormats.UnicodeText, textString, true);
                 }
             }
 


### PR DESCRIPTION
Fixes #3965

## Description

During #969, creating `DataObject`s was effectively changed from `autoConvert = true` to `autoConvert = false`. As a result, dragging selection from a `TextBox` no longer sets `System.String` format on the `DataObject`. I believe this change was unintentional, as the same commit keeps `System.String` elsewhere (e.g. in `GetMappedFormats`).

## Customer Impact

Not taking this fix would mean existing applications that rely on `System.String` data format would no longer support dropping text from text boxes. A prominent example of such application is a sample in documentation: https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control?view=netframeworkdesktop-4.8

## Regression

Yes. Introduced in #969, diverting from .NET Framework behaviour.

## Testing

Compiled on 7.0.100-preview.4.22252.9 and verified that `e.Data.GetFormats()` in `DragOver` does not return `System.String` format without the fix, but it does return it in .NET Framework and after the fix.

## Risk

The fix restores the previous behaviour, so the risk should be minimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7028)