### PR TITLE
Drag & Drop virtual files

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -337,6 +337,7 @@
     <Compile Include="System\Windows\EventPrivateKey.cs" />
     <Compile Include="System\Windows\EventRoute.cs" />
     <Compile Include="System\Windows\EventRouteFactory.cs" />
+    <Compile Include="System\Windows\FileDescriptor.cs" />
     <Compile Include="System\Windows\FocusWithinProperty.cs" />
     <Compile Include="System\Windows\FontStretch.cs" />
     <Compile Include="System\Windows\FontStretchConverter.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -259,6 +259,18 @@ namespace System.Windows
         /// Specifies a data format as Xaml Package. This field is read-only.
         /// </summary>
         public static readonly string XamlPackage = "XamlPackage";
+
+        /// <summary>
+        /// Specifies a data format to transfer data as if it were a file,
+        /// regardless of how it is actually stored. This field is read-only.
+        /// </summary>
+        public static readonly string FileContents = "FileContents";
+
+        /// <summary>
+        /// Specifies a data format to transfer data as group of files.
+        /// Used together with <see cref="FileContents"/>. This field is read-only.
+        /// </summary>
+        public static readonly string FileGroupDescriptor = "FileGroupDescriptorW";
         #endregion Public Fields
 
         //------------------------------------------------------
@@ -452,7 +464,19 @@ namespace System.Windows
                         _formatList.Add(new DataFormat(System.Windows.Ink.StrokeCollection.InkSerializedFormat,
                                                         inkServicesFrameworkFormatId));
                     }
-}
+
+                    int fileContentsId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.FileContents);
+                    if (fileContentsId != 0)
+                    {
+                        _formatList.Add(new DataFormat(FileContents, fileContentsId));
+                    }
+                    int fileDescriptorId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.FileGroupDescriptor);
+                    if (applicationTrustFormatId != 0)
+                    {
+                        _formatList.Add(new DataFormat(FileGroupDescriptor, fileDescriptorId));
+                    }
+
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FileDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FileDescriptor.cs
@@ -1,0 +1,221 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace System.Windows
+{
+    public class FileGroup : IReadOnlyList<KeyValuePair<FileDescriptor, Stream>>
+    {
+        private List<FileDescriptor> _fileDescriptors;
+        private List<Stream> _streams;
+        private IDataObjectWithIndex _dataObject;
+
+        public FileGroup()
+        {
+            _fileDescriptors = new List<FileDescriptor>();
+            _streams = new List<Stream>();
+        }
+        internal FileGroup(IDataObjectWithIndex dataObject, IEnumerable<FileDescriptor> fileDescriptors)
+        {
+            if (dataObject == null)
+            {
+                throw new ArgumentNullException(nameof(dataObject));
+            }
+
+            _dataObject = dataObject;
+            _fileDescriptors = new List<FileDescriptor>(fileDescriptors);
+        }
+
+        public int Count
+        {
+            get { return _fileDescriptors.Count; }
+        }
+        public bool IsReadOnly
+        {
+            get { return _streams == null; }
+        }
+
+        public IReadOnlyList<FileDescriptor> FileDescriptors
+        {
+            get { return _fileDescriptors.AsReadOnly(); }
+        }
+
+        public void Add(string filename, byte[] data)
+        {
+            if (filename == null)
+            {
+                throw new ArgumentNullException(nameof(filename));
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            Add(new FileDescriptor(filename), new MemoryStream(data));
+        }
+        public void Add(string filename, Stream stream)
+        {
+            if (filename == null)
+            {
+                throw new ArgumentNullException(nameof(filename));
+            }
+
+            Add(new FileDescriptor(filename), stream);
+        }
+        public void Add(FileDescriptor descriptor, Stream stream)
+        {
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            // stream can be null for directories
+
+            if (IsReadOnly)
+            {
+                throw new InvalidOperationException(); // TODO: SR
+            }
+
+            _fileDescriptors.Add(descriptor);
+            _streams.Add(stream);
+        }
+
+        public Stream GetFileContents(FileDescriptor descriptor)
+        {
+            int index = _fileDescriptors.IndexOf(descriptor);
+            if (index < 0)
+            {
+                throw new KeyNotFoundException();
+            }
+
+            return GetFileContents(index);
+        }
+        public Stream GetFileContents(int index)
+        {
+            if (index < 0 || index >= _fileDescriptors.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            if (_dataObject != null)
+            {
+                if (_fileDescriptors[index].IsDirectory)
+                {
+                    return null;
+                }
+
+                object data = null;
+                try
+                {
+                    data = _dataObject.GetData(DataFormats.FileContents, false, index);
+                }
+                catch (NotImplementedException) { } // e.g. folder contents
+
+                if (data is Stream stream)
+                {
+                    return stream;
+                }
+                else if (data is byte[] buffer)
+                {
+                    return new MemoryStream(buffer);
+                }
+                else
+                {
+                    return null; // if we throw here, the enumerator will throw unrecoverably
+                }
+            }
+            else
+            {
+                return _streams[index];
+            }
+        }
+
+        public IEnumerator<KeyValuePair<FileDescriptor, Stream>> GetEnumerator()
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                yield return KeyValuePair.Create(_fileDescriptors[i], GetFileContents(i));
+            }
+        }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        KeyValuePair<FileDescriptor, Stream> IReadOnlyList<KeyValuePair<FileDescriptor, Stream>>.this[int index]
+        {
+            get { return KeyValuePair.Create(_fileDescriptors[index], GetFileContents(index)); }
+        }
+    }
+
+    public class FileDescriptor
+    {
+        public Guid? Clsid { get; set; }
+        public Int32Rect? Icon { get; set; }
+        public FileAttributes? FileAttributes { get; set; }
+        public DateTime? CreationTime { get; set; }
+        public DateTime? LastAccessTime { get; set; }
+        public DateTime? LastWriteTime { get; set; }
+        public long? FileSize { get; set; }
+        public string FileName { get; }
+
+        public bool IsDirectory
+        {
+            get { return (FileAttributes.GetValueOrDefault() & IO.FileAttributes.Directory) != 0; }
+        }
+
+        public FileDescriptor(string filename)
+        {
+            if (filename == null)
+            {
+                throw new ArgumentNullException(nameof(filename));
+            }
+
+            FileName = filename;
+        }
+
+        public static FileDescriptor FromFile(string path)
+        {
+            FileSystemInfo info;
+
+            FileAttributes attributes = File.GetAttributes(path); // throws as necessary
+            if ((attributes & IO.FileAttributes.Directory) != 0)
+            {
+                info = new DirectoryInfo(path);
+            }
+            else
+            {
+                info = new FileInfo(path);
+            }
+
+            return FromFile(info);
+        }
+        private static FileDescriptor FromFile(FileSystemInfo info)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            FileDescriptor descriptor = new FileDescriptor(info.Name)
+            {
+                FileAttributes = info.Attributes,
+                CreationTime = info.CreationTime,
+                LastAccessTime = info.LastAccessTime,
+                LastWriteTime = info.LastWriteTime,
+            };
+
+            if (info is FileInfo fileInfo)
+            {
+                descriptor.FileSize = fileInfo.Length;
+            }
+
+            return descriptor;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/IDataObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/IDataObject.cs
@@ -122,5 +122,48 @@ namespace System.Windows
      }
 
     #endregion IDataObject interface
+
+    /// <summary>
+    /// Provides a format-independent mechanism for transferring data, supporting multi-part data.
+    /// </summary>
+    public interface IDataObjectWithIndex : IDataObject
+    {
+        /// <summary>
+        /// Retrieves the data associated with the specified data 
+        /// format, using autoConvert to determine whether to convert the data to the
+        /// format. 
+        /// </summary>
+        /// <param name="format">The format of the data to retrieve.</param>
+        /// <param name="autoConvert">true to convert the data to the specified format; 
+        /// otherwise, false.</param>
+        /// <param name="index">Part of the data. The most common value is -1, which
+        /// identifies all of the data.</param>
+        object GetData(string format, bool autoConvert, int index);
+
+        /// <summary>
+        /// Determines whether data stored in this instance is 
+        /// associated with the specified format, using autoConvert to determine whether to
+        /// convert the data to the format.
+        /// </summary>
+        /// <param name="format">The format for which to check.</param>
+        /// <param name="autoConvert">true to determine whether data stored in this instance 
+        /// can be converted.</param>
+        /// <param name="index">Part of the data. The most common value is -1, which
+        /// identifies all of the data.</param>
+        bool GetDataPresent(string format, bool autoConvert, int index);
+
+        /// <summary>
+        /// Stores the specified data and its associated format in 
+        /// this instance, using autoConvert to specify whether the data 
+        /// can be converted to another format.
+        /// </summary>
+        /// <param name="format">The format associated with the data.</param>
+        /// <param name="data">The data to store.</param>
+        /// <param name="autoConvert">true to allow the data to be converted to another format;
+        /// Otherwise, false.</param>
+        /// <param name="index">Part of the data. The most common value is -1, which
+        /// identifies all of the data.</param>
+        void SetData(string format, object data, bool autoConvert, int index);
+    }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -14,6 +14,7 @@
 using MS.Win32;
 using MS.Internal;
 using MS.Internal.PresentationCore;                        // SecurityHelper
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Security;
@@ -106,6 +107,14 @@ namespace System.Windows
         public static bool ContainsFileDropList()
         {
             return ContainsDataInternal(DataFormats.FileDrop);
+        }
+
+        /// <summary>
+        /// Return true if Clipboard contains the file drop list format. Otherwise, return false.
+        /// </summary>
+        public static bool ContainsFileGroup()
+        {
+            return ContainsDataInternal(DataFormats.FileGroupDescriptor);
         }
 
         /// <summary>
@@ -209,6 +218,24 @@ namespace System.Windows
             }
 
             return fileDropListCollection;
+        }
+
+        /// <summary>
+        /// Get the file group from Clipboard.
+        /// </summary>
+        public static FileGroup GetFileGroup()
+        {
+            IDataObjectWithIndex dataObject = GetDataObject() as IDataObjectWithIndex;
+            if (dataObject != null)
+            {
+                IEnumerable<FileDescriptor> descriptor = dataObject.GetData(DataFormats.FileGroupDescriptor) as IEnumerable<FileDescriptor>;
+                if (descriptor != null)
+                {
+                    return new FileGroup(dataObject, descriptor);
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -331,6 +358,26 @@ namespace System.Windows
             fileDropList.CopyTo(fileDropListStrings, 0);
 
             SetDataInternal(DataFormats.FileDrop, fileDropListStrings);
+        }
+
+        /// <summary>
+        /// Set the file group data to Clipboard.
+        /// </summary>
+        public static void SetFileGroup(FileGroup group)
+        {
+            if (group == null)
+            {
+                throw new ArgumentNullException(nameof(group));
+            }
+
+            if (group.Count == 0)
+            {
+                throw new ArgumentException(); // TODO: SR
+            }
+
+            DataObject dataObject = new DataObject();
+            dataObject.SetFileGroup(group);
+            CriticalSetDataObject(dataObject, /*copy*/false);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -471,7 +471,7 @@ namespace System.Windows
         public static System.Windows.DataFormat GetDataFormat(int id) { throw null; }
         public static System.Windows.DataFormat GetDataFormat(string format) { throw null; }
     }
-    public sealed partial class DataObject : System.Runtime.InteropServices.ComTypes.IDataObject, System.Windows.IDataObject
+    public sealed partial class DataObject : System.Runtime.InteropServices.ComTypes.IDataObject, System.Windows.IDataObjectWithIndex, System.Windows.IDataObject
     {
         public static readonly System.Windows.RoutedEvent CopyingEvent;
         public static readonly System.Windows.RoutedEvent PastingEvent;
@@ -492,9 +492,11 @@ namespace System.Windows
         public System.IO.Stream GetAudioStream() { throw null; }
         public object GetData(string format) { throw null; }
         public object GetData(string format, bool autoConvert) { throw null; }
+        public object GetData(string format, bool autoConvert, int index) { throw null; }
         public object GetData(System.Type format) { throw null; }
         public bool GetDataPresent(string format) { throw null; }
         public bool GetDataPresent(string format, bool autoConvert) { throw null; }
+        public bool GetDataPresent(string format, bool autoConvert, int index) { throw null; }
         public bool GetDataPresent(System.Type format) { throw null; }
         public System.Collections.Specialized.StringCollection GetFileDropList() { throw null; }
         public string[] GetFormats() { throw null; }
@@ -510,6 +512,7 @@ namespace System.Windows
         public void SetData(object data) { }
         public void SetData(string format, object data) { }
         public void SetData(string format, object data, bool autoConvert) { }
+        public void SetData(string format, object data, bool autoConvert, int index) { }
         public void SetData(System.Type format, object data) { }
         public void SetFileDropList(System.Collections.Specialized.StringCollection fileDropList) { }
         public void SetImage(System.Windows.Media.Imaging.BitmapSource image) { }
@@ -974,6 +977,12 @@ namespace System.Windows
         void SetData(string format, object data);
         void SetData(string format, object data, bool autoConvert);
         void SetData(System.Type format, object data);
+    }
+    public partial interface IDataObjectWithIndex : System.Windows.IDataObject
+    {
+        object GetData(string format, bool autoConvert, int index);
+        bool GetDataPresent(string format, bool autoConvert, int index);
+        void SetData(string format, object data, bool autoConvert, int index);
     }
     public partial interface IInputElement
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -71,6 +71,7 @@ namespace System.Windows
         public static bool ContainsAudio() { throw null; }
         public static bool ContainsData(string format) { throw null; }
         public static bool ContainsFileDropList() { throw null; }
+        public static bool ContainsFileGroup() { throw null; }
         public static bool ContainsImage() { throw null; }
         public static bool ContainsText() { throw null; }
         public static bool ContainsText(System.Windows.TextDataFormat format) { throw null; }
@@ -79,6 +80,7 @@ namespace System.Windows
         public static object GetData(string format) { throw null; }
         public static System.Windows.IDataObject GetDataObject() { throw null; }
         public static System.Collections.Specialized.StringCollection GetFileDropList() { throw null; }
+        public static System.Windows.FileGroup GetFileGroup() { throw null; }
         public static System.Windows.Media.Imaging.BitmapSource GetImage() { throw null; }
         public static string GetText() { throw null; }
         public static string GetText(System.Windows.TextDataFormat format) { throw null; }
@@ -89,6 +91,7 @@ namespace System.Windows
         public static void SetDataObject(object data) { }
         public static void SetDataObject(object data, bool copy) { }
         public static void SetFileDropList(System.Collections.Specialized.StringCollection fileDropList) { }
+        public static void SetFileGroup(System.Windows.FileGroup group) { }
         public static void SetImage(System.Windows.Media.Imaging.BitmapSource image) { }
         public static void SetText(string text) { }
         public static void SetText(string text, System.Windows.TextDataFormat format) { }
@@ -468,6 +471,8 @@ namespace System.Windows
         public static readonly string WaveAudio;
         public static readonly string Xaml;
         public static readonly string XamlPackage;
+        public static readonly string FileContents;
+        public static readonly string FileGroupDescriptor;
         public static System.Windows.DataFormat GetDataFormat(int id) { throw null; }
         public static System.Windows.DataFormat GetDataFormat(string format) { throw null; }
     }
@@ -486,6 +491,7 @@ namespace System.Windows
         public static void AddSettingDataHandler(System.Windows.DependencyObject element, System.Windows.DataObjectSettingDataEventHandler handler) { }
         public bool ContainsAudio() { throw null; }
         public bool ContainsFileDropList() { throw null; }
+        public bool ContainsFileGroup() { throw null; }
         public bool ContainsImage() { throw null; }
         public bool ContainsText() { throw null; }
         public bool ContainsText(System.Windows.TextDataFormat format) { throw null; }
@@ -499,6 +505,7 @@ namespace System.Windows
         public bool GetDataPresent(string format, bool autoConvert, int index) { throw null; }
         public bool GetDataPresent(System.Type format) { throw null; }
         public System.Collections.Specialized.StringCollection GetFileDropList() { throw null; }
+        public System.Windows.FileGroup GetFileGroup() { throw null; }
         public string[] GetFormats() { throw null; }
         public string[] GetFormats(bool autoConvert) { throw null; }
         public System.Windows.Media.Imaging.BitmapSource GetImage() { throw null; }
@@ -515,6 +522,7 @@ namespace System.Windows
         public void SetData(string format, object data, bool autoConvert, int index) { }
         public void SetData(System.Type format, object data) { }
         public void SetFileDropList(System.Collections.Specialized.StringCollection fileDropList) { }
+        public void SetFileGroup(System.Windows.FileGroup group) { }
         public void SetImage(System.Windows.Media.Imaging.BitmapSource image) { }
         public void SetText(string textData) { }
         public void SetText(string textData, System.Windows.TextDataFormat format) { }
@@ -713,6 +721,35 @@ namespace System.Windows
         public object PopBranchNode() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
         public void PushBranchNode(object node, object source) { }
+    }
+    public partial class FileDescriptor
+    {
+        public FileDescriptor(string filename) { }
+        public System.Guid? Clsid { get { throw null; } set { } }
+        public System.DateTime? CreationTime { get { throw null; } set { } }
+        public System.IO.FileAttributes? FileAttributes { get { throw null; } set { } }
+        public string FileName  { get { throw null; } }
+        public long? FileSize  { get { throw null; } set { } }
+        public static FileDescriptor FromFile(string path) { throw null; }
+        public System.Windows.Int32Rect? Icon { get { throw null; } set { } }
+        public bool IsDirectory { get { throw null; } }
+        public System.DateTime? LastAccessTime { get { throw null; } set { } }
+        public System.DateTime? LastWriteTime { get { throw null; } set { } }
+    }
+    public partial class FileGroup : System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<System.Windows.FileDescriptor, System.IO.Stream>>
+    {
+        public FileGroup() { }
+        public int Count { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public void Add(string filename, byte[] data) { }
+        public void Add(string filename, System.IO.Stream stream) { }
+        public void Add(System.Windows.FileDescriptor descriptor, System.IO.Stream stream) { }
+        public System.Collections.Generic.IReadOnlyList<System.Windows.FileDescriptor> FileDescriptors { get { throw null; } }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<FileDescriptor, System.IO.Stream>> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public System.IO.Stream GetFileContents(System.Windows.FileDescriptor descriptor) { throw null; }
+        public System.IO.Stream GetFileContents(int index) { throw null; }
+        System.Collections.Generic.KeyValuePair<System.Windows.FileDescriptor, System.IO.Stream> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<System.Windows.FileDescriptor, System.IO.Stream>>.this[int index] { get { throw null; } }
     }
     [System.Windows.LocalizabilityAttribute(System.Windows.LocalizationCategory.None, Readability = System.Windows.Readability.Unreadable)]
     public enum FlowDirection

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -7262,6 +7262,37 @@ namespace MS.Win32 {
             /// </summary>
             MDT_DEFAULT = MDT_EFFECTIVE_DPI
         }
+
+        // FILEDESCRIPTOR.dwFlags
+        public const uint
+        FD_CLSID = 0x00000001,
+        FD_SIZEPOINT = 0x00000002,
+        FD_ATTRIBUTES = 0x00000004,
+        FD_CREATETIME = 0x00000008,
+        FD_ACCESSTIME = 0x00000010,
+        FD_WRITESTIME = 0x00000020,
+        FD_FILESIZE = 0x00000040,
+        FD_PROGRESSUI = 0x00004000,
+        FD_LINKUI = 0x00008000,
+        FD_UNICODE = 0x80000000;
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public class FILEDESCRIPTOR {
+            public FILEDESCRIPTOR() {
+            }
+            public uint dwFlags;
+            public Guid clsid;
+            public SIZE sizel;
+            public POINT pointl;
+            public FileAttributes dwFileAttributes;
+            public long ftCreationTime;
+            public long ftLastAccessTime;
+            public long ftLastWriteTime;
+            public int nFileSizeHigh;
+            public int nFileSizeLow;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst=MAX_PATH)]
+            public string cFileName;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #6352. Requires API proposal.

## Description

This is a new feature that allows WPF application to be both a drag source and a drop target for virtual files, i.e. support for CFSTR_FILECONTENTS and CFSTR_FILEDESCRIPTOR.

This enables WPF applications to accept attachments dropped or pasted from Outlook or shell namespaces (phones, cameras etc.) as well as files pasted from e.g. remote desktop. This also enables WPF applications to allow users copying or dragging UI elements from a Window and dropping them as files, attachments, etc. without creating temporary files first.

There is two parts to enable these scenarios. One is the support of getting and setting multi-part data objects, i.e. using `FORMATETC.lindex`. For compatibility reasons, this cannot be added to the `IDataObject` interface, so a new `IDataObjectWithIndex` is introduced that derives from `IDataObject` and all WPF types that implemented `IDataObject` now implement both. This is already a change worth merging on its own, enabling developers to implement the above scenarios with a reasonable effort (replaces #6353).

The second part is the public methods that allow high level access to the feature. Currently on both `DataObject` and `Clipboard`, these are:

* `bool ContainsFileGroup()`
* `FileGroup GetFileGroup()`
* `void SetFileGroup(FileGroup group)`

Two new types are introduced, `System.Windows.FileDescriptor`, roughly corresponding to [FILEDESCRIPTORW](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-filedescriptorw) and `System.Windows.FileGroup`, which is technically a list of file descriptors paired with corresponding streams. The `FileGroup` holds either streams supplied by developer or a reference to `IDataObject` that provides the streams on demand.

While file groups can be backed up by physical files, there is no convenience methods to add physical files to the group at the moment, but developers can do that manually.

For low-level access, two new data formats are defined and registered, `DataFormats.FileContents` which returns a `Stream` and `DataFormats.FileGroupDescriptor` which returns a collection of `FileDescriptor`s.

Feedback on the design welcome.

## Usage

Copy virtual files into clipboard:

```C#
FileGroup group = new FileGroup();
group.Add("E.txt", Encoding.UTF8.GetBytes("EHEHEHE"));
group.Add("F.txt", Encoding.UTF8.GetBytes("FFFFLUFF"));
Clipboard.SetFileGroup(group);
```

Drag virtual files:

```C#
private void OnMouseMove(object sender, MouseEventArgs e)
{
    if (e.LeftButton == MouseButtonState.Pressed)
    {
        FileGroup group = new FileGroup();
        group.Add("E.txt", Encoding.UTF8.GetBytes("EHEHEHE"));
        group.Add("F.txt", Encoding.UTF8.GetBytes("FFFFLUFF"));

        DataObject dataObject = new DataObject();
        dataObject.SetFileGroup(group);
        DragDrop.DoDragDrop(this, dataObject, DragDropEffects.All);
    }
}
```

Save dropped virtual files to the current directory:

```C#
private void OnDrop(object sender, DragEventArgs e)
{
    DataObject dataObject = (DataObject)e.Data;
    if (dataObject.ContainsFileGroup())
    {
        FileGroup group = dataObject.GetFileGroup();

        foreach (var file in group)
        {
            if (file.Key.IsDirectory)
                Directory.CreateDirectory(file.Key.FileName);

            else 
                using (FileStream stream = File.Create(file.Key.FileName))
                    file.Value.CopyTo(stream);
        }
    }
}
```

## Remaining tasks

- [ ] API review
- [ ] XML comments on new classes
- [ ] SR for exceptions

## Testing

Built and tested using .NET 8.0.100-preview.3.23178.7 win-x86:
- dragging virtual files using both FileGroup and SetData from WPF app to Outlook, Windows Explorer and itself
- dragging virtual files and folders using FileGroup from WPF to Outlook, Windows Explorer and itself
- copying virtual files using FileGroup and pasting them into Outlook and Windows Explorer
- dropping attachments from Outlook into WPF app
- pasting files from Remote Desktop into WPF app
- taking FileGroup from clipboard and DoDragDrop
- taking FileGroup from drop and setting it to clipboard

## Risk

"DataObject save any to IStream" commit has changes to existing behaviour, namely, "InkSerializedFormat" allocated byte array, read the stream into the byte array and then wrote the byte array into the destination stream. After the changes, the data are copied stream to stream using a buffer of 81920 bytes.

Otherwise everything else should be a new feature.