### PR TITLE
Use ArgumentNullException.ThrowIfNull in WindowsBase

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CulturePreservingExecutionContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CulturePreservingExecutionContext.cs
@@ -148,10 +148,7 @@ namespace MS.Internal
         /// </remarks>
         public static void Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, object state)
         {
-            if (executionContext == null)
-            {
-                throw new ArgumentNullException(nameof(executionContext));
-            }
+            ArgumentNullException.ThrowIfNull(executionContext);
 
             if (callback == null) return; // Bail out early if callback is null
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -114,10 +114,7 @@ namespace MS.Internal.IO.Packaging
             if (!s.CanRead)
                 throw new NotSupportedException(SR.ReadNotSupported);
 
-            if (buffer == null)
-            {
-                throw new ArgumentNullException("buffer");
-            }
+            ArgumentNullException.ThrowIfNull(buffer);
 
             if (offset < 0)
             {
@@ -151,10 +148,7 @@ namespace MS.Internal.IO.Packaging
             if (!s.CanWrite)
                 throw new NotSupportedException(SR.WriteNotSupported);
 
-            if (buffer == null)
-            {
-                throw new ArgumentNullException("buffer");
-            }
+            ArgumentNullException.ThrowIfNull(buffer);
 
             if (offset < 0)
             {
@@ -579,8 +573,7 @@ namespace MS.Internal.IO.Packaging
                 FileShare share, ReliableIsolatedStorageFileFolder folder)
                 : base(path, mode, access, share, folder.IsoFile)
             {
-                if (path == null)
-                    throw new ArgumentNullException("path");
+                ArgumentNullException.ThrowIfNull(path);
 
                 _path = path;
                 _folder = folder;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockSlimWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReaderWriterLockSlimWrapper.cs
@@ -262,10 +262,7 @@ namespace MS.Internal
         /// </remarks>
         private bool ExecuteWithinLockInternal(Action lockAcquire, Action lockRelease, ref object result, Delegate criticalAction, params object[] args)
         {
-            if (criticalAction == null)
-            {
-                throw new ArgumentNullException(nameof(criticalAction));
-            }
+            ArgumentNullException.ThrowIfNull(criticalAction);
 
             bool lockAcquired = false;
             DispatcherProcessingDisabled? dispatcherProcessingDisabled = null;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -158,10 +158,7 @@ internal static class SecurityHelper
         
         internal static int GetHRForException(Exception exception)
         {
-            if (exception == null)
-            {
-                throw new ArgumentNullException("exception");
-            }
+            ArgumentNullException.ThrowIfNull(exception);
 
             // GetHRForException fills a per thread IErrorInfo object with data from the exception
             // The exception may contain security sensitive data like full file paths that we do not

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -78,10 +78,7 @@ namespace MS.Win32
         /// </returns>
         internal HwndSubclass(HwndWrapperHook hook)
         {
-            if(hook == null)
-            {
-                throw new ArgumentNullException("hook");
-            }
+            ArgumentNullException.ThrowIfNull(hook);
 
             _bond = Bond.Unattached;
             _hook = new WeakReference(hook);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -3577,10 +3577,7 @@ namespace MS.Win32 {
             }
             public LOGFONT( LOGFONT lf )
             {
-                if (lf == null)
-                {
-                    throw new ArgumentNullException("lf");
-                }
+                ArgumentNullException.ThrowIfNull(lf);
 
                 this.lfHeight           = lf.lfHeight;
                 this.lfWidth            = lf.lfWidth;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
@@ -21,10 +21,7 @@ namespace System.Xaml.Replacements
         /// <inheritdoc />
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            if (sourceType == null)
-            {
-                throw new ArgumentNullException(nameof(sourceType));
-            }
+            ArgumentNullException.ThrowIfNull(sourceType);
 
             return sourceType == typeof(string) || sourceType == typeof(Uri);
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -454,10 +454,7 @@ namespace System.Windows.Markup
         /// <returns>A TypeConverter for the Type type if found. Null otherwise.</returns>
         internal static TypeConverter GetTypeConverter(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             TypeConverter typeConverter = GetCoreConverterFromCoreType(type);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ComponentModel/DependencyPropertyAttribute.cs
@@ -28,7 +28,7 @@ namespace MS.Internal.ComponentModel
         /// </summary>
         internal DependencyPropertyAttribute(DependencyProperty dependencyProperty, bool isAttached) 
         {
-            if (dependencyProperty == null) throw new ArgumentNullException("dependencyProperty");
+            ArgumentNullException.ThrowIfNull(dependencyProperty);
 
             _dp = dependencyProperty;
             _isAttached = isAttached;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -83,8 +83,7 @@ namespace MS.Internal
         /// <exception cref="ArgumentException">If the contentType string invalid CR-LF characters</exception>
         internal ContentType(string contentType)
         {
-            if (contentType == null)
-                throw new ArgumentNullException("contentType");
+            ArgumentNullException.ThrowIfNull(contentType);
 
             if (contentType.Length == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -122,8 +122,7 @@ namespace MS.Internal.IO.Packaging
 
         internal void SetCertificate(X509Certificate2 certificate)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            ArgumentNullException.ThrowIfNull(certificate);
 
             _certificate = certificate;
 
@@ -142,11 +141,9 @@ namespace MS.Internal.IO.Packaging
         /// </summary>
         internal CertificatePart(System.IO.Packaging.Package container, Uri partName)
         {
-            if (container == null)
-                throw new ArgumentNullException("container");
-            
-            if (partName == null)
-                throw new ArgumentNullException("partName");
+            ArgumentNullException.ThrowIfNull(container);
+
+            ArgumentNullException.ThrowIfNull(partName);
 
             partName = PackUriHelper.ValidatePartUri(partName);
             

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -142,7 +142,6 @@ namespace MS.Internal.IO.Packaging
         internal CertificatePart(System.IO.Packaging.Package container, Uri partName)
         {
             ArgumentNullException.ThrowIfNull(container);
-
             ArgumentNullException.ThrowIfNull(partName);
 
             partName = PackUriHelper.ValidatePartUri(partName);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
@@ -53,11 +53,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <param name="sink">stream to write to</param>
         public void Decompress(Stream source, Stream sink)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
+            ArgumentNullException.ThrowIfNull(source);
 
-            if (sink == null)
-                throw new ArgumentNullException("sink");
+            ArgumentNullException.ThrowIfNull(sink);
 
             Invariant.Assert(source.CanRead);
             Invariant.Assert(sink.CanWrite, "Logic Error - Cannot decompress into a read-only stream");
@@ -175,11 +173,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// they need not be restored.  We also assume that destination stream length need not be truncated.</remarks>
         public void Compress(Stream source, Stream sink)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
+            ArgumentNullException.ThrowIfNull(source);
 
-            if (sink == null)
-                throw new ArgumentNullException("sink");
+            ArgumentNullException.ThrowIfNull(sink);
 
             Invariant.Assert(source.CanRead);
             Invariant.Assert(sink.CanWrite, "Logic Error - Cannot compress into a read-only stream");

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/CompoundFileDeflateTransform.cs
@@ -174,7 +174,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         public void Compress(Stream source, Stream sink)
         {
             ArgumentNullException.ThrowIfNull(source);
-
             ArgumentNullException.ThrowIfNull(sink);
 
             Invariant.Assert(source.CanRead);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/NativeCompoundFileAPIs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/NativeCompoundFileAPIs.cs
@@ -206,10 +206,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                                                         UnsafeNativeCompoundFileMethods.UnsafeLockBytesOnStream lockBytesStream)
             {
 
-                if (storage == null)
-                {
-                    throw new ArgumentNullException("storage");
-                }
+                ArgumentNullException.ThrowIfNull(storage);
 
                 _unsafeStorage = storage;
                 _unsafePropertySetStorage = (UnsafeNativeCompoundFileMethods.UnsafeNativeIPropertySetStorage) _unsafeStorage;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -343,7 +343,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             )
         {
             ArgumentNullException.ThrowIfNull(user);
-
             ArgumentNullException.ThrowIfNull(useLicense);
 
             if (user.AuthenticationType != AuthenticationType.Windows &&

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/RightsManagementEncryptionTransform.cs
@@ -215,10 +215,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             PublishLicense publishLicense
             )
         {
-            if (publishLicense == null)
-            {
-                throw new ArgumentNullException("publishLicense");
-            }
+            ArgumentNullException.ThrowIfNull(publishLicense);
 
             if (_fixedSettings)
             {
@@ -306,10 +303,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             ContentUser user
             )
         {
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             LoadUseLicenseForUserParams param = new LoadUseLicenseForUserParams(user);
 
@@ -348,15 +342,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             UseLicense useLicense
             )
         {
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
-            if (useLicense == null)
-            {
-                throw new ArgumentNullException("useLicense");
-            }
+            ArgumentNullException.ThrowIfNull(useLicense);
 
             if (user.AuthenticationType != AuthenticationType.Windows &&
                 user.AuthenticationType != AuthenticationType.Passport)
@@ -400,10 +388,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             ContentUser user
             )
         {
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             EnumUseLicenseStreams(
                 new UseLicenseStreamCallback(this.DeleteUseLicenseForUser),
@@ -532,11 +517,8 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                     throw new InvalidOperationException(SR.CannotChangeCryptoProvider);
                 }
 
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-                
+                ArgumentNullException.ThrowIfNull(value);
+
                 if (!value.CanEncrypt && !value.CanDecrypt)
                 {
                     throw new ArgumentException(SR.CryptoProviderIsNotReady, "value");
@@ -674,10 +656,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             object param
             )
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
 
             bool stop = false;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
@@ -200,11 +200,9 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <param name="versionOwner"></param>
         internal VersionedStream(Stream baseStream, VersionedStreamOwner versionOwner)
         {
-            if (baseStream == null)
-                throw new ArgumentNullException("baseStream");
+            ArgumentNullException.ThrowIfNull(baseStream);
 
-            if (versionOwner == null)
-                throw new ArgumentNullException("versionOwner");
+            ArgumentNullException.ThrowIfNull(versionOwner);
 
             _stream = baseStream;
             _versionOwner = versionOwner;
@@ -221,8 +219,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// <param name="baseStream"></param>
         protected VersionedStream(Stream baseStream)
         {
-            if (baseStream == null)
-                throw new ArgumentNullException("baseStream");
+            ArgumentNullException.ThrowIfNull(baseStream);
 
             _stream = baseStream;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
@@ -201,7 +201,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         internal VersionedStream(Stream baseStream, VersionedStreamOwner versionOwner)
         {
             ArgumentNullException.ThrowIfNull(baseStream);
-
             ArgumentNullException.ThrowIfNull(versionOwner);
 
             _stream = baseStream;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
@@ -261,9 +261,8 @@ namespace MS.Internal.IO.Packaging
         {
             if (position < 0)
                 throw new ArgumentOutOfRangeException("position");
-        
-            if (baseStream == null)
-                throw new ArgumentNullException("baseStream");
+
+            ArgumentNullException.ThrowIfNull(baseStream);
 
             // seek and read required for emulation
             if (!baseStream.CanSeek)
@@ -272,11 +271,9 @@ namespace MS.Internal.IO.Packaging
             if (!baseStream.CanRead)
                 throw new InvalidOperationException(SR.ReadNotSupported);
 
-            if (tempStream == null)
-                throw new ArgumentNullException("tempStream");
+            ArgumentNullException.ThrowIfNull(tempStream);
 
-            if (transformer == null)
-                throw new ArgumentNullException("transformer");
+            ArgumentNullException.ThrowIfNull(transformer);
 
             _baseStream = baseStream;
             _tempStream = tempStream;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
@@ -272,7 +272,6 @@ namespace MS.Internal.IO.Packaging
                 throw new InvalidOperationException(SR.ReadNotSupported);
 
             ArgumentNullException.ThrowIfNull(tempStream);
-
             ArgumentNullException.ThrowIfNull(transformer);
 
             _baseStream = baseStream;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/IgnoreFlushAndCloseStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/IgnoreFlushAndCloseStream.cs
@@ -32,8 +32,7 @@ namespace MS.Internal.IO.Packaging
         /// <param name="stream"></param>
         internal IgnoreFlushAndCloseStream(Stream stream)
         {
-            if (stream == null)
-                throw new ArgumentNullException("stream");
+            ArgumentNullException.ThrowIfNull(stream);
 
             _stream = stream;
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
@@ -65,8 +65,7 @@ namespace MS.Internal.IO.Packaging
         /// <returns>true if legal</returns>
         internal static bool LegalFormat(String candidateFormat)
         {
-            if (candidateFormat == null)
-                throw new ArgumentNullException("candidateFormat");
+            ArgumentNullException.ThrowIfNull(candidateFormat);
 
             return (GetIndex(candidateFormat) != -1);
         }
@@ -153,8 +152,7 @@ namespace MS.Internal.IO.Packaging
         /// <returns>signing time</returns>
         internal static DateTime ParseSigningTime(XmlReader reader, string signatureId, out String timeFormat)
         {
-            if (reader == null)
-                throw new ArgumentNullException("reader");
+            ArgumentNullException.ThrowIfNull(reader);
 
             bool signatureTimePropertyFound = false;
             bool signatureTimeIdFound = false;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/InheritanceContextChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/InheritanceContextChangedEventManager.cs
@@ -44,10 +44,8 @@ namespace MS.Internal
         /// </summary>
         public static void AddListener(DependencyObject source, IWeakEventListener listener)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             // Freezable.Freeze() relies on the assumption that a frozen Freezable
             // has no listeners.  This is because Freeze() fails if the Freezable
@@ -63,10 +61,8 @@ namespace MS.Internal
         /// </summary>
         public static void RemoveListener(DependencyObject source, IWeakEventListener listener)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedRemoveListener(source, listener);
         }
@@ -76,8 +72,7 @@ namespace MS.Internal
         /// </summary>
         public static void AddHandler(DependencyObject source, EventHandler<EventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedAddHandler(source, handler);
         }
@@ -87,8 +82,7 @@ namespace MS.Internal
         /// </summary>
         public static void RemoveHandler(DependencyObject source, EventHandler<EventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedRemoveHandler(source, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/ObjectModel/WeakReadOnlyCollection.cs
@@ -38,9 +38,7 @@ namespace System.Collections.ObjectModel
         private Object _syncRoot;
 
         public WeakReadOnlyCollection(IList<WeakReference> list) {  // assumption: the WRs in list refer to T's
-            if (list == null) {
-                throw new ArgumentNullException(nameof(list));
-            }
+            ArgumentNullException.ThrowIfNull(list);
             this.list = list;
         }
 
@@ -145,10 +143,7 @@ namespace System.Collections.ObjectModel
         }
 
         void ICollection.CopyTo(Array array, int index) {
-            if (array == null) {
-                //ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-                throw new ArgumentNullException(nameof(array));
-            }
+            ArgumentNullException.ThrowIfNull(array);
 
             if (array.Rank != 1) {
                 //ThrowHelper.ThrowArgumentException(ExceptionResource.Arg_RankMultiDimNotSupported);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/Specialized/CollectionChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Collections/Specialized/CollectionChangedEventManager.cs
@@ -41,10 +41,8 @@ namespace System.Collections.Specialized
         /// </summary>
         public static void AddListener(INotifyCollectionChanged source, IWeakEventListener listener)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedAddListener(source, listener);
         }
@@ -58,8 +56,7 @@ namespace System.Collections.Specialized
             if (source == null)
                 throw new ArgumentNullException("source");
             */
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedRemoveListener(source, listener);
         }
@@ -69,8 +66,7 @@ namespace System.Collections.Specialized
         /// </summary>
         public static void AddHandler(INotifyCollectionChanged source, EventHandler<NotifyCollectionChangedEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedAddHandler(source, handler);
         }
@@ -80,8 +76,7 @@ namespace System.Collections.Specialized
         /// </summary>
         public static void RemoveHandler(INotifyCollectionChanged source, EventHandler<NotifyCollectionChangedEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedRemoveHandler(source, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangedEventManager.cs
@@ -41,10 +41,8 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddListener(ICollectionView source, IWeakEventListener listener)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedAddListener(source, listener);
         }
@@ -58,8 +56,7 @@ namespace System.ComponentModel
             if (source == null)
                 throw new ArgumentNullException("source");
             */
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedRemoveListener(source, listener);
         }
@@ -69,8 +66,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddHandler(ICollectionView source, EventHandler<EventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedAddHandler(source, handler);
         }
@@ -80,8 +76,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void RemoveHandler(ICollectionView source, EventHandler<EventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedRemoveHandler(source, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangingEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/CurrentChangingEventManager.cs
@@ -42,10 +42,8 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddListener(ICollectionView source, IWeakEventListener listener)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedAddListener(source, listener);
         }
@@ -59,8 +57,7 @@ namespace System.ComponentModel
             if (source == null)
                 throw new ArgumentNullException("source");
             */
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.ProtectedRemoveListener(source, listener);
         }
@@ -70,8 +67,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddHandler(ICollectionView source, EventHandler<CurrentChangingEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedAddHandler(source, handler);
         }
@@ -81,8 +77,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void RemoveHandler(ICollectionView source, EventHandler<CurrentChangingEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedRemoveHandler(source, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/DependencyPropertyDescriptor.cs
@@ -66,7 +66,7 @@ namespace System.ComponentModel
         /// </summary>
         public static DependencyPropertyDescriptor FromProperty(PropertyDescriptor property) 
         {
-            if (property == null) throw new ArgumentNullException(nameof(property));
+            ArgumentNullException.ThrowIfNull(property);
 
             DependencyPropertyDescriptor dpd;
             bool found;
@@ -129,8 +129,8 @@ namespace System.ComponentModel
         /// </summary>
         internal static DependencyPropertyDescriptor FromProperty(DependencyProperty dependencyProperty, Type ownerType, Type targetType, bool ignorePropertyType)
         {
-            if (dependencyProperty == null) throw new ArgumentNullException(nameof(dependencyProperty));
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            ArgumentNullException.ThrowIfNull(dependencyProperty);
+            ArgumentNullException.ThrowIfNull(targetType);
 
             // We have a different codepath here for attached and direct
             // properties.  For direct properties, we route through Type
@@ -196,8 +196,8 @@ namespace System.ComponentModel
         /// </summary>
         public static DependencyPropertyDescriptor FromProperty(DependencyProperty dependencyProperty, Type targetType)
         {
-            if (dependencyProperty == null) throw new ArgumentNullException(nameof(dependencyProperty));
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            ArgumentNullException.ThrowIfNull(dependencyProperty);
+            ArgumentNullException.ThrowIfNull(targetType);
 
             // We have a different codepath here for attached and direct
             // properties.  For direct properties, we route through Type
@@ -259,9 +259,9 @@ namespace System.ComponentModel
         /// </summary>
         public static DependencyPropertyDescriptor FromName(string name, Type ownerType, Type targetType)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
-            if (ownerType == null) throw new ArgumentNullException(nameof(ownerType));
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(ownerType);
+            ArgumentNullException.ThrowIfNull(targetType);
 
             DependencyProperty dp = DependencyProperty.FromName(name, ownerType);
             if (dp != null) 
@@ -282,9 +282,9 @@ namespace System.ComponentModel
         public static DependencyPropertyDescriptor FromName(string name, Type ownerType, Type targetType,
             bool ignorePropertyType)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
-            if (ownerType == null) throw new ArgumentNullException(nameof(ownerType));
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(ownerType);
+            ArgumentNullException.ThrowIfNull(targetType);
 
             DependencyProperty dp = DependencyProperty.FromName(name, ownerType);
             if (dp != null)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/ErrorsChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/ErrorsChangedEventManager.cs
@@ -42,10 +42,8 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddHandler(INotifyDataErrorInfo source, EventHandler<DataErrorsChangedEventArgs> handler)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedAddHandler(source, handler);
         }
@@ -55,10 +53,8 @@ namespace System.ComponentModel
         /// </summary>
         public static void RemoveHandler(INotifyDataErrorInfo source, EventHandler<DataErrorsChangedEventArgs> handler)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.ProtectedRemoveHandler(source, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/ComponentModel/PropertyChangedEventManager.cs
@@ -49,10 +49,8 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddListener(INotifyPropertyChanged source, IWeakEventListener listener, string propertyName)
         {
-            if (source == null)
-                throw new ArgumentNullException("source");
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.PrivateAddListener(source, listener, propertyName);
         }
@@ -66,8 +64,7 @@ namespace System.ComponentModel
             if (source == null)
                 throw new ArgumentNullException("source");
             */
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             CurrentManager.PrivateRemoveListener(source, listener, propertyName);
         }
@@ -77,8 +74,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void AddHandler(INotifyPropertyChanged source, EventHandler<PropertyChangedEventArgs> handler, string propertyName)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.PrivateAddHandler(source, handler, propertyName);
         }
@@ -88,8 +84,7 @@ namespace System.ComponentModel
         /// </summary>
         public static void RemoveHandler(INotifyPropertyChanged source, EventHandler<PropertyChangedEventArgs> handler, string propertyName)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager.PrivateRemoveHandler(source, handler, propertyName);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
@@ -70,14 +70,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                                 VersionPair readerVersion,
                                 VersionPair updaterVersion)
         {
-            if (featureId == null)
-                throw new ArgumentNullException("featureId");
-            if (writerVersion == null)
-                throw new ArgumentNullException("writerVersion");
-            if (readerVersion == null)
-                throw new ArgumentNullException("readerVersion");
-            if (updaterVersion == null)
-                throw new ArgumentNullException("updaterVersion");
+            ArgumentNullException.ThrowIfNull(featureId);
+            ArgumentNullException.ThrowIfNull(writerVersion);
+            ArgumentNullException.ThrowIfNull(readerVersion);
+            ArgumentNullException.ThrowIfNull(updaterVersion);
 
             if (featureId.Length == 0)
             {
@@ -113,10 +109,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 _reader = value;
             }
@@ -133,10 +126,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 _writer = value;
             }
@@ -154,10 +144,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 _updater = value;
             }
@@ -377,10 +364,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         public bool IsReadableBy(VersionPair version)
         {
-            if (version == null)
-            {
-                throw new ArgumentNullException("version");
-            }
+            ArgumentNullException.ThrowIfNull(version);
 
             return (_reader <= version);
         }
@@ -396,10 +380,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         public bool IsUpdatableBy(VersionPair version)
         {
-            if (version == null)
-            {
-                throw new ArgumentNullException("version");
-            }
+            ArgumentNullException.ThrowIfNull(version);
 
             return (_updater <= version);
         }
@@ -446,10 +427,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             checked
             {
-                if (reader == null)
-                {
-                    throw new ArgumentNullException("reader");
-                }
+                ArgumentNullException.ThrowIfNull(reader);
 
                 FormatVersion ver = new FormatVersion();
 
@@ -518,10 +496,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         internal static FormatVersion LoadFromStream(Stream stream, out Int32 bytesRead)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
+            ArgumentNullException.ThrowIfNull(stream);
             // Suppress 56518 Local IDisposable object not disposed: 
             // Reason: The stream is not owned by the BlockManager, therefore we can 
             // close the BinaryWriter as it will Close the stream underneath.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/FormatVersion.cs
@@ -70,10 +70,14 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                                 VersionPair readerVersion,
                                 VersionPair updaterVersion)
         {
-            ArgumentNullException.ThrowIfNull(featureId);
-            ArgumentNullException.ThrowIfNull(writerVersion);
-            ArgumentNullException.ThrowIfNull(readerVersion);
-            ArgumentNullException.ThrowIfNull(updaterVersion);
+            if (featureId == null)
+                throw new ArgumentNullException("featureId");
+            if (writerVersion == null)
+                throw new ArgumentNullException("writerVersion");
+            if (readerVersion == null)
+                throw new ArgumentNullException("readerVersion");
+            if (updaterVersion == null)
+                throw new ArgumentNullException("updaterVersion");
 
             if (featureId.Length == 0)
             {
@@ -109,7 +113,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
 
                 _reader = value;
             }
@@ -126,7 +133,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
             }
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
 
                 _writer = value;
             }
@@ -144,7 +154,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
 
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
 
                 _updater = value;
             }
@@ -364,7 +377,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         public bool IsReadableBy(VersionPair version)
         {
-            ArgumentNullException.ThrowIfNull(version);
+            if (version == null)
+            {
+                throw new ArgumentNullException("version");
+            }
 
             return (_reader <= version);
         }
@@ -380,7 +396,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         public bool IsUpdatableBy(VersionPair version)
         {
-            ArgumentNullException.ThrowIfNull(version);
+            if (version == null)
+            {
+                throw new ArgumentNullException("version");
+            }
 
             return (_updater <= version);
         }
@@ -427,7 +446,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             checked
             {
-                ArgumentNullException.ThrowIfNull(reader);
+                if (reader == null)
+                {
+                    throw new ArgumentNullException("reader");
+                }
 
                 FormatVersion ver = new FormatVersion();
 
@@ -496,7 +518,10 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </remarks>
         internal static FormatVersion LoadFromStream(Stream stream, out Int32 bytesRead)
         {
-            ArgumentNullException.ThrowIfNull(stream);
+            if (stream == null)
+            {
+                throw new ArgumentNullException("stream");
+            }
             // Suppress 56518 Local IDisposable object not disposed: 
             // Reason: The stream is not owned by the BlockManager, therefore we can 
             // close the BinaryWriter as it will Close the stream underneath.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -280,12 +280,11 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-        //check the arguments
-        if( null == name )
-            throw new ArgumentNullException("name");
+            //check the arguments
+            ArgumentNullException.ThrowIfNull(name);
 
-        // Stream names: we preserve casing, but do case-insensitive comparison (Native CompoundFile API behavior)
-        if (((IEqualityComparer) CU.StringCaseInsensitiveComparer).Equals(name,
+            // Stream names: we preserve casing, but do case-insensitive comparison (Native CompoundFile API behavior)
+            if (((IEqualityComparer) CU.StringCaseInsensitiveComparer).Equals(name,
                     EncryptedPackageEnvelope.PackageStreamName))
             throw new ArgumentException(SR.Format(SR.StreamNameNotValid,name));
 
@@ -392,12 +391,11 @@ public class StorageInfo
     public StreamInfo GetStreamInfo(string name)
     {
         CheckDisposedStatus();
-        
-         //check the arguments
-        if( null == name )
-            throw new ArgumentNullException("name");
 
-        StreamInfo streamInfo = new StreamInfo(this, name);
+            //check the arguments
+            ArgumentNullException.ThrowIfNull(name);
+
+            StreamInfo streamInfo = new StreamInfo(this, name);
         if (streamInfo.InternalExists())
         {
             return streamInfo;
@@ -432,12 +430,11 @@ public class StorageInfo
     public void DeleteStream(string name)
     {
         CheckDisposedStatus();
-        
-         //check the arguments
-        if( null == name )
-            throw new ArgumentNullException("name");
-        
-        StreamInfo streamInfo = new StreamInfo(this, name);
+
+            //check the arguments
+            ArgumentNullException.ThrowIfNull(name);
+
+            StreamInfo streamInfo = new StreamInfo(this, name);
         if (streamInfo.InternalExists())
         {
             streamInfo.Delete();
@@ -452,12 +449,11 @@ public class StorageInfo
     public StorageInfo CreateSubStorage( string name )
     {
         CheckDisposedStatus();
-        
-         //check the arguments
-        if( null == name )
-            throw new ArgumentNullException("name");
-        
-        return CreateStorage(name);
+
+            //check the arguments
+            ArgumentNullException.ThrowIfNull(name);
+
+            return CreateStorage(name);
     }
 
     /// <summary>
@@ -499,11 +495,10 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-         //check the arguments
-        if( null == name )
-            throw new ArgumentNullException("name");
+            //check the arguments
+            ArgumentNullException.ThrowIfNull(name);
 
-        StorageInfo storageInfo = new StorageInfo(this, name);
+            StorageInfo storageInfo = new StorageInfo(this, name);
         if (storageInfo.InternalExists(name))
         {
             InvalidateEnumerators();

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageInfo.cs
@@ -280,12 +280,12 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-            //check the arguments
-            ArgumentNullException.ThrowIfNull(name);
+        //check the arguments
+        ArgumentNullException.ThrowIfNull(name);
 
-            // Stream names: we preserve casing, but do case-insensitive comparison (Native CompoundFile API behavior)
-            if (((IEqualityComparer) CU.StringCaseInsensitiveComparer).Equals(name,
-                    EncryptedPackageEnvelope.PackageStreamName))
+        // Stream names: we preserve casing, but do case-insensitive comparison (Native CompoundFile API behavior)
+        if (((IEqualityComparer) CU.StringCaseInsensitiveComparer).Equals(name,
+                EncryptedPackageEnvelope.PackageStreamName))
             throw new ArgumentException(SR.Format(SR.StreamNameNotValid,name));
 
         //create a new streaminfo object
@@ -392,10 +392,10 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-            //check the arguments
-            ArgumentNullException.ThrowIfNull(name);
+        //check the arguments
+        ArgumentNullException.ThrowIfNull(name);
 
-            StreamInfo streamInfo = new StreamInfo(this, name);
+        StreamInfo streamInfo = new StreamInfo(this, name);
         if (streamInfo.InternalExists())
         {
             return streamInfo;
@@ -431,10 +431,10 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-            //check the arguments
-            ArgumentNullException.ThrowIfNull(name);
+        //check the arguments
+        ArgumentNullException.ThrowIfNull(name);
 
-            StreamInfo streamInfo = new StreamInfo(this, name);
+        StreamInfo streamInfo = new StreamInfo(this, name);
         if (streamInfo.InternalExists())
         {
             streamInfo.Delete();
@@ -450,10 +450,10 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-            //check the arguments
-            ArgumentNullException.ThrowIfNull(name);
+        //check the arguments
+        ArgumentNullException.ThrowIfNull(name);
 
-            return CreateStorage(name);
+        return CreateStorage(name);
     }
 
     /// <summary>
@@ -495,10 +495,10 @@ public class StorageInfo
     {
         CheckDisposedStatus();
 
-            //check the arguments
-            ArgumentNullException.ThrowIfNull(name);
+        //check the arguments
+        ArgumentNullException.ThrowIfNull(name);
 
-            StorageInfo storageInfo = new StorageInfo(this, name);
+        StorageInfo storageInfo = new StorageInfo(this, name);
         if (storageInfo.InternalExists(name))
         {
             InvalidateEnumerators();

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
@@ -104,9 +104,9 @@ internal  class StorageRoot : StorageInfo
     /// <returns>New StorageRoot object built on the given Stream</returns>
     internal static StorageRoot CreateOnStream( Stream baseStream )
     {
-            ArgumentNullException.ThrowIfNull(baseStream);
+        ArgumentNullException.ThrowIfNull(baseStream);
 
-            if ( 0 == baseStream.Length )
+        if ( 0 == baseStream.Length )
         {
             return CreateOnStream( baseStream, FileMode.Create );
         }
@@ -124,9 +124,9 @@ internal  class StorageRoot : StorageInfo
     /// <returns>New StorageRoot object built on the given Stream</returns>
     internal static StorageRoot CreateOnStream(Stream baseStream, FileMode mode)
     {
-            ArgumentNullException.ThrowIfNull(baseStream);
+        ArgumentNullException.ThrowIfNull(baseStream);
 
-            IStorage storageOnStream;
+        IStorage storageOnStream;
         int returnValue;
         int openFlags = SafeNativeCompoundFileConstants.STGM_SHARE_EXCLUSIVE;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/CompoundFile/StorageRoot.cs
@@ -104,12 +104,9 @@ internal  class StorageRoot : StorageInfo
     /// <returns>New StorageRoot object built on the given Stream</returns>
     internal static StorageRoot CreateOnStream( Stream baseStream )
     {
-        if (baseStream == null)
-        {
-            throw new ArgumentNullException("baseStream");
-        }
-        
-        if( 0 == baseStream.Length )
+            ArgumentNullException.ThrowIfNull(baseStream);
+
+            if ( 0 == baseStream.Length )
         {
             return CreateOnStream( baseStream, FileMode.Create );
         }
@@ -127,10 +124,9 @@ internal  class StorageRoot : StorageInfo
     /// <returns>New StorageRoot object built on the given Stream</returns>
     internal static StorageRoot CreateOnStream(Stream baseStream, FileMode mode)
     {
-        if( null == baseStream )
-            throw new ArgumentNullException("baseStream");
-        
-        IStorage storageOnStream;
+            ArgumentNullException.ThrowIfNull(baseStream);
+
+            IStorage storageOnStream;
         int returnValue;
         int openFlags = SafeNativeCompoundFileConstants.STGM_SHARE_EXCLUSIVE;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
@@ -63,8 +63,7 @@ namespace System.IO.Packaging
             CryptoProvider cryptoProvider
             )
         {
-            if (envelopeFileName == null)
-                throw new ArgumentNullException("envelopeFileName");
+            ArgumentNullException.ThrowIfNull(envelopeFileName);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
 
@@ -101,8 +100,7 @@ namespace System.IO.Packaging
             CryptoProvider cryptoProvider
             )
         {
-            if (envelopeStream == null)
-                throw new ArgumentNullException("envelopeStream");
+            ArgumentNullException.ThrowIfNull(envelopeStream);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
 
@@ -148,11 +146,9 @@ namespace System.IO.Packaging
             CryptoProvider cryptoProvider
             )
         {
-            if (envelopeFileName == null)
-                throw new ArgumentNullException("envelopeFileName");
+            ArgumentNullException.ThrowIfNull(envelopeFileName);
 
-            if (packageStream == null)
-                throw new ArgumentNullException("packageStream");
+            ArgumentNullException.ThrowIfNull(packageStream);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
 
@@ -194,11 +190,9 @@ namespace System.IO.Packaging
             CryptoProvider cryptoProvider
             )
         {
-            if (envelopeStream == null)
-                throw new ArgumentNullException("envelopeStream");
+            ArgumentNullException.ThrowIfNull(envelopeStream);
 
-            if (packageStream == null)
-                throw new ArgumentNullException("packageStream");
+            ArgumentNullException.ThrowIfNull(packageStream);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
 
@@ -239,8 +233,7 @@ namespace System.IO.Packaging
             FileShare sharing
             )
         {
-            if (envelopeFileName == null)
-                throw new ArgumentNullException("envelopeFileName");
+            ArgumentNullException.ThrowIfNull(envelopeFileName);
 
             _root = StorageRoot.Open(
                                     envelopeFileName,
@@ -264,8 +257,7 @@ namespace System.IO.Packaging
             Stream envelopeStream
             )
         {
-            if (envelopeStream == null)
-                throw new ArgumentNullException("envelopeStream");
+            ArgumentNullException.ThrowIfNull(envelopeStream);
 
             _root = StorageRoot.CreateOnStream(envelopeStream, _defaultFileModeForOpen);
 
@@ -494,8 +486,7 @@ namespace System.IO.Packaging
         {
             bool retval = false;
 
-            if (fileName == null)
-                throw new ArgumentNullException("fileName");
+            ArgumentNullException.ThrowIfNull(fileName);
 
             StorageRoot root = null;
 
@@ -552,8 +543,7 @@ namespace System.IO.Packaging
             Stream stream
             )
         {
-            if (stream == null)
-                throw new ArgumentNullException("stream");
+            ArgumentNullException.ThrowIfNull(stream);
 
             bool retval = false;
             StorageRoot root = null;
@@ -1176,12 +1166,10 @@ namespace System.IO.Packaging
             PublishLicense publishLicense,
             CryptoProvider cryptoProvider)
         {
-            if (publishLicense == null)
-                throw new ArgumentNullException("publishLicense");
+            ArgumentNullException.ThrowIfNull(publishLicense);
 
-            if (cryptoProvider == null)
-                throw new ArgumentNullException("cryptoProvider");
-}
+            ArgumentNullException.ThrowIfNull(cryptoProvider);
+        }
 
         #endregion Private Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/EncryptedPackage.cs
@@ -147,7 +147,6 @@ namespace System.IO.Packaging
             )
         {
             ArgumentNullException.ThrowIfNull(envelopeFileName);
-
             ArgumentNullException.ThrowIfNull(packageStream);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
@@ -191,7 +190,6 @@ namespace System.IO.Packaging
             )
         {
             ArgumentNullException.ThrowIfNull(envelopeStream);
-
             ArgumentNullException.ThrowIfNull(packageStream);
 
             ThrowIfRMEncryptionInfoInvalid(publishLicense, cryptoProvider);
@@ -1167,7 +1165,6 @@ namespace System.IO.Packaging
             CryptoProvider cryptoProvider)
         {
             ArgumentNullException.ThrowIfNull(publishLicense);
-
             ArgumentNullException.ThrowIfNull(cryptoProvider);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignature.cs
@@ -221,8 +221,7 @@ namespace System.IO.Packaging
             set
             {
                 ThrowIfInvalidated();
-                if (value == null)
-                    throw new ArgumentNullException("value");
+                ArgumentNullException.ThrowIfNull(value);
 
                 _processor.Signature = value;
             }
@@ -302,8 +301,7 @@ namespace System.IO.Packaging
 
             VerifyResult result = VerifyResult.NotSigned;
 
-            if (signingCertificate == null)
-                throw new ArgumentNullException("signingCertificate");
+            ArgumentNullException.ThrowIfNull(signingCertificate);
 
             // Check for part existence
             foreach (Uri partUri in SignedParts)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -100,8 +100,7 @@ namespace System.IO.Packaging
             VerifyResult result)
         {
             // verify arguments
-            if (signature == null)
-                throw new ArgumentNullException("signature");
+            ArgumentNullException.ThrowIfNull(signature);
 
             if (result < VerifyResult.Success || result > VerifyResult.NotSigned)
                 throw new System.ArgumentOutOfRangeException("result");
@@ -218,8 +217,7 @@ namespace System.IO.Packaging
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException("value");
+                ArgumentNullException.ThrowIfNull(value);
 
                 if (value.Length == 0)
                     throw new ArgumentException(SR.UnsupportedHashAlgorithm, "value");
@@ -273,8 +271,7 @@ namespace System.IO.Packaging
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException("value");
+                ArgumentNullException.ThrowIfNull(value);
 
                 if (XmlSignatureProperties.LegalFormat(value))
                     _signatureTimeFormat = value;
@@ -343,8 +340,7 @@ namespace System.IO.Packaging
         /// <exception cref="ArgumentNullException">package is null</exception>
         public PackageDigitalSignatureManager(Package package)
         {
-            if (package == null)
-                throw new ArgumentNullException("package");
+            ArgumentNullException.ThrowIfNull(package);
 
             _parentWindow = IntPtr.Zero;
             _container = package;
@@ -620,8 +616,7 @@ namespace System.IO.Packaging
         /// returned signature.</remarks>
         public PackageDigitalSignature Countersign(X509Certificate certificate)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            ArgumentNullException.ThrowIfNull(certificate);
 
             // Counter-sign makes no sense if we are not already signed
             // Check before asking for certificate
@@ -651,11 +646,9 @@ namespace System.IO.Packaging
         /// <exception cref="ArgumentNullException">Both arguments must be non-null.</exception>
         public PackageDigitalSignature Countersign(X509Certificate certificate, IEnumerable<Uri> signatures)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            ArgumentNullException.ThrowIfNull(certificate);
 
-            if (signatures == null)
-                throw new ArgumentNullException("signatures");
+            ArgumentNullException.ThrowIfNull(signatures);
 
             // Counter-sign makes no sense if we are not already signed
             if (!IsSigned)
@@ -720,8 +713,7 @@ namespace System.IO.Packaging
             if (ReadOnly)
                 throw new InvalidOperationException(SR.CannotRemoveSignatureFromReadOnlyFile);
 
-            if (signatureUri == null)
-                throw new ArgumentNullException("signatureUri");
+            ArgumentNullException.ThrowIfNull(signatureUri);
 
             // empty?
             if (!IsSigned)      // calls EnsureSignatures for us
@@ -802,8 +794,7 @@ namespace System.IO.Packaging
         /// <returns>null if signature not found</returns>       
         public PackageDigitalSignature GetSignature(Uri signatureUri)
         {
-            if (signatureUri == null)
-                throw new ArgumentNullException("signatureUri");
+            ArgumentNullException.ThrowIfNull(signatureUri);
 
             int index = GetSignatureIndex(signatureUri);
             if (index < 0)
@@ -823,8 +814,7 @@ namespace System.IO.Packaging
         /// <returns>the first error encountered when inspecting the certificate chain or NoError if the certificate is valid</returns>
         public static X509ChainStatusFlags VerifyCertificate(X509Certificate certificate)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            ArgumentNullException.ThrowIfNull(certificate);
 
             X509ChainStatusFlags status = X509ChainStatusFlags.NoError;
 
@@ -978,8 +968,7 @@ namespace System.IO.Packaging
             IEnumerable<System.Security.Cryptography.Xml.DataObject> signatureObjects,
             IEnumerable<System.Security.Cryptography.Xml.Reference> objectReferences)
         {
-            if (certificate == null)
-                throw new ArgumentNullException("certificate");
+            ArgumentNullException.ThrowIfNull(certificate);
 
             // Check for empty collections in order to provide negative feedback as soon as possible.
             if (EnumeratorEmptyCheck(parts) && EnumeratorEmptyCheck(relationshipSelectors)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/IO/Packaging/PackageDigitalSignatureManager.cs
@@ -647,7 +647,6 @@ namespace System.IO.Packaging
         public PackageDigitalSignature Countersign(X509Certificate certificate, IEnumerable<Uri> signatures)
         {
             ArgumentNullException.ThrowIfNull(certificate);
-
             ArgumentNullException.ThrowIfNull(signatures);
 
             // Counter-sign makes no sense if we are not already signed

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/CryptoProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/CryptoProvider.cs
@@ -71,14 +71,11 @@ namespace System.Security.RightsManagement
         public byte[] Encrypt(byte[] clearText)
         {
             CheckDisposed();
-            
-            if (clearText == null)
-            {
-                throw new ArgumentNullException("clearText");
-            }
+
+            ArgumentNullException.ThrowIfNull(clearText);
 
             // validation of the proper size of the clearText is done by the unmanaged libraries 
-            
+
             if (!CanEncrypt)
             {
                 throw new RightsManagementException(RightsManagementFailureCode.EncryptionNotPermitted);
@@ -130,14 +127,11 @@ namespace System.Security.RightsManagement
         public byte[] Decrypt(byte[] cryptoText)
         {
             CheckDisposed();
-        
-            if (cryptoText == null)
-            {
-                throw new ArgumentNullException("cryptoText");
-            }
+
+            ArgumentNullException.ThrowIfNull(cryptoText);
 
             // validation of the proper size of the cryptoText is done by the unmanaged libraries 
-            
+
             if (!CanDecrypt)
             {
                 throw new RightsManagementException(RightsManagementFailureCode.RightNotGranted);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Exceptions.cs
@@ -148,8 +148,7 @@ namespace System.Security.RightsManagement
 #pragma warning disable SYSLIB0051 // Type or member is obsolete
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null)
-                throw new ArgumentNullException("info");
+            ArgumentNullException.ThrowIfNull(info);
 
             base.GetObjectData(info, context);
             info.AddValue(_serializationFailureCodeAttributeName, (Int32)_failureCode);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
@@ -42,10 +42,7 @@ namespace System.Security.RightsManagement
         {
             // Add validation here 
 
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             if ((right != ContentRight.View) && 
                 (right != ContentRight.Edit) && 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -39,17 +39,11 @@ namespace System.Security.RightsManagement
         /// </summary>
         public LocalizedNameDescriptionPair(string name, string description)
         {
-        
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
 
-            if (description == null)
-            {
-                throw new ArgumentNullException("description");
-            }
-            
+            ArgumentNullException.ThrowIfNull(name);
+
+            ArgumentNullException.ThrowIfNull(description);
+
             _name = name;
             _description = description;
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/LocalizedNameDescriptionPair.cs
@@ -41,7 +41,6 @@ namespace System.Security.RightsManagement
         {
 
             ArgumentNullException.ThrowIfNull(name);
-
             ArgumentNullException.ThrowIfNull(description);
 
             _name = name;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/PublishLicense.cs
@@ -44,11 +44,8 @@ namespace System.Security.RightsManagement
         public PublishLicense(string signedPublishLicense)
         {
 
-            if (signedPublishLicense == null)
-            {
-                throw new ArgumentNullException("signedPublishLicense");
-            }
-            
+            ArgumentNullException.ThrowIfNull(signedPublishLicense);
+
             _serializedPublishLicense = signedPublishLicense;
 
             /////////////////
@@ -92,11 +89,8 @@ namespace System.Security.RightsManagement
         /// </summary>
         public UnsignedPublishLicense DecryptUnsignedPublishLicense(CryptoProvider cryptoProvider )
         {
-            
-            if (cryptoProvider == null)
-            {
-                throw new ArgumentNullException("cryptoProvider");
-            }
+
+            ArgumentNullException.ThrowIfNull(cryptoProvider);
 
             return cryptoProvider.DecryptPublishLicense(_serializedPublishLicense);
         }
@@ -169,11 +163,8 @@ namespace System.Security.RightsManagement
         /// </summary>
         public UseLicense AcquireUseLicense(SecureEnvironment secureEnvironment)
         {
-            
-            if (secureEnvironment == null)
-            {
-                throw new ArgumentNullException("secureEnvironment");
-            }
+
+            ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
             // Accordingly suppressing preSharp warning about having to validate ClientSession.
@@ -191,11 +182,8 @@ namespace System.Security.RightsManagement
         /// </summary>
         public UseLicense AcquireUseLicenseNoUI(SecureEnvironment secureEnvironment)
         {
-                    
-            if (secureEnvironment == null)
-            {
-                throw new ArgumentNullException("secureEnvironment");
-            }
+
+            ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
             // Accordingly suppressing preSharp warning about having to validate ClientSession.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
@@ -251,7 +251,6 @@ namespace System.Security.RightsManagement
         private static SecureEnvironment CriticalCreate(string applicationManifest, ContentUser user)
         {
             ArgumentNullException.ThrowIfNull(applicationManifest);
-
             ArgumentNullException.ThrowIfNull(user);
 
             // we only let specifically identifyed users to be used here  

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/SecureEnvironment.cs
@@ -74,11 +74,8 @@ namespace System.Security.RightsManagement
         /// </summary>
         public static bool IsUserActivated(ContentUser user)
         {
-        
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+
+            ArgumentNullException.ThrowIfNull(user);
 
             // we only let specifically identified users to be used here  
             if ((user.AuthenticationType != AuthenticationType.Windows) && 
@@ -99,11 +96,8 @@ namespace System.Security.RightsManagement
         /// </summary>
         public static void RemoveActivatedUser(ContentUser user)
         {
-            
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+
+            ArgumentNullException.ThrowIfNull(user);
 
             // we only let specifically identifyed users to be used here  
             if ((user.AuthenticationType != AuthenticationType.Windows) && 
@@ -256,15 +250,9 @@ namespace System.Security.RightsManagement
         /// </summary>
         private static SecureEnvironment CriticalCreate(string applicationManifest, ContentUser user)
         {
-            if (applicationManifest == null)
-            {
-                throw new ArgumentNullException("applicationManifest");
-            }
+            ArgumentNullException.ThrowIfNull(applicationManifest);
 
-            if (user == null)
-            {
-                throw new  ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             // we only let specifically identifyed users to be used here  
             if ((user.AuthenticationType != AuthenticationType.Windows) && 
@@ -298,10 +286,7 @@ namespace System.Security.RightsManagement
             AuthenticationType authentication,
             UserActivationMode userActivationMode)
         {
-            if (applicationManifest == null)
-            {
-                throw new ArgumentNullException("applicationManifest");
-            }
+            ArgumentNullException.ThrowIfNull(applicationManifest);
 
             if ((authentication != AuthenticationType.Windows) && 
                  (authentication != AuthenticationType.Passport))

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UnsignedPublishLicense.cs
@@ -52,12 +52,9 @@ namespace System.Security.RightsManagement
         public UnsignedPublishLicense(string publishLicenseTemplate) :this ()
         {
 
-            if (publishLicenseTemplate == null)
-            {   
-                throw new ArgumentNullException("publishLicenseTemplate");
-            }
-            
-            using(IssuanceLicense issuanceLicense = new IssuanceLicense(
+            ArgumentNullException.ThrowIfNull(publishLicenseTemplate);
+
+            using (IssuanceLicense issuanceLicense = new IssuanceLicense(
                                         DateTime.MinValue,  // validFrom, - default 
                                         DateTime.MaxValue,  // validUntil, - default 
                                         null,  // referralInfoName,
@@ -84,10 +81,7 @@ namespace System.Security.RightsManagement
         public PublishLicense Sign(SecureEnvironment secureEnvironment, out UseLicense authorUseLicense)
         {
 
-            if (secureEnvironment == null)
-            {
-                throw new ArgumentNullException("secureEnvironment");
-            }
+            ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // in case owner wasn't specified we can just assume default owner 
             // based on the user identity that was used to build the secure environment

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/UseLicense.cs
@@ -40,10 +40,7 @@ namespace System.Security.RightsManagement
         public UseLicense(string useLicense)
         {
 
-            if (useLicense == null)
-            {
-                throw new ArgumentNullException("useLicense");
-            }
+            ArgumentNullException.ThrowIfNull(useLicense);
             _serializedUseLicense = useLicense;
 
 
@@ -115,10 +112,7 @@ namespace System.Security.RightsManagement
         public CryptoProvider Bind (SecureEnvironment secureEnvironment)
         {
 
-            if (secureEnvironment == null)
-            {
-                throw new ArgumentNullException("secureEnvironment");
-            }
+            ArgumentNullException.ThrowIfNull(secureEnvironment);
 
             // The SecureEnvironment constructor makes sure ClientSession cannot be null.
             // Accordingly suppressing preSharp warning about having to validate ClientSession.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/User.cs
@@ -39,10 +39,7 @@ namespace System.Security.RightsManagement
         public ContentUser(string name, AuthenticationType authenticationType)
         {
 
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Trim().Length == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableForTypeAttribute.cs
@@ -31,7 +31,7 @@ namespace System.Windows
         /// </summary>
         public AttachedPropertyBrowsableForTypeAttribute(Type targetType)
         {
-            if (targetType == null) throw new ArgumentNullException("targetType");
+            ArgumentNullException.ThrowIfNull(targetType);
             _targetType = targetType;
         }
         
@@ -109,8 +109,8 @@ namespace System.Windows
         /// </summary>
         internal override bool IsBrowsable(DependencyObject d, DependencyProperty dp)
         {
-            if (d == null) throw new ArgumentNullException("d");
-            if (dp == null) throw new ArgumentNullException("dp");
+            ArgumentNullException.ThrowIfNull(d);
+            ArgumentNullException.ThrowIfNull(dp);
 
             // Get the dependency object type for our target type.
             // We cannot assume the user didn't do something wrong and

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AttachedPropertyBrowsableWhenAttributePresentAttribute.cs
@@ -29,7 +29,7 @@ namespace System.Windows
         /// </summary>
         public AttachedPropertyBrowsableWhenAttributePresentAttribute(Type attributeType)
         {
-            if (attributeType == null) throw new ArgumentNullException("attributeType");
+            ArgumentNullException.ThrowIfNull(attributeType);
 
             _attributeType = attributeType;
         }
@@ -94,8 +94,8 @@ namespace System.Windows
         /// </summary>
         internal override bool IsBrowsable(DependencyObject d, DependencyProperty dp)
         {
-            if (d == null) throw new ArgumentNullException("d");
-            if (dp == null) throw new ArgumentNullException("dp");
+            ArgumentNullException.ThrowIfNull(d);
+            ArgumentNullException.ThrowIfNull(dp);
 
             Attribute a = TypeDescriptor.GetAttributes(d)[_attributeType];
             return (a != null && !a.IsDefaultAttribute());

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -171,10 +171,7 @@ namespace System.Windows
             //
             this.VerifyAccess();
 
-            if (dp == null)
-            {
-                throw new ArgumentNullException("dp");
-            }
+            ArgumentNullException.ThrowIfNull(dp);
 
             // Call Forwarded
             return GetValueEntry(
@@ -1215,10 +1212,7 @@ namespace System.Windows
             //
             this.VerifyAccess();
 
-            if (dp == null)
-            {
-                throw new ArgumentNullException("dp");
-            }
+            ArgumentNullException.ThrowIfNull(dp);
 
             EffectiveValueEntry newEntry = new EffectiveValueEntry(dp, BaseValueSourceInternal.Unknown);
             newEntry.IsCoercedWithCurrentValue = preserveCurrentValue;
@@ -1251,12 +1245,9 @@ namespace System.Windows
                 bool                coerceWithCurrentValue,
                 OperationType       operationType)
         {
-            if (dp == null)
-            {
-                throw new ArgumentNullException("dp");
-            }
+            ArgumentNullException.ThrowIfNull(dp);
 
-#region EventTracing
+            #region EventTracing
 #if VERBOSE_PROPERTY_EVENT
             bool isDynamicTracing = EventTrace.IsEnabled(EventTrace.Flags.performance, EventTrace.Level.verbose); // This was under "normal"
             if (isDynamicTracing)
@@ -1278,7 +1269,7 @@ namespace System.Windows
 #endif
 
 
-#endregion EventTracing
+            #endregion EventTracing
 
 #if NESTED_OPERATIONS_CHECK
             // Are we invalidating out of control?
@@ -2101,10 +2092,7 @@ namespace System.Windows
         internal BaseValueSourceInternal GetValueSource(DependencyProperty dp, PropertyMetadata metadata,
                 out bool hasModifiers, out bool isExpression, out bool isAnimated, out bool isCoerced, out bool isCurrent)
         {
-            if (dp == null)
-            {
-                throw new ArgumentNullException("dp");
-            }
+            ArgumentNullException.ThrowIfNull(dp);
 
             EntryIndex entryIndex = LookupEntry(dp.GlobalIndex);
 
@@ -2180,10 +2168,7 @@ namespace System.Windows
             //
             this.VerifyAccess();
 
-            if (dp == null)
-            {
-                throw new ArgumentNullException("dp");
-            }
+            ArgumentNullException.ThrowIfNull(dp);
 
             EntryIndex entryIndex = LookupEntry(dp.GlobalIndex);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObject.cs
@@ -596,21 +596,16 @@ namespace System.Windows
         /// </summary>
         private PropertyMetadata SetupPropertyChange(DependencyProperty dp)
         {
-            if ( dp != null )
+            ArgumentNullException.ThrowIfNull(dp);
+
+            if (!dp.ReadOnly)
             {
-                if ( !dp.ReadOnly )
-                {
-                    // Get type-specific metadata for this property
-                    return dp.GetMetadata(DependencyObjectType);
-                }
-                else
-                {
-                    throw new InvalidOperationException(SR.Format(SR.ReadOnlyChangeNotAllowed, dp.Name));
-                }
+                // Get type-specific metadata for this property
+                return dp.GetMetadata(DependencyObjectType);
             }
             else
             {
-                throw new ArgumentNullException("dp");
+                throw new InvalidOperationException(SR.Format(SR.ReadOnlyChangeNotAllowed, dp.Name));
             }
         }
 
@@ -620,20 +615,15 @@ namespace System.Windows
         /// </summary>
         private PropertyMetadata SetupPropertyChange(DependencyPropertyKey key, out DependencyProperty dp)
         {
-            if ( key != null )
-            {
-                dp = key.DependencyProperty;
-                Debug.Assert(dp != null);
+            ArgumentNullException.ThrowIfNull(key);
 
-                dp.VerifyReadOnlyKey(key);
+            dp = key.DependencyProperty;
+            Debug.Assert(dp != null);
 
-                // Get type-specific metadata for this property
-                return dp.GetMetadata(DependencyObjectType);
-            }
-            else
-            {
-                throw new ArgumentNullException("key");
-            }
+            dp.VerifyReadOnlyKey(key);
+
+            // Get type-specific metadata for this property
+            return dp.GetMetadata(DependencyObjectType);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyObjectType.cs
@@ -45,10 +45,7 @@ namespace System.Windows
         /// </returns>
         public static DependencyObjectType FromSystemType(Type systemType)
         {
-            if (systemType == null)
-            {
-                throw new ArgumentNullException("systemType");
-            }
+            ArgumentNullException.ThrowIfNull(systemType);
 
             if (!typeof(DependencyObject).IsAssignableFrom(systemType))
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -244,25 +244,16 @@ namespace System.Windows
 
         private static void RegisterParameterValidation(string name, Type propertyType, Type ownerType)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException("name");
-            }
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Length == 0)
             {
                 throw new ArgumentException(SR.StringEmpty, "name");
             }
 
-            if (ownerType == null)
-            {
-                throw new ArgumentNullException("ownerType");
-            }
+            ArgumentNullException.ThrowIfNull(ownerType);
 
-            if (propertyType == null)
-            {
-                throw new ArgumentNullException("propertyType");
-            }
+            ArgumentNullException.ThrowIfNull(propertyType);
         }
 
         private static DependencyProperty RegisterCommon(string name, Type propertyType, Type ownerType, PropertyMetadata defaultMetadata, ValidateValueCallback validateValueCallback)
@@ -468,15 +459,9 @@ namespace System.Windows
             out DependencyObjectType dType,
             out PropertyMetadata baseMetadata )
         {
-            if (forType == null)
-            {
-                throw new ArgumentNullException("forType");
-            }
+            ArgumentNullException.ThrowIfNull(forType);
 
-            if (typeMetadata == null)
-            {
-                throw new ArgumentNullException("typeMetadata");
-            }
+            ArgumentNullException.ThrowIfNull(typeMetadata);
 
             if (typeMetadata.Sealed)
             {
@@ -547,10 +532,7 @@ namespace System.Windows
 
             SetupOverrideMetadata(forType, typeMetadata, out dType, out baseMetadata);
 
-            if (key == null)
-            {
-                throw new ArgumentNullException("key");
-            }
+            ArgumentNullException.ThrowIfNull(key);
 
             if (ReadOnly)
             {
@@ -783,10 +765,7 @@ namespace System.Windows
         /// <returns>This property</returns>
         public DependencyProperty AddOwner(Type ownerType, PropertyMetadata typeMetadata)
         {
-            if (ownerType == null)
-            {
-                throw new ArgumentNullException("ownerType");
-            }
+            ArgumentNullException.ThrowIfNull(ownerType);
 
             // Map owner type to this property
             // Build key

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/DependencyProperty.cs
@@ -252,7 +252,6 @@ namespace System.Windows
             }
 
             ArgumentNullException.ThrowIfNull(ownerType);
-
             ArgumentNullException.ThrowIfNull(propertyType);
         }
 
@@ -460,7 +459,6 @@ namespace System.Windows
             out PropertyMetadata baseMetadata )
         {
             ArgumentNullException.ThrowIfNull(forType);
-
             ArgumentNullException.ThrowIfNull(typeMetadata);
 
             if (typeMetadata.Sealed)
@@ -633,11 +631,8 @@ namespace System.Windows
         /// <returns>Property metadata</returns>
         public PropertyMetadata GetMetadata(Type forType)
         {
-            if (forType != null)
-            {
-                return GetMetadata(DependencyObjectType.FromSystemType(forType));
-            }
-            throw new ArgumentNullException("forType");
+            ArgumentNullException.ThrowIfNull(forType);
+            return GetMetadata(DependencyObjectType.FromSystemType(forType));
         }
 
         /// <summary>
@@ -647,11 +642,8 @@ namespace System.Windows
         /// <returns>Property metadata</returns>
         public PropertyMetadata GetMetadata(DependencyObject dependencyObject)
         {
-            if (dependencyObject != null)
-            {
-                return GetMetadata(dependencyObject.DependencyObjectType);
-            }
-            throw new ArgumentNullException("dependencyObject");
+            ArgumentNullException.ThrowIfNull(dependencyObject);
+            return GetMetadata(dependencyObject.DependencyObjectType);
         }
 
         /// <summary>
@@ -984,37 +976,27 @@ namespace System.Windows
         {
             DependencyProperty dp = null;
 
-            if (name != null)
+            ArgumentNullException.ThrowIfNull(name);
+            ArgumentNullException.ThrowIfNull(ownerType);
+
+            FromNameKey key = new FromNameKey(name, ownerType);
+
+            while ((dp == null) && (ownerType != null))
             {
-                if (ownerType != null)
+                // Ensure static constructor of type has run
+                MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(ownerType);
+
+                // Locate property
+                key.UpdateNameKey(ownerType);
+
+                lock (Synchronized)
                 {
-                    FromNameKey key = new FromNameKey(name, ownerType);
-
-                    while ((dp == null) && (ownerType != null))
-                    {
-                        // Ensure static constructor of type has run
-                        MS.Internal.WindowsBase.SecurityHelper.RunClassConstructor(ownerType);
-
-                        // Locate property
-                        key.UpdateNameKey(ownerType);
-
-                        lock (Synchronized)
-                        {
-                            dp = (DependencyProperty)PropertyFromName[key];
-                        }
-
-                        ownerType = ownerType.BaseType;
-                    }
+                    dp = (DependencyProperty)PropertyFromName[key];
                 }
-                else
-                {
-                    throw new ArgumentNullException("ownerType");
-                }
+
+                ownerType = ownerType.BaseType;
             }
-            else
-            {
-                throw new ArgumentNullException("name");
-            }
+
             return dp;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Expression.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Expression.cs
@@ -200,14 +200,10 @@ namespace System.Windows
         /// <param name="newSources">New sources</param>
         internal void ChangeSources(DependencyObject d, DependencyProperty dp, DependencySource[] newSources)
         {
-            if (d == null && !ForwardsInvalidations)
+            if (!ForwardsInvalidations)
             {
-                throw new ArgumentNullException("d");
-            }
-
-            if (dp == null && !ForwardsInvalidations)
-            {
-                throw new ArgumentNullException("dp");
+                ArgumentNullException.ThrowIfNull(d);
+                ArgumentNullException.ThrowIfNull(dp);
             }
 
             if (Shareable)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -110,8 +110,7 @@ namespace System.Windows.Input
         /// <ExternalAPI/> 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType == null)
-                throw new ArgumentNullException("destinationType");
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             if (destinationType == typeof(string) && value != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -104,8 +104,7 @@ namespace System.Windows.Input
         /// <ExternalAPI/> 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType == null)
-                throw new ArgumentNullException("destinationType");
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             if (destinationType == typeof(string))
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
@@ -50,15 +50,9 @@ namespace System.Windows.Markup
         /// <param name="service"></param>
         public void AddService(Type serviceType, Object service)
         {
-            if (serviceType == null)
-            {
-                throw new ArgumentNullException("serviceType");
-            }
+            ArgumentNullException.ThrowIfNull(serviceType);
 
-            if (service == null)
-            {
-                throw new ArgumentNullException("service");
-            }
+            ArgumentNullException.ThrowIfNull(service);
 
             if (_objDict.ContainsKey(serviceType) == false)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Markup/ServiceProviders.cs
@@ -51,7 +51,6 @@ namespace System.Windows.Markup
         public void AddService(Type serviceType, Object service)
         {
             ArgumentNullException.ThrowIfNull(serviceType);
-
             ArgumentNullException.ThrowIfNull(service);
 
             if (_objDict.ContainsKey(serviceType) == false)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
@@ -42,7 +42,6 @@ namespace System.Windows
         public void RegisterName(string name, object scopedElement)
         {
             ArgumentNullException.ThrowIfNull(name);
-
             ArgumentNullException.ThrowIfNull(scopedElement);
 
             if (name.Length == 0)
@@ -297,7 +296,6 @@ namespace System.Windows
             set
             {
                 ArgumentNullException.ThrowIfNull(key);
-
                 ArgumentNullException.ThrowIfNull(value);
 
                 RegisterName(key, value);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/NameScope.cs
@@ -41,11 +41,9 @@ namespace System.Windows
         /// <param name="scopedElement">object mapped to name</param>
         public void RegisterName(string name, object scopedElement)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
-            if (scopedElement == null)
-                throw new ArgumentNullException(nameof(scopedElement));
+            ArgumentNullException.ThrowIfNull(scopedElement);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -89,8 +87,7 @@ namespace System.Windows
         /// <param name="name">name to be registered</param>
         public void UnregisterName(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
             if (name.Length == 0)
                 throw new ArgumentException(SR.NameScopeNameNotEmptyString);
@@ -164,10 +161,7 @@ namespace System.Windows
         /// <param name="value">NameScope property value.</param>
         public static void SetNameScope(DependencyObject dependencyObject, INameScope value)
         {
-            if (dependencyObject == null)
-            {
-                throw new ArgumentNullException(nameof(dependencyObject));
-            }
+            ArgumentNullException.ThrowIfNull(dependencyObject);
 
             dependencyObject.SetValue(NameScopeProperty, value);
         }
@@ -180,10 +174,7 @@ namespace System.Windows
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public static INameScope GetNameScope(DependencyObject dependencyObject)
         {
-            if (dependencyObject == null)
-            {
-                throw new ArgumentNullException(nameof(dependencyObject));
-            }
+            ArgumentNullException.ThrowIfNull(dependencyObject);
 
             return ((INameScope)dependencyObject.GetValue(NameScopeProperty));
         }
@@ -300,23 +291,14 @@ namespace System.Windows
         {
             get
             {
-                if (key == null)
-                {
-                    throw new ArgumentNullException("key");
-                }
+                ArgumentNullException.ThrowIfNull(key);
                 return FindName(key);
             }
             set
             {
-                if (key == null)
-                {
-                    throw new ArgumentNullException("key");
-                }
+                ArgumentNullException.ThrowIfNull(key);
 
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 RegisterName(key, value);
             }
@@ -324,20 +306,14 @@ namespace System.Windows
 
         public void Add(string key, object value)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException("key");
-            }
+            ArgumentNullException.ThrowIfNull(key);
 
             RegisterName(key, value);
         }
 
         public bool ContainsKey(string key)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException("key");
-            }
+            ArgumentNullException.ThrowIfNull(key);
 
             object value = FindName(key);
             return (value != null);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
@@ -568,10 +568,7 @@ namespace System.Windows
         /// <param name="dp">DependencyProperty that this metadata is being applied to</param>
         protected virtual void Merge(PropertyMetadata baseMetadata, DependencyProperty dp)
         {
-            if (baseMetadata == null)
-            {
-                throw new ArgumentNullException("baseMetadata");
-            }
+            ArgumentNullException.ThrowIfNull(baseMetadata);
 
             if (Sealed)
             {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -43,10 +43,7 @@ namespace System.Windows
 
         public SplashScreen(Assembly resourceAssembly, string resourceName)
         {
-            if (resourceAssembly == null)
-            {
-                throw new ArgumentNullException("resourceAssembly");
-            }
+            ArgumentNullException.ThrowIfNull(resourceAssembly);
             if (String.IsNullOrEmpty(resourceName))
             {
                 throw new ArgumentNullException("resourceName");

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -312,10 +312,7 @@ namespace System.Windows.Threading
         /// </param>
         public static void PushFrame(DispatcherFrame frame)
         {
-            if(frame == null)
-            {
-                throw new ArgumentNullException("frame");
-            }
+            ArgumentNullException.ThrowIfNull(frame);
 
             Dispatcher dispatcher = Dispatcher.CurrentDispatcher;
             if(dispatcher._hasShutdownFinished) // Dispatcher thread - no lock needed for read
@@ -581,10 +578,7 @@ namespace System.Windows.Threading
         /// </param>
         public void Invoke(Action callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
         {
-            if(callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
             ValidatePriority(priority, "priority");
 
             if( timeout.TotalMilliseconds < 0 &&
@@ -726,10 +720,7 @@ namespace System.Windows.Threading
         /// </returns>
         public TResult Invoke<TResult>(Func<TResult> callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
         {
-            if(callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
             ValidatePriority(priority, "priority");
 
             if( timeout.TotalMilliseconds < 0 &&
@@ -842,10 +833,7 @@ namespace System.Windows.Threading
         /// </returns>
         public DispatcherOperation InvokeAsync(Action callback, DispatcherPriority priority, CancellationToken cancellationToken)
         {
-            if(callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
             ValidatePriority(priority, "priority");
 
             DispatcherOperation operation = new DispatcherOperation(this, priority, callback);
@@ -915,10 +903,7 @@ namespace System.Windows.Threading
         /// </returns>
         public DispatcherOperation<TResult> InvokeAsync<TResult>(Func<TResult> callback, DispatcherPriority priority, CancellationToken cancellationToken)
         {
-            if(callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
             ValidatePriority(priority, "priority");
 
             DispatcherOperation<TResult> operation = new DispatcherOperation<TResult>(this, priority, callback);
@@ -930,10 +915,7 @@ namespace System.Windows.Threading
         private DispatcherOperation LegacyBeginInvokeImpl(DispatcherPriority priority, Delegate method, object args, int numArgs)
         {
             ValidatePriority(priority, "priority");
-            if(method == null)
-            {
-                throw new ArgumentNullException("method");
-            }
+            ArgumentNullException.ThrowIfNull(method);
 
             DispatcherOperation operation = new DispatcherOperation(this, method, priority, args, numArgs);
             InvokeAsyncImpl(operation, CancellationToken.None);
@@ -1286,12 +1268,9 @@ namespace System.Windows.Threading
                 throw new ArgumentException(SR.InvalidPriority, "priority");
             }
 
-            if(method == null)
-            {
-                throw new ArgumentNullException("method");
-            }
+            ArgumentNullException.ThrowIfNull(method);
 
-            if( timeout.TotalMilliseconds < 0 &&
+            if ( timeout.TotalMilliseconds < 0 &&
                 timeout != TimeSpan.FromMilliseconds(-1))
             {
                 if(CheckAccess())

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherSynchronizationContext.cs
@@ -39,11 +39,8 @@ namespace System.Windows.Threading
         /// </summary>
         public DispatcherSynchronizationContext(Dispatcher dispatcher, DispatcherPriority priority)
         {
-            if(dispatcher == null)
-            {
-                throw new ArgumentNullException("dispatcher");
-            }
-            
+            ArgumentNullException.ThrowIfNull(dispatcher);
+
             Dispatcher.ValidatePriority(priority, "priority");
             
             _dispatcher = dispatcher;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherTimer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/DispatcherTimer.cs
@@ -49,11 +49,8 @@ namespace System.Windows.Threading
         /// </param>
         public DispatcherTimer(DispatcherPriority priority, Dispatcher dispatcher)  // NOTE: should be Priority
         {
-            if(dispatcher == null)
-            {
-                throw new ArgumentNullException("dispatcher");
-            }
-            
+            ArgumentNullException.ThrowIfNull(dispatcher);
+
             Initialize(dispatcher, priority, TimeSpan.FromMilliseconds(0));
         }
 
@@ -76,14 +73,8 @@ namespace System.Windows.Threading
         /// </param>
         public DispatcherTimer(TimeSpan interval, DispatcherPriority priority, EventHandler callback, Dispatcher dispatcher) // NOTE: should be Priority
         {
-            if(callback == null)
-            {
-                throw new ArgumentNullException("callback");
-            }
-            if(dispatcher == null)
-            {
-                throw new ArgumentNullException("dispatcher");
-            }
+            ArgumentNullException.ThrowIfNull(callback);
+            ArgumentNullException.ThrowIfNull(dispatcher);
 
             if (interval.TotalMilliseconds < 0)
                 throw new ArgumentOutOfRangeException("interval", SR.TimeSpanPeriodOutOfRange_TooSmall);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManager.cs
@@ -228,8 +228,7 @@ namespace System.Windows
         /// </summary>
         protected void ProtectedAddListener(object source, IWeakEventListener listener)
         {
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             AddListener(source, listener, null);
         }
@@ -239,8 +238,7 @@ namespace System.Windows
         /// </summary>
         protected void ProtectedRemoveListener(object source, IWeakEventListener listener)
         {
-            if (listener == null)
-                throw new ArgumentNullException("listener");
+            ArgumentNullException.ThrowIfNull(listener);
 
             RemoveListener(source, listener, null);
         }
@@ -250,8 +248,7 @@ namespace System.Windows
         /// </summary>
         protected void ProtectedAddHandler(object source, Delegate handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             AddListener(source, null, handler);
         }
@@ -261,8 +258,7 @@ namespace System.Windows
         /// </summary>
         protected void ProtectedRemoveHandler(object source, Delegate handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             RemoveListener(source, null, handler);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/WeakEventManagerT.cs
@@ -46,8 +46,7 @@ namespace System.Windows
         /// </summary>
         public static void AddHandler(TEventSource source, string eventName, EventHandler<TEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager(eventName).ProtectedAddHandler(source, handler);
         }
@@ -57,8 +56,7 @@ namespace System.Windows
         /// </summary>
         public static void RemoveHandler(TEventSource source, string eventName, EventHandler<TEventArgs> handler)
         {
-            if (handler == null)
-                throw new ArgumentNullException("handler");
+            ArgumentNullException.ThrowIfNull(handler);
 
             CurrentManager(eventName).ProtectedRemoveHandler(source, handler);
         }


### PR DESCRIPTION
## Description

Use ArgumentNullException.ThrowIfNull in WindowsBase, as in #7181

## Regression

No

## Testing

CI

## Risk

Low: changes are mostly mechanic, using fixer CA1510

Note that StorageInfo.cs and StorageRoot.cs don't follow indentation conventions, so I had to manually realign what the analyzer changed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8125)