### PR TITLE
Disable WriteOnlyWhenDifferent if Overwrite=false

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.targets
@@ -397,7 +397,7 @@ using namespace System::Runtime::Versioning;
 
     <WriteLinesToFile Lines="%(CppClrSupportProject.Text)"
                       File="$(CppCliHelperProject)"
-                      Overwrite="false" WriteOnlyWhenDifferent="true" />
+                      Overwrite="false" WriteOnlyWhenDifferent="false" />
 
     <!--
     Do not build - just ask ResolveReferences + IdentifyNetCoreReferences for the information
@@ -551,7 +551,7 @@ using namespace System::Runtime::Versioning;
 
     <WriteLinesToFile Lines="%(CppSupportProject.Text)"
                       File="$(CppHelperProject)"
-                      Overwrite="false" WriteOnlyWhenDifferent="true" />
+                      Overwrite="false" WriteOnlyWhenDifferent="false" />
 
     <!--
     Do not build - just ask IdentifyNetCoreReferences for the information


### PR DESCRIPTION
## Description
WriteOnlyWhenDifferent is considered only when Overwrite is set in the WriteLinesToFile task. Therefore, disabling the WriteOnlyWhenDifferent property when Overwrite=false in Wpf.Cpp.targets. See https://github.com/dotnet/msbuild/issues/8363
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers facing issues with local builds will be unblocked.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
--
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local build is working
<!-- What kind of testing has been done with the fix. -->

## Risk
No.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7678)