### PR TITLE
Use ArgumentNullException.ThrowIfNull in UIAutomation projects

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsCLR.cs
@@ -3577,10 +3577,7 @@ namespace MS.Win32 {
             }
             public LOGFONT( LOGFONT lf )
             {
-                if (lf == null)
-                {
-                    throw new ArgumentNullException("lf");
-                }
+                ArgumentNullException.ThrowIfNull(lf);
 
                 this.lfHeight           = lf.lfHeight;
                 this.lfWidth            = lf.lfWidth;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -45,7 +45,11 @@ namespace MS.Internal.Automation
         // compare two arrays
         internal static bool Compare(int[] a1, int[] a2)
         {
-            CheckNonNull(a1, a2);
+            if (a1 == null)
+                throw new ArgumentNullException("el1");
+
+            if (a2 == null)
+                throw new ArgumentNullException("el2");
 
             int l = a1.Length;
 
@@ -66,7 +70,11 @@ namespace MS.Internal.Automation
         // compare two AutomationElements
         internal static bool Compare(AutomationElement el1, AutomationElement el2)
         {
-            CheckNonNull(el1, el2);
+            if (el1 == null)
+                throw new ArgumentNullException("el1");
+
+            if (el2 == null)
+                throw new ArgumentNullException("el2");
             return Compare(el1.GetRuntimeId(), el2.GetRuntimeId());
         }
         #endregion Element Comparisons
@@ -738,16 +746,6 @@ namespace MS.Internal.Automation
         //------------------------------------------------------
 
         #region Private Methods
-
-        // Helper used by the various comparison functions above
-        private static void CheckNonNull(object el1, object el2)
-        {
-            if (el1 == null)
-                throw new ArgumentNullException("el1");
-
-            if (el2 == null)
-                throw new ArgumentNullException("el2");
-        }
 
         //This function throws corresponding exception depending on the last error.
         private static void EvaluateSendMessageTimeoutError(int error)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -168,15 +168,6 @@ namespace MS.Internal.Automation
 
         #region Param validation & Error related
 
-        // Check that specified argument is non-null, if so, throw exception
-        internal static void ValidateArgumentNonNull(object obj, string argName)
-        {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(argName);
-            }
-        }
-
         // Throw an argument Exception with a generic error
         internal static void ThrowInvalidArgument(string argName)
         {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -45,11 +45,8 @@ namespace MS.Internal.Automation
         // compare two arrays
         internal static bool Compare(int[] a1, int[] a2)
         {
-            if (a1 == null)
-                throw new ArgumentNullException("el1");
-
-            if (a2 == null)
-                throw new ArgumentNullException("el2");
+            ArgumentNullException.ThrowIfNull(a1);
+            ArgumentNullException.ThrowIfNull(a2);
 
             int l = a1.Length;
 
@@ -70,11 +67,8 @@ namespace MS.Internal.Automation
         // compare two AutomationElements
         internal static bool Compare(AutomationElement el1, AutomationElement el2)
         {
-            if (el1 == null)
-                throw new ArgumentNullException("el1");
-
-            if (el2 == null)
-                throw new ArgumentNullException("el2");
+            ArgumentNullException.ThrowIfNull(el1);
+            ArgumentNullException.ThrowIfNull(el2);
             return Compare(el1.GetRuntimeId(), el2.GetRuntimeId());
         }
         #endregion Element Comparisons

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
@@ -36,11 +36,18 @@ namespace System.Windows.Automation
         /// <param name="conditions">One or more sub-condition</param>
         public AndCondition( params Condition [ ] conditions )
         {
-            Misc.ValidateArgumentNonNull( conditions, "conditions" );
+            if (conditions == null)
+            {
+                throw new ArgumentNullException("conditions");
+            }
+
             Misc.ValidateArgument( conditions.Length >= 2, nameof(SR.MustBeAtLeastTwoConditions) );
             foreach( Condition condition in conditions )
             {
-                Misc.ValidateArgumentNonNull( condition, "conditions" );
+                if (condition == null)
+                {
+                    throw new ArgumentNullException("conditions");
+                }
             }
 
             // clone array to prevent accidental tampering

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AndCondition.cs
@@ -36,18 +36,11 @@ namespace System.Windows.Automation
         /// <param name="conditions">One or more sub-condition</param>
         public AndCondition( params Condition [ ] conditions )
         {
-            if (conditions == null)
-            {
-                throw new ArgumentNullException("conditions");
-            }
-
+            ArgumentNullException.ThrowIfNull(conditions);
             Misc.ValidateArgument( conditions.Length >= 2, nameof(SR.MustBeAtLeastTwoConditions) );
             foreach( Condition condition in conditions )
             {
-                if (condition == null)
-                {
-                    throw new ArgumentNullException("conditions");
-                }
+                ArgumentNullException.ThrowIfNull(condition, nameof(conditions));
             }
 
             // clone array to prevent accidental tampering

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
@@ -98,11 +98,7 @@ namespace System.Windows.Automation
         /// <returns>Sting containing human-readable name of specified property</returns>
         public static string PropertyName( AutomationProperty property )
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException("property");
-            }
-
+            ArgumentNullException.ThrowIfNull(property);
             // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
 #pragma warning suppress 56506
             string full = property.ProgrammaticName.Split('.')[1]; // remove portion before the ".", leaving just "NameProperty" or similar
@@ -116,11 +112,7 @@ namespace System.Windows.Automation
         /// <returns>Sting containing human-readable name of specified pattern</returns>
         public static string PatternName( AutomationPattern pattern )
         {
-            if (pattern == null)
-            {
-                throw new ArgumentNullException("pattern");
-            }
-
+            ArgumentNullException.ThrowIfNull(pattern);
             // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
 #pragma warning suppress 56506
             string full = pattern.ProgrammaticName;
@@ -143,16 +135,8 @@ namespace System.Windows.Automation
             AutomationEventHandler eventHandler
             )
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
             Misc.ValidateArgument( eventId != AutomationElement.AutomationFocusChangedEvent, nameof(SR.EventIdMustNotBeAutomationFocusChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.StructureChangedEvent, nameof(SR.EventIdMustNotBeStructureChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.AutomationPropertyChangedEvent, nameof(SR.EventIdMustNotBeAutomationPropertyChanged) );
@@ -222,16 +206,8 @@ namespace System.Windows.Automation
             AutomationEventHandler eventHandler
             )
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
             Misc.ValidateArgument( eventId != AutomationElement.AutomationFocusChangedEvent, nameof(SR.EventIdMustNotBeAutomationFocusChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.StructureChangedEvent, nameof(SR.EventIdMustNotBeStructureChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.AutomationPropertyChangedEvent, nameof(SR.EventIdMustNotBeAutomationPropertyChanged) );
@@ -254,21 +230,9 @@ namespace System.Windows.Automation
             params AutomationProperty [] properties           // listen for changes to these properties
             )
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
-
-            if (properties == null)
-            {
-                throw new ArgumentNullException("properties");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
+            ArgumentNullException.ThrowIfNull(properties);
             if (properties.Length == 0)
             {
                 throw new ArgumentException( SR.AtLeastOnePropertyMustBeSpecified );
@@ -300,15 +264,8 @@ namespace System.Windows.Automation
             AutomationPropertyChangedEventHandler eventHandler     // callback object (used as cookie here)
             )
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveListener(AutomationElement.AutomationPropertyChangedEvent, element, eventHandler);
@@ -322,15 +279,8 @@ namespace System.Windows.Automation
         /// <param name="eventHandler">Delegate to call when a structure change event occurs.</param>
         public static void AddStructureChangedEventHandler(AutomationElement element, TreeScope scope, StructureChangedEventHandler eventHandler)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
 
             // Add a client-side listener for for this event request
             EventListener l = new EventListener(AutomationElement.StructureChangedEvent, scope, null, CacheRequest.CurrentUiaCacheRequest);
@@ -345,15 +295,8 @@ namespace System.Windows.Automation
         /// <param name="eventHandler">The handler object that was passed to AddStructureChangedListener</param>
         public static void RemoveStructureChangedEventHandler(AutomationElement element, StructureChangedEventHandler eventHandler)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(eventHandler);
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveListener(AutomationElement.StructureChangedEvent, element, eventHandler);
@@ -367,10 +310,7 @@ namespace System.Windows.Automation
             AutomationFocusChangedEventHandler eventHandler
             )
         {
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
+            ArgumentNullException.ThrowIfNull(eventHandler);
 
             // Add a client-side listener for for this event request
             EventListener l = new EventListener(AutomationElement.AutomationFocusChangedEvent, 
@@ -388,10 +328,7 @@ namespace System.Windows.Automation
             AutomationFocusChangedEventHandler eventHandler
             )
         {
-            if (eventHandler == null)
-            {
-                throw new ArgumentNullException("eventHandler");
-            }
+            ArgumentNullException.ThrowIfNull(eventHandler);
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveFocusListener(eventHandler);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
@@ -243,10 +243,7 @@ namespace System.Windows.Automation
             // on interpreted properties to the real property that raises events.
             foreach (AutomationProperty property in properties)
             {
-                if (property == null)
-                {
-                    throw new ArgumentNullException("properties");
-                }
+                ArgumentNullException.ThrowIfNull(property, nameof(properties));
             }
 
             // Add a client-side listener for for this event request

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Automation.cs
@@ -98,7 +98,11 @@ namespace System.Windows.Automation
         /// <returns>Sting containing human-readable name of specified property</returns>
         public static string PropertyName( AutomationProperty property )
         {
-            Misc.ValidateArgumentNonNull(property, "property");
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
+
             // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
 #pragma warning suppress 56506
             string full = property.ProgrammaticName.Split('.')[1]; // remove portion before the ".", leaving just "NameProperty" or similar
@@ -112,7 +116,11 @@ namespace System.Windows.Automation
         /// <returns>Sting containing human-readable name of specified pattern</returns>
         public static string PatternName( AutomationPattern pattern )
         {
-            Misc.ValidateArgumentNonNull(pattern, "pattern");
+            if (pattern == null)
+            {
+                throw new ArgumentNullException("pattern");
+            }
+
             // Suppress PRESHARP Parameter to this public method must be validated; element is checked above.
 #pragma warning suppress 56506
             string full = pattern.ProgrammaticName;
@@ -135,8 +143,16 @@ namespace System.Windows.Automation
             AutomationEventHandler eventHandler
             )
         {
-            Misc.ValidateArgumentNonNull(element, "element" );
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
+
             Misc.ValidateArgument( eventId != AutomationElement.AutomationFocusChangedEvent, nameof(SR.EventIdMustNotBeAutomationFocusChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.StructureChangedEvent, nameof(SR.EventIdMustNotBeStructureChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.AutomationPropertyChangedEvent, nameof(SR.EventIdMustNotBeAutomationPropertyChanged) );
@@ -206,8 +222,16 @@ namespace System.Windows.Automation
             AutomationEventHandler eventHandler
             )
         {
-            Misc.ValidateArgumentNonNull(element, "element" );
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
+
             Misc.ValidateArgument( eventId != AutomationElement.AutomationFocusChangedEvent, nameof(SR.EventIdMustNotBeAutomationFocusChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.StructureChangedEvent, nameof(SR.EventIdMustNotBeStructureChanged) );
             Misc.ValidateArgument( eventId != AutomationElement.AutomationPropertyChangedEvent, nameof(SR.EventIdMustNotBeAutomationPropertyChanged) );
@@ -230,9 +254,21 @@ namespace System.Windows.Automation
             params AutomationProperty [] properties           // listen for changes to these properties
             )
         {
-            Misc.ValidateArgumentNonNull(element, "element" );
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
-            Misc.ValidateArgumentNonNull(properties, "properties" );
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
+
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties");
+            }
+
             if (properties.Length == 0)
             {
                 throw new ArgumentException( SR.AtLeastOnePropertyMustBeSpecified );
@@ -243,7 +279,10 @@ namespace System.Windows.Automation
             // on interpreted properties to the real property that raises events.
             foreach (AutomationProperty property in properties)
             {
-                Misc.ValidateArgumentNonNull(property, "properties" );
+                if (property == null)
+                {
+                    throw new ArgumentNullException("properties");
+                }
             }
 
             // Add a client-side listener for for this event request
@@ -261,8 +300,15 @@ namespace System.Windows.Automation
             AutomationPropertyChangedEventHandler eventHandler     // callback object (used as cookie here)
             )
         {
-            Misc.ValidateArgumentNonNull(element, "element" );
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveListener(AutomationElement.AutomationPropertyChangedEvent, element, eventHandler);
@@ -276,8 +322,15 @@ namespace System.Windows.Automation
         /// <param name="eventHandler">Delegate to call when a structure change event occurs.</param>
         public static void AddStructureChangedEventHandler(AutomationElement element, TreeScope scope, StructureChangedEventHandler eventHandler)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
 
             // Add a client-side listener for for this event request
             EventListener l = new EventListener(AutomationElement.StructureChangedEvent, scope, null, CacheRequest.CurrentUiaCacheRequest);
@@ -292,8 +345,15 @@ namespace System.Windows.Automation
         /// <param name="eventHandler">The handler object that was passed to AddStructureChangedListener</param>
         public static void RemoveStructureChangedEventHandler(AutomationElement element, StructureChangedEventHandler eventHandler)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveListener(AutomationElement.StructureChangedEvent, element, eventHandler);
@@ -307,7 +367,10 @@ namespace System.Windows.Automation
             AutomationFocusChangedEventHandler eventHandler
             )
         {
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
 
             // Add a client-side listener for for this event request
             EventListener l = new EventListener(AutomationElement.AutomationFocusChangedEvent, 
@@ -325,7 +388,10 @@ namespace System.Windows.Automation
             AutomationFocusChangedEventHandler eventHandler
             )
         {
-            Misc.ValidateArgumentNonNull(eventHandler, "eventHandler" );
+            if (eventHandler == null)
+            {
+                throw new ArgumentNullException("eventHandler");
+            }
 
             // Remove the client-side listener for for this event
             ClientEventManager.RemoveFocusListener(eventHandler);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -459,7 +459,10 @@ namespace System.Windows.Automation
         /// </remarks>
         public static AutomationElement FromLocalProvider(IRawElementProviderSimple localImpl)
         {
-            Misc.ValidateArgumentNonNull(localImpl, "localImpl");
+            if (localImpl == null)
+            {
+                throw new ArgumentNullException("localImpl");
+            }
 
             return AutomationElement.Wrap(UiaCoreApi.UiaNodeFromProvider(localImpl));
         }
@@ -502,7 +505,11 @@ namespace System.Windows.Automation
         /// </remarks>
         public object GetCurrentPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
-            Misc.ValidateArgumentNonNull(property, "property");
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
+
             CheckElement();
 
             AutomationPropertyInfo pi;
@@ -585,7 +592,11 @@ namespace System.Windows.Automation
         public bool TryGetCurrentPattern(AutomationPattern pattern, out object patternObject)
         {
             patternObject = null;
-            Misc.ValidateArgumentNonNull(pattern, "pattern");
+            if (pattern == null)
+            {
+                throw new ArgumentNullException("pattern");
+            }
+
             CheckElement();
             // Need to catch non-critical exceptions. The WinFormsSpinner will raise an
             // InvalidOperationException if it is a domain spinner and the SelectionPattern is asked for.
@@ -652,7 +663,10 @@ namespace System.Windows.Automation
         /// </remarks>
         public object GetCachedPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
-            Misc.ValidateArgumentNonNull(property, "property");
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
 
             // true -> throw if not available, true -> wrap
             object val = LookupCachedValue(property, true, true);
@@ -704,7 +718,10 @@ namespace System.Windows.Automation
             // Lookup a cached remote reference - but even if we get
             // back null, still go ahead an create a pattern wrapper
             // to provide access to cached properties
-            Misc.ValidateArgumentNonNull(pattern, "pattern");
+            if (pattern == null)
+            {
+                throw new ArgumentNullException("pattern");
+            }
 
             // false -> don't throw, false -> don't wrap
             object obj = LookupCachedValue(pattern, false, false);
@@ -738,7 +755,11 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement GetUpdatedCache(CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             CheckElement();
 
             UiaCoreApi.UiaCacheRequest cacheRequest = request.GetUiaCacheRequest();
@@ -758,7 +779,11 @@ namespace System.Windows.Automation
         /// or null if no match is found.</returns>
         public AutomationElement FindFirst(TreeScope scope, Condition condition)
         {
-            Misc.ValidateArgumentNonNull(condition, "condition");
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
+
             UiaCoreApi.UiaCacheResponse[] responses = Find(scope, condition, CacheRequest.CurrentUiaCacheRequest, true, null);
             if (responses.Length < 1)
             {
@@ -781,7 +806,11 @@ namespace System.Windows.Automation
         /// no matches found.</returns>
         public AutomationElementCollection FindAll(TreeScope scope, Condition condition)
         {
-            Misc.ValidateArgumentNonNull(condition, "condition");
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
+
             UiaCoreApi.UiaCacheRequest request = CacheRequest.CurrentUiaCacheRequest;
             UiaCoreApi.UiaCacheResponse[] responses = Find(scope, condition, request, false, null);
 
@@ -1299,7 +1328,11 @@ namespace System.Windows.Automation
         // called by FindFirst and FindAll
         private UiaCoreApi.UiaCacheResponse[] Find(TreeScope scope, Condition condition, UiaCoreApi.UiaCacheRequest request, bool findFirst, BackgroundWorker worker)
         {
-            Misc.ValidateArgumentNonNull(condition, "condition");
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
+
             if (scope == 0)
             {
                 throw new ArgumentException(SR.TreeScopeNeedAtLeastOne);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/AutomationElement.cs
@@ -459,10 +459,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public static AutomationElement FromLocalProvider(IRawElementProviderSimple localImpl)
         {
-            if (localImpl == null)
-            {
-                throw new ArgumentNullException("localImpl");
-            }
+            ArgumentNullException.ThrowIfNull(localImpl);
 
             return AutomationElement.Wrap(UiaCoreApi.UiaNodeFromProvider(localImpl));
         }
@@ -505,11 +502,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public object GetCurrentPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException("property");
-            }
-
+            ArgumentNullException.ThrowIfNull(property);
             CheckElement();
 
             AutomationPropertyInfo pi;
@@ -592,11 +585,7 @@ namespace System.Windows.Automation
         public bool TryGetCurrentPattern(AutomationPattern pattern, out object patternObject)
         {
             patternObject = null;
-            if (pattern == null)
-            {
-                throw new ArgumentNullException("pattern");
-            }
-
+            ArgumentNullException.ThrowIfNull(pattern);
             CheckElement();
             // Need to catch non-critical exceptions. The WinFormsSpinner will raise an
             // InvalidOperationException if it is a domain spinner and the SelectionPattern is asked for.
@@ -663,10 +652,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public object GetCachedPropertyValue(AutomationProperty property, bool ignoreDefaultValue)
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException("property");
-            }
+            ArgumentNullException.ThrowIfNull(property);
 
             // true -> throw if not available, true -> wrap
             object val = LookupCachedValue(property, true, true);
@@ -718,10 +704,7 @@ namespace System.Windows.Automation
             // Lookup a cached remote reference - but even if we get
             // back null, still go ahead an create a pattern wrapper
             // to provide access to cached properties
-            if (pattern == null)
-            {
-                throw new ArgumentNullException("pattern");
-            }
+            ArgumentNullException.ThrowIfNull(pattern);
 
             // false -> don't throw, false -> don't wrap
             object obj = LookupCachedValue(pattern, false, false);
@@ -755,11 +738,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement GetUpdatedCache(CacheRequest request)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(request);
             CheckElement();
 
             UiaCoreApi.UiaCacheRequest cacheRequest = request.GetUiaCacheRequest();
@@ -779,11 +758,7 @@ namespace System.Windows.Automation
         /// or null if no match is found.</returns>
         public AutomationElement FindFirst(TreeScope scope, Condition condition)
         {
-            if (condition == null)
-            {
-                throw new ArgumentNullException("condition");
-            }
-
+            ArgumentNullException.ThrowIfNull(condition);
             UiaCoreApi.UiaCacheResponse[] responses = Find(scope, condition, CacheRequest.CurrentUiaCacheRequest, true, null);
             if (responses.Length < 1)
             {
@@ -806,11 +781,7 @@ namespace System.Windows.Automation
         /// no matches found.</returns>
         public AutomationElementCollection FindAll(TreeScope scope, Condition condition)
         {
-            if (condition == null)
-            {
-                throw new ArgumentNullException("condition");
-            }
-
+            ArgumentNullException.ThrowIfNull(condition);
             UiaCoreApi.UiaCacheRequest request = CacheRequest.CurrentUiaCacheRequest;
             UiaCoreApi.UiaCacheResponse[] responses = Find(scope, condition, request, false, null);
 
@@ -1328,11 +1299,7 @@ namespace System.Windows.Automation
         // called by FindFirst and FindAll
         private UiaCoreApi.UiaCacheResponse[] Find(TreeScope scope, Condition condition, UiaCoreApi.UiaCacheRequest request, bool findFirst, BackgroundWorker worker)
         {
-            if (condition == null)
-            {
-                throw new ArgumentNullException("condition");
-            }
-
+            ArgumentNullException.ThrowIfNull(condition);
             if (scope == 0)
             {
                 throw new ArgumentException(SR.TreeScopeNeedAtLeastOne);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
@@ -337,7 +337,7 @@ namespace System.Windows.Automation
             
             set
             {
-                ArgumentNullException.ThrowIfNull(value);
+                ArgumentNullException.ThrowIfNull(value, nameof(TreeFilter));
                 lock (_instanceLock)
                 {
                     CheckAccess();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
@@ -242,7 +242,11 @@ namespace System.Windows.Automation
         /// <param name="property">The identifier of the property to add to this CacheRequest</param>
         public void Add(AutomationProperty property)
         {
-            Misc.ValidateArgumentNonNull(property, "property");
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
+
             lock (_instanceLock)
             {
                 CheckAccess();
@@ -260,7 +264,11 @@ namespace System.Windows.Automation
         /// <param name="pattern">The identifier of the pattern to add to this CacheRequest</param>
         public void Add(AutomationPattern pattern)
         {
-            Misc.ValidateArgumentNonNull(pattern, "pattern");
+            if (pattern == null)
+            {
+                throw new ArgumentNullException("pattern");
+            }
+
             lock (_instanceLock)
             {
                 CheckAccess();
@@ -337,7 +345,11 @@ namespace System.Windows.Automation
             
             set
             {
-                Misc.ValidateArgumentNonNull(value, "TreeFilter");
+                if (value == null)
+                {
+                    throw new ArgumentNullException("TreeFilter");
+                }
+
                 lock (_instanceLock)
                 {
                     CheckAccess();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/CacheRequest.cs
@@ -242,11 +242,7 @@ namespace System.Windows.Automation
         /// <param name="property">The identifier of the property to add to this CacheRequest</param>
         public void Add(AutomationProperty property)
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException("property");
-            }
-
+            ArgumentNullException.ThrowIfNull(property);
             lock (_instanceLock)
             {
                 CheckAccess();
@@ -264,11 +260,7 @@ namespace System.Windows.Automation
         /// <param name="pattern">The identifier of the pattern to add to this CacheRequest</param>
         public void Add(AutomationPattern pattern)
         {
-            if (pattern == null)
-            {
-                throw new ArgumentNullException("pattern");
-            }
-
+            ArgumentNullException.ThrowIfNull(pattern);
             lock (_instanceLock)
             {
                 CheckAccess();
@@ -345,11 +337,7 @@ namespace System.Windows.Automation
             
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("TreeFilter");
-                }
-
+                ArgumentNullException.ThrowIfNull(value);
                 lock (_instanceLock)
                 {
                     CheckAccess();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSettings.cs
@@ -45,10 +45,7 @@ namespace System.Windows.Automation
         /// </param>
         public static void RegisterClientSideProviderAssembly(AssemblyName assemblyName)
         {
-            if (assemblyName == null)
-            {
-                throw new ArgumentNullException("assemblyName");
-            }
+            ArgumentNullException.ThrowIfNull(assemblyName);
 
             ProxyManager.RegisterProxyAssembly( assemblyName );
         } 
@@ -59,10 +56,7 @@ namespace System.Windows.Automation
         /// <param name="clientSideProviderDescription">Array of ClientSideProviderDescription structs that specify window class names and factory delegate</param>
         public static void RegisterClientSideProviders(ClientSideProviderDescription[] clientSideProviderDescription)
         {
-            if (clientSideProviderDescription == null)
-            {
-                throw new ArgumentNullException("clientSideProviderDescription ");
-            }
+            ArgumentNullException.ThrowIfNull(clientSideProviderDescription);
 
             ProxyManager.RegisterWindowHandlers(clientSideProviderDescription);
         } 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ClientSettings.cs
@@ -45,7 +45,10 @@ namespace System.Windows.Automation
         /// </param>
         public static void RegisterClientSideProviderAssembly(AssemblyName assemblyName)
         {
-            Misc.ValidateArgumentNonNull( assemblyName, "assemblyName" );
+            if (assemblyName == null)
+            {
+                throw new ArgumentNullException("assemblyName");
+            }
 
             ProxyManager.RegisterProxyAssembly( assemblyName );
         } 
@@ -56,7 +59,10 @@ namespace System.Windows.Automation
         /// <param name="clientSideProviderDescription">Array of ClientSideProviderDescription structs that specify window class names and factory delegate</param>
         public static void RegisterClientSideProviders(ClientSideProviderDescription[] clientSideProviderDescription)
         {
-            Misc.ValidateArgumentNonNull(clientSideProviderDescription, "clientSideProviderDescription ");
+            if (clientSideProviderDescription == null)
+            {
+                throw new ArgumentNullException("clientSideProviderDescription ");
+            }
 
             ProxyManager.RegisterWindowHandlers(clientSideProviderDescription);
         } 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/NotCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/NotCondition.cs
@@ -32,7 +32,10 @@ namespace System.Windows.Automation
         /// <param name="condition">Condition to negate</param>
         public NotCondition( Condition condition )
         {
-            Misc.ValidateArgumentNonNull( condition, "condition" );
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
 
             _condition = condition;
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/NotCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/NotCondition.cs
@@ -32,10 +32,7 @@ namespace System.Windows.Automation
         /// <param name="condition">Condition to negate</param>
         public NotCondition( Condition condition )
         {
-            if (condition == null)
-            {
-                throw new ArgumentNullException("condition");
-            }
+            ArgumentNullException.ThrowIfNull(condition);
 
             _condition = condition;
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
@@ -35,11 +35,18 @@ namespace System.Windows.Automation
         /// <param name="conditions">One or more sub-condition</param>
         public OrCondition( params Condition [ ] conditions )
         {
-            Misc.ValidateArgumentNonNull( conditions, "conditions" );
+            if (conditions == null)
+            {
+                throw new ArgumentNullException("conditions");
+            }
+
             Misc.ValidateArgument( conditions.Length >= 2, nameof(SR.MustBeAtLeastTwoConditions) );
             foreach( Condition condition in conditions )
             {
-                Misc.ValidateArgumentNonNull( condition, "conditions" );
+                if (condition == null)
+                {
+                    throw new ArgumentNullException("conditions");
+                }
             }
 
             // clone array to prevent accidental tampering

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/OrCondition.cs
@@ -35,18 +35,11 @@ namespace System.Windows.Automation
         /// <param name="conditions">One or more sub-condition</param>
         public OrCondition( params Condition [ ] conditions )
         {
-            if (conditions == null)
-            {
-                throw new ArgumentNullException("conditions");
-            }
-
+            ArgumentNullException.ThrowIfNull(conditions);
             Misc.ValidateArgument( conditions.Length >= 2, nameof(SR.MustBeAtLeastTwoConditions) );
             foreach( Condition condition in conditions )
             {
-                if (condition == null)
-                {
-                    throw new ArgumentNullException("conditions");
-                }
+                ArgumentNullException.ThrowIfNull(condition, nameof(conditions));
             }
 
             // clone array to prevent accidental tampering

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
@@ -122,10 +122,7 @@ namespace System.Windows.Automation
 
         void Init(AutomationProperty property, object val, PropertyConditionFlags flags )
         {
-            if (property == null)
-            {
-                throw new ArgumentNullException("property");
-            }
+            ArgumentNullException.ThrowIfNull(property);
 
             AutomationPropertyInfo info;
             if (!Schema.GetPropertyInfo(property, out info))

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/PropertyCondition.cs
@@ -122,7 +122,10 @@ namespace System.Windows.Automation
 
         void Init(AutomationProperty property, object val, PropertyConditionFlags flags )
         {
-            Misc.ValidateArgumentNonNull(property, "property");
+            if (property == null)
+            {
+                throw new ArgumentNullException("property");
+            }
 
             AutomationPropertyInfo info;
             if (!Schema.GetPropertyInfo(property, out info))

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
@@ -178,7 +178,7 @@ namespace System.Windows.Automation.Text
         public TextPatternRange FindAttribute(AutomationTextAttribute attribute, object value, bool backward)
         {
             ArgumentNullException.ThrowIfNull(attribute);
-            ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(value); // no text attributes can have null as a valid value
 
             // Check that attribute value is of expected type...
             AutomationAttributeInfo ai;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
@@ -177,8 +177,15 @@ namespace System.Windows.Automation.Text
         /// <returns>A subrange with the specified attribute, or null if no such subrange exists.</returns>
         public TextPatternRange FindAttribute(AutomationTextAttribute attribute, object value, bool backward)
         {
-            Misc.ValidateArgumentNonNull(attribute, "attribute");
-            Misc.ValidateArgumentNonNull(value, "value"); // no text attributes can have null as a valid value
+            if (attribute == null)
+            {
+                throw new ArgumentNullException("attribute");
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
 
             // Check that attribute value is of expected type...
             AutomationAttributeInfo ai;
@@ -219,7 +226,11 @@ namespace System.Windows.Automation.Text
             // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(text)' over checks for null and/or emptiness.
             // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-            Misc.ValidateArgumentNonNull(text, "text");
+            if (text == null)
+            {
+                throw new ArgumentNullException("text");
+            }
+
 #pragma warning suppress 6507
             Misc.ValidateArgument(text.Length != 0, nameof(SR.TextMustNotBeNullOrEmpty));
 
@@ -235,7 +246,10 @@ namespace System.Windows.Automation.Text
         /// If the attribute's value varies over the range then the value is TextPattern.MixedAttributeValue</returns>
         public object GetAttributeValue(AutomationTextAttribute attribute)
         {
-            Misc.ValidateArgumentNonNull(attribute, "attribute");
+            if (attribute == null)
+            {
+                throw new ArgumentNullException("attribute");
+            }
 
             AutomationAttributeInfo ai;
             if(!Schema.GetAttributeInfo(attribute, out ai))

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
@@ -177,15 +177,8 @@ namespace System.Windows.Automation.Text
         /// <returns>A subrange with the specified attribute, or null if no such subrange exists.</returns>
         public TextPatternRange FindAttribute(AutomationTextAttribute attribute, object value, bool backward)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException("attribute");
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(attribute);
+            ArgumentNullException.ThrowIfNull(value);
 
             // Check that attribute value is of expected type...
             AutomationAttributeInfo ai;
@@ -226,11 +219,7 @@ namespace System.Windows.Automation.Text
             // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(text)' over checks for null and/or emptiness.
             // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-            if (text == null)
-            {
-                throw new ArgumentNullException("text");
-            }
-
+            ArgumentNullException.ThrowIfNull(text);
 #pragma warning suppress 6507
             Misc.ValidateArgument(text.Length != 0, nameof(SR.TextMustNotBeNullOrEmpty));
 
@@ -246,10 +235,7 @@ namespace System.Windows.Automation.Text
         /// If the attribute's value varies over the range then the value is TextPattern.MixedAttributeValue</returns>
         public object GetAttributeValue(AutomationTextAttribute attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException("attribute");
-            }
+            ArgumentNullException.ThrowIfNull(attribute);
 
             AutomationAttributeInfo ai;
             if(!Schema.GetAttributeInfo(attribute, out ai))

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TextPattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TextPattern.cs
@@ -200,10 +200,7 @@ namespace System.Windows.Automation
         /// <returns>A range that spans the child element.</returns>
         public TextPatternRange RangeFromChild(AutomationElement childElement)
         {
-            if (childElement == null)
-            {
-                throw new ArgumentNullException("childElement");
-            }
+            ArgumentNullException.ThrowIfNull(childElement);
             SafeTextRangeHandle hTextRange = UiaCoreApi.TextPattern_RangeFromChild(_hPattern, childElement.RawNode);
             return TextPatternRange.Wrap(hTextRange, this);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
@@ -35,11 +35,7 @@ namespace System.Windows.Automation
         /// <param name="condition">Condition defining the view - nodes that do not satisfy this condition are skipped over</param>
         public TreeWalker(Condition condition)
         {
-            if (condition == null)
-            {
-                throw new ArgumentNullException("condition");
-            }
-
+            ArgumentNullException.ThrowIfNull(condition);
             _condition = condition;
         }
 
@@ -91,11 +87,7 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetParent(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Navigate(NavigateDirection.Parent, _condition, null);
         }
 
@@ -110,11 +102,7 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetFirstChild(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Navigate(NavigateDirection.FirstChild, _condition, null);
         }
 
@@ -129,11 +117,7 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetLastChild(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Navigate(NavigateDirection.LastChild, _condition, null);
         }
 
@@ -148,11 +132,7 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetNextSibling(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Navigate(NavigateDirection.NextSibling, _condition, null);
         }
 
@@ -167,11 +147,7 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetPreviousSibling(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Navigate(NavigateDirection.PreviousSibling, _condition, null);
         }
 
@@ -196,11 +172,7 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement Normalize(AutomationElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
             return element.Normalize(_condition, null);
         }
 
@@ -218,16 +190,8 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetParent(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(request);
             return element.Navigate(NavigateDirection.Parent, _condition, request);
         }
 
@@ -244,16 +208,8 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetFirstChild(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(request);
             return element.Navigate(NavigateDirection.FirstChild, _condition, request);
         }
 
@@ -270,16 +226,8 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetLastChild(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(request);
             return element.Navigate(NavigateDirection.LastChild, _condition, request);
         }
 
@@ -296,16 +244,8 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetNextSibling(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(request);
             return element.Navigate(NavigateDirection.NextSibling, _condition, request);
         }
 
@@ -322,16 +262,8 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetPreviousSibling(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(request);
             return element.Navigate(NavigateDirection.PreviousSibling, _condition, request);
         }
 
@@ -358,16 +290,9 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement Normalize(AutomationElement element, CacheRequest request)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
 
-            if (request == null)
-            {
-                throw new ArgumentNullException("request");
-            }
-
+            ArgumentNullException.ThrowIfNull(request);
             return element.Normalize(_condition, request);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
@@ -291,7 +291,6 @@ namespace System.Windows.Automation
         public AutomationElement Normalize(AutomationElement element, CacheRequest request)
         {
             ArgumentNullException.ThrowIfNull(element);
-
             ArgumentNullException.ThrowIfNull(request);
             return element.Normalize(_condition, request);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/TreeWalker.cs
@@ -35,7 +35,11 @@ namespace System.Windows.Automation
         /// <param name="condition">Condition defining the view - nodes that do not satisfy this condition are skipped over</param>
         public TreeWalker(Condition condition)
         {
-            Misc.ValidateArgumentNonNull(condition, "condition");
+            if (condition == null)
+            {
+                throw new ArgumentNullException("condition");
+            }
+
             _condition = condition;
         }
 
@@ -87,7 +91,11 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetParent(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Navigate(NavigateDirection.Parent, _condition, null);
         }
 
@@ -102,7 +110,11 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetFirstChild(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Navigate(NavigateDirection.FirstChild, _condition, null);
         }
 
@@ -117,7 +129,11 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetLastChild(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Navigate(NavigateDirection.LastChild, _condition, null);
         }
 
@@ -132,7 +148,11 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetNextSibling(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Navigate(NavigateDirection.NextSibling, _condition, null);
         }
 
@@ -147,7 +167,11 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetPreviousSibling(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Navigate(NavigateDirection.PreviousSibling, _condition, null);
         }
 
@@ -172,7 +196,11 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement Normalize(AutomationElement element)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
             return element.Normalize(_condition, null);
         }
 
@@ -190,8 +218,16 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetParent(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Navigate(NavigateDirection.Parent, _condition, request);
         }
 
@@ -208,8 +244,16 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetFirstChild(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Navigate(NavigateDirection.FirstChild, _condition, request);
         }
 
@@ -226,8 +270,16 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetLastChild(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Navigate(NavigateDirection.LastChild, _condition, request);
         }
 
@@ -244,8 +296,16 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetNextSibling(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Navigate(NavigateDirection.NextSibling, _condition, request);
         }
 
@@ -262,8 +322,16 @@ namespace System.Windows.Automation
         /// are skipped over</remarks>
         public AutomationElement GetPreviousSibling(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Navigate(NavigateDirection.PreviousSibling, _condition, request);
         }
 
@@ -290,8 +358,16 @@ namespace System.Windows.Automation
         /// </remarks>
         public AutomationElement Normalize(AutomationElement element, CacheRequest request)
         {
-            Misc.ValidateArgumentNonNull(element, "element");
-            Misc.ValidateArgumentNonNull(request, "request");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
             return element.Normalize(_condition, request);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
@@ -72,8 +72,11 @@ namespace System.Windows.Automation
         /// <param name="value">Value to set the UI to, the provider is responsible for converting from a string into the appropriate data type</param>
         public void SetValue( string value )
         {
-            Misc.ValidateArgumentNonNull(value, "value");
-            
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+
             // Test the Enabled state prior to the more general Read-Only state.            
             object enabled = _el.GetCurrentPropertyValue(AutomationElementIdentifiers.IsEnabledProperty);
             if (enabled is bool && !(bool)enabled)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/ValuePattern.cs
@@ -72,10 +72,7 @@ namespace System.Windows.Automation
         /// <param name="value">Value to set the UI to, the provider is responsible for converting from a string into the appropriate data type</param>
         public void SetValue( string value )
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             // Test the Enabled state prior to the more general Read-Only state.            
             object enabled = _el.GetCurrentPropertyValue(AutomationElementIdentifiers.IsEnabledProperty);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
@@ -203,10 +203,7 @@ namespace MS.Internal.AutomationProxies
             // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
 #pragma warning suppress 6507
-            if (text == null)
-            {
-                throw new ArgumentNullException("text");
-            }
+            ArgumentNullException.ThrowIfNull(text);
 #pragma warning suppress 6507
             if (text.Length == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBoxRange.cs
@@ -199,16 +199,7 @@ namespace MS.Internal.AutomationProxies
 
         ITextRangeProvider ITextRangeProvider.FindText(string text, bool backwards, bool ignoreCase)
         {
-            // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(text)' over checks for null and/or emptiness.
-            // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
-            // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-#pragma warning suppress 6507
-            ArgumentNullException.ThrowIfNull(text);
-#pragma warning suppress 6507
-            if (text.Length == 0)
-            {
-                throw new ArgumentException(SR.InvalidParameter);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(text);
 
             // get the text of the range
             string rangeText = _provider.GetText();

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListViewItem.cs
@@ -749,10 +749,7 @@ namespace MS.Internal.AutomationProxies
             // An empty strings is valued here, while a null string is not.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
 #pragma warning suppress 6507
-            if (val == null)
-            {
-                throw new ArgumentNullException ("val");
-            }
+            ArgumentNullException.ThrowIfNull(val);
 
             if (!WindowsListView.ListViewEditable (hwnd))
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
@@ -129,10 +129,7 @@ namespace MS.Internal.AutomationProxies
             // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
             // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
 #pragma warning suppress 6507
-            if (text == null)
-            {
-                throw new ArgumentNullException("text");
-            }
+            ArgumentNullException.ThrowIfNull(text);
 #pragma warning suppress 6507
             if (text.Length == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
@@ -125,16 +125,7 @@ namespace MS.Internal.AutomationProxies
 
         ITextRangeProvider ITextRangeProvider.FindText(string text, bool backwards, bool ignoreCase)
         {
-            // PerSharp/PreFast will flag this as warning 6507/56507: Prefer 'string.IsNullOrEmpty(text)' over checks for null and/or emptiness.
-            // A null string is not should throw an ArgumentNullException while an empty string should throw an ArgumentException.
-            // Therefore we can not use IsNullOrEmpty() here, suppress the warning.
-#pragma warning suppress 6507
-            ArgumentNullException.ThrowIfNull(text);
-#pragma warning suppress 6507
-            if (text.Length == 0)
-            {
-                throw new ArgumentException(SR.InvalidParameter);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(text);
 
             // copy the our range and search from the start point or end point depending on 
             // whether we are searching backwards.

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
@@ -76,8 +76,11 @@ namespace System.Windows.Automation.Provider
         public static IntPtr ReturnRawElementProvider (IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el )
         {
             ValidateArgument( hwnd != IntPtr.Zero, nameof(SR.HwndMustBeNonNULL));
-            ValidateArgumentNonNull(el, "el" );
-            
+            if (el == null)
+            {
+                throw new ArgumentNullException("el");
+            }
+
             return UiaCoreProviderApi.UiaReturnRawElementProvider(hwnd, wParam, lParam, el);
         }
 
@@ -99,8 +102,14 @@ namespace System.Windows.Automation.Provider
         /// <param name="e">Contains information about the property that changed.</param>
         public static void RaiseAutomationPropertyChangedEvent(IRawElementProviderSimple element, AutomationPropertyChangedEventArgs e)
         {
-            ValidateArgumentNonNull(element, "element");
-            ValidateArgumentNonNull(e, "e");
+            if (element == null)
+            {
+                throw new ArgumentNullException("element");
+            }
+            if (e == null)
+            {
+                throw new ArgumentNullException("e");
+            }
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above
@@ -110,16 +119,25 @@ namespace System.Windows.Automation.Provider
 
         /// <summary>
         /// Called to notify listeners of a pattern or custom event.  This could could be called by a server implementation or by a proxy's event
-        /// translator.  
+        /// translator.
         /// </summary>
         /// <param name="eventId">An AutomationEvent representing this event.</param>
         /// <param name="provider">The actual server-side element associated with this event.</param>
         /// <param name="e">Contains information about the event (may be null).</param>
         public static void RaiseAutomationEvent(AutomationEvent eventId, IRawElementProviderSimple provider, AutomationEventArgs e)
         {
-            ValidateArgumentNonNull(eventId, "eventId");
-            ValidateArgumentNonNull(provider, "provider");
-            ValidateArgumentNonNull(e, "e");
+            if (eventId == null)
+            {
+                throw new ArgumentNullException("eventId");
+            }
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+            if (e == null)
+            {
+                throw new ArgumentNullException("e");
+            }
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above
@@ -184,8 +202,14 @@ namespace System.Windows.Automation.Provider
         /// <param name="e">Contains information about the event.</param>
         public static void RaiseStructureChangedEvent(IRawElementProviderSimple provider, StructureChangedEventArgs e)
         {
-            ValidateArgumentNonNull(provider, "provider");
-            ValidateArgumentNonNull(e, "e");
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+            if (e == null)
+            {
+                throw new ArgumentNullException("e");
+            }
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above
@@ -202,15 +226,6 @@ namespace System.Windows.Automation.Provider
         //------------------------------------------------------
 
         #region Private Methods
-
-        // Check that specified argument is non-null, if so, throw exception
-        private static void ValidateArgumentNonNull(object obj, string argName)
-        {
-            if (obj == null)
-            {
-                throw new ArgumentNullException(argName);
-            }
-        }
 
         // Throw an argument Exception with a generic error
         private static void ThrowInvalidArgument(string argName)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationProvider/System/Windows/Automation/Provider/AutomationInteropProvider.cs
@@ -76,10 +76,7 @@ namespace System.Windows.Automation.Provider
         public static IntPtr ReturnRawElementProvider (IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el )
         {
             ValidateArgument( hwnd != IntPtr.Zero, nameof(SR.HwndMustBeNonNULL));
-            if (el == null)
-            {
-                throw new ArgumentNullException("el");
-            }
+            ArgumentNullException.ThrowIfNull(el);
 
             return UiaCoreProviderApi.UiaReturnRawElementProvider(hwnd, wParam, lParam, el);
         }
@@ -102,14 +99,8 @@ namespace System.Windows.Automation.Provider
         /// <param name="e">Contains information about the property that changed.</param>
         public static void RaiseAutomationPropertyChangedEvent(IRawElementProviderSimple element, AutomationPropertyChangedEventArgs e)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
+            ArgumentNullException.ThrowIfNull(element);
+            ArgumentNullException.ThrowIfNull(e);
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above
@@ -126,18 +117,9 @@ namespace System.Windows.Automation.Provider
         /// <param name="e">Contains information about the event (may be null).</param>
         public static void RaiseAutomationEvent(AutomationEvent eventId, IRawElementProviderSimple provider, AutomationEventArgs e)
         {
-            if (eventId == null)
-            {
-                throw new ArgumentNullException("eventId");
-            }
-            if (provider == null)
-            {
-                throw new ArgumentNullException("provider");
-            }
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
+            ArgumentNullException.ThrowIfNull(eventId);
+            ArgumentNullException.ThrowIfNull(provider);
+            ArgumentNullException.ThrowIfNull(e);
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above
@@ -202,14 +184,8 @@ namespace System.Windows.Automation.Provider
         /// <param name="e">Contains information about the event.</param>
         public static void RaiseStructureChangedEvent(IRawElementProviderSimple provider, StructureChangedEventArgs e)
         {
-            if (provider == null)
-            {
-                throw new ArgumentNullException("provider");
-            }
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
+            ArgumentNullException.ThrowIfNull(provider);
+            ArgumentNullException.ThrowIfNull(e);
 
             // PRESHARP will flag this as warning 56506/6506:Parameter 'e' to this public method must be validated: A null-dereference can occur here.
             // False positive, e is checked, see above

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/AutomationIdentifier.cs
@@ -125,8 +125,7 @@ namespace System.Windows.Automation
         public int CompareTo(object obj)
         {
             Debug.Assert(obj != null, "Null obj!");
-            if (obj == null)
-                throw new ArgumentNullException("obj");
+            ArgumentNullException.ThrowIfNull(obj);
 
             // Ordering allows arrays of references to these to be sorted - though the sort order is undefined.
             Debug.Assert(obj is AutomationIdentifier, "CompareTo called with unexpected type");

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/StructureChangedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/StructureChangedEventArgs.cs
@@ -76,10 +76,7 @@ namespace System.Windows.Automation
         public StructureChangedEventArgs(StructureChangeType structureChangeType, int [] runtimeId) 
             : base(AutomationElementIdentifiers.StructureChangedEvent) 
         {
-            if (runtimeId == null)
-            {
-                throw new ArgumentNullException("runtimeId");
-            }
+            ArgumentNullException.ThrowIfNull(runtimeId);
             _structureChangeType = structureChangeType;
             _runtimeID = (int [])runtimeId.Clone();
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/WindowClosedEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/System/Windows/Automation/WindowClosedEventArgs.cs
@@ -33,10 +33,7 @@ namespace System.Windows.Automation
         public WindowClosedEventArgs (int [] runtimeId) 
             : base(WindowPatternIdentifiers.WindowClosedEvent)
         {
-            if (runtimeId == null)
-            {
-                throw new ArgumentNullException("runtimeId");
-            }
+            ArgumentNullException.ThrowIfNull(runtimeId);
             _runtimeId = (int[])runtimeId.Clone();
         }
 


### PR DESCRIPTION
There were manual throw helper methods that don't make much sense keeping around anymore now that they exist in the BCL in another form, so I inlined them before using the CA1510 fixer, and then verified that all places that used to call those helpers now call `ArgumentNullException.ThrowIfNull`

## Description

- Inline two throw helper methods in UIAutomationClient
- Use `ArgumentNullException.ThrowIfNull` in UIAutomationClient
- Inline a throw helper method in UIAutomationProvider
- Use `ArgumentNullException.ThrowIfNull` in UIAutomationProvider
- Use `ArgumentNullException.ThrowIfNull` in UIAutomationClientSideProviders
- Use `ArgumentNullException.ThrowIfNull` in UIAutomationTypes


## Regression

No

## Testing

CI

## Risk

Low: changes are mostly mechanic, using the IDE to inline methods, and then fixer CA1510



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8148)