### PR TITLE
Fixing the AssemblyName in temporary project file for GenerateTemporaryTargetAssembly task

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -279,6 +279,9 @@ namespace Microsoft.Build.Tasks.Windows
                     ( "_TargetAssemblyProjectName", Path.GetFileNameWithoutExtension(CurrentProject) ),
                 };
 
+                //Removing duplicate AssemblyName
+                RemovePropertiesByName(xmlProjectDoc, nameof(AssemblyName));
+
                 AddNewProperties(xmlProjectDoc, properties);
 
                 // Save the xmlDocument content into the temporary project file.
@@ -568,10 +571,11 @@ namespace Microsoft.Build.Tasks.Windows
         #region Private Methods
 
         //
-        // Remove specific items from project file. Every item should be under an ItemGroup.
+        // Remove specific entity from project file.
         //
-        private void RemoveItemsByName(XmlDocument xmlProjectDoc, string sItemName)
+        private void RemoveEntityByName(XmlDocument xmlProjectDoc, string sItemName, string groupName)
         {
+            
             if (xmlProjectDoc == null || String.IsNullOrEmpty(sItemName))
             {
                 // When the parameters are not valid, simply return it, instead of throwing exceptions.
@@ -617,7 +621,7 @@ namespace Microsoft.Build.Tasks.Windows
             {
                 XmlElement nodeGroup = root.ChildNodes[i] as XmlElement;
 
-                if (nodeGroup != null && String.Compare(nodeGroup.Name, ITEMGROUP_NAME, StringComparison.OrdinalIgnoreCase) == 0)
+                if (nodeGroup != null && String.Compare(nodeGroup.Name, groupName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     //
                     // This is ItemGroup element.
@@ -668,9 +672,24 @@ namespace Microsoft.Build.Tasks.Windows
                 }
 
             }   // end of "for i" statement.
-
+        }
+        
+        //
+        // Remove specific items from project file. Every item should be under an ItemGroup.
+        //
+        private void RemoveItemsByName(XmlDocument xmlProjectDoc, string sItemName)
+        {
+            RemoveEntityByName(xmlProjectDoc, sItemName, ITEMGROUP_NAME);
         }
 
+        //
+        // Remove specific property from project file. Every property should be under an PropertyGroup.
+        //
+        private void RemovePropertiesByName(XmlDocument xmlProjectDoc, string sPropertyName)
+        {
+            RemoveEntityByName(xmlProjectDoc, sPropertyName, PROPERTYGROUP_NAME);
+        }
+        
         //
         // Add a list of files into an Item in the project file, the ItemName is specified by sItemName.
         //
@@ -911,6 +930,7 @@ namespace Microsoft.Build.Tasks.Windows
         private const string RESOURCENAME = "Resource";
 
         private const string ITEMGROUP_NAME = "ItemGroup";
+        private const string PROPERTYGROUP_NAME = "PropertyGroup";
         private const string INCLUDE_ATTR_NAME = "Include";
 
         private const string WPFTMP = "wpftmp";


### PR DESCRIPTION
Fixes 
#5711
#5576

Main PR https://github.com/dotnet/wpf/pull/7557

## Description

When running the `GenerateTemporaryTargetAssmebly` task, a temporary project file gets created from the user defined project and in the process of creation, two instances of `AssemblyName` gets inserted in the file. 

First instance will have evaluated value for assembly name (i.e. all the macros will be resolved) whereas second instance will still have the unresolved macros in the `AssemblyName`.

If `MSBuildProjectName` is being used computation of `AssemblyName`, it will cause MSBuild to pick current project name for naming the assembly and because temporary project file is being used we will have temporary project file name as assembly name and eventually no local references will be found in MarkupCompilation2.

Removing the second instance of `AssemblyName` from aforementioned project file resolves the issue as `MSBuild` will have only evaluated `AssemblyName`. 

## Customer Impact

Projects are not building if `$(MSBuildProjectName)` is being used in `AssemblyName`

## Regression

Yes

## Testing

In Progress

## Risk

In evaluation

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7560)