### PR TITLE
Use TextAlignment for TextBox.GetCharacterIndexFromPoint

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -1680,10 +1680,13 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    if (!snapToText &&
-                        (point.X < 0 || point.X >= record.Width))
+                    if (!snapToText)
                     {
-                        index = -1;
+                        double alignmentOffset = GetContentOffset(record.Width, CalculatedTextAlignment);
+                        if (point.X < alignmentOffset || point.X >= record.Width + alignmentOffset)
+                        {
+                            index = -1;
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
Fixes #7651 

## Description

When text box (view) uses any text alignment different from left, `TextBox.GetCharacterIndexFromPoint` does not work: wherever the line bounds do not intersect with what would be a left-aligned line bounds, it returns -1.

The PR fixes the bug by taking into account text alignment when deciding whether a point is on a line or not.

## Customer Impact

Customers not taking this fix cannot use `TextBox.GetCharacterIndexFromPoint` for text aligned to the right or centered.

## Regression

No.

## Testing

Built and tested with the repro in #7651, ensuring the characters do not get returned before the fix but correct characters get returned after the fix (using .NET 8.0.0-preview.3.23174.8).

## Risk

Low. Existing working behavior is not changed (the `GetContentOffset` returns 0). Slight performance hit for the extra calls and calculations, but only once - in the specific case of when `snapToText` is disabled and the relevant line is being tested.