### PR TITLE
Implement IList on PageContentCollection and DocumentReferenceCollection

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -10224,12 +10224,25 @@ namespace System.Windows.Documents
         void System.Windows.Markup.IAddChild.AddChild(object value) { }
         void System.Windows.Markup.IAddChild.AddText(string text) { }
     }
-    public sealed partial class PageContentCollection : System.Collections.Generic.IEnumerable<System.Windows.Documents.PageContent>, System.Collections.IEnumerable
+    public sealed partial class PageContentCollection : System.Collections.IList, System.Collections.Generic.IEnumerable<System.Windows.Documents.PageContent>, System.Collections.IEnumerable
     {
         internal PageContentCollection() { }
         public int Count { get { throw null; } }
         public System.Windows.Documents.PageContent this[int pageIndex] { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
         public int Add(System.Windows.Documents.PageContent newPageContent) { throw null; }
+        int System.Collections.IList.Add(object value) { throw null; }
+        void System.Collections.IList.Clear() { }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+        void System.Collections.IList.RemoveAt(int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public System.Collections.Generic.IEnumerator<System.Windows.Documents.PageContent> GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -9704,14 +9704,27 @@ namespace System.Windows.Documents
         public void SetDocument(System.Windows.Documents.FixedDocument doc) { }
     }
     [System.CLSCompliantAttribute(false)]
-    public sealed partial class DocumentReferenceCollection : System.Collections.Generic.IEnumerable<System.Windows.Documents.DocumentReference>, System.Collections.IEnumerable, System.Collections.Specialized.INotifyCollectionChanged
+    public sealed partial class DocumentReferenceCollection : System.Collections.IList, System.Collections.Generic.IEnumerable<System.Windows.Documents.DocumentReference>, System.Collections.IEnumerable, System.Collections.Specialized.INotifyCollectionChanged
     {
         internal DocumentReferenceCollection() { }
         public int Count { get { throw null; } }
         public System.Windows.Documents.DocumentReference this[int index] { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
         public event System.Collections.Specialized.NotifyCollectionChangedEventHandler CollectionChanged { add { } remove { } }
         public void Add(System.Windows.Documents.DocumentReference item) { }
         public void CopyTo(System.Windows.Documents.DocumentReference[] array, int arrayIndex) { }
+        int System.Collections.IList.Add(object value) { throw null; }
+        void System.Collections.IList.Clear() { }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+        void System.Collections.IList.RemoveAt(int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public System.Collections.Generic.IEnumerator<System.Windows.Documents.DocumentReference> GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentReferenceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/DocumentReferenceCollection.cs
@@ -12,6 +12,7 @@ namespace System.Windows.Documents
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections;
     using System.Collections.Specialized;
     using System.Diagnostics;
 
@@ -21,7 +22,7 @@ namespace System.Windows.Documents
     /// DocumentReferenceCollection is an ordered collection of DocumentReference
     /// </summary>
     [CLSCompliant(false)]
-    public sealed class DocumentReferenceCollection : IEnumerable<DocumentReference>, INotifyCollectionChanged
+    public sealed class DocumentReferenceCollection : IList, IEnumerable<DocumentReference>, INotifyCollectionChanged
     {
         //--------------------------------------------------------------------
         //
@@ -41,24 +42,6 @@ namespace System.Windows.Documents
         //
         //---------------------------------------------------------------------
         #region Public Methods
-        
-        #region IEnumerable
-        /// <summary>
-        /// <!-- see cref="System.Collections.Generic.IEnumerable&lt;&gt;.GetEnumerator" / -->
-        /// </summary>
-        public IEnumerator<DocumentReference> GetEnumerator()
-        {
-            return _InternalList.GetEnumerator();
-        }
-
-
-	 System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable<DocumentReference>)this).GetEnumerator();
-        }
-       
-
-        #endregion IEnumerable
 
         ///<summary>
         ///
@@ -80,6 +63,69 @@ namespace System.Windows.Documents
             _InternalList.CopyTo(array, arrayIndex);
         }
 
+        int IList.Add(object value)
+        {
+            Add(Cast(value));
+
+            return Count - 1;
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return ((IList)_InternalList).Contains(value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return ((IList)_InternalList).IndexOf(value);
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            if (index != Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            Add(Cast(value));
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ((ICollection)_InternalList).CopyTo(array, index);
+        }
+
+        #region IEnumerable
+        /// <summary>
+        /// <!-- see cref="System.Collections.Generic.IEnumerable&lt;&gt;.GetEnumerator" / -->
+        /// </summary>
+        public IEnumerator<DocumentReference> GetEnumerator()
+        {
+            return _InternalList.GetEnumerator();
+        }
+
+	    IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<DocumentReference>)this).GetEnumerator();
+        }
+
+        #endregion IEnumerable
+
         #endregion Public Methods
 
         #region Public Properties
@@ -89,10 +135,7 @@ namespace System.Windows.Documents
         /// </summary>
         public int Count
         {
-            get
-            {
-                return _InternalList.Count;
-            }
+            get { return _InternalList.Count; }
         }
 
         /// <summary>
@@ -106,8 +149,37 @@ namespace System.Windows.Documents
             }
         }
 
+        bool IList.IsFixedSize
+        {
+            get { return false; }
+        }
 
-        
+        bool IList.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        object IList.this[int index]
+        {
+            get
+            {
+                return this[index];
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
 
         #endregion Public Properties
 
@@ -158,6 +230,21 @@ namespace System.Windows.Documents
         //
         //---------------------------------------------------------------------
 
+        private DocumentReference Cast(object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!(value is DocumentReference))
+            {
+                throw new ArgumentException(SR.Get(SRID.Collection_BadType, nameof(DocumentReferenceCollection), value.GetType().Name, nameof(DocumentReference)));
+            }
+
+            return (DocumentReference) value;
+        }
+
         // fire CollectionChanged event to any listeners
         private void OnCollectionChanged(NotifyCollectionChangedAction action, object item, int index)
         {
@@ -183,4 +270,3 @@ namespace System.Windows.Documents
         #endregion Private Fields
     }
 }
-

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContentCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/PageContentCollection.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Documents
     /// <summary>
     /// PageContentCollection is an ordered collection of PageContent 
     /// </summary>
-    public sealed class PageContentCollection : IEnumerable<PageContent>
+    public sealed class PageContentCollection : IList, IEnumerable<PageContent>
     {
         //--------------------------------------------------------------------
         //
@@ -58,7 +58,7 @@ namespace System.Windows.Documents
         {
             if (newPageContent == null)
             {
-                throw new ArgumentNullException("newPageContent");
+                throw new ArgumentNullException(nameof(newPageContent));
             }
 
             _logicalParent.AddLogicalChild(newPageContent);
@@ -67,6 +67,51 @@ namespace System.Windows.Documents
             int index = InternalList.Count - 1;
             _logicalParent.OnPageContentAppended(index);
             return index;
+        }
+
+        int IList.Add(object value)
+        {
+            return Add(Cast(value));
+        }
+
+        void IList.Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return ((IList)InternalList).Contains(value);
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return ((IList)InternalList).IndexOf(value);
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            if (index != Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            Add(Cast(value));
+        }
+
+        void IList.Remove(object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        void IList.RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ((ICollection)InternalList).CopyTo(array, index);
         }
 
         #endregion Public Methods
@@ -95,6 +140,15 @@ namespace System.Windows.Documents
         //---------------------------------------------------------------------
 
         #region Public Properties
+
+        /// <summary>
+        /// Number of PageContent items in this collection
+        /// </summary>
+        public int Count
+        {
+            get { return InternalList.Count; }
+        }
+
         /// <summary>
         /// Indexer to retrieve individual PageContent contained within this collection
         /// </summary>
@@ -106,15 +160,38 @@ namespace System.Windows.Documents
             }
         }
 
-        /// <summary>
-        /// Number of PageContent items in this collection
-        /// </summary>
-
-        public int Count
+        bool IList.IsFixedSize
         {
-            get { return InternalList.Count; }
+            get { return false; }
         }
-        
+
+        bool IList.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        object IList.this[int index]
+        {
+            get
+            {
+                return this[index];
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get { return this; }
+        }
+
         #endregion Public Properties
 
         //--------------------------------------------------------------------
@@ -174,6 +251,22 @@ namespace System.Windows.Documents
         //---------------------------------------------------------------------
 
         #region Private Methods
+
+        private PageContent Cast(object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!(value is PageContent))
+            {
+                throw new ArgumentException(SR.Get(SRID.Collection_BadType, nameof(PageContentCollection), value.GetType().Name, nameof(PageContent)));
+            }
+
+            return (PageContent) value;
+        }
+
         #endregion Private Methods
 
         //--------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
@@ -495,11 +495,6 @@ namespace System.Windows.Baml2006
                 {
                     return XamlCollectionKind.Collection;
                 }
-                // Several types in V3 implemented IAddChildInternal which allowed them to be collections
-                if (typeof(System.Windows.Documents.DocumentReferenceCollection).IsAssignableFrom(UnderlyingType))
-                {
-                    return XamlCollectionKind.Collection;
-                } 
                 // Doing a type comparison against XmlNamespaceMappingCollection will load System.Xml. We get around
                 // this by only doing the comparison if it's an ICollection<XmlNamespaceMapping>
                 if (typeof(ICollection<System.Windows.Data.XmlNamespaceMapping>).IsAssignableFrom(UnderlyingType) 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfXamlType.cs
@@ -496,8 +496,7 @@ namespace System.Windows.Baml2006
                     return XamlCollectionKind.Collection;
                 }
                 // Several types in V3 implemented IAddChildInternal which allowed them to be collections
-                if (typeof(System.Windows.Documents.DocumentReferenceCollection).IsAssignableFrom(UnderlyingType) || 
-                    typeof(System.Windows.Documents.PageContentCollection).IsAssignableFrom(UnderlyingType))
+                if (typeof(System.Windows.Documents.DocumentReferenceCollection).IsAssignableFrom(UnderlyingType))
                 {
                     return XamlCollectionKind.Collection;
                 } 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -9717,14 +9717,27 @@ namespace System.Windows.Documents
         public void SetDocument(System.Windows.Documents.FixedDocument doc) { }
     }
     [System.CLSCompliantAttribute(false)]
-    public sealed partial class DocumentReferenceCollection : System.Collections.Generic.IEnumerable<System.Windows.Documents.DocumentReference>, System.Collections.IEnumerable, System.Collections.Specialized.INotifyCollectionChanged
+    public sealed partial class DocumentReferenceCollection : System.Collections.IList, System.Collections.Generic.IEnumerable<System.Windows.Documents.DocumentReference>, System.Collections.IEnumerable, System.Collections.Specialized.INotifyCollectionChanged
     {
         internal DocumentReferenceCollection() { }
         public int Count { get { throw null; } }
         public System.Windows.Documents.DocumentReference this[int index] { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
         public event System.Collections.Specialized.NotifyCollectionChangedEventHandler CollectionChanged { add { } remove { } }
         public void Add(System.Windows.Documents.DocumentReference item) { }
         public void CopyTo(System.Windows.Documents.DocumentReference[] array, int arrayIndex) { }
+        int System.Collections.IList.Add(object value) { throw null; }
+        void System.Collections.IList.Clear() { }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+        void System.Collections.IList.RemoveAt(int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public System.Collections.Generic.IEnumerator<System.Windows.Documents.DocumentReference> GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -10237,12 +10237,25 @@ namespace System.Windows.Documents
         void System.Windows.Markup.IAddChild.AddChild(object value) { }
         void System.Windows.Markup.IAddChild.AddText(string text) { }
     }
-    public sealed partial class PageContentCollection : System.Collections.Generic.IEnumerable<System.Windows.Documents.PageContent>, System.Collections.IEnumerable
+    public sealed partial class PageContentCollection : System.Collections.IList, System.Collections.Generic.IEnumerable<System.Windows.Documents.PageContent>, System.Collections.IEnumerable
     {
         internal PageContentCollection() { }
         public int Count { get { throw null; } }
         public System.Windows.Documents.PageContent this[int pageIndex] { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
         public int Add(System.Windows.Documents.PageContent newPageContent) { throw null; }
+        int System.Collections.IList.Add(object value) { throw null; }
+        void System.Collections.IList.Clear() { }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+        void System.Collections.IList.RemoveAt(int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
         public System.Collections.Generic.IEnumerator<System.Windows.Documents.PageContent> GetEnumerator() { throw null; }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
     }


### PR DESCRIPTION
Fixes #966

## Description

Microsoft Visual Studio (and Blend) XAML designer seems to follow [Collections and collection types for XAML](https://learn.microsoft.com/en-us/dotnet/desktop/xaml-services/collections-and-types), which means that collections are recognized as `IList` or `IDictionary`.  `PageContentCollection` and `DocumentReferenceCollection` do not implement either of them. This leads to `Invalid Markup` error in designer and weird errors in code editor/Error List. These types have `Add` method and special handling to make them work. The code will compile and run just fine.

So instead of fixing visual designer this MR adds `ILIst` to them.

## Customer Impact

No visual preview in designer and error(s) that are not actual errors in code editor.

## Regression

No. As I can tell, this bug originates in the initial release of WPF for Microsoft .NET Framework.

## Testing

Manual.

## Risk

NA.