### PR TITLE
Replace String.CompareOrdinal to string.Equals Final Part

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
@@ -189,7 +189,7 @@ namespace System.Windows.Markup
                 // see http://www.w3.org/International/questions/qa-no-language
                 //
                 // Just treat it the same as xml:lang=""
-                if(String.CompareOrdinal(lowerCaseTag, "und") == 0)
+                if(string.Equals(lowerCaseTag, "und", StringComparison.Ordinal))
                 {
                     lowerCaseTag = String.Empty;
                 }            
@@ -229,7 +229,7 @@ namespace System.Windows.Markup
         {
             if (_specificCulture == null)
             {
-                if (_lowerCaseTag.Length == 0 || String.CompareOrdinal(_lowerCaseTag, "und") == 0)
+                if (_lowerCaseTag.Length == 0 || string.Equals(_lowerCaseTag, "und", StringComparison.Ordinal))
                 {
                     _specificCulture = GetEquivalentCulture();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XamlFilter.cs
@@ -694,7 +694,7 @@ namespace MS.Internal.IO.Packaging
                 return null;
             }
 
-            if (String.CompareOrdinal(elementFullName.BaseName, _glyphRunName) == 0)
+            if (string.Equals(elementFullName.BaseName, _glyphRunName, StringComparison.Ordinal))
             {
                 // Ignore glyph runs during flow pass over a FixedPage.
                 if (_filterState == FilterState.FindNextFlowUnit)
@@ -708,7 +708,7 @@ namespace MS.Internal.IO.Packaging
                 }
             }
 
-            if (String.CompareOrdinal(elementFullName.BaseName, _fixedPageName) == 0)
+            if (string.Equals(elementFullName.BaseName, _fixedPageName, StringComparison.Ordinal))
             {
                 // Ignore FixedPage element (i.e. root element) during flow pass over a fixed page.
                 if (_filterState == FilterState.FindNextFlowUnit)
@@ -723,7 +723,7 @@ namespace MS.Internal.IO.Packaging
                 }
             }
 
-            if (String.CompareOrdinal(elementFullName.BaseName, _pageContentName) == 0)
+            if (string.Equals(elementFullName.BaseName, _pageContentName, StringComparison.Ordinal))
             {
                 // If the element has a Source attribute, any inlined content should be ignored.
                 string sourceUri = _xamlReader.GetAttribute(_pageContentSourceAttribute);
@@ -777,7 +777,7 @@ namespace MS.Internal.IO.Packaging
         private IndexingContentUnit ProcessFixedPage()
         {
             // Reader is positioned on the start-tag for a FixedPage element.
-            Debug.Assert(String.CompareOrdinal(_xamlReader.LocalName, _fixedPageName) == 0);
+            Debug.Assert(string.Equals(_xamlReader.LocalName, _fixedPageName, StringComparison.Ordinal));
 
             // A FixedPage nested in a FixedPage is invalid.
             // XmlException gets handled inside this class (see GetChunk).

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XmlGlyphRunInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/IO/Packaging/XmlGlyphRunInfo.cs
@@ -39,8 +39,8 @@ namespace MS.Internal.IO.Packaging
             // Assert that XmlFixedPageInfo (only caller) has correctly identified glyph runs
             // prior to invoking this constructor.
             Debug.Assert(_glyphsNode != null 
-                && String.CompareOrdinal(_glyphsNode.LocalName, _glyphRunName) == 0
-                && String.CompareOrdinal(_glyphsNode.NamespaceURI, ElementTableKey.FixedMarkupNamespace) == 0);
+                && string.Equals(_glyphsNode.LocalName, _glyphRunName, StringComparison.Ordinal)
+                && string.Equals(_glyphsNode.NamespaceURI, ElementTableKey.FixedMarkupNamespace, StringComparison.Ordinal));
         }
         #endregion Constructors
 
@@ -176,7 +176,7 @@ namespace MS.Internal.IO.Packaging
                             // That's what the Indexing Search team told us to do.
                             // There's no CultureInfo for "und". 
                             // CultureInfo("und") will cause an error.
-                            if (string.CompareOrdinal(languageString.ToUpperInvariant(), _undeterminedLanguageStringUpper) == 0)
+                            if (string.Equals(languageString.ToUpperInvariant(), _undeterminedLanguageStringUpper, StringComparison.Ordinal))
                             {
                                 _languageID = 0;
                             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Image.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Image.cs
@@ -496,12 +496,7 @@ namespace System.Windows.Controls
         /// </summary>
         bool IProvidePropertyFallback.CanProvidePropertyFallback(string property)
         {
-            if (String.CompareOrdinal(property, "Source") == 0)
-            {
-                return true;
-            }
-
-            return false;
+            return string.Equals(property, "Source", StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -509,7 +504,7 @@ namespace System.Windows.Controls
         /// </summary>
         object IProvidePropertyFallback.ProvidePropertyFallback(string property, Exception cause)
         {
-            if (String.CompareOrdinal(property, "Source") == 0)
+            if (string.Equals(property, "Source", StringComparison.Ordinal))
             {
                 RaiseEvent(new ExceptionRoutedEventArgs(ImageFailedEvent, this, cause));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -1375,7 +1375,7 @@ namespace System.Windows.Documents
                 CompositionEventRecord previousRecord = (this.CompositionEventList.Count == 0) ? null : this.CompositionEventList[this.CompositionEventList.Count - 1];
 
                 if (_lastCompositionText == null ||
-                    String.CompareOrdinal(compositionText, _lastCompositionText) != 0)
+                    !string.Equals(compositionText, _lastCompositionText, StringComparison.Ordinal))
                 {
                     // Add the new update event.
                     this.CompositionEventList.Add(record);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -700,12 +700,12 @@ namespace System.Windows.Markup
                 KnownProperties knownId = (KnownProperties)(-id);
                 string propertyName = GetAttributeNameFromKnownId(knownId);
                 KnownElements knownElement = KnownTypes.GetKnownElementFromKnownCommonProperty(knownId);
-                return  (ownerTypeId == -(short)knownElement && (String.CompareOrdinal(propertyName, name) == 0));
+                return  (ownerTypeId == -(short)knownElement && (string.Equals(propertyName, name, StringComparison.Ordinal)));
             }
             else
             {
                 BamlAttributeInfoRecord record = (BamlAttributeInfoRecord)AttributeIdMap[id];
-                return (record.OwnerTypeId == ownerTypeId) && (String.CompareOrdinal(record.Name, name) == 0);
+                return (record.OwnerTypeId == ownerTypeId) && (string.Equals(record.Name, name, StringComparison.Ordinal));
             }
         }
 
@@ -714,7 +714,7 @@ namespace System.Windows.Markup
             string propertyName = GetAttributeNameFromId(id);
             if (null == propertyName)
                 return false;
-            return (String.CompareOrdinal(propertyName, name) == 0);
+            return (string.Equals(propertyName, name, StringComparison.Ordinal));
         }
 
         internal bool DoesAttributeMatch(short id, BamlAttributeUsage attributeUsage)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -6874,7 +6874,7 @@ namespace System.Windows.Markup
         public override bool Equals(object o)
         {
             XamlPropertyFullName other = (XamlPropertyFullName)o;
-            return (_ownerType == other.OwnerType && (0==string.CompareOrdinal(_name, other.Name)));
+            return (_ownerType == other.OwnerType && (string.Equals(_name, other.Name, StringComparison.Ordinal)));
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlnsCache.cs
@@ -228,7 +228,7 @@ namespace System.Windows.Markup
                 // get the Constructor info
                 CustomAttributeData data = allAttributes[i];
                 ConstructorInfo cinfo = data.Constructor;
-                if(0 == String.CompareOrdinal(cinfo.ReflectedType.FullName, fullClrName))
+                if(string.Equals(cinfo.ReflectedType.FullName, fullClrName, StringComparison.Ordinal))
                 {
                     foundAttributes.Add(allAttributes[i]);
                 }
@@ -362,7 +362,7 @@ namespace System.Windows.Markup
                         throw new ArgumentException(SR.Format(SR.ParserAttributeArgsLow, "XmlnsDefinitionAttribute"));
                     }
 
-                    if (0 == String.CompareOrdinal(xmlnsRequested, xmlns))
+                    if (string.Equals(xmlnsRequested, xmlns, StringComparison.Ordinal))
                     {
                         pairList.Add(new ClrNamespaceAssemblyPair(clrns, assemblyName));
                     }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
@@ -1917,7 +1917,7 @@ namespace System.Windows.Xps.Packaging
             String fileName = Path.GetFileNameWithoutExtension(path);
 
             ContentType contentType = null;
-            if (String.CompareOrdinal(extension, XpsS0Markup.ObfuscatedFontExt.ToLower(CultureInfo.InvariantCulture)) == 0)
+            if (string.Equals(extension, XpsS0Markup.ObfuscatedFontExt, StringComparison.OrdinalIgnoreCase))
             {
                 // Verify that the filename is a valid GUID string
                 // Until Guid has a TryParse method we will have to depend on an exception being thrown

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsFixedPageReaderWriter.cs
@@ -1913,7 +1913,7 @@ namespace System.Windows.Xps.Packaging
         {
             //Extract file extension
             String path = fontUri.OriginalString;
-            String extension = Path.GetExtension(path).ToLower(CultureInfo.InvariantCulture);
+            String extension = Path.GetExtension(path);
             String fileName = Path.GetFileNameWithoutExtension(path);
 
             ContentType contentType = null;

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Packaging/XpsManager.cs
@@ -1278,8 +1278,7 @@ namespace System.Windows.Xps.Packaging
             }
             else
             {
-                if (String.CompareOrdinal(contentType.TypeComponent.ToUpper(CultureInfo.InvariantCulture),
-                                          "Image".ToUpper(CultureInfo.InvariantCulture))==0)
+                if (string.Equals(contentType.TypeComponent, "Image", StringComparison.OrdinalIgnoreCase))
                 {
                     key = "Image";
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CaseInsensitiveOrdinalStringComparer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CaseInsensitiveOrdinalStringComparer.cs
@@ -29,8 +29,7 @@ namespace MS.Internal.IO.Packaging
         bool IEqualityComparer.Equals(Object x, Object y)
         {
             Invariant.Assert((x is String) && (y is String));
-            return (String.CompareOrdinal(((String) x).ToUpperInvariant(),
-                                ((String) y).ToUpperInvariant()) == 0);
+            return string.Equals(((string) x), ((string) y), StringComparison.OrdinalIgnoreCase);
         }
 
         int IComparer.Compare(Object x, Object y)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileStorageReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileStorageReference.cs
@@ -76,7 +76,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             // Note that because of the GetType() checking above, the casting must be valid.
             CompoundFileStorageReference r = (CompoundFileStorageReference)o;
-            return (String.CompareOrdinal(_fullName.ToUpperInvariant(), r._fullName.ToUpperInvariant()) == 0);
+            return (string.Equals(_fullName, r._fullName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>Returns an integer suitable for including this object in a hash table</summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileStreamReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileStreamReference.cs
@@ -91,7 +91,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                 return false;
 
             CompoundFileStreamReference r = (CompoundFileStreamReference)o;
-            return (String.CompareOrdinal(_fullName.ToUpperInvariant(), r._fullName.ToUpperInvariant()) == 0);
+            return (string.Equals(_fullName, r._fullName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>Returns an integer suitable for including this object in a hash table</summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
@@ -408,9 +408,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                 // Ensure that the feature name is as expected.
                 //
                 // NOTE: We preserve case, but do case-insensitive comparison.
-                if (String.CompareOrdinal(
-                                _fileVersion.FeatureIdentifier.ToUpper(CultureInfo.InvariantCulture),
-                                _codeVersion.FeatureIdentifier.ToUpper(CultureInfo.InvariantCulture)) != 0)
+                if (!string.Equals(_fileVersion.FeatureIdentifier, _codeVersion.FeatureIdentifier, StringComparison.OrdinalIgnoreCase))
                 {
                     throw new FileFormatException(
                                     SR.Format(

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CustomSignedXml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CustomSignedXml.cs
@@ -80,7 +80,7 @@ namespace MS.Internal.IO.Packaging
             foreach (DataObject dataObject in signature.ObjectList)
             {
                 // direct reference to Object id - supported for all reference typs
-                if (String.CompareOrdinal(idValue, dataObject.Id) == 0)
+                if (string.Equals(idValue, dataObject.Id, StringComparison.Ordinal))
                 {
                     // anticipate duplicate ID's and throw if any found
                     if (node != null)
@@ -116,7 +116,7 @@ namespace MS.Internal.IO.Packaging
             foreach (Reference reference in signature.SignedInfo.References)
             {
                 // if we get a match by Type?
-                if (String.CompareOrdinal(reference.Type, _XAdESTargetType) == 0)
+                if (string.Equals(reference.Type, _XAdESTargetType, StringComparison.Ordinal))
                 {
                     // now try to match by Uri
                     // strip off any preceding # mark to facilitate matching
@@ -128,7 +128,7 @@ namespace MS.Internal.IO.Packaging
 
                     // if we have a XAdES type reference and the ID matches the requested one
                     // search all object tags for the XML with this ID
-                    if (String.CompareOrdinal(uri, idValue) == 0)
+                    if (string.Equals(uri, idValue, StringComparison.Ordinal))
                     {
                         node = SelectSubObjectNodeForXAdESInDataObjects(signature, idValue);
                         break;
@@ -155,7 +155,7 @@ namespace MS.Internal.IO.Packaging
             foreach (DataObject dataObject in signature.ObjectList)
             {
                 // skip the package object
-                if (String.CompareOrdinal(dataObject.Id, XTable.Get(XTable.ID.OpcAttrValue)) != 0)
+                if (!string.Equals(dataObject.Id, XTable.Get(XTable.ID.OpcAttrValue), StringComparison.Ordinal))
                 {
                     XmlElement element = dataObject.GetXml();
 
@@ -184,7 +184,7 @@ namespace MS.Internal.IO.Packaging
                                 temp = temp.ParentNode;
 
                             // only match if the target is in the XAdES namespace
-                            if ((temp != null) && (String.CompareOrdinal(temp.NamespaceURI, _XAdESNameSpace) == 0))
+                            if ((temp != null) && (string.Equals(temp.NamespaceURI, _XAdESNameSpace, StringComparison.Ordinal)))
                             {
                                 node = local as XmlElement;
                                 // continue searching, to find duplicates from different objects

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -195,7 +195,7 @@ namespace MS.Internal.IO.Packaging
             //to verify the uri correctly.
             //We perform the comparison in a case-insensitive manner, as at this point,
             //only escaped hex digits (A-F) might vary in casing.
-            if (String.CompareOrdinal(partUri.OriginalString.ToUpperInvariant(), wellFormedPartName.ToUpperInvariant()) != 0)
+            if (!string.Equals(partUri.OriginalString, wellFormedPartName, StringComparison.OrdinalIgnoreCase))
                 return new ArgumentException(SR.InvalidPartUri);
 
             //if we get here, the partUri is valid and so we return null, as there is no exception.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/PackUriHelper.cs
@@ -513,7 +513,7 @@ namespace MS.Internal.IO.Packaging
                     (segments[segments.Length - 1].Length > _relationshipPartExtensionName.Length))
                 {
                     // look for "_RELS" segment which must be second last segment
-                    result = (String.CompareOrdinal(segments[segments.Length - 2], _relationshipPartUpperCaseSegmentName) == 0);
+                    result = string.Equals(segments[segments.Length - 2], _relationshipPartUpperCaseSegmentName, StringComparison.Ordinal);
                 }
 
                 // In addition we need to make sure that the relationship is not created by taking another relationship

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/StorageBasedPackageProperties.cs
@@ -710,7 +710,7 @@ namespace MS.Internal.IO.Packaging
                     pszVal = Marshal.StringToCoTaskMemAnsi(inputString);
                     string convertedString = Marshal.PtrToStringAnsi(pszVal);
 
-                    if (String.CompareOrdinal(inputString, convertedString) != 0)
+                    if (!string.Equals(inputString, convertedString, StringComparison.Ordinal))
                     {
                         // The string is not an ASCII string. Use UTF-8 to encode it!
                         byte[] byteArray = UTF8Encoding.UTF8.GetBytes(inputString);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -150,9 +150,7 @@ namespace MS.Internal.IO.Packaging
                             // Compare ordinal case-sensitive which is more strict than normal ContentType
                             // comparision because this is manadated by the OPC specification.
                             PackagePart part = _manager.Package.GetPart(partEntry.Uri);
-                            if (String.CompareOrdinal(
-                                partEntry.ContentType.OriginalString,
-                                part.ValidatedContentType().OriginalString) != 0)
+                            if (!string.Equals(partEntry.ContentType.OriginalString, part.ValidatedContentType().OriginalString, StringComparison.Ordinal))
                             {
                                 result = false;     // content type mismatch
                                 break;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlDigitalSignatureProcessor.cs
@@ -164,7 +164,7 @@ namespace MS.Internal.IO.Packaging
                         {
                             // ensure hash algorithm object is available - re-use if possible
                             if (((hashAlgorithm != null) && (!hashAlgorithm.CanReuseTransform)) ||
-                                String.CompareOrdinal(partEntry.HashAlgorithm, currentHashAlgorithmName) != 0)
+                                !string.Equals(partEntry.HashAlgorithm, currentHashAlgorithmName, StringComparison.Ordinal))
                             {
                                 if (hashAlgorithm != null)
                                     ((IDisposable)hashAlgorithm).Dispose();
@@ -185,7 +185,7 @@ namespace MS.Internal.IO.Packaging
                             String base64EncodedHashValue = GenerateDigestValue(s, partEntry.Transforms, hashAlgorithm);
 
                             // now compare the hash - must be identical
-                            if (String.CompareOrdinal(base64EncodedHashValue, partEntry.HashValue) != 0)
+                            if (!string.Equals(base64EncodedHashValue, partEntry.HashValue, StringComparison.Ordinal))
                             {
                                 result = false;     // hash mismatch
                                 break;
@@ -459,7 +459,7 @@ namespace MS.Internal.IO.Packaging
                 {
                     // ignore empty strings at this point (as well as Relationship Transforms) - these are legal
                     if ((transformName.Length == 0)
-                        || (String.CompareOrdinal(transformName, XTable.Get(XTable.ID.RelationshipsTransformName)) == 0))
+                        || (string.Equals(transformName, XTable.Get(XTable.ID.RelationshipsTransformName), StringComparison.Ordinal)))
                     {
                         continue;
                     }
@@ -556,11 +556,11 @@ namespace MS.Internal.IO.Packaging
         {
             Invariant.Assert(transformName != null);
 
-            if (String.CompareOrdinal(transformName, SignedXml.XmlDsigC14NTransformUrl) == 0)
+            if (string.Equals(transformName, SignedXml.XmlDsigC14NTransformUrl, StringComparison.Ordinal))
             {
                 return new XmlDsigC14NTransform();
             }
-            else if (String.CompareOrdinal(transformName, SignedXml.XmlDsigC14NWithCommentsTransformUrl) == 0)
+            else if (string.Equals(transformName, SignedXml.XmlDsigC14NWithCommentsTransformUrl, StringComparison.Ordinal))
             {
                 return new XmlDsigC14NWithCommentsTransform();
             }
@@ -582,8 +582,8 @@ namespace MS.Internal.IO.Packaging
         {
             Invariant.Assert(transformName != null);
 
-            if (String.CompareOrdinal(transformName, SignedXml.XmlDsigC14NTransformUrl) == 0 ||
-                String.CompareOrdinal(transformName, SignedXml.XmlDsigC14NWithCommentsTransformUrl) == 0)
+            if (string.Equals(transformName, SignedXml.XmlDsigC14NTransformUrl, StringComparison.Ordinal) ||
+                string.Equals(transformName, SignedXml.XmlDsigC14NWithCommentsTransformUrl, StringComparison.Ordinal))
             {
                 return true;
             }
@@ -650,8 +650,8 @@ namespace MS.Internal.IO.Packaging
                         }
 
                         if ((node.NodeType != XmlNodeType.Element) ||
-                           (String.CompareOrdinal(node.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0) ||
-                           (String.CompareOrdinal(node.LocalName, XTable.Get(XTable.ID.SignatureTagName)) != 0))
+                           (!string.Equals(node.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)) ||
+                           (!string.Equals(node.LocalName, XTable.Get(XTable.ID.SignatureTagName), StringComparison.Ordinal)))
                         {
                             throw new XmlException(SR.PackageSignatureCorruption);
                         }
@@ -993,7 +993,7 @@ namespace MS.Internal.IO.Packaging
 
                 // parse the <Object> tag - ensure that it is in the correct namespace
                 reader.Read();  // enter the Object tag
-                if (String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0)
+                if (!string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal))
                     throw new XmlException(SR.XmlSignatureParseError);
 
                 string signaturePropertiesTagName = XTable.Get(XTable.ID.SignaturePropertiesTagName);
@@ -1003,10 +1003,10 @@ namespace MS.Internal.IO.Packaging
                 while (reader.Read() && (reader.NodeType == XmlNodeType.Element))
                 {
                     if (reader.MoveToContent() == XmlNodeType.Element
-                        && (String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) == 0)
+                        && (string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal))
                         && reader.Depth == 1)
                     {
-                        if (!signaturePropertiesTagFound && String.CompareOrdinal(reader.LocalName, signaturePropertiesTagName) == 0)
+                        if (!signaturePropertiesTagFound && string.Equals(reader.LocalName, signaturePropertiesTagName, StringComparison.Ordinal))
                         {
                             signaturePropertiesTagFound = true;
 
@@ -1016,7 +1016,7 @@ namespace MS.Internal.IO.Packaging
 
                             continue;
                         }
-                        else if (!manifestTagFound && String.CompareOrdinal(reader.LocalName, manifestTagName) == 0)
+                        else if (!manifestTagFound && string.Equals(reader.LocalName, manifestTagName, StringComparison.Ordinal))
                         {
                             manifestTagFound = true;
 
@@ -1052,7 +1052,7 @@ namespace MS.Internal.IO.Packaging
             DataObject returnValue = null;
             foreach (DataObject dataObject in _signedXml.Signature.ObjectList)
             {
-                if (String.CompareOrdinal(dataObject.Id, opcId) == 0)
+                if (string.Equals(dataObject.Id, opcId, StringComparison.Ordinal))
                 {
                     // duplicates not allowed
                     if (returnValue != null)
@@ -1179,7 +1179,7 @@ namespace MS.Internal.IO.Packaging
                 {
                     //As per the OPC spec, there MUST be exactly one package specific reference to the 
                     //package specific <Object> element 
-                    if (String.CompareOrdinal(currentReference.Uri, XTable.Get(XTable.ID.OpcLinkAttrValue)) == 0)
+                    if (string.Equals(currentReference.Uri, XTable.Get(XTable.ID.OpcLinkAttrValue), StringComparison.Ordinal))
                     {
                         if (!allowPackageSpecificReferences)
                             throw new ArgumentException(SR.PackageSpecificReferenceTagMustBeUnique);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureManifest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureManifest.cs
@@ -131,8 +131,8 @@ namespace MS.Internal.IO.Packaging
             while (reader.Read() && (reader.MoveToContent() == XmlNodeType.Element))
             {
                 // should be on a <Reference> tag
-                if (String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) == 0
-                    && (String.CompareOrdinal(reader.LocalName, referenceTagName) == 0)
+                if (string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)
+                    && (string.Equals(reader.LocalName, referenceTagName, StringComparison.Ordinal))
                     && reader.Depth == 2)
                 {
                     // Parse each reference - distinguish between Relationships and Parts
@@ -168,7 +168,7 @@ namespace MS.Internal.IO.Packaging
         {
             // verify namespace and lack of attributes
             if (PackagingUtilities.GetNonXmlnsAttributeCount(reader) > 1
-                || String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0
+                || !string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)
                 || reader.Depth != 3)
                 throw new XmlException(SR.XmlSignatureParseError);
 
@@ -195,7 +195,7 @@ namespace MS.Internal.IO.Packaging
 
             // verify namespace and lack of attributes
             if (PackagingUtilities.GetNonXmlnsAttributeCount(reader) > 0
-                || String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0
+                || !string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)
                 || reader.Depth != 3)
                 throw new XmlException(SR.XmlSignatureParseError);
 
@@ -261,7 +261,7 @@ namespace MS.Internal.IO.Packaging
             while (reader.Read() && (reader.MoveToContent() == XmlNodeType.Element))
             {
                 // Correct Namespace?
-                if (String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0
+                if (!string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)
                     || reader.Depth != 3)
                 {
                     throw new XmlException(SR.PackageSignatureCorruption);
@@ -269,7 +269,7 @@ namespace MS.Internal.IO.Packaging
 
                 // DigestMethod?
                 if (hashAlgorithm == null &&
-                    String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.DigestMethodTagName)) == 0)
+                    string.Equals(reader.LocalName, XTable.Get(XTable.ID.DigestMethodTagName), StringComparison.Ordinal))
                 {
                     hashAlgorithm = ParseDigestAlgorithmTag(reader);
                     continue;
@@ -277,7 +277,7 @@ namespace MS.Internal.IO.Packaging
 
                 // DigestValue?
                 if (hashValue == null &&
-                    String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.DigestValueTagName)) == 0)
+                    string.Equals(reader.LocalName, XTable.Get(XTable.ID.DigestValueTagName), StringComparison.Ordinal))
                 {
                     hashValue = ParseDigestValueTag(reader);
                     continue;
@@ -285,7 +285,7 @@ namespace MS.Internal.IO.Packaging
 
                 // TransformsTag?
                 if (!transformsParsed &&
-                    String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.TransformsTagName)) == 0)
+                    string.Equals(reader.LocalName, XTable.Get(XTable.ID.TransformsTagName), StringComparison.Ordinal))
                 {
                     transforms = ParseTransformsTag(reader, partUri, ref relationshipSelectors);
                     transformsParsed = true;
@@ -341,8 +341,8 @@ namespace MS.Internal.IO.Packaging
 
                 // at this level, all tags must be Transform tags
                 if (reader.Depth != 4
-                    || String.CompareOrdinal(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl) != 0
-                    || String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.TransformTagName)) != 0)
+                    || !string.Equals(reader.NamespaceURI, SignedXml.XmlDsigNamespaceUrl, StringComparison.Ordinal)
+                    || !string.Equals(reader.LocalName, XTable.Get(XTable.ID.TransformTagName), StringComparison.Ordinal))
                 {
                     throw new XmlException(SR.XmlSignatureParseError);
                 }
@@ -357,7 +357,7 @@ namespace MS.Internal.IO.Packaging
                 if ((transformName != null) && (transformName.Length > 0))
                 {
                     // what type of transform?
-                    if (String.CompareOrdinal(transformName, XTable.Get(XTable.ID.RelationshipsTransformName)) == 0)
+                    if (string.Equals(transformName, XTable.Get(XTable.ID.RelationshipsTransformName), StringComparison.Ordinal))
                     {
                         if (!relationshipTransformFound)
                         {
@@ -430,10 +430,10 @@ namespace MS.Internal.IO.Packaging
                 // both types have no children, a single required attribute and belong to the OPC namespace
                 if (reader.IsEmptyElement
                     && PackagingUtilities.GetNonXmlnsAttributeCount(reader) == 1
-                    && (String.CompareOrdinal(reader.NamespaceURI, XTable.Get(XTable.ID.OpcSignatureNamespace)) == 0))
+                    && (string.Equals(reader.NamespaceURI, XTable.Get(XTable.ID.OpcSignatureNamespace), StringComparison.Ordinal)))
                 {
                     // <RelationshipReference>?
-                    if (String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.RelationshipReferenceTagName)) == 0)
+                    if (string.Equals(reader.LocalName, XTable.Get(XTable.ID.RelationshipReferenceTagName), StringComparison.Ordinal))
                     {
                         // RelationshipReference tags are legal and these must be empty with a single SourceId attribute
                         // get the SourceId attribute 
@@ -448,7 +448,7 @@ namespace MS.Internal.IO.Packaging
                             continue;
                         }
                     }   // <RelationshipsGroupReference>?
-                    else if ((String.CompareOrdinal(reader.LocalName, XTable.Get(XTable.ID.RelationshipsGroupReferenceTagName)) == 0))
+                    else if ((string.Equals(reader.LocalName, XTable.Get(XTable.ID.RelationshipsGroupReferenceTagName), StringComparison.Ordinal)))
                     {
                         // RelationshipsGroupReference tags must be empty with a single SourceType attribute
                         string type = reader.GetAttribute(XTable.Get(XTable.ID.SourceTypeAttrName));

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
@@ -172,8 +172,8 @@ namespace MS.Internal.IO.Packaging
             {
                 //Looking for <SignatureProperty> tag
                 if (reader.MoveToContent() == XmlNodeType.Element
-                    && (String.CompareOrdinal(reader.NamespaceURI, w3cSignatureNameSpace) == 0)
-                    && (String.CompareOrdinal(reader.LocalName, signaturePropertyTag) == 0)
+                    && (string.Equals(reader.NamespaceURI, w3cSignatureNameSpace, StringComparison.Ordinal))
+                    && (string.Equals(reader.LocalName, signaturePropertyTag, StringComparison.Ordinal))
                     && reader.Depth == 2)
                 {
                     //Verify Attributes
@@ -201,13 +201,13 @@ namespace MS.Internal.IO.Packaging
                     //Look for end tag corresponding to </SignatureProperty> or 
                     //if these are other custom defined properties, then anything with
                     //depth greater than 2 should be ignored as these can be nested elements.
-                    if (((String.CompareOrdinal(signaturePropertyTag, reader.LocalName) == 0
+                    if (((string.Equals(signaturePropertyTag, reader.LocalName, StringComparison.Ordinal)
                         && (reader.NodeType == XmlNodeType.EndElement)))
                         || reader.Depth > 2)
                         continue;
                     else
                         //If we find the end tag for </SignatureProperties> then we can stop parsing
-                        if ((String.CompareOrdinal(signaturePropertiesTag, reader.LocalName) == 0
+                        if ((string.Equals(signaturePropertiesTag, reader.LocalName, StringComparison.Ordinal)
                         && (reader.NodeType == XmlNodeType.EndElement)))
                             break;
                         else
@@ -255,19 +255,19 @@ namespace MS.Internal.IO.Packaging
             //Look for <SignatureTime> Tag
             if (reader.Read()
                 && reader.MoveToContent() == XmlNodeType.Element
-                && (String.CompareOrdinal(reader.NamespaceURI, opcSignatureNameSpace) == 0)
-                && (String.CompareOrdinal(reader.LocalName, signatureTimeTag) == 0)
+                && (string.Equals(reader.NamespaceURI, opcSignatureNameSpace, StringComparison.Ordinal))
+                && (string.Equals(reader.LocalName, signatureTimeTag, StringComparison.Ordinal))
                 && reader.Depth == 3
                 && PackagingUtilities.GetNonXmlnsAttributeCount(reader) == expectedAttributeCount)
             {
                 while (reader.Read())
                 {
-                    if (String.CompareOrdinal(reader.NamespaceURI, opcSignatureNameSpace) == 0
+                    if (string.Equals(reader.NamespaceURI, opcSignatureNameSpace, StringComparison.Ordinal)
                         && reader.MoveToContent() == XmlNodeType.Element
                         && reader.Depth == 4)
                     {
                         // which tag do we have?
-                        if ((String.CompareOrdinal(reader.LocalName, timeValueTagName) == 0)
+                        if ((string.Equals(reader.LocalName, timeValueTagName, StringComparison.Ordinal))
                             && PackagingUtilities.GetNonXmlnsAttributeCount(reader) == expectedAttributeCount)
                         {
                             if (timeValue == null
@@ -287,7 +287,7 @@ namespace MS.Internal.IO.Packaging
                                 //are other nested elements of if they are of a different XmlNodeType type
                                 throw new XmlException(SR.PackageSignatureCorruption);
 }
-                        else if ((String.CompareOrdinal(reader.LocalName, timeFormatTagName) == 0)
+                        else if ((string.Equals(reader.LocalName, timeFormatTagName, StringComparison.Ordinal))
                                  && PackagingUtilities.GetNonXmlnsAttributeCount(reader) == expectedAttributeCount)
                         {
                             if (timeFormat == null
@@ -314,7 +314,7 @@ namespace MS.Internal.IO.Packaging
                     else
                         //If we have encountered the end tag for the <SignatureTime> tag
                         //then we are done parsing the tag, and we can stop the parsing.
-                        if (String.CompareOrdinal(signatureTimeTag, reader.LocalName) == 0
+                        if (string.Equals(signatureTimeTag, reader.LocalName, StringComparison.Ordinal)
                         && (reader.NodeType == XmlNodeType.EndElement))
                         {
                             //We must find a  </SignatureProperty> tag at this point, 
@@ -322,7 +322,7 @@ namespace MS.Internal.IO.Packaging
                             //other tags nested here and that is an error.
                             if (reader.Read()
                                 && reader.MoveToContent() == XmlNodeType.EndElement
-                                && String.CompareOrdinal(signaturePropertyTag, reader.LocalName) == 0)
+                                && string.Equals(signaturePropertyTag, reader.LocalName, StringComparison.Ordinal))
                                 break;
                             else
                                 throw new XmlException(SR.PackageSignatureCorruption);
@@ -386,7 +386,7 @@ namespace MS.Internal.IO.Packaging
         {
             for (int i = 0; i < _dateTimePatternMap.GetLength(0); i++)
             {
-                if (String.CompareOrdinal(_dateTimePatternMap[i].Format, format) == 0)
+                if (string.Equals(_dateTimePatternMap[i].Format, format, StringComparison.Ordinal))
                 {
                     return i;
                 }
@@ -414,7 +414,7 @@ namespace MS.Internal.IO.Packaging
             string idAttrValue = reader.GetAttribute(XTable.Get(XTable.ID.SignaturePropertyIdAttrName));
 
             if(idAttrValue!=null 
-                && (String.CompareOrdinal(idAttrValue,XTable.Get(XTable.ID.SignaturePropertyIdAttrValue)) == 0))
+                && (string.Equals(idAttrValue, XTable.Get(XTable.ID.SignaturePropertyIdAttrValue), StringComparison.Ordinal)))
                 return true;
             else
                 return false;
@@ -435,7 +435,7 @@ namespace MS.Internal.IO.Packaging
                 //whether there is an Id attribute on the <Signature> tag or no,
                 //an empty Target attribute on <SignatureProperty> tag, is allowed.
                 //Empty string means current document 
-                if (String.CompareOrdinal(idTargetValue, String.Empty) == 0)
+                if (string.Equals(idTargetValue, String.Empty, StringComparison.Ordinal))
                     return true;
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
@@ -441,7 +441,7 @@ namespace MS.Internal.IO.Packaging
                 {
                     //If the Target attribute has a non-empty string then
                     //it must match the <Signature> tag Id attribute value
-                    if (signatureId != null && String.CompareOrdinal(idTargetValue, "#" + signatureId) == 0)
+                    if (signatureId != null && string.Equals(idTargetValue, "#" + signatureId, StringComparison.Ordinal))
                         return true;
                     else
                         return false;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
@@ -663,7 +663,7 @@ namespace MS.Internal.Security.RightsManagement
 
                 foreach (string oldElement in oldList)
                 {
-                    if (String.CompareOrdinal(newElement, oldElement) == 0)
+                    if (string.Equals(newElement, oldElement, StringComparison.Ordinal))
                     {
                         matchFound = true;
                         break;
@@ -1853,7 +1853,7 @@ namespace MS.Internal.Security.RightsManagement
                                                 distributionPointQueryHandle,
                                                 NativeConstants.QUERY_OBJECTTYPE,
                                                 0);
-                        if (String.CompareOrdinal(addressType, distributionPointType) == 0)
+                        if (string.Equals(addressType, distributionPointType, StringComparison.Ordinal))
                         {
                             nameAttributeValue = GetUnboundLicenseStringAttribute(
                                                 distributionPointQueryHandle,
@@ -1936,7 +1936,7 @@ namespace MS.Internal.Security.RightsManagement
 
             for (int i = 0; i < _rightEnums.Length; i++)
             {
-                if (String.CompareOrdinal(_rightNames[i], rightName) == 0)
+                if (string.Equals(_rightNames[i], rightName, StringComparison.Ordinal))
                 {
                     return _rightEnums[i];
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/ClientSession.cs
@@ -1331,9 +1331,7 @@ namespace MS.Internal.Security.RightsManagement
                         0);
 
                     // We recognise authentication type Windows everything else is assumed to be Passport 
-                    if (String.CompareOrdinal(
-                        AuthenticationType.Windows.ToString().ToUpper(CultureInfo.InvariantCulture),
-                        authenticationType.ToUpper(CultureInfo.InvariantCulture)) == 0)
+                    if (string.Equals(AuthenticationType.Windows.ToString(), authenticationType, StringComparison.OrdinalIgnoreCase))
                     {
                         return new ContentUser(name, AuthenticationType.Windows);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Security/RightsManagement/IssuanceLicense.cs
@@ -594,7 +594,7 @@ namespace MS.Internal.Security.RightsManagement
             string userIdTypeStr = null;
             if (userIdType != null)
             {
-                userIdTypeStr = userIdType.ToString().ToUpperInvariant();
+                userIdTypeStr = userIdType.ToString();
             }
 
             string userIdStr = null;
@@ -604,15 +604,15 @@ namespace MS.Internal.Security.RightsManagement
             }
 
             // based on the UserTypeId build appropriate instance of User class 
-            if (String.CompareOrdinal(userIdTypeStr, AuthenticationType.Windows.ToString().ToUpperInvariant()) == 0)
+            if (string.Equals(userIdTypeStr, AuthenticationType.Windows.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 return new ContentUser(userNameStr, AuthenticationType.Windows);
             }
-            else if (String.CompareOrdinal(userIdTypeStr, AuthenticationType.Passport.ToString().ToUpperInvariant()) == 0)
+            else if (string.Equals(userIdTypeStr, AuthenticationType.Passport.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 return new ContentUser(userNameStr, AuthenticationType.Passport);
             }
-            else if (String.CompareOrdinal(userIdTypeStr, AuthenticationType.Internal.ToString().ToUpperInvariant()) == 0)
+            else if (string.Equals(userIdTypeStr, AuthenticationType.Internal.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 // internal anyone user 
                 if (ContentUser.CompareToAnyone(userIdStr))
@@ -624,7 +624,7 @@ namespace MS.Internal.Security.RightsManagement
                     return ContentUser.OwnerUser;
                 }
             }
-            else if (String.CompareOrdinal(userIdTypeStr, UnspecifiedAuthenticationType.ToUpperInvariant()) == 0)
+            else if (string.Equals(userIdTypeStr, UnspecifiedAuthenticationType, StringComparison.OrdinalIgnoreCase))
             {
                 return new ContentUser(userNameStr, AuthenticationType.WindowsPassport);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
@@ -231,7 +231,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             //    Parameter 'v' to this public method must be validated:  A null-dereference can occur here. 
             //This is a false positive as the checks above can gurantee no null dereference will occur  
 #pragma warning disable 6506
-            if (String.CompareOrdinal(_featureIdentifier.ToUpperInvariant(), v.FeatureIdentifier.ToUpperInvariant()) != 0
+            if (!string.Equals(_featureIdentifier, v.FeatureIdentifier, StringComparison.OrdinalIgnoreCase)
                 || _reader != v.ReaderVersion
                 || _writer != v.WriterVersion
                 || _updater != v.UpdaterVersion)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StreamInfo.cs
@@ -831,19 +831,15 @@ namespace System.IO.Packaging
                     string id = dataTransform.TransformIdentifier as string;
                     if (id != null)
                     {
-                        id = id.ToUpperInvariant();
-
-                        if (String.CompareOrdinal(id,
-                            RightsManagementEncryptionTransform.ClassTransformIdentifier.ToUpperInvariant()) == 0
+                        if (string.Equals(id, RightsManagementEncryptionTransform.ClassTransformIdentifier, StringComparison.OrdinalIgnoreCase)
                             &&
                             (dataTransform as RightsManagementEncryptionTransform) != null)
                         {
                             _encryptionOption = EncryptionOption.RightsManagement;
                         }
-                        else if (String.CompareOrdinal(id,
-                            CompressionTransform.ClassTransformIdentifier.ToUpperInvariant()) == 0
-                            &&
-                            (dataTransform as CompressionTransform) != null)
+                        else if (string.Equals(id, CompressionTransform.ClassTransformIdentifier, StringComparison.OrdinalIgnoreCase)
+                                 &&
+                                 (dataTransform as CompressionTransform) != null)
                         {
                             // We don't persist the compression level used during compression process
                             // When we access the stream, all we can determine is whether it is compressed or not

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
@@ -937,8 +937,7 @@ namespace System.IO.Packaging
             {
                 string id = dataTransform.TransformIdentifier as string;
                 if (id != null &&
-                        String.CompareOrdinal(id.ToUpperInvariant(),
-                            RightsManagementEncryptionTransform.ClassTransformIdentifier.ToUpperInvariant()) == 0)
+                    string.Equals(id, RightsManagementEncryptionTransform.ClassTransformIdentifier, StringComparison.OrdinalIgnoreCase))
                 {
                     // Do not allow more than one RM Transform
                     if (rmet != null)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -931,7 +931,7 @@ namespace System.IO.Packaging
 
             public bool Match(String id)
             {
-                return (String.CompareOrdinal(_id, id) == 0);
+                return (string.Equals(_id, id, StringComparison.Ordinal));
             }
 
             private string _id;
@@ -993,7 +993,7 @@ namespace System.IO.Packaging
                 foreach (DataObject obj in signatureObjects)
                 {
                     // ensure they don't duplicate the reserved one
-                    if (String.CompareOrdinal(obj.Id, XTable.Get(XTable.ID.OpcAttrValue)) == 0)
+                    if (string.Equals(obj.Id, XTable.Get(XTable.ID.OpcAttrValue), StringComparison.Ordinal))
                         throw new ArgumentException(SR.SignaturePackageObjectTagMustBeUnique, "signatureObjects");
 
                     // check for duplicates

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -94,9 +94,9 @@ namespace System.Security.RightsManagement
             //PRESHARP:Parameter to this public method must be validated:  A null-dereference can occur here. 
             //This is a false positive as the checks above can gurantee no null dereference will occur  
 #pragma warning disable 6506
-            return (String.CompareOrdinal(localizedNameDescr.Name, Name) == 0)
+            return (string.Equals(localizedNameDescr.Name, Name, StringComparison.Ordinal))
                         &&
-                    (String.CompareOrdinal(localizedNameDescr.Description, Description) == 0);
+                    (string.Equals(localizedNameDescr.Description, Description, StringComparison.Ordinal));
 #pragma warning restore 6506
         }        
             

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
@@ -158,7 +158,7 @@ namespace System.Security.RightsManagement
 
             // Note that because of the GetType() checking above, the casting must be valid.
             UseLicense obj = (UseLicense)x;
-            return (String.CompareOrdinal(_serializedUseLicense, obj._serializedUseLicense) == 0);
+            return (string.Equals(_serializedUseLicense, obj._serializedUseLicense, StringComparison.Ordinal));
 }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
@@ -135,7 +135,7 @@ namespace System.Security.RightsManagement
 
             ContentUser userObj = (ContentUser)obj;
 
-            return (string.Equals(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant(), StringComparison.Ordinal))
+            return (string.Equals(_name, userObj._name, StringComparison.OrdinalIgnoreCase))
                         &&
                             _authenticationType.Equals(userObj._authenticationType);
         }
@@ -228,7 +228,7 @@ namespace System.Security.RightsManagement
             }
             else
             {
-                return (string.Equals(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant(), StringComparison.Ordinal))
+                return (string.Equals(_name, userObj._name, StringComparison.OrdinalIgnoreCase))
                             &&
                                 _authenticationType.Equals(userObj._authenticationType);
             }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
@@ -135,7 +135,7 @@ namespace System.Security.RightsManagement
 
             ContentUser userObj = (ContentUser)obj;
 
-            return (String.CompareOrdinal(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant()) == 0)
+            return (string.Equals(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant(), StringComparison.Ordinal))
                         &&
                             _authenticationType.Equals(userObj._authenticationType);
         }
@@ -228,7 +228,7 @@ namespace System.Security.RightsManagement
             }
             else
             {
-                return (String.CompareOrdinal(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant()) == 0)
+                return (string.Equals(_name.ToUpperInvariant(), userObj._name.ToUpperInvariant(), StringComparison.Ordinal))
                             &&
                                 _authenticationType.Equals(userObj._authenticationType);
             }
@@ -263,12 +263,12 @@ namespace System.Security.RightsManagement
 
         internal static bool CompareToAnyone(string name)
         {
-            return (0 == String.CompareOrdinal(AnyoneUserName.ToUpperInvariant(), name.ToUpperInvariant()));
+            return string.Equals(AnyoneUserName, name, StringComparison.OrdinalIgnoreCase);
         }
 
         internal static bool CompareToOwner(string name)
         {
-            return (0 == String.CompareOrdinal(OwnerUserName.ToUpperInvariant(), name.ToUpperInvariant()));
+            return string.Equals(OwnerUserName, name, StringComparison.OrdinalIgnoreCase);
         }
 
         private const string WindowsAuthProvider = "WindowsAuthProvider";


### PR DESCRIPTION
## Description

We can use string.Equals(string1, string2, StringComparison.Ordinal) to check for equality, see https://learn.microsoft.com/en-us/dotnet/csharp/how-to/compare-strings and https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings

> Use the [String.Compare](https://learn.microsoft.com/en-us/dotnet/api/system.string.compare) and [String.CompareTo](https://learn.microsoft.com/en-us/dotnet/api/system.string.compareto) methods to sort strings, not to check for equality.

Reference: https://github.com/dotnet/wpf/issues/7834

## Customer Impact

Small performance improvements

## Regression

None.

## Testing

Just CI.

## Risk

Low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8042)