### PR TITLE
download latest artifacts rather than specific

### DIFF
--- a/eng/wpfautomatedtests.yml
+++ b/eng/wpfautomatedtests.yml
@@ -176,8 +176,8 @@ jobs:
           buildType: 'specific'
           project: '7ea9116e-9fac-403d-b258-b31fcf1bb293'
           definition: '479'
-          buildVersionToDownload: 'specific'
-          buildId: '2052933'
+          buildVersionToDownload: latestFromBranch
+          branchName: refs/heads/master
           checkDownloadedFiles: true
           artifactName: Tests.$(_BuildConfig).$(_Platform).zip
           downloadPath: '$(System.ArtifactsDirectory)\testbinzip\'


### PR DESCRIPTION
Currently specific artifacts are being downloaded which require the change in the build version every time the latest build changes. Making the change to download latest artifacts for test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7475)