### PR TITLE
Fix NullReferenceException in DynamicRenderer

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/DynamicRenderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/DynamicRenderer.cs
@@ -520,7 +520,8 @@ namespace System.Windows.Input.StylusPlugIns
                 // See if we are done transitioning this stroke!!
                 if (si.StrokeHV.Clip == null)
                 {
-                    TransitionComplete(si);
+                    // Getting _applicationDispatcher is safe, because this runs in main UI thread.
+                    TransitionComplete(si, _applicationDispatcher);
                     _renderCompleteStrokeInfo = null;
                 }
                 else
@@ -602,12 +603,12 @@ namespace System.Windows.Input.StylusPlugIns
                         else
                         {
                             Debug.Assert(_waitingForRenderComplete, "We were expecting to be waiting for a RenderComplete to call our OnRenderComplete, we might never reset and get flashing strokes from here on out");
-                            TransitionComplete(si); // We're done
+                            TransitionComplete(si, dispatcher); // We're done
                         }
                     }
                     else
                     {
-                        TransitionComplete(si); // We're done
+                        TransitionComplete(si, dispatcher); // We're done
                     }
                     return null;
                 },
@@ -697,7 +698,7 @@ namespace System.Windows.Input.StylusPlugIns
             TransitionStrokeVisuals(si, !targetVerified);
         }
 
-        private void OnInternalRenderComplete(object sender, EventArgs e)
+        private void  OnInternalRenderComplete(object sender, EventArgs e)
         {
             // First unhook event handler
             MediaContext.From(_applicationDispatcher).RenderComplete -= _onRenderComplete;
@@ -1023,10 +1024,10 @@ namespace System.Windows.Input.StylusPlugIns
 
 
         // Removes ref from DynamicRendererHostVisual.
-        void TransitionComplete(StrokeInfo si)
+        void TransitionComplete(StrokeInfo si, Dispatcher applicationDispatcher)
         {
             // make sure lock does not cause reentrancy on application thread!
-            using(_applicationDispatcher.DisableProcessing())
+            using(applicationDispatcher.DisableProcessing())
             {
                 lock(__siLock)
                 {


### PR DESCRIPTION
Fixes #7537


## Description

The `_applicationDispatcher` may be null with the thread-safe issues, see https://github.com/dotnet/wpf/issues/7537

I use the argument instead of field to solve thread-safe issues.

## Customer Impact

Fix #7537

## Regression

None.

## Testing

CI and the [Demo](https://github.com/dotnet/wpf/files/10762876/PC-Test-develop-2.zip)

But I did not do enough testing.

## Risk

Low


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7552)