### PR TITLE
Cleanup following replacing resource constants with properties.

### DIFF
--- a/eng/WpfArcadeSdk/tools/SystemResources.props
+++ b/eng/WpfArcadeSdk/tools/SystemResources.props
@@ -10,37 +10,14 @@
     -->
     <GenerateResxSource>true</GenerateResxSource>
 
-    <_GenerateResourcesCodeAsConstants>true</_GenerateResourcesCodeAsConstants>
-
-    <!-- 
-         Projects that compile XAML must also check for AssemblyName because XAML compilation generates a temporary project with a different project name.
-         We use AssemblyName because AssemblyName is copied from the main project to the generated project.
-    -->
-
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='PresentationBuildTasks'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='PresentationCore'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='PresentationFramework'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='PresentationUI' or '$(AssemblyName)'=='PresentationUI'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='ReachFramework'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='UIAutomationClient'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='UIAutomationClientSideProviders'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='UIAutomationProvider'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='System.Windows.Controls.Ribbon' or '$(AssemblyName)'=='System.Windows.Controls.Ribbon'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='System.Xaml'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='WindowsBase'">false</_GenerateResourcesCodeAsConstants>
-    <_GenerateResourcesCodeAsConstants Condition="'$(MSBuildProjectName)'=='WindowsFormsIntegration'">false</_GenerateResourcesCodeAsConstants>
-
-    <DefineConstants Condition="'$(_GenerateResourcesCodeAsConstants)'=='true'">$(DefineConstants);GENERATE_RESOURCES_CODE_AS_CONSTANTS</DefineConstants>
-
     <!-- We define our own implementation of GetResourceString -->
-    <GenerateResxSourceOmitGetResourceString Condition="'$(_GenerateResourcesCodeAsConstants)'!='true'">true</GenerateResxSourceOmitGetResourceString>
+    <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
     <EmbeddedResource>
       <GenerateSource>true</GenerateSource>
       <ManifestResourceName>FxResources.$(AssemblyName).SR</ManifestResourceName>
-      <GenerateResourcesCodeAsConstants>$(_GenerateResourcesCodeAsConstants)</GenerateResourcesCodeAsConstants>
 
       <ClassName Condition="'$(AssemblyName)'=='PresentationBuildTasks'">MS.Utility.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='UIAutomationClient'">System.SR</ClassName>
@@ -56,7 +33,7 @@
       <ClassName Condition="'$(AssemblyName)'=='WindowsFormsIntegration'">System.Windows.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='PresentationCore'">MS.Internal.PresentationCore.SR</ClassName>
       <ClassName Condition="'$(AssemblyName)'=='System.Xaml'">System.SR</ClassName>
-      <Classname Condition="'%(ClassName)'==''">System.SRID</Classname>
+      <Classname Condition="'%(ClassName)'==''">System.SR</Classname>
     </EmbeddedResource>
   </ItemDefinitionGroup>
 </Project>

--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/SR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/SR.cs
@@ -30,10 +30,6 @@ namespace System
 {
     internal partial class SR
     {
-#if GENERATE_RESOURCES_CODE_AS_CONSTANTS
-        private static ResourceManager ResourceManager => SRID.ResourceManager;
-#endif
-
         // This method is used to decide if we need to append the exception message parameters to the message when calling SR.Format.
         // by default it returns false.
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
@@ -7,6 +7,9 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx"/>
+    <Compile Include="$(WpfCommonDir)src\System\SR.cs">
+        <Link>Common\System\SR.cs</Link>
+    </Compile>
     <Compile Include="System\Windows\Input\Manipulations\DoubleUtil.cs" />
     <Compile Include="System\Windows\Input\Manipulations\Exceptions.cs" />
     <Compile Include="System\Windows\Input\Manipulations\GlobalSuppressions.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
@@ -15,6 +15,9 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx" />
+    <Compile Include="$(WpfCommonDir)src\System\SR.cs">
+        <Link>Common\System\SR.cs</Link>
+    </Compile>
     <Compile Include="$(WpfSharedDir)\RefAssemblyAttrs.cs" />
     <Compile Include="$(WpfSharedDir)\System\Windows\Interop\OperatingSystemVersion.cs" />
     <Compile Include="$(WpfSharedDir)\System\Windows\Interop\OSVersionHelper.cs" />


### PR DESCRIPTION
Closes dotnet/wpf#1

## Description
Cleanup following replacing resource constants with properties.

## Customer Impact
None.

## Regression
No.

## Testing
Local build + CI.

## Risk
Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7691)