### PR TITLE
Add NavigationService.RemoveForwardEntry

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/INavigator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/INavigator.cs
@@ -266,6 +266,12 @@ namespace MS.Internal.AppModel
         /// </summary>
         /// <returns>The JournalEntry removed</returns>
         JournalEntry RemoveBackEntry();
+        
+        /// <summary>
+        /// Remove the first JournalEntry from NavigationWindow's forward history
+        /// </summary>
+        /// <returns>The JournalEntry removed</returns>
+        JournalEntry RemoveForwardEntry();
 
         /// <summary>
         /// The back stack of the navigator, when it owns a journal (JournalNavigationScope).

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/JournalNavigationScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/JournalNavigationScope.cs
@@ -231,6 +231,12 @@ namespace MS.Internal.AppModel
             _host.VerifyContextAndObjectState();
             return _journal == null ? null : _journal.RemoveBackEntry();
         }
+        
+        public JournalEntry RemoveForwardEntry()
+        {
+            _host.VerifyContextAndObjectState();
+            return _journal == null ? null : _journal.RemoveForwardEntry();
+        }
 
         public System.Collections.IEnumerable BackStack
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -54,13 +54,13 @@ namespace System.Windows.Navigation
         Automatic = 0,
 
         /// <summary>
-        /// The Frame has its own Journal which operates independent of the hosting container’s
+        /// The Frame has its own Journal which operates independent of the hosting containerâ€™s
         /// journal (if it has one).
         /// </summary>
         OwnsJournal,
 
         /// <summary>
-        /// The Frame’s journal entries are merged into the hosting container’s journal, if available.
+        /// The Frameâ€™s journal entries are merged into the hosting containerâ€™s journal, if available.
         /// Otherwise navigations in this frame are not journaled.
         /// </summary>
         UsesParentJournal
@@ -862,6 +862,17 @@ namespace System.Windows.Controls
             if (_ownJournalScope == null)
                 throw new InvalidOperationException(SR.Get(SRID.InvalidOperation_NoJournal));
             return _ownJournalScope.RemoveBackEntry();
+        }
+        
+        /// <summary>
+        /// Removes the first JournalEntry from the frame's forward stack.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"> The frame doesn't own a journal. </exception>
+        public JournalEntry RemoveForwardEntry()
+        {
+            if (_ownJournalScope == null)
+                throw new InvalidOperationException(SR.Get(SRID.InvalidOperation_NoJournal));
+            return _ownJournalScope.RemoveForwardEntry();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
@@ -271,6 +271,27 @@ namespace System.Windows.Navigation
             UpdateView();
             return removedEntry;
         }
+        
+        /// <summary>
+        /// Remove the top JournalEntry from forward entry
+        /// </summary>
+        // Not a true "remove" 
+        internal JournalEntry RemoveForwardEntry()
+        {
+            Debug.Assert(ValidateIndexes());
+            int index = _currentEntryIndex; // start from current but do not change it
+            do
+            {
+                if (++index >= TotalCount)
+                {
+                    return null;
+                }
+            } while (IsNavigable(_journalEntryList[index]) == false);
+            JournalEntry removedEntry = RemoveEntryInternal(index);
+            Debug.Assert(ValidateIndexes());
+            UpdateView();
+            return removedEntry;
+        }
 
         /// <summary>
         /// Ensures current data about the current page is stored in the journal.
@@ -433,7 +454,7 @@ namespace System.Windows.Navigation
             int index = _journalEntryList.IndexOf(target);
 
             // When navigating back to a page which contains a previously navigated frame a 
-            // saved journal entry is replayed to restore the frame’s location, in many cases 
+            // saved journal entry is replayed to restore the frameÂ’s location, in many cases 
             // this entry is not in the journal.
             if (index > -1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -1477,6 +1477,20 @@ namespace System.Windows.Navigation
                 return null; //(Normally, no exception is thrown if there is no back entry.)
             return JournalScope.RemoveBackEntry();
         }
+        
+        /// <summary>
+        /// Remove the first JournalEntry from NavigationWindow's forward history
+        /// </summary>
+        public JournalEntry RemoveForwardEntry()
+        {
+            if (IsDisposed)
+            {
+                return null;
+            }
+            if (JournalScope == null)
+                return null; //(Normally, no exception is thrown if there is no forward entry.)
+            return JournalScope.RemoveForwardEntry();
+        }
 
         //
         // bool INavigator.Navigate(Uri source)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationWindow.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationWindow.cs
@@ -397,6 +397,14 @@ namespace System.Windows.Navigation
         {
             return _JNS.RemoveBackEntry();
         }
+        
+        /// <summary>
+        /// Remove the first JournalEntry from NavigationWindow's forward history
+        /// </summary>
+        public JournalEntry RemoveForwardEntry()
+        {
+            return _JNS.RemoveForwardEntry();
+        }
         #endregion INavigator Methods
 
         #region IUriContext Members


### PR DESCRIPTION
Fixes #7215

Main PR

## Description

There is already an API to remove the first entry from back stack. This PR allows developers to remove the first entry from forward stack. This is currently impossible.

## Customer Impact

Customers can now remove items from forward stack.

## Regression

No regression

## Testing



## Risk

No risk
