### PR TITLE
Update DatePicker.FirstDayOfWeek on Language change

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DatePicker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DatePicker.cs
@@ -91,6 +91,7 @@ namespace System.Windows.Controls
             KeyboardNavigation.TabNavigationProperty.OverrideMetadata(typeof(DatePicker), new FrameworkPropertyMetadata(KeyboardNavigationMode.Once));
             KeyboardNavigation.IsTabStopProperty.OverrideMetadata(typeof(DatePicker), new FrameworkPropertyMetadata(false));
             IsEnabledProperty.OverrideMetadata(typeof(DatePicker), new UIPropertyMetadata(new PropertyChangedCallback(OnIsEnabledChanged)));
+            LanguageProperty.OverrideMetadata(typeof(DatePicker), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnLanguageChanged)));
 
             ControlsTraceLogger.AddControl(TelemetryControls.DatePicker);
         }
@@ -392,6 +393,17 @@ namespace System.Windows.Controls
             typeof(DatePicker));
 
         #endregion IsTodayHighlighted
+
+        #region Language
+        private static void OnLanguageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            DatePicker datePicker = (DatePicker)d;
+            if (DependencyPropertyHelper.GetValueSource(datePicker, DatePicker.FirstDayOfWeekProperty).BaseValueSource ==  BaseValueSource.Default)
+            {
+                datePicker.SetCurrentValueInternal(FirstDayOfWeekProperty, DateTimeHelper.GetDateFormat(DateTimeHelper.GetCulture(datePicker)).FirstDayOfWeek);
+            }
+        }
+        #endregion
 
         #region SelectedDate
 


### PR DESCRIPTION
Fixes #4704

## Description

This MR adds code similar to `Calendar` to track `FrameworkElement.Language` property.

## Customer Impact

You need either implement this yourself or change `DatePicker.FirstDayOfWeek` manually.

## Regression

No. As I can tell, this bug originates from Microsoft .NET Framework.

## Testing

Manual.

## Risk

NA.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7408)