### PR TITLE
Fix InputEventArgs.Timestamp field

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputEventArgs.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Input
         }
 
         private InputDevice _inputDevice;
-        private static int _timestamp;
+        private int _timestamp;
      }
 }
 


### PR DESCRIPTION
Fixes #7887

`InputEventArgs.Timestamp` field should not be static.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7910)