### PR TITLE
Adding CreateBitmapSourceFromWICBitmap method to System.Windows.Interop.Imaging

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/Imaging.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/Imaging.cs
@@ -116,6 +116,13 @@ namespace System.Windows.Interop
 
             return new InteropBitmap(section, pixelWidth, pixelHeight, format, stride, offset);
         }
-}
+
+        public static BitmapSource CreateBitmapSourceFromWICBitmapSource(IntPtr wicBitmapSource)
+        {
+            BitmapSourceSafeMILHandle bitmapSourceSafeMilHandle = new BitmapSourceSafeMILHandle(wicBitmapSource);
+            UnmanagedBitmapWrapper unmanagedBitmapWrapper = new UnmanagedBitmapWrapper(bitmapSourceSafeMilHandle);
+            return unmanagedBitmapWrapper;
+        }
+    }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -4858,6 +4858,7 @@ namespace System.Windows.Interop
         public static System.Windows.Media.Imaging.BitmapSource CreateBitmapSourceFromHBitmap(System.IntPtr bitmap, System.IntPtr palette, System.Windows.Int32Rect sourceRect, System.Windows.Media.Imaging.BitmapSizeOptions sizeOptions) { throw null; }
         public static System.Windows.Media.Imaging.BitmapSource CreateBitmapSourceFromHIcon(System.IntPtr icon, System.Windows.Int32Rect sourceRect, System.Windows.Media.Imaging.BitmapSizeOptions sizeOptions) { throw null; }
         public static System.Windows.Media.Imaging.BitmapSource CreateBitmapSourceFromMemorySection(System.IntPtr section, int pixelWidth, int pixelHeight, System.Windows.Media.PixelFormat format, int stride, int offset) { throw null; }
+        public static System.Windows.Media.Imaging.BitmapSource CreateBitmapSourceFromWICBitmapSource(System.IntPtr wicBitmapSource) { throw null; }
     }
     public sealed partial class InteropBitmap : System.Windows.Media.Imaging.BitmapSource
     {


### PR DESCRIPTION


Fixes https://github.com/dotnet/wpf/issues/7217



## Description

Adding CreateBitmapSourceFromWICBitmap method to System.Windows.Interop.Imaging. 

## Customer Impact

We can call the System.Windows.Interop.Imaging.CreateBitmapSourceFromWICBitmapSource to create the BitmapSource from WICBitmap. 

## Regression

None.

## Testing

CI and my demo code.

My demo code: https://github.com/lindexi/lindexi_gd/tree/60d5324219fef0b55ef6eb130e0c7a698554eab5/WpfVorticeWicTest

## Risk

Adding the API and I do not change any behavior.
