### PR TITLE
Rectify documentation - Use PlatformTarget instead of Platform tag

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -212,7 +212,7 @@ Your final csproj file should look like as below:
       <OutputType>WinExe</OutputType>
       <TargetFramework>net6.0-windows</TargetFramework>
       <UseWPF>true</UseWPF>
-      <Platform>x86</Platform>
+      <PlatformTarget>x86</PlatformTarget>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
## Description

We need to add PlatformTarget instead of Platform tag

## Customer Impact

None

## Regression

NA

## Testing

NA

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7400)