### PR TITLE
Update SDK to 8.0.100-alpha.1.22601.6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-alpha.1.22512.5",
+    "dotnet": "8.0.100-alpha.1.22601.6",
     "runtimes": {
       "dotnet": [
         "2.1.7",


### PR DESCRIPTION
The 8.0.100-alpha.1.22512.5 SDK was built in a window where System references were versioned `8.0.0.0`, but in a way that broke some things. That was backed out in dotnet/runtime#77899, which means that assemblies built from this repo can't run on the current .NET 8 runtime, which cannot satisfy a dependency on, for example, `System.Runtime, Version=8.0.0.0`.

Move forward to a newer .NET 8 that has those assemblies versioned at `7.0.0.0` again, which should work even when dotnet/runtime#78354 bumps the version again, because the loader will accept higher versions.

Should unblock dotnet/sdk#28897 (once it builds and flows).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7336)