### PR TITLE
Use ArgumentNullException.ThrowIfNull in System.Xaml

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ArrayExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ArrayExtension.cs
@@ -46,10 +46,7 @@ namespace System.Windows.Markup
         /// <param name="elements">The array to write</param>
         public ArrayExtension(Array elements)
         {
-            if (elements == null)
-            {
-                throw new ArgumentNullException(nameof(elements));
-            }
+            ArgumentNullException.ThrowIfNull(elements);
 
             _arrayList.AddRange(elements);
             _arrayType = elements.GetType().GetElementType();

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
@@ -80,10 +80,7 @@ namespace System.Windows.Markup
 
                 // Get the IXamlTypeResolver from the service provider
 
-                if (serviceProvider == null)
-                {
-                    throw new ArgumentNullException(nameof(serviceProvider));
-                }
+                ArgumentNullException.ThrowIfNull(serviceProvider);
 
                 IXamlTypeResolver xamlTypeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
                 if (xamlTypeResolver == null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
@@ -74,10 +74,7 @@ namespace System.Windows.Markup
 
             // Get the IXamlTypeResolver from the service provider
 
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }            
+            ArgumentNullException.ThrowIfNull(serviceProvider);            
 
             IXamlTypeResolver xamlTypeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
             if( xamlTypeResolver == null )

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
@@ -118,8 +118,7 @@ namespace System.Windows.Markup
         /// <returns>The value serializer associated with the given type</returns>
         public static ValueSerializer GetSerializerFor(Type type)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
+            ArgumentNullException.ThrowIfNull(type);
 
             object value = _valueSerializers[type];
             if (value != null)
@@ -176,10 +175,7 @@ namespace System.Windows.Markup
         public static ValueSerializer GetSerializerFor(PropertyDescriptor descriptor)
         {
             ValueSerializer result;
-            if (descriptor == null)
-            {
-                throw new ArgumentNullException(nameof(descriptor));
-            }
+            ArgumentNullException.ThrowIfNull(descriptor);
             
             #pragma warning suppress 6506 // descriptor is obviously not null
             ValueSerializerAttribute serializerAttribute = descriptor.Attributes[typeof(ValueSerializerAttribute)] as ValueSerializerAttribute;
@@ -244,8 +240,7 @@ namespace System.Windows.Markup
         /// </summary>
         protected Exception GetConvertToException(object value, Type destinationType)
         {
-            if (destinationType == null)
-                throw new ArgumentNullException(nameof(destinationType));
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             string text;
             if (value == null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/NameScope.cs
@@ -27,11 +27,8 @@ namespace System.Xaml
         /// <param name="scopedElement">object mapped to name</param>
         public void RegisterName(string name, object scopedElement)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (scopedElement == null)
-                throw new ArgumentNullException(nameof(scopedElement));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(scopedElement);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -75,8 +72,7 @@ namespace System.Xaml
         /// <param name="name">name to be registered</param>
         public void UnregisterName(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -221,23 +217,13 @@ namespace System.Xaml
         {
             get
             {
-                if (key == null)
-                {
-                    throw new ArgumentNullException(nameof(key));
-                }
+                ArgumentNullException.ThrowIfNull(key);
                 return FindName(key);
             }
             set
             {
-                if (key == null)
-                {
-                    throw new ArgumentNullException(nameof(key));
-                }
-
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(key);
+                ArgumentNullException.ThrowIfNull(value);
 
                 RegisterName(key, value);
             }
@@ -245,20 +231,14 @@ namespace System.Xaml
 
         public void Add(string key, object value)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key);
 
             RegisterName(key, value);
         }
 
         public bool ContainsKey(string key)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key);
 
             object value = FindName(key);
             return (value != null);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
@@ -69,10 +69,7 @@ namespace System.Xaml
                 return;
             }
 
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             IAttachedPropertyStore ap = instance as IAttachedPropertyStore;
             if (ap != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
@@ -130,10 +130,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
                                                     IEnumerable<XamlType> ceilingTypes,
                                                     params XamlMember[] properties)
         {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
+            ArgumentNullException.ThrowIfNull(properties);
 
             foreach (var property in properties)
             {
@@ -149,10 +146,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
 
         object IAmbientProvider.GetFirstAmbientValue(params XamlType[] types)
         {
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
             foreach (var type in types)
             {
@@ -170,10 +164,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
                                                     IEnumerable<XamlType> ceilingTypes,
                                                     params XamlMember[] properties)
         {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
+            ArgumentNullException.ThrowIfNull(properties);
 
             foreach (var property in properties)
             {
@@ -189,10 +180,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
 
         IEnumerable<object> IAmbientProvider.GetAllAmbientValues(params XamlType[] types)
         {
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
             foreach (var type in types)
             {
@@ -212,10 +200,7 @@ internal class ServiceProviderContext : ITypeDescriptorContext,  // derives from
                                                     IEnumerable<XamlType> types,
                                                     params XamlMember[] properties)
         {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
+            ArgumentNullException.ThrowIfNull(properties);
 
             foreach (var property in properties)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Events/ObjectCreatedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Events/ObjectCreatedEventArgs.cs
@@ -16,10 +16,7 @@ namespace System.Xaml
     {
         public XamlCreatedObjectEventArgs(Object createdObject)
         {
-            if (createdObject == null)
-            {
-                throw new ArgumentNullException("createdObject");
-            }
+            ArgumentNullException.ThrowIfNull(createdObject);
 
             CreatedObject = createdObject;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -47,28 +47,19 @@ namespace System.Xaml
 
         public XamlObjectWriter(XamlSchemaContext schemaContext)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             Initialize(schemaContext, (XamlSavedContext)null, (XamlObjectWriterSettings)null);
         }
 
         public XamlObjectWriter(XamlSchemaContext schemaContext, XamlObjectWriterSettings settings)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             Initialize(schemaContext, (XamlSavedContext)null, settings);
         }
 
         internal XamlObjectWriter(XamlSavedContext savedContext, XamlObjectWriterSettings settings)
         {
-            if (savedContext == null)
-            {
-                throw new ArgumentNullException(nameof(savedContext));
-            }
+            ArgumentNullException.ThrowIfNull(savedContext);
             if (savedContext.SchemaContext == null)
             {
                 throw new ArgumentException(SR.SavedContextSchemaContextNull, nameof(savedContext));
@@ -81,10 +72,7 @@ namespace System.Xaml
             _inDispose = false;
             //ObjectWriter must be passed in a non-null SchemaContext.  We check that here, since the CreateContext method
             //will create one if a null SchemaContext was passed in.
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             if (savedContext != null && schemaContext != savedContext.SchemaContext)
             {
                 throw new ArgumentException(SR.SavedContextSchemaContextMismatch, nameof(schemaContext));
@@ -322,10 +310,7 @@ namespace System.Xaml
         public override void WriteStartObject(XamlType xamlType)
         {
             ThrowIfDisposed();
-            if (xamlType == null)
-            {
-                throw new ArgumentNullException(nameof(xamlType));
-            }
+            ArgumentNullException.ThrowIfNull(xamlType);
 
             // Deferring Checking
             //
@@ -576,10 +561,7 @@ namespace System.Xaml
         public override void WriteStartMember(XamlMember property)
         {
             ThrowIfDisposed();
-            if (property == null)
-            {
-                throw new ArgumentNullException(nameof(property));
-            }
+            ArgumentNullException.ThrowIfNull(property);
 
             // Deferring Checking
             //
@@ -894,10 +876,7 @@ namespace System.Xaml
         public override void WriteNamespace(NamespaceDeclaration namespaceDeclaration)
         {
             ThrowIfDisposed();
-            if (namespaceDeclaration == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceDeclaration));
-            }
+            ArgumentNullException.ThrowIfNull(namespaceDeclaration);
             if(namespaceDeclaration.Prefix == null)
             {
                 throw new ArgumentException(SR.NamespaceDeclarationPrefixCannotBeNull);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriterSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriterSettings.cs
@@ -15,10 +15,7 @@ namespace System.Xaml
 
         public XamlObjectWriterSettings(XamlObjectWriterSettings settings)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            ArgumentNullException.ThrowIfNull(settings);
             AfterBeginInitHandler = settings.AfterBeginInitHandler;
             BeforePropertiesHandler = settings.BeforePropertiesHandler;
             AfterPropertiesHandler = settings.AfterPropertiesHandler;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlTextReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlTextReader.cs
@@ -49,16 +49,14 @@ namespace System.Xaml
 
         public XamlTextReader(XmlReader xmlReader, XamlSchemaContext schemaContext)
         {
-            if (schemaContext == null)
-                throw new ArgumentNullException("schemaContext");
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(xmlReader, schemaContext, null);
         }
 
         public XamlTextReader(XmlReader xmlReader, XamlSchemaContext schemaContext, XamlTextReaderSettings settings)
         {
-            if (schemaContext == null)
-                throw new ArgumentNullException("schemaContext");
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(xmlReader, schemaContext, settings);
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -27,95 +27,59 @@ namespace System.Xaml
 
         public XamlXmlReader(XmlReader xmlReader)
         {
-            if (xmlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xmlReader));
-            }
+            ArgumentNullException.ThrowIfNull(xmlReader);
 
             Initialize(xmlReader, null, null);
         }
 
         public XamlXmlReader(XmlReader xmlReader, XamlXmlReaderSettings settings)
         {
-            if (xmlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xmlReader));
-            }
+            ArgumentNullException.ThrowIfNull(xmlReader);
 
             Initialize(xmlReader, null, settings);
         }
 
         public XamlXmlReader(XmlReader xmlReader, XamlSchemaContext schemaContext)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
-            if (xmlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xmlReader));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
+            ArgumentNullException.ThrowIfNull(xmlReader);
 
             Initialize(xmlReader, schemaContext, null);
         }
 
         public XamlXmlReader(XmlReader xmlReader, XamlSchemaContext schemaContext, XamlXmlReaderSettings settings)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
-            if (xmlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xmlReader));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
+            ArgumentNullException.ThrowIfNull(xmlReader);
 
             Initialize(xmlReader, schemaContext, settings);
         }
 
         public XamlXmlReader(string fileName)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
             Initialize(CreateXmlReader(fileName, null), null, null);
         }
 
         public XamlXmlReader(string fileName, XamlXmlReaderSettings settings)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
 
             Initialize(CreateXmlReader(fileName, settings), null, settings);
         }
 
         public XamlXmlReader(string fileName, XamlSchemaContext schemaContext)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(fileName, null), schemaContext, null);
         }
 
         public XamlXmlReader(string fileName, XamlSchemaContext schemaContext, XamlXmlReaderSettings settings)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(fileName, settings), schemaContext, settings);
         }
@@ -128,46 +92,28 @@ namespace System.Xaml
 
         public XamlXmlReader(Stream stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
             Initialize(CreateXmlReader(stream, null), null, null);
         }
 
         public XamlXmlReader(Stream stream, XamlXmlReaderSettings settings)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
             Initialize(CreateXmlReader(stream, settings), null, settings);
         }
 
         public XamlXmlReader(Stream stream, XamlSchemaContext schemaContext)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(stream, null), schemaContext, null);
         }
 
         public XamlXmlReader(Stream stream, XamlSchemaContext schemaContext, XamlXmlReaderSettings settings)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(stream, settings), schemaContext, settings);
         }
@@ -180,46 +126,28 @@ namespace System.Xaml
 
         public XamlXmlReader(TextReader textReader)
         {
-            if (textReader == null)
-            {
-                throw new ArgumentNullException(nameof(textReader));
-            }
+            ArgumentNullException.ThrowIfNull(textReader);
             Initialize(CreateXmlReader(textReader, null), null, null);
         }
 
         public XamlXmlReader(TextReader textReader, XamlXmlReaderSettings settings)
         {
-            if (textReader == null)
-            {
-                throw new ArgumentNullException(nameof(textReader));
-            }
+            ArgumentNullException.ThrowIfNull(textReader);
             Initialize(CreateXmlReader(textReader, settings), null, settings);
         }
 
         public XamlXmlReader(TextReader textReader, XamlSchemaContext schemaContext)
         {
-            if (textReader == null)
-            {
-                throw new ArgumentNullException(nameof(textReader));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(textReader);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(textReader, null), schemaContext, null);
         }
 
         public XamlXmlReader(TextReader textReader, XamlSchemaContext schemaContext, XamlXmlReaderSettings settings)
         {
-            if (textReader == null)
-            {
-                throw new ArgumentNullException(nameof(textReader));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(textReader);
+            ArgumentNullException.ThrowIfNull(schemaContext);
 
             Initialize(CreateXmlReader(textReader, settings), schemaContext, settings);
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameReferenceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameReferenceConverter.cs
@@ -22,10 +22,7 @@ namespace System.Windows.Markup
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
             
             var nameResolver = (IXamlNameResolver)context.GetService(typeof(IXamlNameResolver));
             if (nameResolver == null)
@@ -65,10 +62,7 @@ namespace System.Windows.Markup
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var nameProvider = (IXamlNameProvider)context.GetService(typeof(IXamlNameProvider));
             if (nameProvider == null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
@@ -35,11 +35,9 @@ namespace System.Xaml
 
         public void RegisterName(string name, object scopedElement)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
-            if (scopedElement == null)
-                throw new ArgumentNullException(nameof(scopedElement));
+            ArgumentNullException.ThrowIfNull(scopedElement);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -79,8 +77,7 @@ namespace System.Xaml
 
         public void UnregisterName(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -105,8 +102,7 @@ namespace System.Xaml
 
         public object FindName(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlBackgroundReader.cs
@@ -37,10 +37,7 @@ namespace System.Xaml
 
         public XamlBackgroundReader(XamlReader wrappedReader)
         {
-            if (wrappedReader == null)
-            {
-                throw new ArgumentNullException(nameof(wrappedReader));
-            }
+            ArgumentNullException.ThrowIfNull(wrappedReader);
             Initialize(wrappedReader, 64);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeList.cs
@@ -22,19 +22,13 @@ namespace System.Xaml
 
         public XamlNodeList(XamlSchemaContext schemaContext)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             Initialize(schemaContext, 0);
         }
 
         public XamlNodeList(XamlSchemaContext schemaContext, int size)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             Initialize(schemaContext, size);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeQueue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Primitives/XamlNodeQueue.cs
@@ -23,10 +23,7 @@ namespace System.Xaml
 
         public XamlNodeQueue(XamlSchemaContext schemaContext)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             _nodeQueue = new Queue<XamlNode>();
             _endOfStreamNode = new XamlNode(XamlNode.InternalNodeType.EndOfStream);
             _writer = new WriterDelegate(Add, AddLineInfo, schemaContext);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/Reference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/Reference.cs
@@ -23,10 +23,7 @@ namespace System.Windows.Markup
 
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }
+            ArgumentNullException.ThrowIfNull(serviceProvider);
             IXamlNameResolver nameResolver = serviceProvider.GetService(typeof(IXamlNameResolver)) as IXamlNameResolver;
             if (nameResolver == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
@@ -34,14 +34,8 @@ namespace System.Xaml
             XamlValueConverter<TypeConverter> typeConverter, AllowedMemberLocations allowedLocation)
             : base(name, new MemberReflector(xamlType, typeConverter))
         {
-            if (xamlType == null)
-            {
-                throw new ArgumentNullException(nameof(xamlType));
-            }
-            if (xamlNamespaces == null)
-            {
-                throw new ArgumentNullException(nameof(xamlNamespaces));
-            }
+            ArgumentNullException.ThrowIfNull(xamlType);
+            ArgumentNullException.ThrowIfNull(xamlNamespaces);
 
             List<string> nsList = new List<string>(xamlNamespaces);
             foreach (string ns in nsList)
@@ -59,10 +53,7 @@ namespace System.Xaml
         public XamlDirective(string xamlNamespace, string name)
             :base(name, null)
         {
-            if (xamlNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(xamlNamespace));
-            }
+            ArgumentNullException.ThrowIfNull(xamlNamespace);
 
             _xamlNamespaces = new ReadOnlyCollection<string>(new string[] { xamlNamespace });
             _allowedLocation = AllowedMemberLocations.Any;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
@@ -51,10 +51,7 @@ namespace System.Xaml.Schema
 
         public virtual object GetValue(object instance)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
             ThrowIfUnknown();
             if (UnderlyingGetter == null)
             {
@@ -77,10 +74,7 @@ namespace System.Xaml.Schema
 
         public virtual void SetValue(object instance, object value)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
             ThrowIfUnknown();
             if (UnderlyingSetter == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -62,10 +62,7 @@ namespace System.Xaml.Schema
 
         public virtual void AddToCollection(object instance, object item)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
             IList list = instance as IList;
             if (list != null)
             {
@@ -97,10 +94,7 @@ namespace System.Xaml.Schema
 
         public virtual void AddToDictionary(object instance, object key, object item)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
             IDictionary dictionary = instance as IDictionary;
             if (dictionary != null)
             {
@@ -146,10 +140,7 @@ namespace System.Xaml.Schema
 
         public virtual MethodInfo GetAddMethod(XamlType contentType)
         {
-            if (contentType == null)
-            {
-                throw new ArgumentNullException(nameof(contentType));
-            }
+            ArgumentNullException.ThrowIfNull(contentType);
             if (IsUnknown || _xamlType.ItemType == null)
             {
                 return null;
@@ -211,10 +202,7 @@ namespace System.Xaml.Schema
 
         public virtual IEnumerator GetItems(object instance)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
             IEnumerable enumerable = instance as IEnumerable;
             if (enumerable != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferLoadAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferLoadAttribute.cs
@@ -12,14 +12,8 @@ namespace System.Windows.Markup
 
         public XamlDeferLoadAttribute(Type loaderType, Type contentType)
         {
-            if (loaderType == null)
-            {
-                throw new ArgumentNullException(nameof(loaderType));
-            }
-            if (contentType == null)
-            {
-                throw new ArgumentNullException(nameof(contentType));
-            }
+            ArgumentNullException.ThrowIfNull(loaderType);
+            ArgumentNullException.ThrowIfNull(contentType);
             _loaderTypeName = loaderType.AssemblyQualifiedName;
             _contentTypeName = contentType.AssemblyQualifiedName;
             LoaderType = loaderType;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
@@ -64,10 +64,7 @@ namespace System.Xaml
         protected XamlException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
             LineNumber = info.GetInt32("Line");
             LinePosition = info.GetInt32("Offset");
         }
@@ -77,10 +74,7 @@ namespace System.Xaml
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
 
             info.AddValue("Line", LineNumber);
             info.AddValue("Offset", LinePosition);
@@ -160,10 +154,7 @@ namespace System.Xaml
         protected XamlDuplicateMemberException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
             DuplicateMember = (XamlMember)info.GetValue("DuplicateMember", typeof(XamlMember));
             ParentType = (XamlType)info.GetValue("ParentType", typeof(XamlType));
         }
@@ -173,10 +164,7 @@ namespace System.Xaml
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info);
             info.AddValue("DuplicateMember", DuplicateMember);
             info.AddValue("ParentType", ParentType);
             base.GetObjectData(info, context);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -52,14 +52,8 @@ namespace System.Xaml
 
         internal XamlMember(PropertyInfo propertyInfo, XamlSchemaContext schemaContext, XamlMemberInvoker invoker, MemberReflector reflector)
         {
-            if (propertyInfo == null)
-            {
-                throw new ArgumentNullException(nameof(propertyInfo));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(propertyInfo);
+            ArgumentNullException.ThrowIfNull(schemaContext);
             _name = propertyInfo.Name;
             _declaringType = schemaContext.GetXamlType(propertyInfo.DeclaringType);
             _memberType = MemberType.Instance;
@@ -81,14 +75,8 @@ namespace System.Xaml
 
         internal XamlMember(EventInfo eventInfo, XamlSchemaContext schemaContext, XamlMemberInvoker invoker, MemberReflector reflector)
         {
-            if (eventInfo == null)
-            {
-                throw new ArgumentNullException(nameof(eventInfo));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(eventInfo);
+            ArgumentNullException.ThrowIfNull(schemaContext);
             _name = eventInfo.Name;
             _declaringType = schemaContext.GetXamlType(eventInfo.DeclaringType);
             _memberType = MemberType.Instance;
@@ -113,10 +101,7 @@ namespace System.Xaml
         internal XamlMember(string attachablePropertyName, MethodInfo getter, MethodInfo setter,
             XamlSchemaContext schemaContext, XamlMemberInvoker invoker, MemberReflector reflector)
         {
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(schemaContext);
             MethodInfo accessor = getter ?? setter;
             if (accessor == null)
             {
@@ -149,14 +134,8 @@ namespace System.Xaml
         internal XamlMember(string attachableEventName, MethodInfo adder, XamlSchemaContext schemaContext,
             XamlMemberInvoker invoker, MemberReflector reflector)
         {
-            if (adder == null)
-            {
-                throw new ArgumentNullException(nameof(adder));
-            }
-            if (schemaContext == null)
-            {
-                throw new ArgumentNullException(nameof(schemaContext));
-            }
+            ArgumentNullException.ThrowIfNull(adder);
+            ArgumentNullException.ThrowIfNull(schemaContext);
             ValidateSetter(adder, "adder");
 
             _name = attachableEventName ?? throw new ArgumentNullException(nameof(attachableEventName));

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -2850,10 +2850,7 @@ namespace System.Xaml
 
             public string GetName(object value)
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 return context.GetName(value);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -136,10 +136,7 @@ namespace System.Xaml
 
         public virtual string GetPreferredPrefix(string xmlns)
         {
-            if (xmlns == null)
-            {
-                throw new ArgumentNullException(nameof(xmlns));
-            }
+            ArgumentNullException.ThrowIfNull(xmlns);
             UpdateXmlNsInfo();
             if (_preferredPrefixes == null)
             {
@@ -250,14 +247,8 @@ namespace System.Xaml
 
         public virtual XamlDirective GetXamlDirective(string xamlNamespace, string name)
         {
-            if (xamlNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(xamlNamespace));
-            }
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(xamlNamespace);
+            ArgumentNullException.ThrowIfNull(name);
 
             if (XamlLanguage.XamlNamespaces.Contains(xamlNamespace))
             {
@@ -272,10 +263,7 @@ namespace System.Xaml
 
         public XamlType GetXamlType(XamlTypeName xamlTypeName)
         {
-            if (xamlTypeName == null)
-            {
-                throw new ArgumentNullException(nameof(xamlTypeName));
-            }
+            ArgumentNullException.ThrowIfNull(xamlTypeName);
             if (xamlTypeName.Name == null)
             {
                 throw new ArgumentException(SR.Format(SR.ReferenceIsNull, "xamlTypeName.Name"), nameof(xamlTypeName));
@@ -307,14 +295,8 @@ namespace System.Xaml
 
         protected internal virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
         {
-            if (xamlNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(xamlNamespace));
-            }
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentNullException.ThrowIfNull(xamlNamespace);
+            ArgumentNullException.ThrowIfNull(name);
             if (typeArguments != null)
             {
                 foreach (XamlType typeArg in typeArguments)
@@ -382,10 +364,7 @@ namespace System.Xaml
         // Note: this method doesn't apply transitive subsuming, the caller is responsible for doing that.
         public virtual bool TryGetCompatibleXamlNamespace(string xamlNamespace, out string compatibleNamespace)
         {
-            if (xamlNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(xamlNamespace));
-            }
+            ArgumentNullException.ThrowIfNull(xamlNamespace);
 
             // Note: this method has order-dependent behavior for backcompat.
             // When we look up a namespace, we throw if it has conflicting XmlnsCompatAttributes.
@@ -542,18 +521,14 @@ namespace System.Xaml
 
         public virtual XamlType GetXamlType(Type type)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
+            ArgumentNullException.ThrowIfNull(type);
 
             return GetXamlType(type, XamlLanguage.TypeAlias(type));
         }
 
         internal XamlType GetXamlType(Type type, string alias)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
             XamlType xamlType = null;
             if (!MasterTypeList.TryGetValue(type, out xamlType))
             {
@@ -570,10 +545,7 @@ namespace System.Xaml
         /// </summary>
         internal Dictionary<string, SpecialBracketCharacters> InitBracketCharacterCacheForType(XamlType type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             Dictionary<string, SpecialBracketCharacters> bracketCharacterCache = null;
             if (type.IsMarkupExtension)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
@@ -18,10 +18,7 @@ namespace System.Xaml
 
         public static object Parse(string xaml)
         {
-            if (xaml == null)
-            {
-                throw new ArgumentNullException(nameof(xaml));
-            }
+            ArgumentNullException.ThrowIfNull(xaml);
 
             StringReader stringReader = new StringReader(xaml);
             using (XmlReader xmlReader = XmlReader.Create(stringReader))
@@ -33,10 +30,7 @@ namespace System.Xaml
 
         public static object Load(string fileName)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
 
             using (XmlReader xmlReader = XmlReader.Create(fileName))
             {
@@ -47,10 +41,7 @@ namespace System.Xaml
 
         public static object Load(Stream stream)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             using (XmlReader xmlReader = XmlReader.Create(stream))
             {
@@ -61,10 +52,7 @@ namespace System.Xaml
 
         public static object Load(TextReader textReader)
         {
-            if (textReader == null)
-            {
-                throw new ArgumentNullException(nameof(textReader));
-            }
+            ArgumentNullException.ThrowIfNull(textReader);
 
             using (XmlReader xmlReader = XmlReader.Create(textReader))
             {
@@ -75,10 +63,7 @@ namespace System.Xaml
 
         public static object Load(XmlReader xmlReader)
         {
-            if (xmlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xmlReader));
-            }
+            ArgumentNullException.ThrowIfNull(xmlReader);
 
             using (XamlXmlReader xamlReader = new XamlXmlReader(xmlReader))
             {
@@ -90,10 +75,7 @@ namespace System.Xaml
 
         public static object Load(XamlReader xamlReader)
         {
-            if (xamlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xamlReader));
-            }
+            ArgumentNullException.ThrowIfNull(xamlReader);
 
             XamlObjectWriter objectWriter = new XamlObjectWriter(xamlReader.SchemaContext);
 
@@ -110,15 +92,9 @@ namespace System.Xaml
 
         public static void Transform(XamlReader xamlReader, XamlWriter xamlWriter, bool closeWriter)
         {
-            if (xamlReader == null)
-            {
-                throw new ArgumentNullException(nameof(xamlReader));
-            }
+            ArgumentNullException.ThrowIfNull(xamlReader);
 
-            if (xamlWriter == null)
-            {
-                throw new ArgumentNullException(nameof(xamlWriter));
-            }
+            ArgumentNullException.ThrowIfNull(xamlWriter);
 
             IXamlLineInfo xamlLineInfo = xamlReader as IXamlLineInfo;
             IXamlLineInfoConsumer xamlLineInfoConsumer = xamlWriter as IXamlLineInfoConsumer;
@@ -160,10 +136,7 @@ namespace System.Xaml
 
         public static void Save(String fileName, object instance)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
+            ArgumentNullException.ThrowIfNull(fileName);
             //
             // At this point it can only be empty
             if (string.IsNullOrEmpty(fileName))
@@ -179,10 +152,7 @@ namespace System.Xaml
 
         public static void Save(Stream stream, object instance)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
             using (var writer = XmlWriter.Create(stream, new XmlWriterSettings { Indent = true, OmitXmlDeclaration = true }))
             {
                 Save(writer, instance);
@@ -192,10 +162,7 @@ namespace System.Xaml
 
         public static void Save(TextWriter writer, object instance)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
+            ArgumentNullException.ThrowIfNull(writer);
             using (var xmlWriter = XmlWriter.Create(writer, new XmlWriterSettings { Indent = true, OmitXmlDeclaration = true }))
             {
                 Save(xmlWriter, instance);
@@ -205,10 +172,7 @@ namespace System.Xaml
 
         public static void Save(XmlWriter writer, object instance)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
+            ArgumentNullException.ThrowIfNull(writer);
             using (XamlXmlWriter xamlWriter = new XamlXmlWriter(writer, new XamlSchemaContext()))
             {
                 Save(xamlWriter, instance);
@@ -217,10 +181,7 @@ namespace System.Xaml
 
         public static void Save(XamlWriter writer, object instance)
         {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
+            ArgumentNullException.ThrowIfNull(writer);
 
             XamlObjectReader objectReader = new XamlObjectReader(instance, writer.SchemaContext);
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -46,10 +46,7 @@ namespace System.Xaml
 
         public XamlType(string unknownTypeNamespace, string unknownTypeName, IList<XamlType> typeArguments, XamlSchemaContext schemaContext)
         {
-            if (unknownTypeNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(unknownTypeNamespace));
-            }
+            ArgumentNullException.ThrowIfNull(unknownTypeNamespace);
 
             _name = unknownTypeName ?? throw new ArgumentNullException(nameof(unknownTypeName));
             _namespaces = new ReadOnlyCollection<string>(new string[] { unknownTypeNamespace });
@@ -70,10 +67,7 @@ namespace System.Xaml
 
         internal XamlType(string alias, Type underlyingType, XamlSchemaContext schemaContext, XamlTypeInvoker invoker, TypeReflector reflector)
         {
-            if (underlyingType == null)
-            {
-                throw new ArgumentNullException(nameof(underlyingType));
-            }
+            ArgumentNullException.ThrowIfNull(underlyingType);
 
             _reflector = reflector ?? new TypeReflector(underlyingType);
             _name = alias ?? GetTypeName(underlyingType);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -39,10 +39,7 @@ namespace System.Xaml.Schema
 
         public XamlTypeName(XamlType xamlType)
         {
-            if (xamlType == null)
-            {
-                throw new ArgumentNullException(nameof(xamlType));
-            }
+            ArgumentNullException.ThrowIfNull(xamlType);
             Name = xamlType.Name;
             Namespace = xamlType.GetXamlNamespaces()[0];
             if (xamlType.TypeArguments != null)
@@ -87,27 +84,15 @@ namespace System.Xaml.Schema
 
         public static string ToString(IList<XamlTypeName> typeNameList, INamespacePrefixLookup prefixLookup)
         {
-            if (typeNameList == null)
-            {
-                throw new ArgumentNullException(nameof(typeNameList));
-            }
-            if (prefixLookup == null)
-            {
-                throw new ArgumentNullException(nameof(prefixLookup));
-            }
+            ArgumentNullException.ThrowIfNull(typeNameList);
+            ArgumentNullException.ThrowIfNull(prefixLookup);
             return ConvertListToStringInternal(typeNameList, prefixLookup.LookupPrefix);
         }
 
         public static XamlTypeName Parse(string typeName, IXamlNamespaceResolver namespaceResolver)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
-            if (namespaceResolver == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceResolver));
-            }
+            ArgumentNullException.ThrowIfNull(typeName);
+            ArgumentNullException.ThrowIfNull(namespaceResolver);
 
             string error;
             XamlTypeName result = ParseInternal(typeName, namespaceResolver.GetNamespace, out error);
@@ -120,14 +105,8 @@ namespace System.Xaml.Schema
 
         public static IList<XamlTypeName> ParseList(string typeNameList, IXamlNamespaceResolver namespaceResolver)
         {
-            if (typeNameList == null)
-            {
-                throw new ArgumentNullException(nameof(typeNameList));
-            }
-            if (namespaceResolver == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceResolver));
-            }
+            ArgumentNullException.ThrowIfNull(typeNameList);
+            ArgumentNullException.ThrowIfNull(namespaceResolver);
 
             string error;
             IList<XamlTypeName> result = ParseListInternal(typeNameList, namespaceResolver.GetNamespace, out error);
@@ -141,14 +120,8 @@ namespace System.Xaml.Schema
         public static bool TryParse(string typeName, IXamlNamespaceResolver namespaceResolver,
             out XamlTypeName result)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
-            if (namespaceResolver == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceResolver));
-            }
+            ArgumentNullException.ThrowIfNull(typeName);
+            ArgumentNullException.ThrowIfNull(namespaceResolver);
 
             result = ParseInternal(typeName, namespaceResolver.GetNamespace, out _);
             return (result != null);
@@ -157,14 +130,8 @@ namespace System.Xaml.Schema
         public static bool TryParseList(string typeNameList, IXamlNamespaceResolver namespaceResolver,
             out IList<XamlTypeName> result)
         {
-            if (typeNameList == null)
-            {
-                throw new ArgumentNullException(nameof(typeNameList));
-            }
-            if (namespaceResolver == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceResolver));
-            }
+            ArgumentNullException.ThrowIfNull(typeNameList);
+            ArgumentNullException.ThrowIfNull(namespaceResolver);
 
             result = ParseListInternal(typeNameList, namespaceResolver.GetNamespace, out _);
             return (result != null);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriter.cs
@@ -19,10 +19,7 @@ namespace System.Xaml
 
         public void WriteNode(XamlReader reader)
         {
-            if (reader == null)
-            {
-                throw new ArgumentNullException(nameof(reader));
-            }
+            ArgumentNullException.ThrowIfNull(reader);
 
             switch (reader.NodeType)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -50,10 +50,7 @@ namespace System.Xaml
 
         public XamlXmlWriter(Stream stream, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
+            ArgumentNullException.ThrowIfNull(stream);
 
             if (settings != null && settings.CloseOutput)
             {
@@ -72,10 +69,7 @@ namespace System.Xaml
 
         public XamlXmlWriter(TextWriter textWriter, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
         {
-            if (textWriter == null)
-            {
-                throw new ArgumentNullException(nameof(textWriter));
-            }
+            ArgumentNullException.ThrowIfNull(textWriter);
 
             if (settings != null && settings.CloseOutput)
             {
@@ -94,10 +88,7 @@ namespace System.Xaml
 
         public XamlXmlWriter(XmlWriter xmlWriter, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
         {
-            if (xmlWriter == null)
-            {
-                throw new ArgumentNullException(nameof(xmlWriter));
-            }
+            ArgumentNullException.ThrowIfNull(xmlWriter);
 
             InitializeXamlXmlWriter(xmlWriter, schemaContext, settings);
         }
@@ -169,10 +160,7 @@ namespace System.Xaml
         {
             CheckIsDisposed();
 
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             if (!type.IsNameValid)
             {
@@ -197,10 +185,7 @@ namespace System.Xaml
         {
             CheckIsDisposed();
 
-            if (property == null)
-            {
-                throw new ArgumentNullException(nameof(property));
-            }
+            ArgumentNullException.ThrowIfNull(property);
 
             if (!property.IsNameValid)
             {
@@ -239,10 +224,7 @@ namespace System.Xaml
         {
             CheckIsDisposed();
 
-            if (namespaceDeclaration == null)
-            {
-                throw new ArgumentNullException(nameof(namespaceDeclaration));
-            }
+            ArgumentNullException.ThrowIfNull(namespaceDeclaration);
 
             if (namespaceDeclaration.Prefix == null)
             {


### PR DESCRIPTION
## Description
Use ArgumentNullException.ThrowIfNull in System.Xaml which is shorter and cleaner (IMO). The IL is also smaller and the JIT should be able to better inline the code since it moves the throw into a non-inlineable method.

In the future we could remove throws of ArgumentNullException inside a null-coalescing operator ( `_value = value ?? throw new ArgumentNullException(nameof(value))`) by using something similar to WinForms' `OrThrowIfNull`:
https://github.com/dotnet/winforms/blob/13d4d7813ed0d894c239e2f696106c166d130c43/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ArgumentValidation.cs#L11-L15

## Customer Impact
Might be faster.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7181)