### PR TITLE
Fix the SortDescriptionCollection may throw NullReferenceException when clear

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -2572,7 +2572,7 @@ namespace System.Windows.Data
 
             IList list = AllowsCrossThreadChanges ? ShadowCollection : (SourceCollection as IList);
 
-            if (!UsesLocalArray)
+            if (!UsesLocalArray || list is null)
             {
                 // if there's no sort/filter, just use the collection's array
                 _internalList = list;


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/7389



## Description

The `list` will be null, as the https://github.com/dotnet/wpf/issues/7389 says. And we should not copy from the `list` when it be null.

## Customer Impact

Fix https://github.com/dotnet/wpf/issues/7389

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI.

## Risk

Low
