### PR TITLE
Fix FileNotFoundException during markup compilation if PresentationBuildTasks.dll is loaded from a byte array

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/TaskHelper.cs
@@ -53,6 +53,8 @@ namespace MS.Internal.Tasks
         internal static void DisplayLogo(TaskLoggingHelper log, string taskName)
         {
             string acPath = Assembly.GetExecutingAssembly().Location;
+            if (acPath.Length == 0) return; // ignore if loaded from a byte array
+
             FileVersionInfo acFileVersionInfo = FileVersionInfo.GetVersionInfo(acPath);
 
             string avalonFileVersion = acFileVersionInfo.FileVersion;


### PR DESCRIPTION
Hi!

In case of PresentationBuildTasks.dll is loaded from a byte array, markup compilation fails with `FileNotFoundException` exception from `MS.Internal.Tasks.TaskHelper.DisplayLogo()` because its assembly location `acPath` is an empty string. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7456)