### PR TITLE
Replace Dictionary with HashSet

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -159,10 +159,8 @@ namespace MS.Internal.FontCache
                                     }
                                 }
 
-                                foreach (string file in Directory.GetFiles(_uri.LocalPath))
-                                {
-                                    fontPaths.Add(file);
-                                }
+                                fontPaths.UnionWith(Directory.EnumerateFiles(_uri.LocalPath));
+
                                 files = fontPaths;
                             }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSourceCollection.cs
@@ -137,7 +137,7 @@ namespace MS.Internal.FontCache
                             {
                                 // fontPaths accumulates font file paths obtained from the registry and the file system
                                 // This collection is a set, i.e. only keys matter, not values.
-                                Dictionary<string, object> fontPaths = new Dictionary<string, object>(512, StringComparer.OrdinalIgnoreCase);
+                                HashSet<string> fontPaths = new HashSet<string>(512, StringComparer.OrdinalIgnoreCase);
 
                                 using (RegistryKey fontsKey = Registry.LocalMachine.OpenSubKey(InstalledWindowsFontsRegistryKey))
                                 {
@@ -154,16 +154,16 @@ namespace MS.Internal.FontCache
                                             if (Path.GetFileName(fileName) == fileName)
                                                 fileName = Path.Combine(Util.WindowsFontsLocalPath, fileName);
 
-                                            fontPaths[fileName] = null;
+                                            fontPaths.Add(fileName);
                                         }
                                     }
                                 }
 
                                 foreach (string file in Directory.GetFiles(_uri.LocalPath))
                                 {
-                                    fontPaths[file] = null;
+                                    fontPaths.Add(file);
                                 }
-                                files = fontPaths.Keys;
+                                files = fontPaths;
                             }
 }
                         else

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -1917,7 +1917,7 @@ namespace System.Windows.Markup
             bool _all;
             string _namespaceName;
             XmlCompatibilityReader _reader;
-            Dictionary<string, object> _names;
+            HashSet<string> _names;
 
             public ProcessContentSet(string namespaceName, XmlCompatibilityReader reader)
             {
@@ -1927,7 +1927,7 @@ namespace System.Windows.Markup
 
             public bool ShouldProcessContent(string elementName)
             {
-                return _all || (_names != null && _names.ContainsKey(elementName));
+                return _all || (_names != null && _names.Contains(elementName));
             }
 
             public void Add(string elementName)
@@ -1959,10 +1959,10 @@ namespace System.Windows.Markup
                 {
                     if (_names == null)
                     {
-                        _names = new Dictionary<string, object>();
+                        _names = new HashSet<string>();
                     }
 
-                    _names[elementName] = null; // we don't care about value, just key
+                    _names.Add(elementName);
                 }
             }
 }


### PR DESCRIPTION
Follow up to dotnet/wpf#4177

## Description
I found more places where we used a Dictionary without using the value just to filter out duplicates.

See dotnet/wpf#4177 for benchmarks.

## Customer Impact
Better performance.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7486)