### PR TITLE
Updated precedence for project templates

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a .NET WPF Application",
   "groupIdentity": "Microsoft.Common.WPF",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.CSharp.7.0",
   "shortName": "wpf",
   "tags": {
     "language": "C#",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-VisualBasic/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a .NET WPF Application",
   "groupIdentity": "Microsoft.Common.WPF",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.VisualBasic.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.VisualBasic.7.0",
   "shortName": "wpf",
   "tags": {
     "language": "VB",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets a .NET WPF Application",
   "groupIdentity": "Microsoft.Common.WPF.Library",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.Library.CSharp.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.Library.CSharp.7.0",
   "shortName": "wpflib",
   "tags": {
     "language": "C#",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfClassLibrary-VisualBasic/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets a .NET WPF Application",
   "groupIdentity": "Microsoft.Common.WPF.Library",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.Library.VisualBasic.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.Library.VisualBasic.7.0",
   "shortName": "wpflib",
   "tags": {
     "language": "VB",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a custom control library for .NET WPF Applications",
   "groupIdentity": "Microsoft.Common.WPF.CustomControl",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.CustomControl.CSharp.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.CustomControl.CSharp.7.0",
   "shortName": "wpfcustomcontrollib",
   "tags": {
     "language": "C#",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-VisualBasic/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a custom control library for .NET WPF Applications",
   "groupIdentity": "Microsoft.Common.WPF.CustomControl",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.CustomControl.VisualBasic.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.CustomControl.VisualBasic.7.0",
   "shortName": "wpfcustomcontrollib",
   "tags": {
     "language": "VB",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-CSharp/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a user control library for .NET WPF Applications",
   "groupIdentity": "Microsoft.Common.WPF.Control",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.Control.CSharp.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.Control.CSharp.7.0",
   "shortName": "wpfusercontrollib",
   "tags": {
     "language": "C#",

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/template.json
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfUserControlLibrary-VisualBasic/.template.config/template.json
@@ -6,8 +6,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a user control library for .NET WPF Applications",
   "groupIdentity": "Microsoft.Common.WPF.Control",
-  "precedence": "3000",
-  "identity": "Microsoft.Common.WPF.Control.VisualBasic.5.0",
+  "precedence": "7000",
+  "identity": "Microsoft.Common.WPF.Control.VisualBasic.7.0",
   "shortName": "wpfusercontrollib",
   "tags": {
     "language": "VB",


### PR DESCRIPTION
Fixes #7204 

## Description
Updates the precedence and identity of WPF Project Templates

## Customer Impact
Enables localization of template names when using dotnet new --list
<!-- What is the impact to customers of not taking this fix? -->

## Regression
No
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Installed templates and created sample test apps
<!-- What kind of testing has been done with the fix. -->

## Risk
Minimal
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7213)