### PR TITLE
Re-enabling test on CI

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -249,40 +249,40 @@ jobs:
           workingDirectory: '$(System.ArtifactsDirectory)\testbins'
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
       
-      # - task: CopyFiles@2
-      #   inputs:
-      #     SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
-      #     Contents: '**'
-      #     TargetFolder: '$(System.DefaultWorkingDirectory)\Results\'
-      #     CleanTargetFolder: true
-      #     OverWrite: true
-      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
+          Contents: '**'
+          TargetFolder: '$(System.DefaultWorkingDirectory)\Results\'
+          CleanTargetFolder: true
+          OverWrite: true
+        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
         
-      # - task: CopyFiles@2
-      #   inputs:
-      #     SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
-      #     Contents: '**'
-      #     TargetFolder: '$(System.DefaultWorkingDirectory)\ResultsX86\'
-      #     CleanTargetFolder: true
-      #     OverWrite: true
-      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
+      - task: CopyFiles@2
+        inputs:
+          SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
+          Contents: '**'
+          TargetFolder: '$(System.DefaultWorkingDirectory)\ResultsX86\'
+          CleanTargetFolder: true
+          OverWrite: true
+        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
 
-      # - task: PublishPipelineArtifact@1
-      #   inputs:
-      #     artifactName: 'TestResultsX64'
-      #     targetPath: '$(System.DefaultWorkingDirectory)\Results\'      
-      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: 'TestResultsX64'
+          targetPath: '$(System.DefaultWorkingDirectory)\Results\'      
+        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
 
-      # - task: PublishPipelineArtifact@1
-      #   inputs:
-      #     artifactName: 'TestResultsX86'
-      #     targetPath: '$(System.DefaultWorkingDirectory)\ResultsX86\'
-      #   condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: 'TestResultsX86'
+          targetPath: '$(System.DefaultWorkingDirectory)\ResultsX86\'
+        condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
           
-      # - task: PublishTestResults@2
-      #   inputs:
-      #     testResultsFormat: 'XUnit'
-      #     testResultsFiles: 'testResults.xml'
-      #     searchFolder: '$(System.DefaultWorkingDirectory)\Results\'
-      #     testRunTitle: 'CTP results'
-      #     condition: eq(variables['System.TeamProject'], 'public')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'XUnit'
+          testResultsFiles: 'testResults.xml'
+          searchFolder: '$(System.DefaultWorkingDirectory)\Results\'
+          testRunTitle: 'CTP results'
+          condition: eq(variables['System.TeamProject'], 'public')


### PR DESCRIPTION

## Description
Undoes #7775, since we have fixed the pipeline issue, we are re-enabling tests in the pipeline.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
DRTs will now run whenever a PR is triggered and users can check the results for feedbacks.
<!-- What is the impact to customers of not taking this fix? -->
## Testing
CI Build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7809)