### PR TITLE
Update ApiCompat.targets

### DIFF
--- a/eng/WpfArcadeSdk/tools/ApiCompat.targets
+++ b/eng/WpfArcadeSdk/tools/ApiCompat.targets
@@ -180,7 +180,7 @@
     <Touch Condition="'$(ApiCompatExitCode)' != '0'" Files="$(IntermediateOutputPath)$(_ApiCompatSemaphoreFile)" AlwaysCreate="true">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
-    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed for '$(TargetPath)'" />
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed for '$(TargetPath)' (WpfValidateApiCompatForNetFramework)" />
   </Target>
 
   <Target Name="WpfValidateApiCompatForRef"
@@ -237,7 +237,7 @@
     <Touch Condition="'$(ApiCompatExitCode)' != '0'" Files="$(IntermediateOutputPath)$(_RefApiCompatSemaphoreFile)" AlwaysCreate="true">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
-    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed for '$(TargetPath)'" />
+    <Error Condition="'$(ApiCompatExitCode)' != '0'" Text="ApiCompat failed for '$(TargetPath)' (WpfValidateApiCompatForRef)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This change updates the error message for when ApiCompat tasks fail. There are two tasks for ApiCompat, `WpfValidateApiCompatForNetFramework` and `WpfValidateApiCompatForRef`, but it is not possible to tell which one failed from the standard build output.

(Alternatively, `--left-operand` and `--right-operand` arguments could be passed to ApiCompat to state which assembly is which, but that would require to update all baselines.)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7238)