### PR TITLE
Revert "avoid boxing (#4220)"

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -2,7 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using MS.Internal.KnownBoxes;
 using MS.Internal.WindowsBase;  // for FriendAccessAllowed
@@ -51,7 +52,7 @@ namespace System.Windows
                 EntryIndex entryIndex = instance.LookupEntry(_globalIndex);
 
                 // Set the value if it's not the default, otherwise remove the value.
-                if (!EqualityComparer<T>.Default.Equals(value, _defaultValue))
+                if (!object.ReferenceEquals(value, _defaultValue))
                 {
                     object valueObject;
 


### PR DESCRIPTION
This reverts commit 4dfe58650ac63e76b76659cea850df57c0182440.

Fixes #7321 #7315 

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
The changes in PR https://github.com/dotnet/wpf/pull/4220 are disturbing the HierarchicalVirtualizationConstraints calculation, which is further used in calculation of the sizes of the virtualizing items and availableSize, DesiredSize, Viewport and extendedViewport calculations.
The result of all this is showing just the first item rather than all the items in the group.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
The customers will see only the first item in the list of items, as opposed to all the items in the list.
## Regression
Yes. 
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local WPF Testing. 
<!-- What kind of testing has been done with the fix. -->

## Risk
Low. Just reverting the change causing the regressions.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7426)