### PR TITLE
Surround Keyboard Datagrid F3 sort with switch

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Controls
     /// </summary>
     public class DataGridCell : ContentControl, IProvideDataGridColumn
     {
-        private static bool IsDataGridKeyboardSortFeatureEnabled = true;
+        private static bool WPFIsDataGridKeyboardSortFeatureDisabled;
 
         #region Constructors
 
@@ -48,7 +48,7 @@ namespace System.Windows.Controls
             EventManager.RegisterClassHandler(typeof(DataGridCell), LostFocusEvent, new RoutedEventHandler(OnAnyLostFocus), true);
             EventManager.RegisterClassHandler(typeof(DataGridCell), GotFocusEvent, new RoutedEventHandler(OnAnyGotFocus), true);
             
-            AppContext.TryGetSwitch("DataGridKeyboardSortFeature", out IsDataGridKeyboardSortFeatureEnabled);
+            AppContext.TryGetSwitch("DataGridKeyboardSortFeature", out WPFIsDataGridKeyboardSortFeatureDisabled);
         }
 
         /// <summary>
@@ -996,7 +996,7 @@ namespace System.Windows.Controls
                     }
                     return;
                 }
-                else if(IsDataGridKeyboardSortFeatureEnabled && e.Key == Key.F3)
+                else if(!WPFIsDataGridKeyboardSortFeatureDisabled && e.Key == Key.F3)
                 {
                     if (Column.CanUserSort)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Controls
     /// </summary>
     public class DataGridCell : ContentControl, IProvideDataGridColumn
     {
-        private static bool IsDataGridKeyboardSortDisabled;
+        private static readonly bool IsDataGridKeyboardSortDisabled;
 
         #region Constructors
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -23,6 +23,8 @@ namespace System.Windows.Controls
     /// </summary>
     public class DataGridCell : ContentControl, IProvideDataGridColumn
     {
+        private static bool IsDataGridKeyboardSortFeatureEnabled = true;
+
         #region Constructors
 
         /// <summary>
@@ -45,6 +47,8 @@ namespace System.Windows.Controls
 
             EventManager.RegisterClassHandler(typeof(DataGridCell), LostFocusEvent, new RoutedEventHandler(OnAnyLostFocus), true);
             EventManager.RegisterClassHandler(typeof(DataGridCell), GotFocusEvent, new RoutedEventHandler(OnAnyGotFocus), true);
+            
+            AppContext.TryGetSwitch("DataGridKeyboardSortFeature", out IsDataGridKeyboardSortFeatureEnabled);
         }
 
         /// <summary>
@@ -992,7 +996,7 @@ namespace System.Windows.Controls
                     }
                     return;
                 }
-                else if(e.Key == Key.F3)
+                else if(IsDataGridKeyboardSortFeatureEnabled && e.Key == Key.F3)
                 {
                     if (Column.CanUserSort)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Controls
     /// </summary>
     public class DataGridCell : ContentControl, IProvideDataGridColumn
     {
-        private static bool WPFIsDataGridKeyboardSortFeatureDisabled;
+        private static bool IsDataGridKeyboardSortDisabled;
 
         #region Constructors
 
@@ -48,7 +48,7 @@ namespace System.Windows.Controls
             EventManager.RegisterClassHandler(typeof(DataGridCell), LostFocusEvent, new RoutedEventHandler(OnAnyLostFocus), true);
             EventManager.RegisterClassHandler(typeof(DataGridCell), GotFocusEvent, new RoutedEventHandler(OnAnyGotFocus), true);
             
-            AppContext.TryGetSwitch("DataGridKeyboardSortFeature", out WPFIsDataGridKeyboardSortFeatureDisabled);
+            AppContext.TryGetSwitch("System.Windows.Controls.DisableDataGridKeyboardSort", out IsDataGridKeyboardSortDisabled);
         }
 
         /// <summary>
@@ -996,7 +996,7 @@ namespace System.Windows.Controls
                     }
                     return;
                 }
-                else if(!WPFIsDataGridKeyboardSortFeatureDisabled && e.Key == Key.F3)
+                else if(!IsDataGridKeyboardSortDisabled && e.Key == Key.F3)
                 {
                     if (Column.CanUserSort)
                     {


### PR DESCRIPTION
Fixes #7288 

Main PR https://github.com/dotnet/wpf/pull/6873

## Description
F3 sort on Datagrid was causing compatibility issues. Surrounding the F3 datagrid sort feature around an opt Out switch.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Customers can run into problem with F3 handling in datagrid scenarios. Unintended sorting rather than a specifically expected behaviour.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local testing by sample datagrid app.
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7297)