### PR TITLE
Adding static constructor to StyleHelper class

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -41,6 +41,12 @@ namespace System.Windows
 
     internal static class StyleHelper
     {
+        static StyleHelper()
+        {
+            // Register for the "alternative Expression storage" feature, since
+            // we store Expressions in per-instance StyleData.
+            RegisterAlternateExpressionStorage();
+        }
         //  ===========================================================================
         //  These methods are invoked when a Style/Template cache needs to be updated
         //  ===========================================================================
@@ -5466,9 +5472,13 @@ namespace System.Windows
         //
         internal static void RegisterAlternateExpressionStorage()
         {
-            DependencyObject.RegisterForAlternativeExpressionStorage(
+            if(_getExpression == null)
+            {
+                DependencyObject.RegisterForAlternativeExpressionStorage(
                                 new AlternativeExpressionStorageCallback(GetExpressionCore),
                                 out _getExpression);
+            }
+            
         }
 
         private static Expression GetExpressionCore(


### PR DESCRIPTION
Fixes #7205
Fixes #7291

## Description

Adding static constructor to StyleHelper class to do the required initialization i.e. registering the "alternative Expression storage". Also, adding check to "RegisterAlternateExpressionStorage" function to avoid re-registration being called.

## Customer Impact

An attempt to call the BindingOperations.GetBindingExpression method in .NET 7.0 leads to Null Reference Exception.

## Regression

Yes

## Testing

In progress

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7295)