### PR TITLE
Disabled tasks after RunTests (#7775)

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -217,40 +217,40 @@ jobs:
           workingDirectory: '$(System.ArtifactsDirectory)\testbins'
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
       
-      - task: CopyFiles@2
-        inputs:
-          SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
-          Contents: '**'
-          TargetFolder: '$(System.DefaultWorkingDirectory)\Results\'
-          CleanTargetFolder: true
-          OverWrite: true
-        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
+      # - task: CopyFiles@2
+      #   inputs:
+      #     SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
+      #     Contents: '**'
+      #     TargetFolder: '$(System.DefaultWorkingDirectory)\Results\'
+      #     CleanTargetFolder: true
+      #     OverWrite: true
+      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
         
-      - task: CopyFiles@2
-        inputs:
-          SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
-          Contents: '**'
-          TargetFolder: '$(System.DefaultWorkingDirectory)\ResultsX86\'
-          CleanTargetFolder: true
-          OverWrite: true
-        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
+      # - task: CopyFiles@2
+      #   inputs:
+      #     SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
+      #     Contents: '**'
+      #     TargetFolder: '$(System.DefaultWorkingDirectory)\ResultsX86\'
+      #     CleanTargetFolder: true
+      #     OverWrite: true
+      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
 
-      - task: PublishPipelineArtifact@1
-        inputs:
-          artifactName: 'TestResultsX64'
-          targetPath: '$(System.DefaultWorkingDirectory)\Results\'      
-        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
+      # - task: PublishPipelineArtifact@1
+      #   inputs:
+      #     artifactName: 'TestResultsX64'
+      #     targetPath: '$(System.DefaultWorkingDirectory)\Results\'      
+      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
 
-      - task: PublishPipelineArtifact@1
-        inputs:
-          artifactName: 'TestResultsX86'
-          targetPath: '$(System.DefaultWorkingDirectory)\ResultsX86\'
-        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
+      # - task: PublishPipelineArtifact@1
+      #   inputs:
+      #     artifactName: 'TestResultsX86'
+      #     targetPath: '$(System.DefaultWorkingDirectory)\ResultsX86\'
+      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
           
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'XUnit'
-          testResultsFiles: 'testResults.xml'
-          searchFolder: '$(System.DefaultWorkingDirectory)\Results\'
-          testRunTitle: 'CTP results'
-          condition: eq(variables['System.TeamProject'], 'public')
+      # - task: PublishTestResults@2
+      #   inputs:
+      #     testResultsFormat: 'XUnit'
+      #     testResultsFiles: 'testResults.xml'
+      #     searchFolder: '$(System.DefaultWorkingDirectory)\Results\'
+      #     testRunTitle: 'CTP results'
+      #     condition: eq(variables['System.TeamProject'], 'public')


### PR DESCRIPTION

## Description
Disabling RunDrt tasks temporarily, to enable pipeline build.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7778)