### PR TITLE
fix(knowntypes): adding IsReadOnly as known property for TextBox and RichTextBox

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfGeneratedKnownProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfGeneratedKnownProperties.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Baml2006
 {
     partial class WpfSharedBamlSchemaContext: XamlSchemaContext
     {
-        const int KnownPropertyCount = 268;
+        const int KnownPropertyCount = 270;
 
 
         private WpfKnownMember CreateKnownMember(short bamlNumber)
@@ -284,6 +284,8 @@ namespace System.Windows.Baml2006
                 case 266: return Create_BamlProperty_Window_Content();
                 case 267: return Create_BamlProperty_WrapPanel_Children();
                 case 268: return Create_BamlProperty_XmlDataProvider_XmlSerializer();
+                case 269: return Create_BamlProperty_TextBox_IsReadOnly();
+                case 270: return Create_BamlProperty_RichTextBox_IsReadOnly();
                 default:
                     throw new InvalidOperationException("Invalid BAML number");
             }
@@ -640,6 +642,7 @@ namespace System.Windows.Baml2006
                     switch(property)
                     {
                         case "Text": return GetKnownBamlMember(-114);
+                        case "IsReadOnly": return GetKnownBamlMember(-269);
                         case "TextWrapping": return Create_BamlProperty_TextBox_TextWrapping();
                         case "TextAlignment": return Create_BamlProperty_TextBox_TextAlignment();
                         default: return null;
@@ -1196,6 +1199,7 @@ namespace System.Windows.Baml2006
                     switch(property)
                     {
                         case "Document": return GetKnownBamlMember(-224);
+                        case "IsReadOnly": return GetKnownBamlMember(-270);
                         default: return null;
                     }
                 case 1536792507:
@@ -3629,6 +3633,23 @@ namespace System.Windows.Baml2006
         }
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private WpfKnownMember Create_BamlProperty_TextBox_IsReadOnly()
+        {
+            Type type = typeof(System.Windows.Controls.TextBox);
+            DependencyProperty dp = System.Windows.Controls.TextBox.IsReadOnlyProperty;
+            var bamlMember = new WpfKnownMember(this,  // Schema Context
+                            this.GetXamlType(typeof(System.Windows.Controls.TextBox)), // DeclaringType
+                            "IsReadOnly", // Name
+                             dp, // DependencyProperty
+                            false, // IsReadOnly
+                            false // IsAttachable
+                                     );
+            bamlMember.TypeConverterType = typeof(System.ComponentModel.BooleanConverter);
+            bamlMember.Freeze();
+            return bamlMember;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private WpfKnownMember Create_BamlProperty_TextElement_Background()
         {
             Type type = typeof(System.Windows.Documents.TextElement);
@@ -5485,6 +5506,23 @@ namespace System.Windows.Baml2006
                                      );
             bamlMember.SetDelegate = delegate(object target, object value) { ((System.Windows.Controls.RichTextBox)target).Document = (System.Windows.Documents.FlowDocument)value; };
             bamlMember.GetDelegate = delegate(object target) { return ((System.Windows.Controls.RichTextBox)target).Document; };
+            bamlMember.Freeze();
+            return bamlMember;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private WpfKnownMember Create_BamlProperty_RichTextBox_IsReadOnly()
+        {
+            Type type = typeof(System.Windows.Controls.RichTextBox);
+            DependencyProperty dp = System.Windows.Controls.RichTextBox.IsReadOnlyProperty;
+            var bamlMember = new WpfKnownMember(this,  // Schema Context
+                            this.GetXamlType(typeof(System.Windows.Controls.RichTextBox)), // DeclaringType
+                            "IsReadOnly", // Name
+                             dp, // DependencyProperty
+                            false, // IsReadOnly
+                            false // IsAttachable
+                                     );
+            bamlMember.TypeConverterType = typeof(System.ComponentModel.BooleanConverter);
             bamlMember.Freeze();
             return bamlMember;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
@@ -1106,6 +1106,8 @@ namespace System.Windows.Markup
         WrapPanel_Children,
         XmlDataProvider_XmlSerializer,
         MaxProperty,
+        TextBox_IsReadOnly,
+        RichTextBox_IsReadOnly
     }
 
 #if !BAMLDASM
@@ -1862,6 +1864,8 @@ namespace System.Windows.Markup
                     return System.Windows.Controls.Primitives.Popup.PlacementProperty;
                 case KnownProperties.Popup_PopupAnimation:
                     return System.Windows.Controls.Primitives.Popup.PopupAnimationProperty;
+                case KnownProperties.RichTextBox_IsReadOnly:
+                    return System.Windows.Controls.RichTextBox.IsReadOnlyProperty;
                 case KnownProperties.RowDefinition_Height:
                     return System.Windows.Controls.RowDefinition.HeightProperty;
                 case KnownProperties.RowDefinition_MaxHeight:
@@ -1906,6 +1910,8 @@ namespace System.Windows.Markup
                     return System.Windows.Controls.TextBlock.TextWrappingProperty;
                 case KnownProperties.TextBox_Text:
                     return System.Windows.Controls.TextBox.TextProperty;
+                case KnownProperties.TextBox_IsReadOnly:
+                    return System.Windows.Controls.TextBox.IsReadOnlyProperty;
                 case KnownProperties.TextElement_Background:
                     return System.Windows.Documents.TextElement.BackgroundProperty;
                 case KnownProperties.TextElement_FontFamily:
@@ -2251,6 +2257,8 @@ namespace System.Windows.Markup
                     return KnownElements.RepeatButton;
                 case KnownProperties.RichTextBox_Document:
                     return KnownElements.RichTextBox;
+                case KnownProperties.RichTextBox_IsReadOnly:
+                    return KnownElements.RichTextBox;
                 case KnownProperties.Rotation3DAnimationUsingKeyFrames_KeyFrames:
                     return KnownElements.Rotation3DAnimationUsingKeyFrames;
                 case KnownProperties.RowDefinition_Height:
@@ -2318,6 +2326,8 @@ namespace System.Windows.Markup
                 case KnownProperties.TextBlock_TextWrapping:
                     return KnownElements.TextBlock;
                 case KnownProperties.TextBox_Text:
+                    return KnownElements.TextBox;
+                case KnownProperties.TextBox_IsReadOnly:
                     return KnownElements.TextBox;
                 case KnownProperties.TextElement_Background:
                 case KnownProperties.TextElement_FontFamily:
@@ -3379,6 +3389,8 @@ namespace System.Windows.Markup
                 case KnownElements.RichTextBox:
                     if (String.CompareOrdinal(fieldName, "Document") == 0)
                         return (short)KnownProperties.RichTextBox_Document;
+                    if (String.CompareOrdinal(fieldName, "IsReadOnly") == 0)
+                        return (short)KnownProperties.RichTextBox_IsReadOnly;
                     break;
                 case KnownElements.Rotation3DAnimationUsingKeyFrames:
                     if (String.CompareOrdinal(fieldName, "KeyFrames") == 0)
@@ -3515,6 +3527,8 @@ namespace System.Windows.Markup
                 case KnownElements.TextBox:
                     if (String.CompareOrdinal(fieldName, "Text") == 0)
                         return (short)KnownProperties.TextBox_Text;
+                    if (String.CompareOrdinal(fieldName, "IsReadOnly") == 0)
+                        return (short)KnownProperties.TextBox_IsReadOnly;
                     break;
                 case KnownElements.TextElement:
                     if (String.CompareOrdinal(fieldName, "Background") == 0)


### PR DESCRIPTION
Fixes #6977

## Description

Adding _IsReadOnly_ as a known property for _TextBox_ and _RichTextBox_

## Customer Impact

Users were not able to use _IsReadOnly_ property in the _ControlTemplate.Triggers_ while using it in _ResourceDictionary_ in a separate file.

## Regression

NO

## Testing

NA

## Risk

Risk is low as fix does not modify existing code or changes any public api

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7164)