### PR TITLE
Enabling Hardware Acceleration on RDP

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -380,6 +380,21 @@ namespace MS.Internal
 
         #endregion
 
+        #region EnableHardwareAccelerationInRdp
+
+        internal const string EnableHardwareAccelerationInRdpSwitchName = "Switch.System.Windows.Media.EnableHardwareAccelerationInRdp";
+        private static int _enableHardwareAccelerationInRdp;
+        public static bool EnableHardwareAccelerationInRdp
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(EnableHardwareAccelerationInRdpSwitchName, ref _enableHardwareAccelerationInRdp);
+            }
+        }
+
+        #endregion
+
     }
 #pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
@@ -60,6 +60,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStationSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotUsePresentationDpiCapabilityTier3OrGreaterSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.AllowExternalProcessToBlockAccessToTemporaryFilesSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.EnableHardwareAccelerationInRdpSwitchName, false);
         }
     }
 #pragma warning restore 436

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaSystem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaSystem.cs
@@ -79,6 +79,10 @@ namespace System.Windows.Media
                 }
                 s_refCount++;
             }
+
+            // Setting renderOption for Hardware acceleration in RDP as per appcontext switch.
+            UnsafeNativeMethods.RenderOptions_EnableHardwareAccelerationInRdp(CoreAppContextSwitches.EnableHardwareAccelerationInRdp);
+
             // Consider making MediaSystem.ConnectTransport return the state of transport connectedness so
             // that we can initialize the media system to a disconnected state.
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
@@ -208,7 +208,10 @@ namespace MS.Win32.PresentationCore
                 bool fForce);
 
             [DllImport(DllImport.MilCore, EntryPoint = "RenderOptions_IsSoftwareRenderingForcedForProcess")]
-            internal unsafe static extern bool RenderOptions_IsSoftwareRenderingForcedForProcess();            
+            internal unsafe static extern bool RenderOptions_IsSoftwareRenderingForcedForProcess();
+
+            [DllImport(DllImport.MilCore, EntryPoint = "RenderOptions_EnableHardwareAccelerationInRdp")]
+            internal unsafe static extern bool RenderOptions_EnableHardwareAccelerationInRdp(bool value);                 
 
             [DllImport(DllImport.MilCore, EntryPoint = "MilResource_CreateCWICWrapperBitmap")]
             internal unsafe static extern int /* HRESULT */ CreateCWICWrapperBitmap(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/UnsafeNativeMethodsMilCoreApi.cs
@@ -211,7 +211,7 @@ namespace MS.Win32.PresentationCore
             internal unsafe static extern bool RenderOptions_IsSoftwareRenderingForcedForProcess();
 
             [DllImport(DllImport.MilCore, EntryPoint = "RenderOptions_EnableHardwareAccelerationInRdp")]
-            internal unsafe static extern bool RenderOptions_EnableHardwareAccelerationInRdp(bool value);                 
+            internal unsafe static extern void RenderOptions_EnableHardwareAccelerationInRdp(bool value);                 
 
             [DllImport(DllImport.MilCore, EntryPoint = "MilResource_CreateCWICWrapperBitmap")]
             internal unsafe static extern int /* HRESULT */ CreateCWICWrapperBitmap(

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/d3dutils.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/d3dutils.cpp
@@ -232,10 +232,11 @@ GetMinimalTextureDesc(
         }
 
         // If format is ok, restore HR from width/height check
-        if (hr == S_OK)
+        if(SUCCEEDED(hr))
         {
             hr = hrWH;
         }
+        
     }
 
 #if DBG
@@ -315,8 +316,3 @@ GetSuperiorSurfaceFormat(
 
     return D3DFMT_UNKNOWN;
 }
-
-
-
-
-

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/display.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/display.cpp
@@ -2125,7 +2125,7 @@ CDisplaySet::GetGraphicsAccelerationCaps(
         *pulDisplayUniqueness = m_ulDisplayUniquenessLoader;
     }
 
-    if (m_rgpDisplays.GetCount() == 0 || m_fNonLocalDevicePresent)
+    if (m_rgpDisplays.GetCount() == 0 || (!RenderOptions::IsHardwareAccelerationInRdpEnabled() && m_fNonLocalDevicePresent))
     {
         //
         // No display - no acceleration

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/renderoptions.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/renderoptions.cpp
@@ -23,10 +23,17 @@ RenderOptions_IsSoftwareRenderingForcedForProcess()
     return RenderOptions::IsSoftwareRenderingForcedForProcess();
 }
 
+void WINAPI
+RenderOptions_EnableHardwareAccelerationInRdp(BOOL fEnable)
+{
+    RenderOptions::EnableHardwareAccelerationInRdp(fEnable);
+}
+
 // m_cs must be entered before accessing m_fForceSoftware because multiple
 // managed threads plus the render thread could try to access it
 static CCriticalSection m_cs;
 static bool m_fForceSoftware;
+static bool m_fHwAccelerationInRdpEnabled;
 
 //+---------------------------------------------------------------------------------
 //
@@ -41,6 +48,7 @@ HRESULT
 RenderOptions::Init()
 {
     m_fForceSoftware = false;
+    m_fHwAccelerationInRdpEnabled = false;
     RRETURN(m_cs.Init());
 }
 
@@ -94,4 +102,30 @@ RenderOptions::IsSoftwareRenderingForcedForProcess()
     return m_fForceSoftware;
 }
 
+//+---------------------------------------------------------------------------------
+//
+//  RenderOptions::EnableGraphicHWAccelerationInRdp
+//
+//  Synopsis:   Sets whether or not Hardware Acceleration should be enabled for RDP.
+//
+//----------------------------------------------------------------------------------
+void
+RenderOptions::EnableHardwareAccelerationInRdp(BOOL fEnable)
+{
+    CGuard<CCriticalSection> guard(m_cs);
+    m_fHwAccelerationInRdpEnabled = !!fEnable;
+}
+
+//+---------------------------------------------------------------------------------
+//
+//  RenderOptions::IsHardwareAccelerationInRdpEnabled
+//
+//  Synopsis:   return whether or not Hardware Acceleration for RDP is enabled.
+//
+//----------------------------------------------------------------------------------
+BOOL
+RenderOptions::IsHardwareAccelerationInRdpEnabled()
+{
+    return m_fHwAccelerationInRdpEnabled;
+}
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/renderoptions.h
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/common/renderoptions.h
@@ -18,6 +18,10 @@ namespace RenderOptions
     void ForceSoftwareRenderingForProcess(BOOL fForce);
 
     BOOL IsSoftwareRenderingForcedForProcess();
+
+    void EnableHardwareAccelerationInRdp(BOOL fEnable);
+
+    BOOL IsHardwareAccelerationInRdpEnabled();
 };
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/dll/wpfgfx.def
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/dll/wpfgfx.def
@@ -137,4 +137,5 @@ EXPORTS
 
     RenderOptions_ForceSoftwareRenderingModeForProcess
     RenderOptions_IsSoftwareRenderingForcedForProcess
+    RenderOptions_EnableHardwareAccelerationInRdp
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/hwbitmapcolorsource.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/hw/hwbitmapcolorsource.cpp
@@ -1421,16 +1421,17 @@ CHwBitmapColorSource::ComputeRealizationParameters(
             &uLevels
             );
 
-        Assert(pDevice->GetMinimalTextureDesc(
-            &d3dsdRequired,
-            TRUE,
-            (GMTD_CHECK_ALL |
-             (TextureAddressingAllowsConditionalNonPower2Usage(
-                 oRealizationParams.dlU.d3dta,
-                 oRealizationParams.dlV.d3dta) ?
-              GMTD_NONPOW2CONDITIONAL_OK : 0)
-            )
-            ) == S_OK);
+        Assert(SUCCEEDED(pDevice->GetMinimalTextureDesc(
+        &d3dsdRequired,
+        TRUE,
+        (GMTD_CHECK_ALL |
+            (TextureAddressingAllowsConditionalNonPower2Usage(
+                oRealizationParams.dlU.d3dta,
+                oRealizationParams.dlV.d3dta) ?
+            GMTD_NONPOW2CONDITIONAL_OK : 0)
+        )
+        )));
+        
     }
     #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/meta/desktoprt.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/meta/desktoprt.cpp
@@ -93,7 +93,7 @@ HRESULT CDesktopRenderTarget::Create(
     // check whether any adapters don't support Hw acceleration or D3D is not
     // available.
     //
-    if (   pDisplaySet->IsNonLocalDisplayPresent()
+    if (   (!(RenderOptions::IsHardwareAccelerationInRdpEnabled()) && pDisplaySet->IsNonLocalDisplayPresent())
         || !pDisplaySet->D3DObject())
     {
         // If possible, just revert to Sw.  This simply prevents trying Hw and


### PR DESCRIPTION
Fixes #3215

## Description

Enabling Hardware Acceleration on RDP for exes which can opt-in.

## Customer Impact

Without this fix, customers won't be able to get the benefits of Hardware Acceleration on RDP.

## Regression

No

## Testing

In progress

## Risk

Risk is Low as the applications which want to have hardware acceleration on RDP need to Opt-in by setting AppContext Switch (`Switch.System.Windows.Media.EnableHardwareAccelerationForRdp`) to true.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7684)