### PR TITLE
Improve font performance in FamilyCollection.LookupFamily

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -413,7 +413,7 @@ namespace MS.Internal.FontCache
                 {
                     // To obtain the face name, we remove the family name and the next char (A space) from the original family name.
                     int faceNameIndex = familyName.Length + 1;
-                    ReadOnlySpan<char> faceName = originalFamilyName.AsSpan(faceNameIndex, originalFamilyName.Length - faceNameIndex);
+                    ReadOnlySpan<char> faceName = originalFamilyName.AsSpan(faceNameIndex);
                     Text.TextInterface.Font font = GetFontFromFamily(fontFamilyDWrite, faceName);
 
                     if (font != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FamilyCollection.cs
@@ -382,7 +382,7 @@ namespace MS.Internal.FontCache
                 // For example, "Arial Bold"
                 // We will strip off the styling info (one word at a time from the end) and try to find the family name.
                 int indexOfSpace = -1;
-                System.Text.StringBuilder potentialFaceName = new System.Text.StringBuilder();
+                string originalFamilyName = familyName;
 
                 // Start removing off strings from the end hoping they are
                 // style info so as to get down to the family name.
@@ -396,12 +396,11 @@ namespace MS.Internal.FontCache
                     else
                     {
                         // store the stripped off style names to look for the specific face later.
-                        potentialFaceName.Insert(0, familyName.AsSpan(indexOfSpace));
                         familyName = familyName.Substring(0, indexOfSpace);
                     }
 
                     fontFamilyDWrite = _fontCollection[familyName];
-} while (fontFamilyDWrite == null);
+                } while (fontFamilyDWrite == null);
 
 
                 if (fontFamilyDWrite == null)
@@ -410,10 +409,12 @@ namespace MS.Internal.FontCache
                 }
 
                 // If there was styling information.
-                if (potentialFaceName.Length > 0)
+                if (familyName.Length != originalFamilyName.Length)
                 {
-                    // The first character in the potentialFaceName will be a space so we need to strip it off.
-                    Text.TextInterface.Font font = GetFontFromFamily(fontFamilyDWrite, potentialFaceName.ToString(1, potentialFaceName.Length - 1));
+                    // To obtain the face name, we remove the family name and the next char (A space) from the original family name.
+                    int faceNameIndex = familyName.Length + 1;
+                    ReadOnlySpan<char> faceName = originalFamilyName.AsSpan(faceNameIndex, originalFamilyName.Length - faceNameIndex);
+                    Text.TextInterface.Font font = GetFontFromFamily(fontFamilyDWrite, faceName);
 
                     if (font != null)
                     {
@@ -464,10 +465,8 @@ namespace MS.Internal.FontCache
         /// <param name="fontFamily">The font family to look in.</param>
         /// <param name="faceName">The face to look for.</param>
         /// <returns>The font face if found and null if nothing was found.</returns>
-        private static Text.TextInterface.Font GetFontFromFamily(Text.TextInterface.FontFamily fontFamily, string faceName)
+        private static Text.TextInterface.Font GetFontFromFamily(Text.TextInterface.FontFamily fontFamily, ReadOnlySpan<char> faceName)
         {
-            faceName = faceName.ToUpper(CultureInfo.InvariantCulture);
-
             // The search that DWrite supports is a linear search.
             // Look at every font face.
             foreach (Text.TextInterface.Font font in fontFamily)
@@ -475,8 +474,7 @@ namespace MS.Internal.FontCache
                 // and at every locale name this font face has.
                 foreach (KeyValuePair<CultureInfo, string> name in font.FaceNames)
                 {
-                    string currentFontName = name.Value.ToUpper(CultureInfo.InvariantCulture);
-                    if (currentFontName == faceName)
+                    if (faceName.Equals(name.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         return font;
                     }
@@ -488,7 +486,7 @@ namespace MS.Internal.FontCache
             // thus we will start again removing words (separated by ' ') from its end and looking
             // for the resulting faceName in that dictionary. So this dictionary is 
             // used to speed the search.
-            Dictionary<string, Text.TextInterface.Font> faces = new Dictionary<string, Text.TextInterface.Font>();
+            Dictionary<string, Text.TextInterface.Font> faces = new Dictionary<string, Text.TextInterface.Font>(StringComparer.OrdinalIgnoreCase);
 
             //We could have merged this loop with the one above. However this will degrade the performance 
             //of the scenario where the user entered  a correct face name (which is the common scenario).
@@ -498,8 +496,7 @@ namespace MS.Internal.FontCache
             {
                 foreach (KeyValuePair<CultureInfo, string> name in font.FaceNames)
                 {
-                    string currentFontName = name.Value.ToUpper(CultureInfo.InvariantCulture);
-                    faces.TryAdd(currentFontName, font);
+                    faces.TryAdd(name.Value, font);
                 }
             }
 
@@ -509,8 +506,8 @@ namespace MS.Internal.FontCache
 
             while (indexOfSpace > 0)
             {
-                faceName = faceName.Substring(0, indexOfSpace);
-                if (faces.TryGetValue(faceName, out matchingFont))
+                faceName = faceName.Slice(0, indexOfSpace);
+                if (faces.TryGetValue(faceName.ToString(), out matchingFont))
                 {
                     return matchingFont;
                 }


### PR DESCRIPTION
## Description
I improved performance and allocations by using spans and using ordinal ignore case comparison instead of allocating new strings with ToUpper.

Here's the result of my benchmark (I'll post the code soon):
``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 10 (10.0.19045.2846/22H2/2022Update)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100-preview.3.23178.7
  [Host]     : .NET 8.0.0 (8.0.23.17408), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.17408), X64 RyuJIT AVX2


```
|          Method | id |   familyName |       fontCollection |         Mean |      Error |     StdDev |       Median | Ratio | RatioSD | Code Size |   Gen0 | Allocated | Alloc Ratio |
|---------------- |--- |------------- |--------------------- |-------------:|-----------:|-----------:|-------------:|------:|--------:|----------:|-------:|----------:|------------:|
| **LookupFamilyOld** |  **1** |        **Font1** | **Syste(...)mily] [80]** |    **15.032 ns** |  **0.1291 ns** |  **0.1145 ns** |    **15.070 ns** |  **1.00** |    **0.00** |   **1,843 B** | **0.0331** |     **104 B** |        **1.00** |
| LookupFamilyNew |  1 |        Font1 | Syste(...)mily] [80] |     4.219 ns |  0.1353 ns |  0.1130 ns |     4.243 ns |  0.28 |    0.01 |   3,364 B |      - |         - |        0.00 |
|                 |    |              |                      |              |            |            |              |       |         |           |        |           |             |
| **LookupFamilyOld** |  **2** |  **Font1 Face1** | **Syste(...)mily] [80]** |   **319.038 ns** | **14.1718 ns** | **41.7859 ns** |   **291.383 ns** |  **1.00** |    **0.00** |   **4,155 B** | **0.1783** |     **560 B** |        **1.00** |
| LookupFamilyNew |  2 |  Font1 Face1 | Syste(...)mily] [80] |   171.464 ns |  1.3229 ns |  1.1727 ns |   171.683 ns |  0.52 |    0.07 |   2,536 B | 0.1044 |     328 B |        0.59 |
|                 |    |              |                      |              |            |            |              |       |         |           |        |           |             |
| **LookupFamilyOld** |  **3** |  **Font1 Face5** | **Syste(...)mily] [80]** |   **426.723 ns** |  **5.4717 ns** |  **7.8474 ns** |   **428.868 ns** |  **1.00** |    **0.00** |   **4,155 B** | **0.1373** |     **432 B** |        **1.00** |
| LookupFamilyNew |  3 |  Font1 Face5 | Syste(...)mily] [80] |   232.649 ns |  3.8664 ns |  3.4275 ns |   233.997 ns |  0.55 |    0.01 |   2,536 B | 0.0229 |      72 B |        0.17 |
|                 |    |              |                      |              |            |            |              |       |         |           |        |           |             |
| **LookupFamilyOld** |  **4** | **Font1 Face50** | **Syste(...)mily] [80]** | **2,531.224 ns** | **27.8396 ns** | **42.5140 ns** | **2,550.462 ns** |  **1.00** |    **0.00** |   **4,155 B** | **0.7057** |    **2216 B** |        **1.00** |
| LookupFamilyNew |  4 | Font1 Face50 | Syste(...)mily] [80] | 1,499.158 ns | 14.6092 ns | 13.6655 ns | 1,502.840 ns |  0.59 |    0.01 |   2,536 B | 0.0229 |      72 B |        0.03 |

## Customer Impact
Better perf.

## Regression
No.

## Testing
I ran FamilyCollection.LookupFamily with different combinations to make sure that the result was the same.

## Risk
Low.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7794)