### PR TITLE
GlyphSerializer rounding fix

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
@@ -64,8 +64,8 @@ namespace System.Windows.Media
             _advances = glyphRun.AdvanceWidths;
             _offsets = glyphRun.GlyphOffsets;
 
-            _currentAdvanceTotal = 0;
-            _idealAdvanceTotal = 0;
+            _currentAdvanceTotal = 0.0;
+            _idealAdvanceTotal = 0.0;
 
             // "100,50,,0;".Length is a capacity estimate for an individual glyph
             _glyphStringBuider = new StringBuilder(10);
@@ -85,8 +85,8 @@ namespace System.Windows.Media
         /// </summary>
         public void ComputeContentStrings(out string characters, out string indices, out string caretStops)
         {
-            _currentAdvanceTotal = 0;
-            _idealAdvanceTotal = 0;
+            _currentAdvanceTotal = 0.0;
+            _idealAdvanceTotal = 0.0;
 
             if (_clusters != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphsSerializer.cs
@@ -64,7 +64,8 @@ namespace System.Windows.Media
             _advances = glyphRun.AdvanceWidths;
             _offsets = glyphRun.GlyphOffsets;
 
-            _advanceWidthRoundingError = 0.0;
+            _currentAdvanceTotal = 0;
+            _idealAdvanceTotal = 0;
 
             // "100,50,,0;".Length is a capacity estimate for an individual glyph
             _glyphStringBuider = new StringBuilder(10);
@@ -84,7 +85,8 @@ namespace System.Windows.Media
         /// </summary>
         public void ComputeContentStrings(out string characters, out string indices, out string caretStops)
         {
-            _advanceWidthRoundingError = 0.0;
+            _currentAdvanceTotal = 0;
+            _idealAdvanceTotal = 0;
 
             if (_clusters != null)
             {
@@ -188,13 +190,28 @@ namespace System.Windows.Media
             _glyphStringBuider.Append(GlyphSubEntrySeparator);
 
             // advance width
-            double unroundedAdvance = _advances[glyph] * _milToEm;
-            int normalizedAdvance = (int)Math.Round(unroundedAdvance + _advanceWidthRoundingError);
-            _advanceWidthRoundingError += (unroundedAdvance - (double)normalizedAdvance);
+            // #7499 Advance width needs to be specified if it differs from what is in the font tables. [ECMA-388 O5.5]
+            // Most commonly it differs after shaping, e.g. when kerning is applied. (Ex. 12-15)
+            // XPS supports floating point values, but in the interest of file size, we want to specify integers.
+
+            double shapingAdvance = _advances[glyph] * _milToEm;
             double fontAdvance = _sideways ? _glyphTypeface.AdvanceHeights[fontIndex] : _glyphTypeface.AdvanceWidths[fontIndex];
-            if (normalizedAdvance != (int)Math.Round(fontAdvance * EmScaleFactor))
+
+            // To minimize rounding errors, we keep track of the unrounded advance total as required by [M5.6].
+            int roundedShapingAdvance = (int)Math.Round(_idealAdvanceTotal + shapingAdvance - _currentAdvanceTotal);
+            int roundedFontAdvance = (int)Math.Round(fontAdvance);
+
+            if (roundedShapingAdvance != roundedFontAdvance)
             {
-                _glyphStringBuider.Append(normalizedAdvance.ToString(CultureInfo.InvariantCulture));
+                _glyphStringBuider.Append(roundedShapingAdvance.ToString(CultureInfo.InvariantCulture));
+                _currentAdvanceTotal += roundedShapingAdvance;
+                _idealAdvanceTotal += shapingAdvance;
+            }
+            else
+            {
+                // when the value comes from the font tables, the specification does not mandate clients to do any rounding
+                _currentAdvanceTotal += fontAdvance;
+                _idealAdvanceTotal += fontAdvance;
             }
 
             _glyphStringBuider.Append(GlyphSubEntrySeparator);
@@ -326,7 +343,9 @@ namespace System.Windows.Media
 
         private int _glyphClusterInitialOffset;
 
-        private double _advanceWidthRoundingError;
+        private double _currentAdvanceTotal;
+
+        private double _idealAdvanceTotal;
 
         private IList<ushort> _clusters;
 


### PR DESCRIPTION
Fixes #7499

Related: #6295

## Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

Previous rounding strategy
1. did not calculate the error according to XPS specification
2. updated error with shaping value when font value is used by the client

The PR fixes 1. by keeping track of total advance width (desired and rounded) and 2. by using the font advance width when no value is output to XPS.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

Customers not taking this fix will see either gaps or overlapped characters when producing XPS with text. See #7499 for an example.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

Yes. Introduced by #6295 trying to fix #6525. This PR addresses both issues.

## Testing

<!-- What kind of testing has been done with the fix. -->

Tested manually using repro projects for #6525 and #7499.

![image](https://user-images.githubusercontent.com/10546952/219394733-1ea807a1-b03c-4133-8103-0f4a1ae35062.png)

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Same risks as with #6295. This PR changes relative positioning of glyphs in a GlyphRun to match the bounding box, so it should not cause reflow of documents.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7545)