### PR TITLE
Fix the stream do not be closed in ImageSourceTypeConverter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ImageSourceTypeConverter.cs
@@ -242,9 +242,10 @@ namespace System.Windows.Xps.Serialization
                     try
                     {
                         Uri sourceUri = new Uri(decoder.ToString());
-                        Stream srcStream = MS.Internal.WpfWebRequestHelper.CreateRequestAndGetResponseStream(sourceUri);
-                        CopyImageStream(srcStream, resourceStream.Stream);
-                        srcStream.Close();
+                        using (Stream srcStream = MS.Internal.WpfWebRequestHelper.CreateRequestAndGetResponseStream(sourceUri))
+                        {
+                            CopyImageStream(srcStream, resourceStream.Stream);
+                        }
                         bCopiedStream = true;
                     }
                     catch (UriFormatException)


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/6842



## Description

The ImageSourceTypeConverter will request the stream. And the ImageSourceTypeConverter will close the stream after `CopyImageStream` method. But the stream will not be closed when the `CopyImageStream` throw the exception.

This will make the ZipArchiveEntry throw the `System.IO.IOException: 'Entries cannot be opened multiple times in Update mode.'` when we next time to request the stream.

## Customer Impact

Maybe this can fix https://github.com/dotnet/wpf/issues/6842

## Regression

None.

## Testing

Just CI

## Risk

Very low?


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7091)