### PR TITLE
Allow right click in system menu

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemCommands.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemCommands.cs
@@ -76,6 +76,7 @@ namespace System.Windows
         {
             const uint TPM_RETURNCMD = 0x0100;
             const uint TPM_LEFTBUTTON = 0x0;
+            const uint TPM_RIGHTBUTTON = 0x2;
 
             Verify.IsNotNull(window, "window");
             IntPtr hwnd = new WindowInteropHelper(window).Handle;
@@ -86,7 +87,7 @@ namespace System.Windows
 
             IntPtr hmenu = NativeMethods.GetSystemMenu(hwnd, false);
 
-            uint cmd = NativeMethods.TrackPopupMenuEx(hmenu, TPM_LEFTBUTTON | TPM_RETURNCMD, (int)physicalScreenLocation.X, (int)physicalScreenLocation.Y, hwnd, IntPtr.Zero);
+            uint cmd = NativeMethods.TrackPopupMenuEx(hmenu, TPM_LEFTBUTTON | TPM_RIGHTBUTTON | TPM_RETURNCMD, (int)physicalScreenLocation.X, (int)physicalScreenLocation.Y, hwnd, IntPtr.Zero);
             if (0 != cmd)
             {
                 NativeMethods.PostMessage(hwnd, WM.SYSCOMMAND, new IntPtr(cmd), IntPtr.Zero);


### PR DESCRIPTION
Fixes #7739 

## Description

The `SystemCommands.ShowSystemMenu` command shows the system menu in a way that it does not accept right click, although the menu does accept right click when shown by the Windows system.

This PR updates the flag passed to the native API to allow right click to work.

## Customer Impact

Customers not taking the fix will not be able to use right click in system menu shown explicitly, as is for example the case for `WindowChrome`, introducing inconsistencies between the WPF and Windows system.

## Regression

No.

## Testing

Built using .NET 8.0.100-preview.3.23178.7 and tested with the repro in #7739, verified that the _Minimize_ command gets ignored before the fix and works after the fix.

## Risk

Low. Existing behavior not changed. Allowed right click to not go through the system menu when invoked programmatically.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7743)