### PR TITLE
Removing xamltypemapper clearance from finally in compile function

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -225,8 +225,7 @@ namespace MS.Internal
             {
                 // Don't rely on next compilation to reset as that would unnecessarily delay
                 // garbage collection of this static data that cannot be reused by the next compilation.
-                // Also, the ReflectionHelper must be disposed now to release file locks on assemblies.
-                XamlTypeMapper.Clear();
+                // Also, the ReflectionHelper must be disposed now to release file locks on assemblies
                 KnownTypes.Clear();
                 ReflectionHelper.Dispose();
             }


### PR DESCRIPTION
Fixes #7439

## Description

Removing call to XamlTyperMapper.Clear() function from finally block in compile function as the static members `HasInternal` is refrenced at the later part of codeflow and it is unsafe to clear the static members at this point of time. That being said, XamlTypeMapper gets clear in the next iteration of call to compile function.

## Customer Impact

Application having user control with internal constructors will crash.

## Regression

NA

## Testing

In-progress

## Risk

Assessing


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7846)