### PR TITLE
Fixed PublishTestResult task and renamed Run xUnit Test task

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -192,7 +192,7 @@ jobs:
           $(_OfficialBuildIdArgs)
           $(_PlatformArgs)
           $(_InternalRuntimeDownloadArgs)
-        displayName: Windows Build / Publish
+        displayName: Run xUnit Tests
         condition: and(or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))), ne(variables['_Platform'], 'arm64'))
 
       - task: PublishTestResults@2
@@ -203,7 +203,7 @@ jobs:
           searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
           mergeTestResults: true
         continueOnError: true
-        condition: and(succeeded(), eq(variables['_BuildConfig'], 'Release'), ne(variables['_Platform'], 'arm64'))     
+        condition: and(eq(variables['_BuildConfig'], 'Release'), ne(variables['_Platform'], 'arm64'))     
 
       - task: PowerShell@2
         displayName: Install .NET Core


### PR DESCRIPTION
## Description
- As of now, whenever, xUnit tests fail the Publish xUnit test result task is not run, due to the condition `succeeded()` in the task. Fixing this behavior in this PR.
- Updated the name of the xUnit tests run task to differentiate between build and the run test steps


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8133)