### PR TITLE
Replace String.CompareOrdinal to string.Equals Part 3

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/PseudoWebRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/PseudoWebRequest.cs
@@ -331,7 +331,7 @@ namespace MS.Internal.IO.Packaging
         //------------------------------------------------------
         private bool IsScheme(String schemeName)
         {
-            return (String.CompareOrdinal(_innerUri.Scheme, schemeName) == 0);
+            return (string.Equals(_innerUri.Scheme, schemeName, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/clipboard.cs
@@ -762,8 +762,8 @@ namespace System.Windows
         {
             bool autoConvert;
 
-            if (String.CompareOrdinal(format, DataFormats.FileDrop) == 0 ||
-                String.CompareOrdinal(format, DataFormats.Bitmap) == 0)
+            if (string.Equals(format, DataFormats.FileDrop, StringComparison.Ordinal) ||
+                string.Equals(format, DataFormats.Bitmap, StringComparison.Ordinal))
             {
                 autoConvert = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -2177,7 +2177,7 @@ namespace System.Windows
         /// </summary>
         private static bool IsFormatEqual(string format1, string format2)
         {
-            return (String.CompareOrdinal(format1, format2) == 0);
+            return (string.Equals(format1, format2, StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/ContentDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/ContentDescriptor.cs
@@ -49,8 +49,8 @@ namespace MS.Internal.IO.Packaging
             // Note that because of the GetType() checking above, the casting must be valid.
             ElementTableKey otherElement = (ElementTableKey)other;
 
-            return (   String.CompareOrdinal(BaseName,otherElement.BaseName) == 0
-                && String.CompareOrdinal(XmlNamespace,otherElement.XmlNamespace) == 0 );
+            return (   string.Equals(BaseName, otherElement.BaseName, StringComparison.Ordinal)
+                && string.Equals(XmlNamespace, otherElement.XmlNamespace, StringComparison.Ordinal) );
         }
             
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -2887,7 +2887,7 @@ namespace System.Windows.Markup
 
 #if !PBTCOMPILER
             // Optimize for SystemMetric types that are very frequently used.
-            if (string.CompareOrdinal(xmlns, XamlReaderHelper.DefaultNamespaceURI) == 0)
+            if (string.Equals(xmlns, XamlReaderHelper.DefaultNamespaceURI, StringComparison.Ordinal))
             {
                 switch (typeString)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -81,8 +81,8 @@ namespace MS.Internal.IO.Packaging
                     //Note: For Byte order markings that require additional information to be specified in
                     //the encoding attribute in XmlDeclaration have already been ruled out by this check as we allow for
                     //only two valid values.
-                    if (String.CompareOrdinal(encoding, _webNameUTF8) == 0
-                        || String.CompareOrdinal(encoding, _webNameUnicode) == 0)
+                    if (string.Equals(encoding, _webNameUTF8, StringComparison.Ordinal)
+                        || string.Equals(encoding, _webNameUnicode, StringComparison.Ordinal))
                         return;
                     else
                         //if the encoding attribute has any other value we throw an exception


### PR DESCRIPTION
## Description

We can use `string.Equals(string1, string2, StringComparison.Ordinal)` to check for equality, see https://learn.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings and https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings

> Use the [String.Compare](https://learn.microsoft.com/en-us/dotnet/api/system.string.compare) and [String.CompareTo](https://learn.microsoft.com/en-us/dotnet/api/system.string.compareto) methods to sort strings, not to check for equality.

Reference: https://github.com/dotnet/wpf/issues/7834

## Customer Impact

Small performance improvements

## Regression

None.

## Testing

Just CI.

## Risk

Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7833)