### PR TITLE
Remove Source Generator workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,11 +7,4 @@
           Project="Sdk.targets"
           Condition="!Exists('$(WpfArcadeSdkProps)') Or !Exists('$(WpfArcadeSdkTargets)')"/>
 
-  <!-- Temporarily remove analyzers from framework references until we can update to VS 2022 which handles them correctly
-       https://github.com/dotnet/wpf/issues/5224 -->
-  <Target Name="_RemoveFrameworkReferenceAnalyzers" AfterTargets="ResolveTargetingPackAssets">
-    <ItemGroup>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.FrameworkReferenceName)' != ''" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes dotnet/wpf#5224

## Description
Removes a workaround, which disables the usage of source generator in this repo, to support VS versions older than VS2022. VS2022 is required to build this repo according to the [README](https://github.com/dotnet/wpf/blob/cfec0cc3f3ded32c4d6dc409e41af516afe64073/README.md?plain=1#L16) and AFAIK the CI also use VS2022.

## Customer Impact
None. This PR changes only the build of this repo.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7396)