### PR TITLE
Guard with null checks in adorners

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/RawStylusInput.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/RawStylusInput.cs
@@ -88,7 +88,10 @@ namespace System.Windows.Input.StylusPlugIns
                     group.Children.Add(new MatrixTransform(_report.InputSource.CompositionTarget.TransformFromDevice));
                 }
                 group.Children.Add(_tabletToElementTransform);
-                group.Children.Add(transform);
+                if(transform != null)
+                {
+                    group.Children.Add(transform);
+                }
                 return new StylusPointCollection(_report.StylusPointDescription, _report.GetRawPacketData(), group, Matrix.Identity);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
@@ -1086,7 +1086,8 @@ namespace System.Windows.Controls
 
                 if (offsetTransform != null)
                     transformations.Children.Add(offsetTransform);
-                transformations.Children.Add(transform);
+                if (transform != null)
+                    transformations.Children.Add(transform);                
                 return transformations;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/TemplatedAdorner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/TemplatedAdorner.cs
@@ -76,7 +76,10 @@ namespace MS.Internal.Controls
                 return transform;
 
             GeneralTransformGroup group = new GeneralTransformGroup();
-            group.Children.Add(transform);
+            if(transform != null)
+            {
+                group.Children.Add(transform);
+            }
 
             GeneralTransform t = this.TransformToDescendant(ReferenceElement);
             if (t != null)


### PR DESCRIPTION
Fixes #8070 

Main PR <!-- Link to PR if any that fixed this in the main branch. -->
None
## Description
Missing null checks lead to ArgumentNullException when adding transform to collection, in case transform is null.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
ArgumentNullException in apps using Validation adorners and similar adorners.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
No. The bug can be reproduced in .NET7 as well, with a different repro route.
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local, WPF Test Suite.
<!-- What kind of testing has been done with the fix. -->

## Risk
Low. 
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8086)