### PR TITLE
update .NET version for replacing assemblies.

### DIFF
--- a/eng/copy-wpf.ps1
+++ b/eng/copy-wpf.ps1
@@ -63,7 +63,7 @@ function CopyManagedBinariesToLocation($location, $localBinLocation)
     # x64 - artifacts\packaging\Debug\x64\Microsoft.DotNet.Wpf.GitHub\lib\net6.0
 
     $PackageName = "Microsoft.DotNet.Wpf.GitHub"
-    $BinaryLocationInPackage = "net7.0"
+    $BinaryLocationInPackage = "net8.0"
     CopyPackagedBinaries $location $localBinLocation $PackageName $BinaryLocationInPackage
 }
 
@@ -153,7 +153,7 @@ elseif($testhost)
 else
 {
     $runtimeIdentifer = "win-$arch"
-    $location = [System.IO.Path]::Combine($destination, "bin\Debug\net7.0", $runtimeIdentifer, "publish")
+    $location = [System.IO.Path]::Combine($destination, "bin\Debug\net8.0", $runtimeIdentifer, "publish")
     if(![System.IO.Directory]::Exists($location))
     {
         Write-Host "App publishing directory unavailable: " $location -ForegroundColor Red


### PR DESCRIPTION
Update .NET version from 7 to 8 for replacing assemblies before test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7476)