### PR TITLE
fix(column-resize): adding opt-out switch for column resize and column sorting features by keyboard inputs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -31,6 +31,7 @@ namespace System.Windows.Controls
     public class ListBox : Selector
     {
         internal const string ListBoxSelectAllKey = "Ctrl+A";
+        private static readonly bool OptOutOfGridColumnResizeUsingKeyboard;
 
         //-------------------------------------------------------------------
         //
@@ -81,6 +82,7 @@ namespace System.Windows.Controls
             CommandHelpers.RegisterCommandHandler(typeof(ListBox), ListBox.SelectAllCommand, new ExecutedRoutedEventHandler(OnSelectAll), new CanExecuteRoutedEventHandler(OnQueryStatusSelectAll), KeyGesture.CreateFromResourceStrings(ListBoxSelectAllKey, SR.Get(SRID.ListBoxSelectAllKeyDisplayString)));
 
             ControlsTraceLogger.AddControl(TelemetryControls.ListBox);
+            AppContext.TryGetSwitch("System.Windows.Controls.OptOutOfGridColumnResizeUsingKeyboard", out OptOutOfGridColumnResizeUsingKeyboard);
         }
 
         #endregion
@@ -486,6 +488,12 @@ namespace System.Windows.Controls
                     break;
 
                 case Key.System:
+                    if (OptOutOfGridColumnResizeUsingKeyboard)
+                    {
+                        handled = false;
+                        break;
+                    }
+                    
                     Key skey = e.SystemKey;
                     switch (skey)
                     {
@@ -522,7 +530,6 @@ namespace System.Windows.Controls
                     }
 
                     break;
-
 
                 default:
                     handled = false;


### PR DESCRIPTION
Fixes #7322 

## Description

adding opt-out switch for column resize and column sorting features by keyboard inputs

## Customer Impact

Without this changes the features will be enabled by default and any user defined input bindings for Alt + Left/Right arrow keys or F3 function key will not work. Also, user will not have any option to turn of the feature.

## Regression

Yes

## Testing

Internal tests (microsuites + DRT)

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7349)