### PR TITLE
Unblock AltGr+Oem2/5 typing inside ListBox

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ListBox.cs
@@ -319,7 +319,7 @@ namespace System.Windows.Controls
                 case Key.Divide:
                 case Key.Oem2:
                     // Ctrl-Fowardslash = Select All
-                    if (((Keyboard.Modifiers & ModifierKeys.Control) == (ModifierKeys.Control)) && (SelectionMode == SelectionMode.Extended))
+                    if (((Keyboard.Modifiers) == (ModifierKeys.Control)) && (SelectionMode == SelectionMode.Extended))
                     {
                         SelectAll();
                     }
@@ -332,7 +332,7 @@ namespace System.Windows.Controls
 
                 case Key.Oem5:
                     // Ctrl-Backslash = Select the item with focus.
-                    if (((Keyboard.Modifiers & ModifierKeys.Control) == (ModifierKeys.Control)) && (SelectionMode == SelectionMode.Extended))
+                    if (((Keyboard.Modifiers) == (ModifierKeys.Control)) && (SelectionMode == SelectionMode.Extended))
                     {
                         ListBoxItem focusedItemUI = (FocusedInfo != null) ? FocusedInfo.Container as ListBoxItem : null;
                         if (focusedItemUI != null)


### PR DESCRIPTION
Fixes #7641

## Description

`ListBox` and classes derived from it (notably `ListView`) are expected to _select all_ on <kbd>Ctrl</kbd>+<kbd>/</kbd> and _select item with focus_ on <kbd>Ctrl</kbd>+<kbd>\\</kbd>. However, the implementation only checks the status of the <kbd>Ctrl</kbd> modifier, not the others. As a result, this shortcut hijacks any other combination of keys, most importantly <kbd>Ctrl</kbd>+<kbd>Alt</kbd> which is used for typing on [around 60 keyboard layouts](http://kbdlayout.info/kbdus/shortcut/VK_OEM_2+VK_RMENU) that Windows ships.

This PR fixes the problem by limiting the shortcuts to what has been documented in the code comments as intent, i.e. they will work only when <kbd>Ctrl</kbd> is pressed and nothing else.

## Customer Impact

Not taking this fix prevents users from typing characters using these two keys on their keyboards into a `TextBox` or similar control inside `ListBox` or `ListView`.

## Regression

No.

## Testing

Built and verified using the repro in #7641 and Czech keyboard layout that typing is not possible without the fix and works with the fix (.NET 8.0.100-preview.3.23178.7)

## Risk

Selecting all and selecting the focused item is now limited to <kbd>Ctrl</kbd> only, while it used to work with any modifiers combination involving <kbd>Ctrl</kbd>.

However, the current situation is serious - users cannot type. The former behavior is relatively easily achievable by deriving from the control and overriding `OnKeyDown`.