### PR TITLE
[8.0-preview4] Disable warnings CS0672, SYSLIB00(11,50,51) 

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -1114,7 +1114,9 @@ namespace System.Windows
         protected ResourceReferenceKeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ResourceReferenceKeyNotFoundException(string message, object resourceKey) { }
         public object Key { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class RoutedPropertyChangedEventArgs<T> : System.Windows.RoutedEventArgs
     {
@@ -11397,7 +11399,9 @@ namespace System.Windows.Markup
         public int LinePosition { get { throw null; } }
         public string NameContext { get { throw null; } }
         public string UidContext { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class XamlReader
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/AnimationException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/AnimationException.cs
@@ -53,9 +53,11 @@ namespace System.Windows.Media.Animation
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         private AnimationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         #endregion // Constructors
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/InvalidWMPVersionException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/InvalidWMPVersionException.cs
@@ -39,8 +39,10 @@ namespace System.Windows.Media
         /// <param name="context">
         /// The contextual information about the source or destination.
         /// </param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected InvalidWmpVersionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {}
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         ///<summary>
         /// Constructor

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1620,12 +1620,14 @@ namespace System.Windows
                 // since we directly support TYMED.TYMED_ENHMF.
                 hr = DV_E_TYMED;
             }
+#pragma warning disable SYSLIB0050
             else if (IsFormatEqual(format, DataFormats.Serializable)
                 || data is ISerializable
                 || (data != null && data.GetType().IsSerializable))
             {
                 hr = SaveObjectToHandle(medium.unionmember, data, doNotReallocate);
             }
+#pragma warning restore SYSLIB0050
             else
             {
                 // Couldn't find the proper data for the current TYMED_HGLOBAL
@@ -1752,7 +1754,7 @@ namespace System.Windows
 
             return hr;
         }
-
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
         private int SaveObjectToHandle(IntPtr handle, Object data, bool doNotReallocate)
         {
             Stream stream;
@@ -1774,6 +1776,7 @@ namespace System.Windows
                 }
             }
         }
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
         /// <summary>
         /// Saves stream out to handle.
@@ -2159,6 +2162,7 @@ namespace System.Windows
         /// true if the data is likely to be serializated
         /// through CLR serialization
         /// </returns>
+#pragma warning disable SYSLIB0050
         private static bool IsFormatAndDataSerializable(string format, object data)
         {
             return
@@ -2166,7 +2170,7 @@ namespace System.Windows
                   || data is ISerializable
                   || (data != null && data.GetType().IsSerializable);
         }
-
+#pragma warning restore SYSLIB0050
 
         /// <summary>
         /// Return true if the format string are equal(Case-senstive).
@@ -3111,6 +3115,7 @@ namespace System.Windows
             /// Creates a new instance of the Object that has been persisted into the
             /// handle.
             /// </summary>
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
             private Object ReadObjectFromHandle(IntPtr handle, bool restrictDeserialization)
             {
                 object value;
@@ -3148,7 +3153,7 @@ namespace System.Windows
 
                 return value;
             }
-
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
             /// <summary>
             /// Creates a new instance of BitmapSource that has been saved to the
             /// handle as the memory stream of BitmapSource.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/DataStreams.cs
@@ -353,7 +353,7 @@ namespace MS.Internal.AppModel
             _subStreams = null;
             _customJournaledObjects = null; 
         }
-
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
         #region Private and internal fields and properties
         private BinaryFormatter Formatter
         {
@@ -382,4 +382,5 @@ namespace MS.Internal.AppModel
         #endregion Private and internal fields and properties
     }
     #endregion DataStreams class
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Pts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Pts.cs
@@ -265,6 +265,7 @@ namespace MS.Internal.PtsHost.UnsafeNativeMethods
         // ------------------------------------------------------------------
         // SecondaryException.
         // ------------------------------------------------------------------
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         [Serializable]
         private class SecondaryException : Exception
         {
@@ -297,7 +298,7 @@ namespace MS.Internal.PtsHost.UnsafeNativeMethods
                 get { return InnerException.StackTrace; }
             }
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         // ------------------------------------------------------------------
         // PTS Exceptions with no inner exception
         // ------------------------------------------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Frame.cs
@@ -54,13 +54,13 @@ namespace System.Windows.Navigation
         Automatic = 0,
 
         /// <summary>
-        /// The Frame has its own Journal which operates independent of the hosting container’s
+        /// The Frame has its own Journal which operates independent of the hosting container's
         /// journal (if it has one).
         /// </summary>
         OwnsJournal,
 
         /// <summary>
-        /// The Frame’s journal entries are merged into the hosting container’s journal, if available.
+        /// The Frame's journal entries are merged into the hosting container's journal, if available.
         /// Otherwise navigations in this frame are not journaled.
         /// </summary>
         UsesParentJournal
@@ -1191,6 +1191,7 @@ namespace System.Windows.Controls
         /// state. It will become part of the journal entry created for the navigation in the parent
         /// container (stored within a DataStreams instance).
         /// </summary>
+#pragma warning disable SYSLIB0050
         [Serializable]
         private class FramePersistState : CustomJournalStateInternal
         {
@@ -1220,7 +1221,7 @@ namespace System.Windows.Controls
                 }
             }
         };
-
+#pragma warning restore SYSLIB0050
         CustomJournalStateInternal IJournalState.GetJournalState(JournalReason journalReason)
         {
             if (journalReason != JournalReason.NewContentNavigation)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialogException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PrintDialogException.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Controls
             : base(message, innerException)
         {
         }
-
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         /// <summary>
         /// 
         /// </summary>
@@ -65,7 +65,7 @@ namespace System.Windows.Controls
             : base(info, context)
         {
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         #endregion Constructors
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ValueUnavailableException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ValueUnavailableException.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Data
         public ValueUnavailableException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         ///<summary>
         /// Constructor
         ///</summary>
@@ -52,7 +52,7 @@ namespace System.Windows.Data
                                             System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         #endregion Constructors
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParseException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlParseException.cs
@@ -229,6 +229,7 @@ namespace System.Windows.Markup
         /// as well as a means for serialization to retain that context and an
         /// additional caller-defined context.
         /// </param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected XamlParseException(
             SerializationInfo info,
             StreamingContext context
@@ -238,7 +239,7 @@ namespace System.Windows.Markup
             _lineNumber = info.GetInt32("Line");
             _linePosition = info.GetInt32("Position");
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         /// <summary>
         /// Populates a SerializationInfo with the data needed to serialize the target object.
         /// </summary>
@@ -253,13 +254,16 @@ namespace System.Windows.Markup
 #if ! PBTCOMPILER
 #else
 #endif
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
             info.AddValue("Line", (Int32)_lineNumber);
             info.AddValue("Position", (Int32)_linePosition);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         #endregion Serialization
 
         #region internal helper methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/Journal.cs
@@ -433,7 +433,7 @@ namespace System.Windows.Navigation
             int index = _journalEntryList.IndexOf(target);
 
             // When navigating back to a page which contains a previously navigated frame a 
-            // saved journal entry is replayed to restore the frame’s location, in many cases 
+            // saved journal entry is replayed to restore the frame's location, in many cases 
             // this entry is not in the journal.
             if (index > -1)
             {
@@ -464,6 +464,7 @@ namespace System.Windows.Navigation
         //  What happens to a bunch of PageFunctions, some of which are KeepAlive
         // and some of which are not? We'll get "holes" in the "call stack" when we go
         // back.
+#pragma warning disable SYSLIB0050
         internal void PruneKeepAliveEntries()
         {
             for (int i = TotalCount - 1; i >= 0; --i)
@@ -490,6 +491,7 @@ namespace System.Windows.Navigation
                 }
             }
         }
+#pragma warning restore SYSLIB0050
 
         /// <remarks> The caller is responsible for calling UpdateView(). </remarks>
         internal JournalEntry RemoveEntryInternal(int index)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -3189,6 +3189,7 @@ namespace System.Windows.Navigation
         /// Makes the appropriate kind of journal entry for the current Content and its state.
         /// For certain types of content, no journal entry is created (null is returned).
         /// </summary>
+#pragma warning disable SYSLIB0050
         internal JournalEntry MakeJournalEntry(JournalReason journalReason)
         {
             if (_bp == null)
@@ -3387,7 +3388,7 @@ namespace System.Windows.Navigation
 
             return journalEntry;
         }
-
+#pragma warning restore SYSLIB0050
         /// <summary>
         /// Called by ApplicationProxyInternal when a XAML Browser Application is about to be shut down
         /// and the entire journal needs to be serialized.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceKeyNotFoundException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourceReferenceKeyNotFoundException.cs
@@ -35,7 +35,7 @@ namespace System.Windows
         {
             _resourceKey = resourceKey;
         }
-
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         ///<summary>
         /// Constructor (required for Xml web service)
         ///</summary>
@@ -43,7 +43,7 @@ namespace System.Windows
         {
             _resourceKey = info.GetValue("Key", typeof(object));
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         ///<summary>
         /// LineNumber that the exception occured on.
         ///</summary>
@@ -62,12 +62,15 @@ namespace System.Windows
         /// <param name="context">
         /// The destination for this serialization.
         /// </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
             info.AddValue("Key", _resourceKey);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         private object _resourceKey;
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1104,7 +1104,9 @@ namespace System.Windows
         protected ResourceReferenceKeyNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ResourceReferenceKeyNotFoundException(string message, object resourceKey) { }
         public object Key { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class RoutedPropertyChangedEventArgs<T> : System.Windows.RoutedEventArgs
     {
@@ -11409,7 +11411,9 @@ namespace System.Windows.Markup
         public int LinePosition { get { throw null; } }
         public string NameContext { get { throw null; } }
         public string UidContext { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class XamlReader
     {
@@ -11974,7 +11978,9 @@ namespace System.Windows.Navigation
         public System.Uri Source { get { throw null; } set { } }
         public static bool GetKeepAlive(System.Windows.DependencyObject dependencyObject) { throw null; }
         public static string GetName(System.Windows.DependencyObject dependencyObject) { throw null; }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
         public static void SetKeepAlive(System.Windows.DependencyObject dependencyObject, bool keepAlive) { }
         public static void SetName(System.Windows.DependencyObject dependencyObject, string name) { }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/XpsViewerException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/XpsViewerException.cs
@@ -57,6 +57,7 @@ namespace MS.Internal.Documents.Application
         internal XpsViewerException(string message, Exception innerException)
             : base(message, innerException)
         {}
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         /// <summary>
         /// Initializes a new instance of the XpsViewerException class with serialized data.
         /// </summary>
@@ -65,7 +66,7 @@ namespace MS.Internal.Documents.Application
         protected XpsViewerException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Exceptions/XpsException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Exceptions/XpsException.cs
@@ -57,6 +57,7 @@ namespace System.Windows.Xps
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected
         XpsException(
             SerializationInfo   info,
@@ -65,7 +66,7 @@ namespace System.Windows.Xps
             : base(info, context)
         {
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         #endregion Constructors
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintSystemExceptions/PrintSystemException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintSystemExceptions/PrintSystemException.cs
@@ -145,6 +145,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override
         void
         GetObjectData(
@@ -154,6 +156,8 @@ namespace System.Printing
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 
         ///<summary>
         ///
@@ -199,6 +203,7 @@ namespace System.Printing
         /// </summary>
         /// <param name="info"> The object that holds the serialized object data. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected
         PrintSystemException(
             System.Runtime.Serialization.SerializationInfo  info,
@@ -206,6 +211,7 @@ namespace System.Printing
             ) : base(info, context)
         {
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         /// <summary>
         /// Loads the resource string for a given resource key.
@@ -397,6 +403,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override
         void
         GetObjectData(
@@ -410,7 +418,8 @@ namespace System.Printing
             }
             base.GetObjectData(info, context);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         ///<summary>
         ///
         ///</summary>
@@ -561,6 +570,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override
         void
         GetObjectData(
@@ -575,7 +586,8 @@ namespace System.Printing
 
             base.GetObjectData(info, context);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         ///<summary>
         ///
         ///</summary>
@@ -712,6 +724,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override
         void
         GetObjectData(
@@ -728,7 +742,8 @@ namespace System.Printing
 
             base.GetObjectData(info, context);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         ///<summary>
         ///
         ///</summary>
@@ -914,6 +929,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override
         void
         GetObjectData(
@@ -927,7 +944,8 @@ namespace System.Printing
             }
             base.GetObjectData(info, context);
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
         /// <summary>
         /// PrintJobException constructor.
         /// </summary>
@@ -1267,6 +1285,7 @@ namespace System.Printing
         /// </summary>
         /// <param name="info"> The object that holds the serialized object data. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected PrintingNotSupportedException(
             System.Runtime.Serialization.SerializationInfo info,
             System.Runtime.Serialization.StreamingContext context
@@ -1274,6 +1293,7 @@ namespace System.Printing
             : base(info, context)
         {
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         /// <summary>
         /// Sets the SerializationInfo with information about the exception.
@@ -1283,6 +1303,8 @@ namespace System.Printing
         /// </remarks>
         /// <param name="info"> Holds the serialized object data about the exception being thrown. </param>
         /// <param name="context"> The contextual information about the source or destination. </param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(
             System.Runtime.Serialization.SerializationInfo info,
             System.Runtime.Serialization.StreamingContext context
@@ -1290,5 +1312,7 @@ namespace System.Printing
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
     };
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/ref/ReachFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/ref/ReachFramework.cs
@@ -380,7 +380,9 @@ namespace System.Printing
         public System.Collections.ObjectModel.Collection<string> CommittedAttributesCollection { get { throw null; } }
         public System.Collections.ObjectModel.Collection<string> FailedAttributesCollection { get { throw null; } }
         public string PrintObjectName { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class PrintingCanceledException : System.Printing.PrintJobException
     {
@@ -399,7 +401,9 @@ namespace System.Printing
         protected PrintingNotSupportedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public PrintingNotSupportedException(string message) { }
         public PrintingNotSupportedException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class PrintJobException : System.Printing.PrintSystemException
     {
@@ -414,7 +418,9 @@ namespace System.Printing
         public int JobId { get { throw null; } }
         public string JobName { get { throw null; } }
         public string PrintQueueName { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class PrintQueueException : System.Printing.PrintSystemException
     {
@@ -426,7 +432,9 @@ namespace System.Printing
         public PrintQueueException(string message) { }
         public PrintQueueException(string message, System.Exception innerException) { }
         public string PrinterName { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class PrintServerException : System.Printing.PrintSystemException
     {
@@ -437,7 +445,9 @@ namespace System.Printing
         public PrintServerException(string message) { }
         public PrintServerException(string message, System.Exception innerException) { }
         public string ServerName { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class PrintSystemException : System.SystemException
     {
@@ -448,7 +458,9 @@ namespace System.Printing
         protected PrintSystemException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public PrintSystemException(string message) { }
         public PrintSystemException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public sealed partial class PrintTicket : System.ComponentModel.INotifyPropertyChanged
     {

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/ref/System.Printing.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/ref/System.Printing.cs
@@ -616,7 +616,9 @@ namespace System.Printing.IndexedProperties
         public void Add(System.Printing.IndexedProperties.PrintProperty attributeValue) { }
         public void Dispose() { }
         protected virtual void Dispose(bool A_0) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
         public System.Printing.IndexedProperties.PrintProperty GetProperty(string attribName) { throw null; }
         public override void OnDeserialization(object sender) { }
         public void SetProperty(string attribName, System.Printing.IndexedProperties.PrintProperty attribValue) { }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
@@ -19,10 +19,11 @@ namespace MS.Internal.Xaml.Parser
                 : base(message)
             {
             }
-
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
             protected TypeNameParserException(SerializationInfo si, StreamingContext sc) : base(si, sc)
             {
             }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         }
 
         private GenericTypeNameScanner _scanner;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -276,14 +276,14 @@ namespace System.Xaml.Schema
                 object inst = CallCtorDelegate(type);
                 return inst;
             }
-
+#pragma warning disable SYSLIB0050
             private static object CallCtorDelegate(XamlTypeInvoker type)
             {
                 object inst = FormatterServices.GetUninitializedObject(type._xamlType.UnderlyingType);
                 InvokeDelegate(type._constructorDelegate, inst);
                 return inst;
             }
-
+#pragma warning restore SYSLIB0050
             private static void InvokeDelegate(Action<object> action, object argument)
             {
                 action.Invoke(argument);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
@@ -61,6 +61,7 @@ namespace System.Xaml
             :base(message) { }
 
         // FxCop required this.
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected XamlException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -68,10 +69,13 @@ namespace System.Xaml
             LineNumber = info.GetInt32("Line");
             LinePosition = info.GetInt32("Offset");
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
 #if TARGETTING35SP1
 #else
 #endif
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             ArgumentNullException.ThrowIfNull(info);
@@ -81,6 +85,8 @@ namespace System.Xaml
             base.GetObjectData(info, context);
         }
     }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 
     [Serializable]  // FxCop advised this be Serializable.
     public class XamlParseException : XamlException
@@ -162,6 +168,8 @@ namespace System.Xaml
 #if TARGETTING35SP1
 #else
 #endif
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             ArgumentNullException.ThrowIfNull(info);
@@ -170,6 +178,8 @@ namespace System.Xaml
             base.GetObjectData(info, context);
         }
     }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 
     [Serializable]  // FxCop advised this be Serializable.
     public class XamlInternalException : XamlException

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml.cs
@@ -495,7 +495,9 @@ namespace System.Xaml
         public XamlDuplicateMemberException(System.Xaml.XamlMember member, System.Xaml.XamlType type) { }
         public System.Xaml.XamlMember DuplicateMember { get { throw null; } set { } }
         public System.Xaml.XamlType ParentType { get { throw null; } set { } }
+        #pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        #pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class XamlException : System.Exception
     {
@@ -507,7 +509,9 @@ namespace System.Xaml
         public int LineNumber { get { throw null; } protected set { } }
         public int LinePosition { get { throw null; } protected set { } }
         public override string Message { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class XamlInternalException : System.Xaml.XamlException
     {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ElementNotAvailableException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ElementNotAvailableException.cs
@@ -64,19 +64,25 @@ namespace System.Windows.Automation
         /// <internalonly>
         /// Initializes a new instance of the ElementNotAvailableException class with serialized data.
         /// </internalonly>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected ElementNotAvailableException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             HResult = UiaCoreTypesApi.UIA_E_ELEMENTNOTAVAILABLE;
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         /// <summary>
         /// Populates a SerializationInfo with the data needed to serialize the target object.
         /// </summary>
         /// <param name="info">The SerializationInfo to populate with data.</param>
         /// <param name="context">The destination for this serialization.</param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ElementNotEnabledException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ElementNotEnabledException.cs
@@ -55,20 +55,25 @@ namespace System.Windows.Automation
         /// <internalonly>
         /// Constructor for serialization
         /// </internalonly>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected ElementNotEnabledException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             HResult = UiaCoreTypesApi.UIA_E_ELEMENTNOTENABLED;
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         /// <summary>
         /// Populates a SerializationInfo with the data needed to serialize the target object.
         /// </summary>
         /// <param name="info">The SerializationInfo to populate with data.</param>
         /// <param name="context">The destination for this serialization.</param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/NoClickablePointException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/NoClickablePointException.cs
@@ -45,17 +45,23 @@ namespace System.Windows.Automation
         /// <internalonly>
         /// Constructor for serialization
         /// </internalonly>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected NoClickablePointException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         /// <summary>
         /// Populates a SerializationInfo with the data needed to serialize the target object.
         /// </summary>
         /// <param name="info">The SerializationInfo to populate with data.</param>
         /// <param name="context">The destination for this serialization.</param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ProxyAssemblyNotLoadedException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/ProxyAssemblyNotLoadedException.cs
@@ -52,17 +52,23 @@ namespace System.Windows.Automation
         /// <internalonly>
         /// Constructor for serialization
         /// </internalonly>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected ProxyAssemblyNotLoadedException(SerializationInfo info, StreamingContext context) : base(info, context) {}
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
 
         /// <summary>
         /// Populates a SerializationInfo with the data needed to serialize the target object.
         /// </summary>
         /// <param name="info">The SerializationInfo to populate with data.</param>
         /// <param name="context">The destination for this serialization.</param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/ref/UIAutomationTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/ref/UIAutomationTypes.cs
@@ -215,7 +215,9 @@ namespace System.Windows.Automation
         protected ElementNotAvailableException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ElementNotAvailableException(string message) { }
         public ElementNotAvailableException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public partial class ElementNotEnabledException : System.InvalidOperationException
     {
@@ -223,7 +225,9 @@ namespace System.Windows.Automation
         protected ElementNotEnabledException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ElementNotEnabledException(string message) { }
         public ElementNotEnabledException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public static partial class ExpandCollapsePatternIdentifiers
     {
@@ -273,7 +277,9 @@ namespace System.Windows.Automation
         protected NoClickablePointException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public NoClickablePointException(string message) { }
         public NoClickablePointException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public sealed partial class NotificationEventArgs : System.Windows.Automation.AutomationEventArgs
     {
@@ -295,7 +301,9 @@ namespace System.Windows.Automation
         protected ProxyAssemblyNotLoadedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ProxyAssemblyNotLoadedException(string message) { }
         public ProxyAssemblyNotLoadedException(string message, System.Exception innerException) { }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public static partial class RangeValuePatternIdentifiers
     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
@@ -130,6 +130,7 @@ namespace System.Security.RightsManagement
         /// </summary>
         /// <param name="info">The object that holds the serialized object data.</param>
         /// <param name="context">The contextual information about the source or destination.</param>
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         protected RightsManagementException(SerializationInfo info, StreamingContext context) : 
                                                     base(info, context)
         {
@@ -137,12 +138,14 @@ namespace System.Security.RightsManagement
                                                          // we do not check the validity of the failureCode range , as it might contain a generic 
                                                          //  HR code, not covered by the RightsManagementFailureCode enumeration 
         }
-
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
         /// <summary>
         /// Sets the SerializationInfo object with the Failure Code and additional exception information. 
         /// </summary>
         /// <param name="info">The object that holds the serialized object data.</param>
         /// <param name="context">The contextual information about the source or destination.</param>
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -151,6 +154,8 @@ namespace System.Security.RightsManagement
             base.GetObjectData(info, context);
             info.AddValue(_serializationFailureCodeAttributeName, (Int32)_failureCode);
         }
+#pragma warning restore SYSLIB0051 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 
         /// <summary>
         /// Returns the specific error code that can be used to indetify and mitigate the reason which caused the exception.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
@@ -493,7 +493,9 @@ namespace System.Security.RightsManagement
         public RightsManagementException(string message) { }
         public RightsManagementException(string message, System.Exception innerException) { }
         public System.Security.RightsManagement.RightsManagementFailureCode FailureCode { get { throw null; } }
+#pragma warning disable CS0672 // Member overrides obsolete member
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
     }
     public enum RightsManagementFailureCode
     {


### PR DESCRIPTION
Disable warnings.
CS0672 : https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0672
SYSLIB0011 : https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0011
SYSLIB0051 : obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.'
SYSLIB0050: obsolete: 'Formatter-based serialization is obsolete and should not be used.'

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7780)