### PR TITLE
Revert "Replacing expensive type checks with "is" checks (#4964)"

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/SynchronizedInputHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/SynchronizedInputHelper.cs
@@ -297,18 +297,21 @@ namespace MS.Internal
 
         internal static void RaiseAutomationEvents()
         {
-            if (InputManager.ListeningElement is UIElement e)
+            if (InputElement.IsUIElement(InputManager.ListeningElement))
             {
+                UIElement e = (UIElement)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(e.GetAutomationPeer());
             }
-            else if (InputManager.ListeningElement is ContentElement ce)
+            else if (InputElement.IsContentElement(InputManager.ListeningElement))
             {
+                ContentElement ce = (ContentElement)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(ce.GetAutomationPeer());
             }
-            else if (InputManager.ListeningElement is UIElement3D e3D)
+            else if (InputElement.IsUIElement3D(InputManager.ListeningElement))
             {
+                UIElement3D e3D = (UIElement3D)InputManager.ListeningElement;
                 //Raise InputDiscarded automation event
                 SynchronizedInputHelper.RaiseAutomationEvent(e3D.GetAutomationPeer());
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/UIElementHelper.cs
@@ -141,7 +141,7 @@ namespace MS.Internal
         [FriendAccessAllowed]
         internal static bool IsUIElementOrUIElement3D(DependencyObject o)
         {
-            return (o is UIElement or UIElement3D);
+            return (o is UIElement || o is UIElement3D);
         }
 
         [FriendAccessAllowed]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/CommandManager.cs
@@ -352,9 +352,9 @@ namespace System.Windows.Input
 
             // Determine UIElement/ContentElement/Neither type
             DependencyObject targetElementAsDO = targetElement as DependencyObject;
-            bool isUIElement = targetElementAsDO is UIElement;
-            bool isContentElement = !isUIElement && targetElementAsDO is ContentElement;
-            bool isUIElement3D = !isUIElement && !isContentElement && targetElementAsDO is UIElement3D;
+            bool isUIElement = InputElement.IsUIElement(targetElementAsDO);
+            bool isContentElement = !isUIElement && InputElement.IsContentElement(targetElementAsDO);
+            bool isUIElement3D = !isUIElement && !isContentElement && InputElement.IsUIElement3D(targetElementAsDO);
 
             // Step 1: Check local input bindings
             InputBindingCollection localInputBindings = null;
@@ -370,7 +370,6 @@ namespace System.Windows.Input
             {
                 localInputBindings = ((UIElement3D)targetElement).InputBindingsInternal;
             }
-
             if (localInputBindings != null)
             {
                 InputBinding inputBinding = localInputBindings.FindMatch(targetElement, inputEventArgs);
@@ -424,7 +423,6 @@ namespace System.Windows.Input
                 {
                     localCommandBindings = ((UIElement3D)targetElement).CommandBindingsInternal;
                 }
-
                 if (localCommandBindings != null)
                 {
                     command = localCommandBindings.FindMatch(targetElement, inputEventArgs);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
@@ -362,17 +362,17 @@ namespace System.Windows.Input
             // both of which derive from DO
             DependencyObject targetAsDO = (DependencyObject)target;
             
-            if (targetAsDO is UIElement uie)
+            if (InputElement.IsUIElement(targetAsDO))
             {
-                uie.RaiseEvent(args, trusted);
+                ((UIElement)targetAsDO).RaiseEvent(args, trusted);
             }
-            else if (targetAsDO is ContentElement ce)
+            else if (InputElement.IsContentElement(targetAsDO))
             {
-                ce.RaiseEvent(args, trusted);
+                ((ContentElement)targetAsDO).RaiseEvent(args, trusted);
             }
-            else if (targetAsDO is UIElement3D uie3D)
+            else if (InputElement.IsUIElement3D(targetAsDO))
             {
-                uie3D.RaiseEvent(args, trusted);
+                ((UIElement3D)targetAsDO).RaiseEvent(args, trusted);
             }            
         }
         internal bool ExecuteCore(object parameter, IInputElement target, bool userInitiated)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -25,42 +25,62 @@ namespace System.Windows.Input
 
         internal static bool IsValid(DependencyObject o)
         {
-            return o is UIElement or ContentElement or UIElement3D; 
+            return IsUIElement(o) || IsContentElement(o) || IsUIElement3D(o); 
 }
+
+        // Returns whether the given DynamicObject is a UIElement or not.
+        internal static bool IsUIElement(DependencyObject o)
+        {
+            return UIElementType.IsInstanceOfType(o);     
+        }
+
+        // Returns whether the given DynamicObject is a UIElement3D or not.
+        internal static bool IsUIElement3D(DependencyObject o)
+        {
+            return UIElement3DType.IsInstanceOfType(o);                       
+        }
+                
+        // Returns whether the given DynamicObject is a ContentElement or not.
+        internal static bool IsContentElement(DependencyObject o)
+        {
+            return ContentElementType.IsInstanceOfType(o);
+        }
 
         // Returns the containing input element of the given DynamicObject.
         // If onlyTraverse2D is set to true, then we stop once we see a 3D object and return null
         internal static DependencyObject GetContainingUIElement(DependencyObject o, bool onlyTraverse2D)
         {
             DependencyObject container = null;
+            Visual v;
+            Visual3D v3D;
 
             if(o != null)
             {
-                if(o is UIElement)
+                if(IsUIElement(o))
                 {
                     container = o;
                 }
-                else if (o is UIElement3D && !onlyTraverse2D)
+                else if (IsUIElement3D(o) && !onlyTraverse2D)
                 {
                     container = o;
                 } 
-                else if(o is ContentElement contentElement)
+                else if(IsContentElement(o))
                 {
-                    DependencyObject parent = ContentOperations.GetParent(contentElement);
+                    DependencyObject parent = ContentOperations.GetParent((ContentElement)o);
                     if(parent != null)
                     {
                         container = GetContainingUIElement(parent, onlyTraverse2D);
                     }
                     else
                     {
-                        parent = contentElement.GetUIParentCore();
+                        parent = ((ContentElement)o).GetUIParentCore();
                         if(parent != null)
                         {
                             container = GetContainingUIElement(parent, onlyTraverse2D);
                         }
                     }
                 }
-                else if (o is Visual v)
+                else if ((v = o as Visual) != null)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v);
                     if(parent != null)
@@ -68,7 +88,7 @@ namespace System.Windows.Input
                         container = GetContainingUIElement(parent, onlyTraverse2D);
                     }
                 }
-                else if (!onlyTraverse2D && o is Visual3D v3D)
+                else if (!onlyTraverse2D && (v3D = o as Visual3D) != null)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v3D);
                     if (parent != null)
@@ -93,22 +113,24 @@ namespace System.Windows.Input
         internal static IInputElement GetContainingInputElement(DependencyObject o, bool onlyTraverse2D)
         {
             IInputElement container = null;
+            Visual v;            
+            Visual3D v3D;
 
             if(o != null)
             {
-                if(o is UIElement uiElement)
+                if(IsUIElement(o))
                 {
-                    container = uiElement;
+                    container = (UIElement) o;
                 }
-                else if(o is ContentElement contentElement)
+                else if(IsContentElement(o))
                 {
-                    container = contentElement;
+                    container = (ContentElement) o;
                 }
-                else if (o is UIElement3D uIElement3D && !onlyTraverse2D)
+                else if (IsUIElement3D(o) && !onlyTraverse2D)
                 {
-                    container = uIElement3D;
+                    container = (UIElement3D)o;
                 }
-                else if(o is Visual v)
+                else if((v = o as Visual) != null)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v);
                     if(parent != null)
@@ -116,7 +138,7 @@ namespace System.Windows.Input
                         container = GetContainingInputElement(parent, onlyTraverse2D);
                     }
                 }
-                else if (!onlyTraverse2D && o is Visual3D v3D)
+                else if (!onlyTraverse2D && (v3D = o as Visual3D) != null)
                 {
                     DependencyObject parent = VisualTreeHelper.GetParent(v3D);
                     if (parent != null)
@@ -143,24 +165,24 @@ namespace System.Windows.Input
 
             if(o != null)
             {
-                if(o is UIElement uiElement)
+                if(IsUIElement(o))
                 {
-                    v = uiElement;
+                    v = (Visual)o;
                 }
-                else if (o is Visual3D visual3D)
+                else if (IsUIElement3D(o))
                 {
-                    v = visual3D;
+                    v = (Visual3D)o;
                 }
-                else if(o is ContentElement contentElement)
+                else if(IsContentElement(o))
                 {
-                    DependencyObject parent = ContentOperations.GetParent(contentElement);
+                    DependencyObject parent = ContentOperations.GetParent((ContentElement)o);
                     if(parent != null)
                     {
                         v = GetContainingVisual(parent);
                     }
                     else
                     {
-                        parent = contentElement.GetUIParentCore();
+                        parent = ((ContentElement)o).GetUIParentCore();
                         if(parent != null)
                         {
                             v = GetContainingVisual(parent);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputManager.cs
@@ -801,16 +801,22 @@ namespace System.Windows.Input
                     {
                         if (eventSource != null)
                         {
-                            if (eventSource is UIElement e)
+                            if (InputElement.IsUIElement(eventSource))
                             {
+                                UIElement e = (UIElement)eventSource;
+
                                 e.RaiseEvent(input, true); // Call the "trusted" flavor of RaiseEvent. 
                             }
-                            else if (eventSource is ContentElement ce)
+                            else if (InputElement.IsContentElement(eventSource))
                             {
+                                ContentElement ce = (ContentElement)eventSource;
+
                                 ce.RaiseEvent(input, true);// Call the "trusted" flavor of RaiseEvent.
                             }
-                            else if (eventSource is UIElement3D e3D)
+                            else if (InputElement.IsUIElement3D(eventSource))
                             {
+                                UIElement3D e3D = (UIElement3D)eventSource;
+
                                 e3D.RaiseEvent(input, true); // Call the "trusted" flavor of RaiseEvent
                             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/KeyboardDevice.cs
@@ -420,53 +420,45 @@ namespace System.Windows.Input
                     if(oldFocus != null)
                     {
                         o = oldFocus;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged -= _isEnabledChangedEventHandler;
-                            uie.IsVisibleChanged -= _isVisibleChangedEventHandler;
-                            uie.FocusableChanged -= _focusableChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged -= _isVisibleChangedEventHandler;
+                            ((UIElement)o).FocusableChanged -= _focusableChangedEventHandler;
                         }
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
                             // NOTE: there is no IsVisible property for ContentElements.
-                            ce.FocusableChanged -= _focusableChangedEventHandler;
-                        }
-                        else if (o is UIElement3D uie3D)
-                        {
-                            uie3D.IsEnabledChanged -= _isEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged -= _isVisibleChangedEventHandler;
-                            uie3D.FocusableChanged -= _focusableChangedEventHandler;
+                            ((ContentElement)o).FocusableChanged -= _focusableChangedEventHandler;
                         }
                         else
                         {
-                            throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                            ((UIElement3D)o).IsEnabledChanged -= _isEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged -= _isVisibleChangedEventHandler;
+                            ((UIElement3D)o).FocusableChanged -= _focusableChangedEventHandler;
                         }
                     }
                     if(_focus != null)
                     {
                         o = _focus;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged += _isEnabledChangedEventHandler;
-                            uie.IsVisibleChanged += _isVisibleChangedEventHandler;
-                            uie.FocusableChanged += _focusableChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged += _isEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged += _isVisibleChangedEventHandler;
+                            ((UIElement)o).FocusableChanged += _focusableChangedEventHandler;
                         }                        
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged += _isEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged += _isEnabledChangedEventHandler;
                             // NOTE: there is no IsVisible property for ContentElements.
-                            ce.FocusableChanged += _focusableChangedEventHandler;
-                        }
-                        else if (o is UIElement3D uie3D)
-                        {
-                            uie3D.IsEnabledChanged += _isEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged += _isVisibleChangedEventHandler;
-                            uie3D.FocusableChanged += _focusableChangedEventHandler;
+                            ((ContentElement)o).FocusableChanged += _focusableChangedEventHandler;
                         }
                         else
                         {
-                            throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
+                            ((UIElement3D)o).IsEnabledChanged += _isEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged += _isVisibleChangedEventHandler;
+                            ((UIElement3D)o).FocusableChanged += _focusableChangedEventHandler;
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -739,17 +739,17 @@ namespace System.Windows.Input
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement uie)
+            if (InputElement.IsUIElement(dependencyObject))
             {
-                killCapture = !ValidateUIElementForCapture(uie);
+                killCapture = !ValidateUIElementForCapture((UIElement)_mouseCapture);
             }
-            else if (dependencyObject is ContentElement ce)
+            else if (InputElement.IsContentElement(dependencyObject))
             {
-                killCapture = !ValidateContentElementForCapture(ce);
+                killCapture = !ValidateContentElementForCapture((ContentElement)_mouseCapture);
             }
-            else if (dependencyObject is UIElement3D uie3D)
+            else if (InputElement.IsUIElement3D(dependencyObject))
             {
-                killCapture = !ValidateUIElement3DForCapture(uie3D);
+                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_mouseCapture);
             }
 
             //
@@ -993,51 +993,51 @@ namespace System.Windows.Input
                     if(oldMouseOver != null)
                     {
                         o = oldMouseOver as DependencyObject;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                            uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is UIElement3D uie3D)
+                        else if (InputElement.IsUIElement3D(o))
                         {
-                            uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                            uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                         }
                     }
                     if(_mouseOver != null)
                     {
                         o = _mouseOver as DependencyObject;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                            uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is UIElement3D uie3D)
+                        else if (InputElement.IsUIElement3D(o))
                         {
-                            uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                            uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                         }
                     }
                 }
@@ -1087,51 +1087,51 @@ namespace System.Windows.Input
                     if (oldMouseCapture != null)
                     {
                         o = oldMouseCapture as DependencyObject;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                            uie.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            uie.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            ((UIElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ce.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            // ce.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is UIElement3D uie3D)
+                        else if (InputElement.IsUIElement3D(o))
                         {
-                            uie3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                            uie3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                         }
                     }
                     if (_mouseCapture != null)
                     {
                         o = _mouseCapture as DependencyObject;
-                        if (o is UIElement uie)
+                        if (InputElement.IsUIElement(o))
                         {
-                            uie.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                            uie.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            uie.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            ((UIElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            ((UIElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            ((UIElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is ContentElement ce)
+                        else if (InputElement.IsContentElement(o))
                         {
-                            ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
 
                             // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                             //
-                            // ce.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            // ce.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            // ((ContentElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
-                        else if (o is UIElement3D uie3D)
+                        else if (InputElement.IsUIElement3D(o))
                         {
-                            uie3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                            uie3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                            uie3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                            ((UIElement3D)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                            ((UIElement3D)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                         }
                     }
                 }
@@ -1538,13 +1538,9 @@ namespace System.Windows.Input
                                             // If we are over something else (like a raw visual)
                                             // find the containing element.
                                             if (!InputElement.IsValid(mouseOver))
-                                            {
                                                 mouseOver = InputElement.GetContainingInputElement(mouseOver as DependencyObject);
-                                            }
                                             if ((rawMouseOver != null) && !InputElement.IsValid(rawMouseOver))
-                                            {
                                                 rawMouseOver = InputElement.GetContainingInputElement(rawMouseOver as DependencyObject);
-                                            }
                                         }
                                         break;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerLogic.cs
@@ -530,52 +530,48 @@ namespace System.Windows.Input.StylusPointer
                 if (oldCapture != null)
                 {
                     o = oldCapture as DependencyObject;
-                    if (o is UIElement element)
+                    if (InputElement.IsUIElement(o))
                     {
+                        UIElement element = o as UIElement;
                         element.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
                         element.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
-                        ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                    }
-                    else if (o is UIElement3D element3D)
-                    {
-                        element3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        element3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        element3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldCapture.GetType())); 
+                        UIElement3D element = o as UIElement3D;
+                        element.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        element.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        element.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
                 }
 
                 if (_stylusCapture != null)
                 {
                     o = _stylusCapture as DependencyObject;
-                    if (o is UIElement element)
+                    if (InputElement.IsUIElement(o))
                     {
+                        UIElement element = o as UIElement;
                         element.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
                         element.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
-                        ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                    }
-                    else if (o is UIElement3D element3D)
-                    {
-                        element3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        element3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        element3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                        UIElement3D element = o as UIElement3D;
+                        element.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        element.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        element.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
                 }
 
@@ -617,59 +613,55 @@ namespace System.Windows.Input.StylusPointer
                 if (oldOver != null)
                 {
                     o = oldOver as DependencyObject;
-                    if (o is UIElement element)
+                    if (InputElement.IsUIElement(o))
                     {
+                        UIElement element = o as UIElement;
                         element.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
                         element.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D element3D)
-                    {
-                        element3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        element3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        element3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                        UIElement3D element = o as UIElement3D;
+                        element.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        element.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        element.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
                 }
                 if (_stylusOver != null)
                 {
                     o = _stylusOver as DependencyObject;
-                    if (o is UIElement element)
+                    if (InputElement.IsUIElement(o))
                     {
+                        UIElement element = o as UIElement;
                         element.IsEnabledChanged += _overIsEnabledChangedEventHandler;
                         element.IsVisibleChanged += _overIsVisibleChangedEventHandler;
                         element.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D element3D)
-                    {
-                        element3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        element3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        element3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                        UIElement3D element = o as UIElement3D;
+                        element.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        element.IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        element.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
                 }
 
@@ -791,21 +783,17 @@ namespace System.Windows.Input.StylusPointer
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement uie)
+            if (InputElement.IsUIElement(dependencyObject))
             {
-                killCapture = !ValidateUIElementForCapture(uie);
+                killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
             }
-            else if (dependencyObject is ContentElement ce)
+            else if (InputElement.IsContentElement(dependencyObject))
             {
-                killCapture = !ValidateContentElementForCapture(ce);
-            }
-            else if (dependencyObject is UIElement3D uie3D)
-            {
-                killCapture = !ValidateUIElement3DForCapture(uie3D);
+                killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
             }
             else
             {
-                throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -2059,59 +2059,51 @@ namespace System.Windows.Input.StylusWisp
                 if (oldCapture != null)
                 {
                     o = oldCapture as DependencyObject;
-                    if (o is UIElement uie)
+                    if (InputElement.IsUIElement(o))
                     {
-                        uie.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        uie.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        uie.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        ((UIElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        ((UIElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        ((UIElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D uie3D)
-                    {
-                        uie3D.IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
-                        uie3D.IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
-                        uie3D.IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldCapture.GetType())); 
+                        ((UIElement3D)o).IsEnabledChanged -= _captureIsEnabledChangedEventHandler;
+                        ((UIElement3D)o).IsVisibleChanged -= _captureIsVisibleChangedEventHandler;
+                        ((UIElement3D)o).IsHitTestVisibleChanged -= _captureIsHitTestVisibleChangedEventHandler;
                     }
                 }
                 if (_stylusCapture != null)
                 {
                     o = _stylusCapture as DependencyObject;
-                    if (o is UIElement uie)
+                    if (InputElement.IsUIElement(o))
                     {
-                        uie.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        uie.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        uie.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        ((UIElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        ((UIElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        ((UIElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D uie3D)
-                    {
-                        uie3D.IsEnabledChanged += _captureIsEnabledChangedEventHandler;
-                        uie3D.IsVisibleChanged += _captureIsVisibleChangedEventHandler;
-                        uie3D.IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                        ((UIElement3D)o).IsEnabledChanged += _captureIsEnabledChangedEventHandler;
+                        ((UIElement3D)o).IsVisibleChanged += _captureIsVisibleChangedEventHandler;
+                        ((UIElement3D)o).IsHitTestVisibleChanged += _captureIsHitTestVisibleChangedEventHandler;
                     }
                 }
 
@@ -2147,59 +2139,51 @@ namespace System.Windows.Input.StylusWisp
                 if (oldOver != null)
                 {
                     o = oldOver as DependencyObject;
-                    if (o is UIElement uie)
+                    if (InputElement.IsUIElement(o))
                     {
-                        uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D uie3D)
-                    {
-                        uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                        uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                        uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                        ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                        ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                        ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                     }
                 }
                 if (_stylusOver != null)
                 {
                     o = _stylusOver as DependencyObject;
-                    if (o is UIElement uie)
+                    if (InputElement.IsUIElement(o))
                     {
-                        uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
-                    else if (o is ContentElement ce)
+                    else if (InputElement.IsContentElement(o))
                     {
-                        ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                         // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                         //
-                        // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
-                    }
-                    else if (o is UIElement3D uie3D)
-                    {
-                        uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                        uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                        uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
                     else
                     {
-                        throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                        ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                        ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                        ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                     }
                 }
 
@@ -2425,21 +2409,17 @@ namespace System.Windows.Input.StylusWisp
             // First, check things like IsEnabled, IsVisible, etc. on a
             // UIElement vs. ContentElement basis.
             //
-            if (dependencyObject is UIElement uie)
+            if (InputElement.IsUIElement(dependencyObject))
             {
-                killCapture = !ValidateUIElementForCapture(uie);
+                killCapture = !ValidateUIElementForCapture((UIElement)_stylusCapture);
             }
-            else if (dependencyObject is ContentElement ce)
+            else if (InputElement.IsContentElement(dependencyObject))
             {
-                killCapture = !ValidateContentElementForCapture(ce);
-            }
-            else if (dependencyObject is UIElement3D uie3D)
-            {
-                killCapture = !ValidateUIElement3DForCapture(uie3D);
+                killCapture = !ValidateContentElementForCapture((ContentElement)_stylusCapture);
             }
             else
             {
-                throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusCapture.GetType())); 
+                killCapture = !ValidateUIElement3DForCapture((UIElement3D)_stylusCapture);
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusDevice.cs
@@ -418,59 +418,51 @@ namespace System.Windows.Input.StylusWisp
             if (oldOver != null)
             {
                 o = oldOver as DependencyObject;
-                if (o is UIElement uie)
+                if (InputElement.IsUIElement(o))
                 {
-                    uie.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                    uie.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    uie.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                    ((UIElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    ((UIElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    ((UIElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
-                else if (o is ContentElement ce)
+                else if (InputElement.IsContentElement(o))
                 {
-                    ce.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    ((ContentElement)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
 
                     // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                     //
-                    // ce.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    // ce.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
-                }
-                else if (o is UIElement3D uie3D)
-                {
-                    uie3D.IsEnabledChanged -= _overIsEnabledChangedEventHandler;
-                    uie3D.IsVisibleChanged -= _overIsVisibleChangedEventHandler;
-                    uie3D.IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
+                    // ((ContentElement)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    // ((ContentElement)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
                 else
                 {
-                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, oldOver.GetType())); 
+                    ((UIElement3D)o).IsEnabledChanged -= _overIsEnabledChangedEventHandler;
+                    ((UIElement3D)o).IsVisibleChanged -= _overIsVisibleChangedEventHandler;
+                    ((UIElement3D)o).IsHitTestVisibleChanged -= _overIsHitTestVisibleChangedEventHandler;
                 }
             }
             if (_stylusOver != null)
             {
                 o = _stylusOver as DependencyObject;
-                if (o is UIElement uie)
+                if (InputElement.IsUIElement(o))
                 {
-                    uie.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                    uie.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    uie.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                    ((UIElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    ((UIElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    ((UIElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
-                else if (o is ContentElement ce)
+                else if (InputElement.IsContentElement(o))
                 {
-                    ce.IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    ((ContentElement)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
 
                     // NOTE: there are no IsVisible or IsHitTestVisible properties for ContentElements.
                     //
-                    // ce.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    // ce.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
-                }
-                else if (o is UIElement3D uie3D)
-                {
-                    uie3D.IsEnabledChanged += _overIsEnabledChangedEventHandler;
-                    uie3D.IsVisibleChanged += _overIsVisibleChangedEventHandler;
-                    uie3D.IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
+                    // ((ContentElement)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    // ((ContentElement)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
                 else
                 {
-                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, _stylusOver.GetType())); 
+                    ((UIElement3D)o).IsEnabledChanged += _overIsEnabledChangedEventHandler;
+                    ((UIElement3D)o).IsVisibleChanged += _overIsVisibleChangedEventHandler;
+                    ((UIElement3D)o).IsHitTestVisibleChanged += _overIsHitTestVisibleChangedEventHandler;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/ShaderEffect.cs
@@ -436,10 +436,11 @@ namespace System.Windows.Media.Effects
 
             if (newValue != null)
             {
-                if (newValue is not VisualBrush
-                    and not BitmapCacheBrush
-                    and not ImplicitInputBrush
-                    and not ImageBrush)
+                if (!(typeof(VisualBrush).IsInstanceOfType(newValue) ||
+                      typeof(BitmapCacheBrush).IsInstanceOfType(newValue) ||
+                      typeof(ImplicitInputBrush).IsInstanceOfType(newValue) ||
+                      typeof(ImageBrush).IsInstanceOfType(newValue))
+                      )
                 {
                     // Note that if the type of the brush is ImplicitInputBrush and the value is non null, the value is actually
                     // Effect.ImplicitInput. This is because ImplicitInputBrush is internal and the user can only get to the singleton

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualTreeHelper.cs
@@ -254,11 +254,14 @@ namespace System.Windows.Media
 
             while ((current != null) && (current != ancestor) && !stopType.IsInstanceOfType(current))
             {
-                if (current is Visual visual)
+                Visual visual;
+                Visual3D visual3D;
+
+                if ((visual = current as Visual) != null)
                 {
                     current = visual.InternalVisualParent;
                 }
-                else if (current is Visual3D visual3D)
+                else if ((visual3D = current as Visual3D) != null)
                 {
                     current = visual3D.InternalVisualParent;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -145,8 +145,9 @@ namespace System.Windows
             {
                 FrugalObjectList<RoutedEventHandlerInfo> info;
 
-                if (o is UIElement uie)
+                if (InputElement.IsUIElement(o))
                 {
+                    UIElement uie = o as UIElement;
                     uie.AddHandler(SourceChangedEvent, handler);
                     info = uie.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
@@ -155,8 +156,9 @@ namespace System.Windows
                         AddElementToWatchList(uie);
                     }
                 }
-                else if (o is UIElement3D uie3D)
+                else if (InputElement.IsUIElement3D(o))
                 {
+                    UIElement3D uie3D = o as UIElement3D;
                     uie3D.AddHandler(SourceChangedEvent, handler);
                     info = uie3D.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
@@ -165,18 +167,13 @@ namespace System.Windows
                         AddElementToWatchList(uie3D);
                     }
                 }
-                else if (o is ContentElement ce)
+                else
                 {
+                    ContentElement ce = o as ContentElement;
                     ce.AddHandler(SourceChangedEvent, handler);
                     info = ce.EventHandlersStore[SourceChangedEvent];
                     if (1 == info.Count)
-                    {
                         AddElementToWatchList(ce);
-                    }
-                }
-                else
-                {
-                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
                 }
             }
         }
@@ -214,11 +211,10 @@ namespace System.Windows
                 FrugalObjectList<RoutedEventHandlerInfo> info = null;
                 EventHandlersStore store;
 
-
-                // Either UIElement, ContentElement or UIElement3D.
-                if (o is UIElement uie)
-
+                // Either UIElement or ContentElement.
+                if (InputElement.IsUIElement(o))
                 {
+                    UIElement uie = o as UIElement;
                     uie.RemoveHandler(SourceChangedEvent, handler);
                     store = uie.EventHandlersStore;
                     if (store != null)
@@ -231,8 +227,9 @@ namespace System.Windows
                         RemoveElementFromWatchList(uie);
                     }
                 }
-                else if (o is UIElement3D uie3D)
+                else if (InputElement.IsUIElement3D(o))
                 {
+                    UIElement3D uie3D = o as UIElement3D;
                     uie3D.RemoveHandler(SourceChangedEvent, handler);
                     store = uie3D.EventHandlersStore;
                     if (store != null)
@@ -245,8 +242,9 @@ namespace System.Windows
                         RemoveElementFromWatchList(uie3D);
                     }
                 }
-                else if (o is ContentElement ce)
+                else
                 {
+                    ContentElement ce = o as ContentElement;
                     ce.RemoveHandler(SourceChangedEvent, handler);
                     store = ce.EventHandlersStore;
                     if (store != null)
@@ -257,10 +255,6 @@ namespace System.Windows
                     {
                         RemoveElementFromWatchList(ce);
                     }
-                }
-                else
-                {
-                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, o.GetType())); 
                 }
             }
         }
@@ -555,7 +549,7 @@ namespace System.Windows
         /// <param name="e">  Event Args.</param>
         internal static void OnVisualAncestorChanged(DependencyObject uie, AncestorChangedEventArgs e)
         {
-            Debug.Assert(uie is UIElement3D or UIElement);
+            Debug.Assert(InputElement.IsUIElement3D(uie) || InputElement.IsUIElement(uie));
             
             if (true == (bool)uie.GetValue(GetsSourceChangedEventProperty))
             {
@@ -729,21 +723,17 @@ namespace System.Windows
                 SourceChangedEventArgs args = new SourceChangedEventArgs(cachedSource, realSource);
 
                 args.RoutedEvent=SourceChangedEvent;
-                if (doTarget is UIElement uiElement)
+                if (InputElement.IsUIElement(doTarget))
                 {
-                    uiElement.RaiseEvent(args);
+                    ((UIElement)doTarget).RaiseEvent(args);
                 }                
-                else if (doTarget is ContentElement contentElement)
+                else if (InputElement.IsContentElement(doTarget))
                 {
-                    contentElement.RaiseEvent(args);
-                }
-                else if (doTarget is UIElement3D uiElement3D)
-                {
-                    uiElement3D.RaiseEvent(args);
+                    ((ContentElement)doTarget).RaiseEvent(args);
                 }
                 else
                 {
-                    throw new InvalidOperationException(SR.Get(SRID.Invalid_IInputElement, doTarget.GetType())); 
+                    ((UIElement3D)doTarget).RaiseEvent(args);
                 }
 
                 calledOut = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1443,7 +1443,7 @@ namespace System.Windows
             {
                 DependencyObject parent = _parent;
 
-                if (parent is not UIElement and not UIElement3D)
+                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
                 {
                     Visual parentAsVisual = parent as Visual;
 
@@ -1490,7 +1490,7 @@ namespace System.Windows
             {
                 DependencyObject parent = oldParent;
 
-                if (parent is not UIElement and not UIElement3D)
+                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
                 {
                     // We are being unplugged from a non-UIElement visual. This
                     // means that our parent didn't play by the same rules we

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement3D.cs
@@ -148,7 +148,7 @@ namespace System.Windows
             {
                 DependencyObject parent = InternalVisualParent;
 
-                if (parent is not UIElement and not UIElement3D)
+                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
                 {
                     Visual parentAsVisual = parent as Visual;
 
@@ -192,7 +192,7 @@ namespace System.Windows
             {
                 DependencyObject parent = oldParent;
 
-                if (parent is not UIElement and not UIElement3D)
+                if (!InputElement.IsUIElement(parent) && !InputElement.IsUIElement3D(parent))
                 {
                     // We are being unplugged from a non-UIElement visual. This
                     // means that our parent didn't play by the same rules we

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
@@ -229,7 +229,7 @@ namespace MS.Internal.Annotations.Anchoring
             Debug.Assert(node != null, "node can not be null");
 
             DependencyObject current = node;
-            DependencyObject parent;
+            DependencyObject parent = null;
 
             while (true)
             {
@@ -255,15 +255,16 @@ namespace MS.Internal.Annotations.Anchoring
                 }
 
                 // Check if located a parent, if so, check if it's the correct type
-                if (parent is null
-                    or FrameworkElement
-                    or FrameworkContentElement)
+                if ((parent == null) ||
+                    FrameworkElement.DType.IsInstanceOfType(parent) ||
+                    FrameworkContentElement.DType.IsInstanceOfType(parent))
                 {
                     break;
                 }
 
                 // Parent found but not of correct type, continue
                 current = parent;
+                parent = null;
             }
 
             return parent;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/FrameworkObject.cs
@@ -57,8 +57,21 @@ namespace MS.Internal
             // [code should be identical to Reset(d)]
             _do = d;
 
-            _fe = d as FrameworkElement;
-            _fce = d as FrameworkContentElement;
+            if (FrameworkElement.DType.IsInstanceOfType(d))
+            {
+                _fe = (FrameworkElement)d;
+                _fce = null;
+            }
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            {
+                _fe = null;
+                _fce = (FrameworkContentElement)d;
+            }
+            else
+            {
+                _fe = null;
+                _fce = null;
+            }
         }
 
         internal FrameworkObject(DependencyObject d, bool throwIfNeither)
@@ -86,8 +99,21 @@ namespace MS.Internal
         {
             _do = d;
 
-            _fe = d as FrameworkElement;
-            _fce = d as FrameworkContentElement;
+            if (FrameworkElement.DType.IsInstanceOfType(d))
+            {
+                _fe = (FrameworkElement)d;
+                _fce = null;
+            }
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
+            {
+                _fe = null;
+                _fce = (FrameworkContentElement)d;
+            }
+            else
+            {
+                _fe = null;
+                _fce = null;
+            }
         }
 
         #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -286,15 +286,15 @@ namespace MS.Internal
                                     out FrameworkElement fe, out FrameworkContentElement fce,
                                     bool throwIfNeither)
         {
-            if (d is FrameworkElement frameworkElement)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
-                fe = frameworkElement;
+                fe = (FrameworkElement)d;
                 fce = null;
             }
-            else if (d is FrameworkContentElement frameworkContentElement)
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
             {
                 fe = null;
-                fce = frameworkContentElement;
+                fce = (FrameworkContentElement)d;
             }
             else if (throwIfNeither)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ClipboardProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/ClipboardProcessor.cs
@@ -213,9 +213,9 @@ namespace MS.Internal.Ink
                                 // If the Xaml data has been set in an InkCanvas, the top element will be a container InkCanvas.
                                 // In this case, the new elements will be the children of the container.
                                 // Otherwise, the new elements will be whatever data from the data object.
-                                if (elements.Count == 1 && elements[0] is InkCanvas inkCanvas)
+                                if (elements.Count == 1 && ClipboardProcessor.InkCanvasDType.IsInstanceOfType(elements[0]))
                                 {
-                                    TearDownInkCanvasContainer(inkCanvas, ref newStrokes, ref newElements);
+                                    TearDownInkCanvasContainer((InkCanvas)( elements[0] ), ref newStrokes, ref newElements);
                                 }
                                 else
                                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PrePostDescendentsWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PrePostDescendentsWalker.cs
@@ -72,7 +72,7 @@ namespace MS.Internal
                     {
                         // This type checking is done in DescendentsWalker.  Doing it here
                         // keeps us consistent.
-                        if (startNode is FrameworkElement or FrameworkContentElement)
+                        if (FrameworkElement.DType.IsInstanceOfType(startNode) || FrameworkContentElement.DType.IsInstanceOfType(startNode))
                         {
                             _postCallback(startNode, this.Data, _priority == TreeWalkPriority.VisualTree);
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/BroadcastEventHelper.cs
@@ -292,10 +292,12 @@ namespace System.Windows
             DependencyObject root = data.Root;
             RoutedEvent routedEvent = data.RoutedEvent;
             List<DependencyObject> eventRoute = data.EventRoute;
-
-            // If this is a FrameworkElement            
-            if (d is FrameworkElement fe)
+            
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
+                // If this is a FrameworkElement
+                FrameworkElement fe = (FrameworkElement)d;
+
                 if (fe != root && routedEvent == FrameworkElement.LoadedEvent && fe.UnloadedPending != null)
                 {
                     // If there is a pending Unloaded event wait till we've broadcast 
@@ -420,22 +422,22 @@ namespace System.Windows
 
         private static bool SubtreeHasLoadedChangeHandlerHelper(DependencyObject d)
         {
-            if (d is FrameworkElement fe)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
-                return fe.SubtreeHasLoadedChangeHandler;
+                return ((FrameworkElement)d).SubtreeHasLoadedChangeHandler;
             }
-            else if (d is FrameworkContentElement fce)
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
             {
-                return fce.SubtreeHasLoadedChangeHandler;
+                return ((FrameworkContentElement)d).SubtreeHasLoadedChangeHandler;
             }
             return false;
         }
 
         private static void FireLoadedOnDescendentsHelper(DependencyObject d)
         {
-            if (d is FrameworkElement fe)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
-                fe.FireLoadedOnDescendentsInternal();
+                ((FrameworkElement)d).FireLoadedOnDescendentsInternal();
             }
             else
             {
@@ -445,9 +447,9 @@ namespace System.Windows
 
         private static void FireUnloadedOnDescendentsHelper(DependencyObject d)
         {
-            if (d is FrameworkElement fe)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
-                fe.FireUnloadedOnDescendentsInternal();
+                ((FrameworkElement)d).FireUnloadedOnDescendentsInternal();
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -942,17 +942,17 @@ namespace System.Windows.Controls
             DependencyObject sourceDO = source as DependencyObject;
             if (userInitiated && sourceDO != null)
             {
-                if (sourceDO is UIElement uiElement)
+                if (InputElement.IsUIElement(sourceDO))
                 {
-                    uiElement.RaiseEvent(args, userInitiated);
+                    ((UIElement)sourceDO).RaiseEvent(args, userInitiated);
                 }
-                else if (sourceDO is ContentElement contentElement)
+                else if (InputElement.IsContentElement(sourceDO))
                 {
-                    contentElement.RaiseEvent(args, userInitiated);
+                    ((ContentElement)sourceDO).RaiseEvent(args, userInitiated);
                 }
-                else if (sourceDO is UIElement3D uiElement3D)
+                else if (InputElement.IsUIElement3D(sourceDO))
                 {
-                    uiElement3D.RaiseEvent(args, userInitiated);
+                    ((UIElement3D)sourceDO).RaiseEvent(args, userInitiated);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DatePickerTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DatePickerTextBox.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Controls.Primitives
         private static T ExtractTemplatePart<T>(string partName, DependencyObject obj) where T : DependencyObject
         {
             Debug.Assert(
-                obj == null || obj is T,
+                obj == null || typeof(T).IsInstanceOfType(obj),
                 string.Format(CultureInfo.InvariantCulture, SR.Get(SRID.DatePickerTextBox_TemplatePartIsOfIncorrectType), partName, typeof(T).Name));
             return obj as T;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalker.cs
@@ -56,8 +56,8 @@ namespace System.Windows
 
             if (!skipStartNode)
             {
-                if (_startNode is FrameworkElement
-                    or FrameworkContentElement)
+                if (FrameworkElement.DType.IsInstanceOfType(_startNode) ||
+                    FrameworkContentElement.DType.IsInstanceOfType(_startNode))
                 {
                     // Callback for the root of the subtree
                     continueWalk = _callback(_startNode, _data, _priority == TreeWalkPriority.VisualTree);
@@ -79,8 +79,9 @@ namespace System.Windows
         {
             _recursionDepth++;
 
-            if (d is FrameworkElement fe)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
+                FrameworkElement fe = (FrameworkElement) d;
                 bool hasLogicalChildren = fe.HasLogicalChildren;
 
                 // FrameworkElement have both a visual and a logical tree.
@@ -99,10 +100,11 @@ namespace System.Windows
                     Debug.Assert( false, "Tree walk priority should be Visual first or Logical first - but this instance of DescendentsWalker has an invalid priority setting that's neither of the two." );
                 }
             }
-            else if (d is FrameworkContentElement fce)
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
             {
                 // FrameworkContentElement only has a logical tree, so we
                 // Walk logical children
+                FrameworkContentElement fce = d as FrameworkContentElement;
                 if (fce.HasLogicalChildren)
                 {
                     WalkLogicalChildren( null, fce, fce.LogicalChildren );
@@ -112,13 +114,18 @@ namespace System.Windows
             {
                 // Neither a FrameworkElement nor FrameworkContentElement.  See
                 //  if it's a Visual and if so walk the Visual collection
-                if (d is Visual v)
+                Visual v = d as Visual;
+                if (v != null)
                 {
                     WalkVisualChildren(v);
                 }
-                else if (d is Visual3D v3D)
+                else
                 {
-                    WalkVisualChildren(v3D);
+                    Visual3D v3D = d as Visual3D;
+                    if (v3D != null)
+                    {
+                        WalkVisualChildren(v3D);
+                    }
                 }
             }
 
@@ -317,12 +324,12 @@ namespace System.Windows
                 for(int i = 0; i < count; i++)
                 {
                     Visual child = feParent.InternalGetVisualChild(i);
-                    if (child != null && child is FrameworkElement fe)
+                    if (child != null && FrameworkElement.DType.IsInstanceOfType(child))
                     {
                         // For the case that both parents are identical, this node should
                         // have already been visited when walking through logical
                         // children, hence we short-circuit here
-                        if (VisualTreeHelper.GetParent(child) != fe.Parent)
+                        if (VisualTreeHelper.GetParent(child) != ((FrameworkElement) child).Parent)
                         {
                             bool visitedViaVisualTree = true;
                             VisitNode(child, visitedViaVisualTree);
@@ -397,11 +404,11 @@ namespace System.Windows
         {
             if (_recursionDepth <= ContextLayoutManager.s_LayoutRecursionLimit)
             {
-                if (d is FrameworkElement fe)
+                if (FrameworkElement.DType.IsInstanceOfType(d))
                 {
-                    VisitNode(fe, visitedViaVisualTree);
+                    VisitNode(d as FrameworkElement, visitedViaVisualTree);
                 }
-                else if (d is FrameworkContentElement)
+                else if (FrameworkContentElement.DType.IsInstanceOfType(d))
                 {
                     _VisitNode(d, visitedViaVisualTree);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalkerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/DescendentsWalkerBase.cs
@@ -38,8 +38,9 @@ namespace System.Windows
             {
                 DependencyObject logicalParent;
 
-                if (ancestor is FrameworkElement fe)
+                if (FrameworkElement.DType.IsInstanceOfType(ancestor))
                 {
+                    FrameworkElement fe = ancestor as FrameworkElement;
                     logicalParent = fe.Parent;
                     // FrameworkElement
                     DependencyObject dependencyObjectParent = VisualTreeHelper.GetParent(fe);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FrameworkElement.cs
@@ -2233,10 +2233,8 @@ namespace System.Windows
                                 {
                                     //let incrementally-updating FrameworkElements to mark the vicinity of the affected child
                                     //to perform partial update.
-                                    if(layoutParent is FrameworkElement fe)
-                                    {
-                                        fe.ParentLayoutInvalidated(this);
-                                    }
+                                    if(FrameworkElement.DType.IsInstanceOfType(layoutParent))
+                                        ((FrameworkElement)layoutParent).ParentLayoutInvalidated(this);
 
                                     if (affectsParentMeasure)
                                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkContentElement.cs
@@ -1220,6 +1220,19 @@ namespace System.Windows
 
         //------------------------------------------------------
         //
+        //  Internal Fields
+        //
+        //------------------------------------------------------
+
+        #region Internal Fields
+
+        // Optimization, to avoid calling FromSystemType too often
+        internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkContentElement));
+
+        #endregion Internal Fields
+
+        //------------------------------------------------------
+        //
         //  Private Fields
         //
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Generated/FrameworkElement.cs
@@ -1269,6 +1269,19 @@ namespace System.Windows
 
         //------------------------------------------------------
         //
+        //  Internal Fields
+        //
+        //------------------------------------------------------
+
+        #region Internal Fields
+
+        // Optimization, to avoid calling FromSystemType too often
+        internal new static DependencyObjectType DType = DependencyObjectType.FromSystemTypeInternal(typeof(FrameworkElement));
+
+        #endregion Internal Fields
+
+        //------------------------------------------------------
+        //
         //  Private Fields
         //
         //------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Storyboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Storyboard.cs
@@ -929,13 +929,13 @@ public class Storyboard : ParallelTimeline
     /// </summary>
     private void VerifyComplexPathSupport( DependencyObject targetObject )
     {
-        if(targetObject is FrameworkElement)
+        if( FrameworkElement.DType.IsInstanceOfType(targetObject) )
         {
             // FrameworkElement and derived types are supported.
             return;
         }
 
-        if(targetObject is FrameworkContentElement)
+        if( FrameworkContentElement.DType.IsInstanceOfType(targetObject) )
         {
             // FrameworkContentElement and derived types are supported.
             return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -2327,15 +2327,15 @@ namespace System.Windows
                                     out FrameworkElement fe, out FrameworkContentElement fce,
                                     bool throwIfNeither)
         {
-            if (d is FrameworkElement frameworkElement)
+            if (FrameworkElement.DType.IsInstanceOfType(d))
             {
-                fe = frameworkElement;
+                fe = (FrameworkElement)d;
                 fce = null;
             }
-            else if (d is FrameworkContentElement frameworkContentElement)
+            else if (FrameworkContentElement.DType.IsInstanceOfType(d))
             {
                 fe = null;
-                fce = frameworkContentElement;
+                fce = (FrameworkContentElement)d;
             }
             else if (throwIfNeither && !(d is System.Windows.Media.Media3D.Visual3D) )
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TreeWalkHelper.cs
@@ -1000,7 +1000,7 @@ namespace System.Windows
                 // only then do we need to Invalidate the property
                 if (BaseValueSourceInternal.Inherited >= oldEntry.BaseValueSourceInternal)
                 {
-                    if (visitedViaVisualTree && d is FrameworkElement)
+                    if (visitedViaVisualTree && FrameworkElement.DType.IsInstanceOfType(d))
                     {
                         DependencyObject logicalParent = LogicalTreeHelper.GetParent(d);
                         if (logicalParent != null)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializer.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachDocumentSequenceSerializerAsync.cs
@@ -232,7 +232,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializer.cs
@@ -277,7 +277,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedDocumentSerializerAsync.cs
@@ -317,7 +317,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializer.cs
@@ -350,7 +350,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializerAsync.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachFixedPageSerializerAsync.cs
@@ -322,7 +322,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMFixedPageSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMFixedPageSerializer.cs
@@ -308,7 +308,7 @@ namespace System.Windows.Xps.Serialization
                                                                        propertyValue);
 
 
-                if (propertyValue is Type)
+                if (typeof(Type).IsInstanceOfType(propertyValue))
                 {
                     int index = valueAsString.LastIndexOf('.');
                     valueAsString = string.Concat(


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/7205
Fixes https://github.com/dotnet/wpf/issues/7291

[Main PR ] (https://github.com/dotnet/wpf/pull/7295)

## Description

Revert "Replacing expensive type checks with "is" checks (#4964)"

## Customer Impact

An attempt to call the BindingOperations.GetBindingExpression method in .NET 7.0 leads to Null Reference Exception.

## Regression

Yes

## Testing

In progress

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7308)