### PR TITLE
Tooltip Direct Manipulation Fix

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -468,10 +468,22 @@ namespace System.Windows.Controls
                 }
 
                 _currentToolTip.SetValue(OwnerProperty, o);
-                _currentToolTip.Opened += OnToolTipOpened;
                 _currentToolTip.Closed += OnToolTipClosed;
                 _currentToolTip.FromKeyboard = fromKeyboard;
                 _currentToolTip.IsOpen = true;
+
+                if (!_currentToolTip.IsOpen)
+                {
+                    // open the tooltip, and finish the initialization when its popup window is available.
+                    _currentToolTip.Opened += OnToolTipOpened;
+                    _currentToolTip.IsOpen = true;
+                }
+                else
+                {
+                    // If the tooltip is already open, initialize it now. This only happens when the
+                    // app manages the tooltip directly.
+                    SetSafeArea(_currentToolTip);
+                }
 
                 CurrentToolTipTimer = new DispatcherTimer(DispatcherPriority.Normal);
                 CurrentToolTipTimer.Interval = TimeSpan.FromMilliseconds(ToolTipService.GetShowDuration(o));
@@ -632,6 +644,7 @@ namespace System.Windows.Controls
             {
                 tooltip.ClearValue(OwnerProperty);
                 tooltip.FromKeyboard = false;
+                tooltip.Closed -= OnToolTipClosed;
 
                 if ((bool)tooltip.GetValue(ServiceOwnedProperty))
                 {
@@ -727,8 +740,27 @@ namespace System.Windows.Controls
         private void OnToolTipClosed(object sender, EventArgs e)
         {
             ToolTip toolTip = (ToolTip)sender;
-            toolTip.Closed -= OnToolTipClosed;
-            ClearServiceProperties(toolTip);
+            if (toolTip != CurrentToolTip)
+            {
+                // if we manage the tooltip (the normal case), the current tooltip closes via
+                //  1. DismissCurrentToolTip sets _currentToolTip=null and calls CloseToolTip
+                //  2. CloseToolTip sets toolTip.IsOpen=false, and returns
+                //  3. Asynchronously, the tooltip raises the Closed event (after popup animations have run)
+                //  4. our event handler OnToolTipClosed gets here
+                // It's now time to do the final cleanup, which includes removing this event handler.
+                ClearServiceProperties(toolTip);
+            }
+            else
+            {
+                // we get here if the app closes the current tooltip or its popup directly.
+                // Do nothing (i.e. ignore the event).  This leaves the service properties in place -
+                // eventually DismissCurrentToolTip will call CloseToolTip, which needs them
+                // (in particular the Owner property).  When that happens, either
+                //  a. tooltip.IsOpen==false.  CloseToolTip clears the service properties immediately.
+                //  b. tooltip.IsOpen==true.  (This can happen if the app re-opens the tooltip directly.)
+                //      CloseToolTip proceeds as in step 2 of the normal case.
+                // Either way, the final cleanup happens.
+            }
         }
 
         // The previous tooltip hasn't closed and we are trying to open a new one

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PopupControlService.cs
@@ -470,7 +470,6 @@ namespace System.Windows.Controls
                 _currentToolTip.SetValue(OwnerProperty, o);
                 _currentToolTip.Closed += OnToolTipClosed;
                 _currentToolTip.FromKeyboard = fromKeyboard;
-                _currentToolTip.IsOpen = true;
 
                 if (!_currentToolTip.IsOpen)
                 {


### PR DESCRIPTION
Fixes # <!-- Issue Number -->
#6319 #7002 
Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
When an app opens the tooltip directly, WPF ( independently ) also activates the tooltip ( marks it 'current; , registers handlers for Opened and Closed events , sets some internal properties and opens the tooltip ). Now, when app closes the tooltip directly, the closed event is raised.
Now, when the app re-opens the tooltip, WPF decides to dismiss the 'current' tooltip and while doing so, it uses the internal properties, which were unset by the closed event. Thus resulting in the error

In this fix, 
1. if WPF sees, that the tooltip is already open, we don't register an Opened handler, but do it's work immediately
2. The closed handler ignores events raised from the "current" tooltip.
3. Move unregistering handler in ClearServiceProperties
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Apps that do direct manipulation of tooltips can crash when run on .NET 6.0+
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes, fixes compat regression
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Tooltip Area Test pass , Ad-Hoc Testing with sample apps, New test cases added.
<!-- What kind of testing has been done with the fix. -->

## Risk
We don't know which real apps/libraries do direct manipulation of tooltips, how they do it, or how they interact with the built-in tooltip management. The examples we have seen some different ways of managing tooltips. And there may be cases that are still not handled with the fix.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7418)