### PR TITLE
Forward the TargetFrameworkRootPath into the generated project

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -179,6 +179,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 globalProperties[assemblyNamePropertyName] = AssemblyName;
                 globalProperties[targetAssemblyProjectNamePropertyName] = currentProjectName;
+                globalProperties[targetFrameworkRootPathPropertyName] = TargetFrameworkRootPath;
 
                 Dictionary<string, ITaskItem[]> targetOutputs = new Dictionary<string, ITaskItem[]>();
                 retValue = BuildEngine.BuildProjectFile(tempProj, new string[] { CompileTargetName }, globalProperties, targetOutputs);
@@ -901,6 +902,7 @@ namespace Microsoft.Build.Tasks.Windows
         private const string intermediateOutputPathPropertyName = "IntermediateOutputPath";
         private const string assemblyNamePropertyName = "AssemblyName";
         private const string targetAssemblyProjectNamePropertyName = "_TargetAssemblyProjectName";
+        private const string targetFrameworkRootPathPropertyName = "TargetFrameworkRootPath";
 
         private const string ALIASES = "Aliases";
         private const string REFERENCETYPENAME = "Reference";


### PR DESCRIPTION
Fixes # NOT FILED YET

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

Fixes an error in WinFX generated proejcts where the `TargetFrameworkRootPath` is not set. This is required when the .NET Framework comes in from the `microsoft.netframework.referenceassemblies.net` NuGet package to ensure that the temporary target assembly can find the .NET Framework.

The error which can occur in the temporary assembly is:

```
O:\.BtCxCache\.A\MsBuild.Corext.mjPxZDmsQzQNXEhpSyaHyw\Current\bin\Microsoft.Common.CurrentVersion.targets(1180,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.7.2 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [CUT_1vxj05p3_wpftmp.csproj]
```

## Customer Impact

This error makes it harder for customers who rely on the `microsoft.netframework.referenceassemblies.net` NuGet package to use WinFX.

## Regression

No.

## Testing

None yet: I will inquire about testing as part of this PR process.

## Risk

This change will apply to all WinFX projects, not just ones which use the `microsoft.netframework.referenceassemblies.net` NuGet package. I believe this is safe as I cannot think of any cases where the `TargetFrameworkRootPath` in the temporary assembly would differ from the checked-in .csproj.