### PR TITLE
Unseal the `PasswordBox` to to allow it to be extended with, for example, a clear button.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -6302,7 +6302,7 @@ namespace System.Windows.Controls
         VerticalOnly = 2,
     }
     [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.FrameworkElement))]
-    public sealed partial class PasswordBox : System.Windows.Controls.Control
+    public partial class PasswordBox : System.Windows.Controls.Control
     {
         public static readonly System.Windows.DependencyProperty CaretBrushProperty;
         public static readonly System.Windows.DependencyProperty IsInactiveSelectionHighlightEnabledProperty;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Controls
     [Automation(AccessibilityControlType = "Edit")]
 #endif
     [TemplatePart(Name = "PART_ContentHost", Type = typeof(FrameworkElement))]
-    public sealed class PasswordBox : Control, ITextBoxViewHost
+    public class PasswordBox : Control, ITextBoxViewHost
 #if OLD_AUTOMATION
         , IAutomationPatternProvider, IAutomationPropertyProvider
 #endif

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -6308,7 +6308,7 @@ namespace System.Windows.Controls
         VerticalFirst = 5,
     }
     [System.Windows.TemplatePartAttribute(Name="PART_ContentHost", Type=typeof(System.Windows.FrameworkElement))]
-    public sealed partial class PasswordBox : System.Windows.Controls.Control
+    public partial class PasswordBox : System.Windows.Controls.Control
     {
         public static readonly System.Windows.DependencyProperty CaretBrushProperty;
         public static readonly System.Windows.DependencyProperty IsInactiveSelectionHighlightEnabledProperty;


### PR DESCRIPTION
## Description

The change is intended to open up the PasswordBox API and allow the creation of derived classes. I believe that an openly accessible control should not be sealed. In this situation, we either have to rewrite the entire `PasswordBox` or use other tricks instead of conveniently creating a derived class.

## Customer Impact

Until now, it is unlikely that anyone has created derived classes, so we are opening up opportunities rather than taking them away.

## Regression

_Not applicable_

## Testing

PR build

## Risk
Changing the behavior of `PasswordBox` by, for example, adding `OnPasswordChanged(e)` can be risky because of how users use the control.
