### PR TITLE
Updated doc comments for common dialogs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonItemDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonItemDialog.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Win32
 
         /// <summary>
         ///  Resets all properties to their default values.
-        ///  Classes derived from FileDialog are expected to 
+        ///  Classes derived from CommonItemDialog are expected to 
         ///  call Base.Reset() at the beginning of their
         ///  implementation of Reset() if they choose to
         ///  override this function.
@@ -124,7 +124,7 @@ namespace Microsoft.Win32
         public Guid? ClientGuid { get; set; }
 
         /// <summary>
-        ///  Gets or sets the initial directory displayed by the file dialog box
+        ///  Gets or sets the directory displayed by the file dialog box
         ///  if there is not a recently used directory value available.
         /// </summary>
         public string DefaultDirectory
@@ -181,7 +181,9 @@ namespace Microsoft.Win32
         }
 
         /// <summary>
-        ///  Gets or sets the initial directory displayed by the file dialog box.
+        ///  Gets or sets the directory displayed as the navigation root for the dialog.
+        ///  Items in the navigation pane are replaced with the specified item, to guide the user
+        ///  from navigating outside of the namespace.
         /// </summary>
         public string RootDirectory
         {
@@ -202,7 +204,7 @@ namespace Microsoft.Win32
         //
         /// <summary>
         ///  Gets or sets a value indicating whether the dialog box will show
-        ///  Include hidden items regardless of user preferences.
+        ///  hidden and system items regardless of user preferences.
         /// </summary>
         public bool ShowHiddenItems
         {
@@ -275,12 +277,11 @@ namespace Microsoft.Win32
 
         //  Because this class, CommonItemDialog, is the parent class for OpenFileDialog
         //  SaveFileDialog and OpenFolderDialog, this function will perform the common setup tasks
-        //  shared between the dialogs, and will then call RunFileDialog, which is
-        //  overridden in the derived classes to show the correct dialog.
+        //  shared between the dialogs.
         //
         /// <summary>
-        /// Performs initialization work in preparation for calling RunFileDialog
-        /// to show a file open or save dialog box.
+        /// Performs initialization work in preparation
+        /// to show a file open, file save or folder open dialog box.
         /// </summary>
         protected override bool RunDialog(IntPtr hwndOwner)
         {
@@ -467,8 +468,8 @@ namespace Microsoft.Win32
 
         //   If multiple files are selected, we only return the first filename.
         /// <summary>
-        ///  Gets a string containing the full path of the file selected in 
-        ///  the file dialog box.
+        ///  Gets a string containing the full path of the file or folder selected in 
+        ///  the dialog box.
         /// </summary>
         private protected string CriticalItemName
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/FileDialog.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Win32
     /// <summary>
     ///    Provides a common base class for wrappers around both the
     ///    File Open and File Save common dialog boxes.  Derives from
-    ///    CommonDialog.
+    ///    CommonItemDialog.
     ///
     ///    This class is not intended to be derived from except by
     ///    the OpenFileDialog and SaveFileDialog classes.
@@ -183,7 +183,7 @@ namespace Microsoft.Win32
                 }
                 else
                 {
-                    // UNDONE : ChrisAn:  This broke the save file dialog.
+                    // UNDONE : This broke the save file dialog.
                     //string temp = Path.GetFullPath(value); // ensure filename is valid...
                     MutableItemNames = new string[] { value };
                 }
@@ -201,7 +201,6 @@ namespace Microsoft.Win32
             }
         }
 
-        //
         //   The behavior governed by this property depends
         //   on whether CheckFileExists is set and whether the
         //   filter contains a valid extension to use.  For
@@ -213,8 +212,6 @@ namespace Microsoft.Win32
         /// </summary>
         public bool AddExtension { get; set; }
 
-
-        //
         //   FOS_FILEMUSTEXIST is only used for Open dialog
         //   boxes, according to MSDN.  It implies 
         //   FOS_PATHMUSTEXIST and "cannot be used" with a

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFileDialog.cs
@@ -7,7 +7,7 @@
 // Description:
 //              OpenFileDialog is a sealed class derived from FileDialog that
 //              implements File Open dialog-specific functions.  It contains
-//              additional properties relevant only to save dialogs.
+//              additional properties relevant only to open dialogs.
 //
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Win32
         #region Public Properties
 
         /// <summary>
-        ///  Gets a string containing the filename component of the 
+        ///  Gets a string containing the folder name component of the 
         ///  folder selected in the dialog box.
         /// 
         ///  Example:  if FolderName = "c:\windows" ,
@@ -101,7 +101,7 @@ namespace Microsoft.Win32
             {
                 // Use the ItemName property to avoid directly accessing
                 // the _itemNames field, then call Path.GetFileName
-                // to do the actual work of stripping out the file name
+                // to do the actual work of stripping out the folder name
                 // from the path.
                 string safeFN = Path.GetFileName(CriticalItemName);
 
@@ -151,8 +151,8 @@ namespace Microsoft.Win32
 
         //   If multiple folders are selected, we only return the first folder name.
         /// <summary>
-        ///  Gets or sets a string containing the full path of the file or folder selected in 
-        ///  the file dialog box.
+        ///  Gets or sets a string containing the full path of the folder selected in 
+        ///  the folder dialog box.
         /// </summary>
         public string FolderName
         {
@@ -181,7 +181,7 @@ namespace Microsoft.Win32
         }
 
         /// <summary>
-        ///     Gets the file names of all selected files or folders in the dialog box.
+        ///     Gets the folder names of all selected folders in the dialog box.
         /// </summary>
         public string[] FolderNames
         {
@@ -220,7 +220,7 @@ namespace Microsoft.Win32
         #region Public Events
 
         /// <summary>
-        ///  Occurs when the user clicks on the Open or Save button on a file dialog
+        ///  Occurs when the user clicks on the Open button on a folder dialog
         ///  box.  
         /// </summary>
         public event CancelEventHandler FolderOk;
@@ -243,7 +243,7 @@ namespace Microsoft.Win32
         #region Protected Methods
 
         /// <summary>
-        /// Raises the System.Windows.FileDialog.FileOk event.
+        /// Raises the System.Windows.OpenFolderDialog.FolderOk event.
         /// </summary>
         protected override void OnItemOk(CancelEventArgs e)
         {
@@ -300,7 +300,6 @@ namespace Microsoft.Win32
         //  We only perform OpenFolderDialog() specific reset tasks here;
         //  it's the calling code's responsibility to ensure that the
         //  base is initialized first.
-        //
         private void Initialize()
         {
             // FOS_FILEMUSTEXIST

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Win32
         }
 
         /// <summary>
-        ///  Returns a string representation of the file dialog with key information
+        ///  Returns a string representation of the folder dialog with key information
         ///  for debugging purposes.
         /// </summary>
         //   We overload ToString() so that we can provide a useful representation of
@@ -209,7 +209,7 @@ namespace Microsoft.Win32
                 SetOption(FOS.ALLOWMULTISELECT, value);
             }
         }
-        
+
         #endregion Public Properties
 
         //---------------------------------------------------


### PR DESCRIPTION
## Description
Fixing doc comments for Win32 common dialogs ( OpenFileDialog, SaveFileDialog, OpenFolderDialog ) 

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Helps developer avoid confusion and understand the API.
<!-- What is the impact to customers of not taking this fix? -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8009)