### PR TITLE
make TriggerBase to "public"

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -1874,16 +1874,18 @@ namespace System.Windows
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public abstract partial class TriggerBase : System.Windows.DependencyObject
     {
-        internal TriggerBase() { }
+        public TriggerBase() { }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.TriggerActionCollection EnterActions { get { throw null; } }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.TriggerActionCollection ExitActions { get { throw null; } }
+        public virtual bool GetCurrentState(DependencyObject container, UncommonField<HybridDictionary[]> dataField) { throw null; }
+        public TriggerCondition[] TriggerConditions { get { throw null; } set { throw null; } }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public sealed partial class TriggerCollection : System.Collections.ObjectModel.Collection<System.Windows.TriggerBase>
     {
-        internal TriggerCollection() { }
+        public TriggerCollection() { }
         public bool IsSealed { get { throw null; } }
         protected override void ClearItems() { }
         protected override void InsertItem(int index, System.Windows.TriggerBase item) { }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -5836,11 +5836,11 @@ namespace System.Windows
     //  Conditions set on [Multi]Trigger are stored
     //  in structures of this kind
     //
-    internal struct TriggerCondition
+    public struct TriggerCondition
     {
         #region Construction
 
-        internal TriggerCondition(DependencyProperty dp, LogicalOp logicalOp, object value, string sourceName)
+        public TriggerCondition(DependencyProperty dp, LogicalOp logicalOp, object value, string sourceName)
         {
             Property = dp;
             Binding = null;
@@ -5851,13 +5851,13 @@ namespace System.Windows
             BindingValueCache = new BindingValueCache(null, null);
         }
 
-        internal TriggerCondition(BindingBase binding, LogicalOp logicalOp, object value) :
+        public TriggerCondition(BindingBase binding, LogicalOp logicalOp, object value) :
             this(binding, logicalOp, value, StyleHelper.SelfName)
         {
             // Call Forwarded
         }
 
-        internal TriggerCondition(BindingBase binding, LogicalOp logicalOp, object value, string sourceName)
+        public TriggerCondition(BindingBase binding, LogicalOp logicalOp, object value, string sourceName)
         {
             Property = null;
             Binding = binding;
@@ -5869,7 +5869,7 @@ namespace System.Windows
         }
 
         // Check for match
-        internal bool Match(object state)
+        public bool Match(object state)
         {
             return Match(state, Value);
         }
@@ -5888,7 +5888,7 @@ namespace System.Windows
 
         // Check for match, after converting the reference value to the type
         // of the state value.  (Used by data triggers)
-        internal bool ConvertAndMatch(object state)
+        public bool ConvertAndMatch(object state)
         {
             // convert the reference value to the type of 'state',
             // provided the reference value is a string and the
@@ -5958,7 +5958,7 @@ namespace System.Windows
 
         // Implemented for #1038821, FxCop ConsiderOverridingEqualsAndOperatorEqualsOnValueTypes
         //  Called from ChildValueLookup.Equals, avoid boxing by not using the generic object-based Equals.
-        internal bool TypeSpecificEquals( TriggerCondition value )
+        public bool TypeSpecificEquals( TriggerCondition value )
         {
             if( Property            == value.Property &&
                 Binding             == value.Binding &&
@@ -5973,12 +5973,12 @@ namespace System.Windows
 
         #endregion Construction
 
-        internal readonly DependencyProperty        Property;
-        internal readonly BindingBase               Binding;
+        public   readonly DependencyProperty        Property;
+        public   readonly BindingBase               Binding;
         internal readonly LogicalOp                 LogicalOp;
         internal readonly object                    Value;
         internal readonly string                    SourceName;
-        internal          int                       SourceChildIndex;
+        public            int                       SourceChildIndex;
         internal          BindingValueCache         BindingValueCache;
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/TriggerBase.cs
@@ -38,7 +38,7 @@ namespace System.Windows
     [Localizability(LocalizationCategory.None, Readability=Readability.Unreadable)]
     public abstract class TriggerBase : DependencyObject
     {
-        internal TriggerBase()
+        public TriggerBase()
         {
         }
 
@@ -374,7 +374,7 @@ namespace System.Windows
         }
 
         // evaluate the current state of the trigger
-        internal virtual bool GetCurrentState(DependencyObject container, UncommonField<HybridDictionary[]> dataField)
+        public virtual bool GetCurrentState(DependencyObject container, UncommonField<HybridDictionary[]> dataField)
         {
             Debug.Assert( false,
                 "This method was written to handle Trigger, MultiTrigger, DataTrigger, and MultiDataTrigger.  It looks like a new trigger type was added - please add support as appropriate.");
@@ -383,7 +383,7 @@ namespace System.Windows
         }
 
         // Collection of TriggerConditions
-        internal TriggerCondition[] TriggerConditions
+        public TriggerCondition[] TriggerConditions
         {
             get { return _triggerConditions; }
             set { _triggerConditions = value; }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1863,16 +1863,18 @@ namespace System.Windows
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public abstract partial class TriggerBase : System.Windows.DependencyObject
     {
-        internal TriggerBase() { }
+        public TriggerBase() { }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.TriggerActionCollection EnterActions { get { throw null; } }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Windows.TriggerActionCollection ExitActions { get { throw null; } }
+        public virtual bool GetCurrentState(DependencyObject container, UncommonField<HybridDictionary[]> dataField) { throw null; }
+        public TriggerCondition[] TriggerConditions { get { throw null; } set { throw null; } }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability=System.Windows.Readability.Unreadable)]
     public sealed partial class TriggerCollection : System.Collections.ObjectModel.Collection<System.Windows.TriggerBase>
     {
-        internal TriggerCollection() { }
+        public TriggerCollection() { }
         public bool IsSealed { get { throw null; } }
         protected override void ClearItems() { }
         protected override void InsertItem(int index, System.Windows.TriggerBase item) { }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/UncommonField.cs
@@ -14,7 +14,7 @@ namespace System.Windows
     ///
     /// </summary>
     [FriendAccessAllowed] // Built into Base, used by Core and Framework
-    internal class UncommonField<T>
+    public class UncommonField<T>
     {
         /// <summary>
         ///     Create a new UncommonField.


### PR DESCRIPTION
Allows users to create custom triggers
I wanted to create a particular trigger, but GetStatus in TriggerBase and Trigger is internal and causes invisibility.
So submit this PR, which is very useful when writing custom frameworks

from [Bing Microsoft Translator]