### PR TITLE
Fix widespread null-reference exception in WPF MediaContext.RenderMessageCore

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaContext.cs
@@ -1740,7 +1740,8 @@ namespace System.Windows.Media
                 EventTrace.EventProvider.TraceEvent(EventTrace.Event.WClientRenderHandlerBegin, EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Level.Info, PerfService.GetPerfElementID(this));
             }
 
-            RenderMessageHandlerCore(resizedCompositionTarget);
+            if (resizedCompositionTarget != null)
+                RenderMessageHandlerCore(resizedCompositionTarget);
 
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordGraphics | EventTrace.Keyword.KeywordPerf, EventTrace.Event.WClientRenderHandlerEnd);
 


### PR DESCRIPTION
As stated in the existing code comment, "can be null if we are not resizing..."  Yes it can, and frequently is. This is the cause of numerous WPF crashes reported across the web:

- https://www.infragistics.com/community/forums/f/ultimate-ui-for-wpf/107396/application-crash-when-user-try-to-enter-text-in-xammulticolumncomboeditor
- https://stackoverflow.com/questions/70799521/random-crash-in-wpf-application-invalid-index-at-ms-win32-unsafenativemethods
- https://stackoverflow.com/questions/2008226/wpf-application-crash
- https://github.com/goatcorp/FFXIVQuickLauncher/issues/635
- https://social.msdn.microsoft.com/Forums/vstudio/en-US/25e07b53-ce57-44a0-983f-23e8d4219674/wpf-application-crashes?forum=wpf
- https://stackoverflow.com/questions/8378051/unexplained-error-in-system-windows-media-composition-duce-channel

...and hundreds of others.

Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7404)