### PR TITLE
Fix for WPF build error post VS 17.7.0 preview 5.0 update

### DIFF
--- a/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -247,7 +247,7 @@
       <!--<AdditionalOptions>/Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>-->
       <!--<ConformanceMode>false</ConformanceMode>-->
 
-      <AdditionalOptions Condition="'$(ManagedCxx)'=='true'">%(AdditionalOptions) /clr:netcore</AdditionalOptions>
+      <AdditionalOptions Condition="'$(ManagedCxx)'=='true'">%(AdditionalOptions) /clr:netcore /wd4956</AdditionalOptions>
       <ShowIncludes Condition="'$(ShowIncludes)'=='true'">true</ShowIncludes>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Description

This PR suppresses [Compiler Warning C4956](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4956?view=msvc-170) for type safety checks in unmanaged code.
eg.
(__clrcall _Arg0::* )(_Types...)': this type is not verifiable.

## Risk
Anyone trying to upgrade VS version to 17.7 preview 5 will not be able to build WPF

## Testing
Local builds are working after this change.

Error log - [err.txt](https://github.com/dotnet/wpf/files/12239118/err.txt)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8061)