### PR TITLE
Avoid crashing if temporary file cannot be deleted

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/IO/FileHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/IO/FileHelper.cs
@@ -168,6 +168,11 @@ namespace System.IO
                     // We may not be able to delete the file if it's being used by some other process (e.g. Anti-virus check).
                     // There's nothing we can do in that case, so just eat the exception and leave the file behind
                 }
+                catch(System.UnauthorizedAccessException)
+                {
+                    // We may not be able to delete the file if we do not have rights to delete from the file folder.
+                    // There's nothing we can do in that case, so just eat the exception and leave the file behind
+                }
             }
         }
         #pragma warning restore 56502


### PR DESCRIPTION
Fixes #3138 

## Description

When a process does not have rights to delete a temporary file, it crashes, see #3138. The code already contains a catch for the case when the file is in use, so this PR adds another catch for when there are insufficient permissions for the deletion.

## Customer Impact

Customers not taking this fix may experience crashes if they do not have permission to delete temporary files. An example of codepath that uses temporary files is `Cursor.LoadFromStream` or WinRT spell checker.

This affects Visual Studio as well.

## Regression

WinRT spell checker codepath has a regression from .NET Framework in that it used to check for file permissions and skip the delete if they were not granted. This PR restores the .NET Framework behavior in this case.

## Testing

Built using 8.0.0-preview.3.23174.8 and verified that a WPF application crashes when denied access to the temporary folder before the fix but not after the fix.

## Risk

Low. Temporary files will already stay behind in the case of crash, and failing to delete temporary files should not make an application to crash.
