### PR TITLE
Add dependencies required by windowsdesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,35 +9,7 @@
       <Uri>https://github.com/dotnet/winforms</Uri>
       <Sha>d5c99d71d02787c42753807e2271d42a01d5b2ca</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.4.23177.3">
-      <Uri>https://github.com/dotnet/winforms</Uri>
-      <Sha>d5c99d71d02787c42753807e2271d42a01d5b2ca</Sha>
-    </Dependency>
     <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
     </Dependency>
@@ -52,10 +24,6 @@
     <Dependency Name="Microsoft.DotNet.Wpf.DncEng" Version="8.0.0-preview.4.23172.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-wpf-int</Uri>
       <Sha>495db4193bd6433c2ee922bbff4a4e67e7e69a82</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
     </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
@@ -72,6 +40,120 @@
     <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.4.23172.14" CoherentParentDependency="Microsoft.Private.Winforms">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>10abc299cc62376043cac6db7a962bb8991b4626</Sha>
+    </Dependency>
+
+    <!-- These dependencies are required by windowsdesktop for coherency. -->
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Management" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Speech" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.4.23177.1" CoherentParentDependency="Microsoft.Private.Winforms">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Drawing.Common" Version="8.0.0-preview.4.23177.3">
+      <Uri>https://github.com/dotnet/winforms</Uri>
+      <Sha>d5c99d71d02787c42753807e2271d42a01d5b2ca</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Blocked by https://github.com/dotnet/winforms/pull/8909
Unblocks https://github.com/dotnet/windowsdesktop/pull/3516

Microsoft.Windows.Compatibility is being migrated from runtime to windowsdesktop and depends on packages from dotnet/runtime. As there's already a subscription from `runtime -> winforms`, a new one can't be added directly between `runtime -> windowsdesktop` as that would cause coherency issues. Instead, we need to flow the dependencies through winforms and wpf.

The `git diff` is confusing. I just added the new dependencies at the end of the product dependencies section and removed the ones that already existed from above so that all the ones that are required by windowsdesktop are grouped together.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7681)