### PR TITLE
Fixing *-defs width calculation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Grid.cs
@@ -2587,6 +2587,20 @@ namespace System.Windows.Controls
                 // Note that if we return to Phase2, at least one *-def will have been
                 // resolved.  This guarantees we don't run Phase2+3 infinitely often.
                 runPhase2and3 = false;
+
+                if(takenSize < finalSize)
+                {
+                    if(DoubleUtil.AreClose(takenSize, finalSize) && minCountPhase2 > 0)
+                    {
+                        // if very small (~ 2.2204460492503131e-016) remaining size is available
+                        // adding it to size of smallest width column resolved as 'min'.
+                        DefinitionBase resolvedDef = definitions[definitionIndices[minCountPhase2 - 1]];
+                        resolvedDef.MeasureSize -= (finalSize - takenSize);
+                        takenSize = finalSize;
+                        remainingAvailableSize = 0.0;
+                    }
+                }
+
                 if (starCount == 0 && takenSize < finalSize)
                 {
                     // if no *-defs remain and we haven't allocated all the space, reconsider the defs


### PR DESCRIPTION
Fixes #5231

## Description

A calculation to see how much width has been allocated to *-columns produces a result that's less than the available width by a tiny amount, due to floating-point drift. This causes a loop to continue when it shouldn't, leading to infinite loop. In such case adding that tiny remaining width to a column resolved as "min".

## Customer Impact

VS XAML Designer freezes when resizing the column width.

## Regression

No

## Testing

Done

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7296)