### PR TITLE
Update api-compat.md

### DIFF
--- a/Documentation/api-compat.md
+++ b/Documentation/api-compat.md
@@ -1,9 +1,9 @@
 # API Compatibility
-API compatibility is a build-time check that ensures that an `implementation` assembly implements the API surface area of a `contract` assembly.
+API compatibility is a build-time check that ensures that an _implementation_ assembly implements the API surface area of a _contract_ assembly.
 
 For `WPF on .NET Core`, this means the following:
-* All `WPF on .NET Core` reference assemblies contain **at least** the API surface area contained by `WPF on .NET Framework 4.8` reference assemblies.
-* All hand-crafted reference assemblies for `WPF on .NET Core` contain **exactly** the needed API surface area defined by their corresponding runtime assemblies.  (If you're adding new API surface area, you will need to update the hand-crafted reference assemblies, following [these instructions](https://github.com/dotnet/wpf/blob/main/Documentation/gen-api.md).)
+* All `WPF on .NET Core` reference assemblies (_implementation_) contain **at least** the API surface area contained by `WPF on .NET Framework 4.8` reference assemblies (_contract_), see [WpfValidateApiCompatForNetFramework](#wpfvalidateapicompatfornetframework).
+* All hand-crafted reference assemblies for `WPF on .NET Core` (_implementation_) contain **exactly** the needed API surface area defined by their corresponding runtime assemblies (_contract_), see [WpfValidateApiCompatForRef](#wpfvalidateapicompatforref). (If you're adding new API surface area, you will need to update the hand-crafted reference assemblies, following [these instructions](https://github.com/dotnet/wpf/blob/main/Documentation/gen-api.md).)
 
 This is accomplished by the use of the [Arcade API Compatibility tool](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.ApiCompat) with some modifications to fit our specific needs.
 


### PR DESCRIPTION
Small documentation change to clarify which assembly is implementation and which assembly is contract for ApiCompat.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7237)