### PR TITLE
Fix sc Color.ToString()

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -286,7 +286,7 @@ namespace System.Windows.Media
                     // Helper to get the numeric list separator for a given culture.
                     char separator = MS.Internal.TokenizerHelper.GetNumericListSeparator(provider);
                     return string.Format(provider,
-                        $"sc#{{1:{format}}}{{0}} {{{format}}}{{0}} {{3:{format}}}{{0}} {{4:{format}}}",
+                        $"sc#{{1:{format}}}{{0}} {{2:{format}}}{{0}} {{3:{format}}}{{0}} {{4:{format}}}",
                         separator, scRgbColor.a, scRgbColor.r, scRgbColor.g, scRgbColor.b);
                 }
             }


### PR DESCRIPTION
Fixes #7918

## Description

A recent removal of `StringBuilders` had a bug in there causing `Color.ToString()` throw `FormatException`.

This PR fixes the typo.

## Customer Impact

Customers not taking this fix will continue experiencing exceptions when trying to display the textual representation of colors in scRGB color space.

## Regression

Yes. #6275 

## Testing

Built using 8.0.0-preview.3.23174.8 and verified that the ToString() no longer throws for scRGB colors and the output is formatted correctly.

## Risk

No risk, fixes regression in .NET 7.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/7923)