### PR TITLE
Fix Intellisense in Visual Studio for wpf

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>
-    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20220822.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>7.0.0-preview-20221010.1</MicrosoftPrivateIntellisenseVersion>
   </PropertyGroup>
   <!-- Packages that come from https://github.com/dotnet/arcade -->
   <PropertyGroup>

--- a/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
+++ b/eng/WpfArcadeSdk/tools/ReferenceAssembly.targets
@@ -1,6 +1,6 @@
 <Project>
    <PropertyGroup>
-    <_DotnetApiDocsFilesRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', '$(_DotnetApiDocsPackageName.ToLower())', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'windowsdesktop', '1033'))</_DotnetApiDocsFilesRoot>
+    <_DotnetApiDocsFilesRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'microsoft.private.intellisense', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'windowsdesktop', '1033'))</_DotnetApiDocsFilesRoot>
   </PropertyGroup>
 
   <ItemGroup>
@@ -67,11 +67,11 @@
       <IntellisenseXmlFile>$(IntellisenseXmlDir)$(AssemblyName).xml</IntellisenseXmlFile>
     </PropertyGroup>
 
-    <Message Condition="!Exists('$(IntellisenseXmlFile)')"
-             Text="$(IntellisenseXmlFile) is missing" />
+    <Message Condition="!Exists('$(IntellisenseXmlFileSource)')"
+             Text="$(IntellisenseXmlFileSource) is missing" />
     
-    <Copy SourceFiles="$(IntellisenseXmlFile)"
-          Condition="Exists('$(IntellisenseXmlFile)')"
+    <Copy SourceFiles="$(IntellisenseXmlFileSource)"
+          Condition="Exists('$(IntellisenseXmlFileSource)')"
           DestinationFolder="$(ReferenceAssemblyDir)"          
           SkipUnchangedFiles="true"/>
   </Target>


### PR DESCRIPTION
Fixes #7753 
Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description
Visual Studio Intellisense wasn't working for wpf. Fixed the intellisense file sources and bumped up the version.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Customers won't be able to see intellisense for wpf projects in visual studio.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7905)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7906)