### PR TITLE
Remove System.Drawing.Common coherent package dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,7 +25,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.3.23161.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,77 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Private.Winforms" Version="8.0.0-preview.3.23161.2">
+    <Dependency Name="Microsoft.Private.Winforms" Version="8.0.0-preview.3.23166.3">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>6da50a7da9c96c217b564974bf63ce39fcec5509</Sha>
+      <Sha>1a220e9268d2d38f719d2cd721628fe6e270d2d2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="8.0.0-preview.3.23161.2">
+    <Dependency Name="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="8.0.0-preview.3.23166.3">
       <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>6da50a7da9c96c217b564974bf63ce39fcec5509</Sha>
+      <Sha>1a220e9268d2d38f719d2cd721628fe6e270d2d2</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.3.23161.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.3.23166.3">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>1a220e9268d2d38f719d2cd721628fe6e270d2d2</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Windows.Extensions" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="8.0.0-preview.3.23165.5">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>7aaa8b41170c70592176aa42e8985ad5ea1d9ef8</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.3.23161.1" CoherentParentDependency="Microsoft.Private.Winforms">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.3.23166.1" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>2bacbca96ddcf7ae809a0e32a0d5dbffd6354199</Sha>
+      <Sha>7f0c19acfcfe1d89d1aaee814e6fd00b3ff1c8a2</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,26 +21,26 @@
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/winforms -->
   <PropertyGroup>
-    <MicrosoftPrivateWinformsVersion>8.0.0-preview.3.23161.2</MicrosoftPrivateWinformsVersion>
+    <MicrosoftPrivateWinformsVersion>8.0.0-preview.3.23166.3</MicrosoftPrivateWinformsVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/runtime -->
   <PropertyGroup>
-    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.3.23161.1</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
-    <MicrosoftNETCoreAppRefVersion>8.0.0-preview.3.23161.1</MicrosoftNETCoreAppRefVersion>
-    <MicrosoftNETCoreAppRuntimewinx64Version>8.0.0-preview.3.23161.1</MicrosoftNETCoreAppRuntimewinx64Version>
-    <MicrosoftNETCorePlatformsVersion>8.0.0-preview.3.23161.1</MicrosoftNETCorePlatformsVersion>
-    <SystemCodeDomPackageVersion>8.0.0-preview.3.23161.1</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>8.0.0-preview.3.23161.1</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>8.0.0-preview.3.23161.1</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDrawingCommonVersion>8.0.0-preview.3.23161.1</SystemDrawingCommonVersion>
-    <SystemDirectoryServicesVersion>8.0.0-preview.3.23161.1</SystemDirectoryServicesVersion>
-    <SystemIOPackagingVersion>8.0.0-preview.3.23161.1</SystemIOPackagingVersion>
-    <SystemReflectionMetadataLoadContextVersion>8.0.0-preview.3.23161.1</SystemReflectionMetadataLoadContextVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.3.23166.1</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
+    <MicrosoftNETCoreAppRefVersion>8.0.0-preview.3.23166.1</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>8.0.0-preview.3.23166.1</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCorePlatformsVersion>8.0.0-preview.3.23166.1</MicrosoftNETCorePlatformsVersion>
+    <SystemCodeDomPackageVersion>8.0.0-preview.3.23166.1</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>8.0.0-preview.3.23166.1</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>8.0.0-preview.3.23166.1</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDrawingCommonVersion>8.0.0-preview.3.23166.3</SystemDrawingCommonVersion>
+    <SystemDirectoryServicesVersion>8.0.0-preview.3.23166.1</SystemDirectoryServicesVersion>
+    <SystemIOPackagingVersion>8.0.0-preview.3.23166.1</SystemIOPackagingVersion>
+    <SystemReflectionMetadataLoadContextVersion>8.0.0-preview.3.23166.1</SystemReflectionMetadataLoadContextVersion>
     <SystemReflectionTypeExtensionsPackageVersion>4.6.0-preview4.19176.11</SystemReflectionTypeExtensionsPackageVersion>
-    <SystemResourcesExtensionsVersion>8.0.0-preview.3.23161.1</SystemResourcesExtensionsVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>8.0.0-preview.3.23161.1</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>8.0.0-preview.3.23161.1</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>8.0.0-preview.3.23161.1</SystemWindowsExtensionsPackageVersion>
+    <SystemResourcesExtensionsVersion>8.0.0-preview.3.23166.1</SystemResourcesExtensionsVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>8.0.0-preview.3.23166.1</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>8.0.0-preview.3.23166.1</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>8.0.0-preview.3.23166.1</SystemWindowsExtensionsPackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>


### PR DESCRIPTION
System.Drawing.Common is now live built in winforms and hence the coherent parent dependency shouldn't be needed anymore.

This unblock dependency updates from winforms --> wpf

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7638)