### PR TITLE
Adding System.Windows.Media.Animation.BackEase as known type.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006KnownTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006KnownTypes.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Baml2006
             public const Int16 XamlPointCollectionSerializer = 748;
             public const Int16 XamlVector3DCollectionSerializer = 752;
 
-            public const Int16 MaxKnownType = 759;
+            public const Int16 MaxKnownType = 760;
             public const Int16 MaxKnownProperty = 268;
             public const Int16 MinKnownProperty = -268;
 
@@ -853,6 +853,7 @@ namespace System.Windows.Baml2006
                     case 757: t = () => typeof(XmlLanguageConverter); break;
                     case 758: t = () => typeof(XmlNamespaceMapping); break;
                     case 759: t = () => typeof(ZoomPercentageConverter); break;
+                    case 760: t = () => typeof(System.Windows.Media.Animation.BackEase); break;
                     default: t = () => null; break;
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfGeneratedKnownTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfGeneratedKnownTypes.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Baml2006
 {
     partial class WpfSharedBamlSchemaContext : XamlSchemaContext
     {
-        const int KnownTypeCount = 759;
+        const int KnownTypeCount = 760;
 
 
         private WpfKnownType CreateKnownBamlType(short bamlNumber, bool isBamlType, bool useV3Rules)
@@ -777,6 +777,7 @@ namespace System.Windows.Baml2006
                 case 757: return Create_BamlType_XmlLanguageConverter(isBamlType, useV3Rules); // type converter
                 case 758: return Create_BamlType_XmlNamespaceMapping(isBamlType, useV3Rules);
                 case 759: return Create_BamlType_ZoomPercentageConverter(isBamlType, useV3Rules);
+                case 760: return Create_BamlType_BackEase(isBamlType, useV3Rules);
                 default:
                     throw new InvalidOperationException("Invalid BAML number");
             }
@@ -982,6 +983,7 @@ namespace System.Windows.Baml2006
                 case 897706848 : return Create_BamlType_TextBlock(isBamlType, useV3Rules);
                 case 905080928 : return Create_BamlType_FixedDocumentSequence(isBamlType, useV3Rules);
                 case 906240700 : return Create_BamlType_UserControl(isBamlType, useV3Rules);
+                case 907931051 : return Create_BamlType_BackEase(isBamlType, useV3Rules);
                 case 912040738 : return Create_BamlType_TextEffectCollection(isBamlType, useV3Rules);
                 case 916823320 : return Create_BamlType_InputDevice(isBamlType, useV3Rules);
                 case 921174220 : return Create_BamlType_TriggerCollection(isBamlType, useV3Rules);
@@ -11526,6 +11528,17 @@ namespace System.Windows.Baml2006
                                               typeof(System.Windows.Documents.ZoomPercentageConverter),
                                               isBamlType, useV3Rules);
             bamlType.DefaultConstructor = delegate() { return new System.Windows.Documents.ZoomPercentageConverter(); };
+            bamlType.Freeze();
+            return bamlType;
+        }
+
+        private WpfKnownType Create_BamlType_BackEase(bool isBamlType, bool useV3Rules)
+        {
+            var bamlType = new WpfKnownType(this, // SchemaContext
+                760, "BackEase",
+                typeof(System.Windows.Media.Animation.BackEase),
+                isBamlType, useV3Rules);
+            bamlType.DefaultConstructor = delegate () { return new System.Windows.Media.Animation.BackEase(); };
             bamlType.Freeze();
             return bamlType;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/KnownTypes.cs
@@ -829,7 +829,8 @@ namespace System.Windows.Markup
         XmlLanguageConverter,
         XmlNamespaceMapping,
         ZoomPercentageConverter,
-        MaxElement
+        BackEase,
+        MaxElement,
     }
 
     // This enum specifies the IDs we use for known CLR and DP Properties in BAML.
@@ -1670,6 +1671,7 @@ namespace System.Windows.Markup
                 case KnownElements.XmlLanguageConverter: o = new System.Windows.Markup.XmlLanguageConverter();   break;
                 case KnownElements.XmlNamespaceMapping: o = new System.Windows.Data.XmlNamespaceMapping();   break;
                 case KnownElements.ZoomPercentageConverter: o = new System.Windows.Documents.ZoomPercentageConverter();   break;
+                case KnownElements.BackEase: o = new System.Windows.Media.Animation.BackEase();   break;
             }
             return o;
         }
@@ -4963,7 +4965,8 @@ namespace System.Windows.Markup
             case KnownElements.Typography: t = _asmFramework.GetType("System.Windows.Documents.Typography"); break;
             case KnownElements.Underline: t = _asmFramework.GetType("System.Windows.Documents.Underline"); break;
             case KnownElements.ZoomPercentageConverter: t = _asmFramework.GetType("System.Windows.Documents.ZoomPercentageConverter"); break;
-            case KnownElements.DynamicResourceExtension: t = _asmFramework.GetType("System.Windows.DynamicResourceExtension"); break;
+            case KnownElements.BackEase: t = _asmFramework.GetType("System.Windows.Media.Animation.BackEase"); break;
+                case KnownElements.DynamicResourceExtension: t = _asmFramework.GetType("System.Windows.DynamicResourceExtension"); break;
             case KnownElements.DynamicResourceExtensionConverter: t = _asmFramework.GetType("System.Windows.DynamicResourceExtensionConverter"); break;
             case KnownElements.SetterBase: t = _asmFramework.GetType("System.Windows.SetterBase"); break;
             case KnownElements.EventSetter: t = _asmFramework.GetType("System.Windows.EventSetter"); break;
@@ -6311,6 +6314,7 @@ namespace System.Windows.Markup
             case KnownElements.XmlLanguageConverter: t = typeof(System.Windows.Markup.XmlLanguageConverter); break;
             case KnownElements.XmlNamespaceMapping: t = typeof(System.Windows.Data.XmlNamespaceMapping); break;
             case KnownElements.ZoomPercentageConverter: t = typeof(System.Windows.Documents.ZoomPercentageConverter); break;
+            case KnownElements.BackEase: t = typeof(System.Windows.Media.Animation.BackEase); break;
             }
 
             return t;


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/6588


## Description

Adding System.Windows.Media.Animation.BackEase as known type.

And I will add the other `System.Windows.Media.Animation.*` types after I understand how to write correctly.

## Customer Impact

We can create the System.Windows.Media.Animation.BackEase from xaml without reflection.

## Regression

None.

## Testing

Just CI

## Risk

Maybe lost the System.Windows.Media.Animation.BackEase.

// Cc @Kuldeep-MS 
