### PR TITLE
Disposing page stream eagerly

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
@@ -343,7 +343,7 @@ namespace System.Windows.Documents
             Debug.Assert(translatedPageNo >= 0 && translatedPageNo < doc.PageCount);
             
             PageContent pageContent = doc.Pages[translatedPageNo];
-            Stream pageStream = pageContent.GetPageStream();
+            using Stream pageStream = pageContent.GetPageStream();
             bool reverseRTL = true;
             if (doc.HasExplicitStructure)
             {


### PR DESCRIPTION
Fixes #7567 

## Description
Stream is not explicitly disposed when retrieving page contents. This causes stream to stay open even when the usage is over. The next iteration of the same code path then throws the error since it sees that the underlying stream is already open.

## Customer Impact
Unable to search when using docviewer control

## Regression
Don't know.

## Testing

Under testing. 

## Risk
Low. Since the scope of the stream is anyways local.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7568)