### PR TITLE
fix(column-resize): adding opt-out switch for column resize and column sorting features by keyboard inputs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCell.cs
@@ -23,6 +23,9 @@ namespace System.Windows.Controls
     /// </summary>
     public class DataGridCell : ContentControl, IProvideDataGridColumn
     {
+        private static readonly bool IsDataGridKeyboardSortDisabled;
+        private static readonly bool OptOutOfGridColumnResizeUsingKeyboard;
+
         #region Constructors
 
         /// <summary>
@@ -45,6 +48,9 @@ namespace System.Windows.Controls
 
             EventManager.RegisterClassHandler(typeof(DataGridCell), LostFocusEvent, new RoutedEventHandler(OnAnyLostFocus), true);
             EventManager.RegisterClassHandler(typeof(DataGridCell), GotFocusEvent, new RoutedEventHandler(OnAnyGotFocus), true);
+
+            AppContext.TryGetSwitch("System.Windows.Controls.DisableDataGridKeyboardSort", out IsDataGridKeyboardSortDisabled);
+            AppContext.TryGetSwitch("System.Windows.Controls.OptOutOfGridColumnResizeUsingKeyboard", out OptOutOfGridColumnResizeUsingKeyboard);
         }
 
         /// <summary>
@@ -966,35 +972,37 @@ namespace System.Windows.Controls
         {
             if (!e.Handled)
             {
-                const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
-                ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
-
-                if (((e.SystemKey == Key.Right) || (e.SystemKey == Key.Left)) && (modifierKeys == ModifierKeys.Alt))
+                if (!OptOutOfGridColumnResizeUsingKeyboard)
                 {
-                    DataGridLength updatedWidth = new DataGridLength();
+                    ModifierKeys modifierKeys = Keyboard.Modifiers & ModifierMask;
+                    if (((e.SystemKey == Key.Right) || (e.SystemKey == Key.Left)) && (modifierKeys == ModifierKeys.Alt))
+                    {
+                        DataGridLength updatedWidth;
 
-                    if (e.SystemKey == Key.Right)
-                    {
-                        updatedWidth = new DataGridLength(Column.ActualWidth + ColumnWidthStepSize);
-                    }
-                    else if (e.SystemKey == Key.Left)
-                    {
-                        updatedWidth = new DataGridLength(Column.ActualWidth - ColumnWidthStepSize);
-                    }
-
-                    if (Column != null)
-                    {
-                        if (Column.CanColumnResize(updatedWidth))
+                        if (e.SystemKey == Key.Right)
                         {
-                            Column.SetCurrentValueInternal(DataGridColumn.WidthProperty, updatedWidth);
+                            updatedWidth = new DataGridLength(Column.ActualWidth + ColumnWidthStepSize);
                         }
-                        e.Handled = true;
+                        else
+                        {
+                            updatedWidth = new DataGridLength(Column.ActualWidth - ColumnWidthStepSize);
+                        }
+
+                        if (Column != null)
+                        {
+                            if (Column.CanColumnResize(updatedWidth))
+                            {
+                                Column.SetCurrentValueInternal(DataGridColumn.WidthProperty, updatedWidth);
+                            }
+                            e.Handled = true;
+                        }
+                        return;
                     }
-                    return;
                 }
-                else if(e.Key == Key.F3)
+
+                if(!IsDataGridKeyboardSortDisabled)
                 {
-                    if (Column.CanUserSort)
+                    if (e.Key == Key.F3 && Column != null && Column.CanUserSort)
                     {
                         Column.DataGridOwner.PerformSort(Column);
                         e.Handled = true;
@@ -1002,7 +1010,6 @@ namespace System.Windows.Controls
                     }
                 }
             }
-
             SendInputToColumn(e);
         }
 
@@ -1140,6 +1147,7 @@ namespace System.Windows.Controls
         private ContainerTracking<DataGridCell> _tracker;
         private bool _syncingIsSelected;                    // Used to prevent unnecessary notifications
         private const double ColumnWidthStepSize = 10d;
+        private const ModifierKeys ModifierMask = ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift | ModifierKeys.Windows;
 
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -31,6 +31,7 @@ namespace System.Windows.Controls
     public class ListBox : Selector
     {
         internal const string ListBoxSelectAllKey = "Ctrl+A";
+        private static readonly bool OptOutOfGridColumnResizeUsingKeyboard;
 
         //-------------------------------------------------------------------
         //
@@ -81,6 +82,7 @@ namespace System.Windows.Controls
             CommandHelpers.RegisterCommandHandler(typeof(ListBox), ListBox.SelectAllCommand, new ExecutedRoutedEventHandler(OnSelectAll), new CanExecuteRoutedEventHandler(OnQueryStatusSelectAll), KeyGesture.CreateFromResourceStrings(ListBoxSelectAllKey, SR.Get(SRID.ListBoxSelectAllKeyDisplayString)));
 
             ControlsTraceLogger.AddControl(TelemetryControls.ListBox);
+            AppContext.TryGetSwitch("System.Windows.Controls.OptOutOfGridColumnResizeUsingKeyboard", out OptOutOfGridColumnResizeUsingKeyboard);
         }
 
         #endregion
@@ -486,6 +488,12 @@ namespace System.Windows.Controls
                     break;
 
                 case Key.System:
+                    if (OptOutOfGridColumnResizeUsingKeyboard)
+                    {
+                        handled = false;
+                        break;
+                    }
+
                     Key skey = e.SystemKey;
                     switch (skey)
                     {
@@ -522,7 +530,6 @@ namespace System.Windows.Controls
                     }
 
                     break;
-
 
                 default:
                     handled = false;


### PR DESCRIPTION
Fixes #7322 

[Main PR ](https://github.com/dotnet/wpf/pull/7349)

## Description

adding opt-out switch for column resize and column sorting features by keyboard inputs

## Customer Impact

Without this changes the features will be enabled by default and any user defined input bindings for Alt + Left/Right arrow keys or F3 function key will not work. Also, user will not have any option to turn of the feature.

## Regression

Yes

## Testing

In-progress

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7350)