### PR TITLE
Fix #122 - NullReferenceException in ItemAutomationPeer.GetNameCore()

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -527,9 +527,10 @@ namespace System.Windows.Automation.Peers
             {
                 name = wrapperPeer.GetName();
             }
-            else if (item != null)
+            // see https://github.com/dotnet/wpf/issues/122
+            else if (item != null && ItemsControlAutomationPeer is { } itemsControlAutomationPeer)
             {
-                using (RecyclableWrapper recyclableWrapper = ItemsControlAutomationPeer.GetRecyclableWrapperPeer(item))
+                using (RecyclableWrapper recyclableWrapper = itemsControlAutomationPeer.GetRecyclableWrapperPeer(item))
                 {
                     name = recyclableWrapper.Peer.GetName();
                 }


### PR DESCRIPTION
For virtualized tree views it can happen that we are calling GetNameCore() on an item that has been scrolled out of view and doesn't have an associated container. ItemContainerGenerator.GetContainerFromItem() returns null, and so ItemsControlAutomationPeer ends up being null as well.

We're still going to retrieve the name from the item.ToString(), so it's much better than crashing here and aborting the entire layout pass.

Fixes #122

## Customer Impact

Most customers using virtualized tree views with large number of items will hit this, and the impact may be severe (corrupted scrolling, rendering, layout)

## Regression

This is not a regression

## Testing

Testing needs to happen after producing a build with the fix. To test: open a virtualized tree view with lots of items and scroll under debugger. There should be no exceptions.

## Risk

Risk is very low. It's just a null check.
