### PR TITLE
Disable nullability warnings for ref projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <TargetFrameworkVersion>8.0</TargetFrameworkVersion>
   </PropertyGroup>
+
+  <PropertyGroup>
+   <!-- Set OutDirName to change the BaseOutputPath and BaseIntermediateOutputPath properties to include the ref subfolder. -->
+    <_projectDirName>$([System.IO.Path]::GetFileName('$(MSBuildProjectDirectory)'))</_projectDirName>
+    <IsReferenceAssemblyProject Condition="'$(_projectDirName)' == 'ref'">true</IsReferenceAssemblyProject>
+  </PropertyGroup>
   <!-- Normalize $(TestWpfArcadeSdkPath) by appending a '\' to it if one is missing -->
   <PropertyGroup Condition="'$(TestWpfArcadeSdkPath)'!=''">
     <WpfArcadeSdkPath>$(TestWpfArcadeSdkPath)</WpfArcadeSdkPath>
@@ -28,4 +34,10 @@
   <Import Sdk="Microsoft.DotNet.Arcade.Wpf.Sdk"
           Project="Sdk.props"
           Condition="!Exists('$(WpfArcadeSdkProps)') Or !Exists('$(WpfArcadeSdkTargets)')"/>
+
+  <PropertyGroup Condition="'$(IsReferenceAssemblyProject)' == 'true'">
+    <!-- disable CS8597 because we throw null on reference assemblies. -->
+    <NoWarn>$(NoWarn);CS8597</NoWarn>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Contributes to #7563

## Description
Disables CS8597 - _Thrown value may be null_ warning for ref projects. 

## Customer Impact
Enables support for nullability annotations

## Regression
No.

## Testing
Enabling nullability annotations for few projects did not produce build time errors for ref projects.

## Risk
Low. Since it disables warnings on ref style projects.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7665)