### PR TITLE
Perl version upgrade

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     -->
     <MicrosoftDotNetWpfTestPackageVersion>1.0.0-beta.19263.1</MicrosoftDotNetWpfTestPackageVersion>
     <!-- These versions are specified in global.json -->
-    <StrawberryPerlVersion>5.36.1</StrawberryPerlVersion>
+    <StrawberryPerlVersion>5.36.1.1</StrawberryPerlVersion>
     <NetFramework48RefAssembliesVersion>0.0.0.1</NetFramework48RefAssembliesVersion>
   </PropertyGroup>
   <!-- External Analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     -->
     <MicrosoftDotNetWpfTestPackageVersion>1.0.0-beta.19263.1</MicrosoftDotNetWpfTestPackageVersion>
     <!-- These versions are specified in global.json -->
-    <StrawberryPerlVersion>5.32.1.1</StrawberryPerlVersion>
+    <StrawberryPerlVersion>5.36.1</StrawberryPerlVersion>
     <NetFramework48RefAssembliesVersion>0.0.0.1</NetFramework48RefAssembliesVersion>
   </PropertyGroup>
   <!-- External Analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     -->
     <MicrosoftDotNetWpfTestPackageVersion>1.0.0-beta.19263.1</MicrosoftDotNetWpfTestPackageVersion>
     <!-- These versions are specified in global.json -->
-    <StrawberryPerlVersion>5.28.1.1-1</StrawberryPerlVersion>
+    <StrawberryPerlVersion>5.32.1.1</StrawberryPerlVersion>
     <NetFramework48RefAssembliesVersion>0.0.0.1</NetFramework48RefAssembliesVersion>
   </PropertyGroup>
   <!-- External Analyzers -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     -->
     <MicrosoftDotNetWpfTestPackageVersion>1.0.0-beta.19263.1</MicrosoftDotNetWpfTestPackageVersion>
     <!-- These versions are specified in global.json -->
-    <StrawberryPerlVersion>5.36.1.1</StrawberryPerlVersion>
+    <StrawberryPerlVersion>5.38.0.1</StrawberryPerlVersion>
     <NetFramework48RefAssembliesVersion>0.0.0.1</NetFramework48RefAssembliesVersion>
   </PropertyGroup>
   <!-- External Analyzers -->

--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
     "version": "8.0.100-preview.5.23303.2"
   },
   "native-tools": {
-    "strawberry-perl": "5.36.1",
+    "strawberry-perl": "5.36.1.1",
     "net-framework-48-ref-assemblies": "0.0.0.1"
   }
 }

--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
     "version": "8.0.100-preview.5.23303.2"
   },
   "native-tools": {
-    "strawberry-perl": "5.36.1.1",
+    "strawberry-perl": "5.38.0.1",
     "net-framework-48-ref-assemblies": "0.0.0.1"
   }
 }

--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
     "version": "8.0.100-preview.5.23303.2"
   },
   "native-tools": {
-    "strawberry-perl": "5.32.1.1",
+    "strawberry-perl": "5.36.1",
     "net-framework-48-ref-assemblies": "0.0.0.1"
   }
 }

--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
     "version": "8.0.100-preview.5.23303.2"
   },
   "native-tools": {
-    "strawberry-perl": "5.28.1.1-1",
+    "strawberry-perl": "5.32.1.1",
     "net-framework-48-ref-assemblies": "0.0.0.1"
   }
 }


### PR DESCRIPTION
## Description
This change is to update the code generation using Strawberry Perl to latest version, i.e. 5.38.0.1.

## Customer Impact
None

## Regression
None

## Testing
Successfully build the WPF locally using .NET 8.0.100-preview.5.23303.2 win-x86
Compared the artifacts folders in current build, i.e. Perl's 5.28.1.1-1 Version, to the latest build.
Did not find significant differences in the files and minor changes were along the expected lines.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8059)