### PR TITLE
Fixing exception thrown in GenerateTemporaryTargetAssembly when project name has GB characters in it

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -122,8 +122,12 @@ namespace Microsoft.Build.Tasks.Windows
                 XmlDocument xmlProjectDoc = null;
 
                 xmlProjectDoc = new XmlDocument( );
-                xmlProjectDoc.Load(CurrentProject);
-
+                //Bugfix for GB chars, exception thrown when using Load(CurrentProject), when project name has GB characters in it.
+                //Using a filestream instead of using string path to avoid the need to properly compose Uri (which is another way of fixing - but more complicated).
+                using(FileStream fs = File.OpenRead(CurrentProject))
+                {
+                    xmlProjectDoc.Load(fs);
+                }
                 //
                 // remove all the WinFX specific item lists
                 // ApplicationDefinition, Page, MarkupResource and Resource
@@ -247,8 +251,12 @@ namespace Microsoft.Build.Tasks.Windows
                 XmlDocument xmlProjectDoc = null;
 
                 xmlProjectDoc = new XmlDocument( );
-                xmlProjectDoc.Load(CurrentProject);
-
+                //Bugfix for GB chars, exception thrown when using Load(CurrentProject), when project name has GB characters in it.
+                //Using a filestream instead of using string path to avoid the need to properly compose Uri (which is another way of fixing - but more complicated).
+                using(FileStream fs = File.OpenRead(CurrentProject))
+                {
+                    xmlProjectDoc.Load(fs);
+                }
                 // remove all the WinFX specific item lists
                 // ApplicationDefinition, Page, MarkupResource and Resource
                 RemoveItemsByName(xmlProjectDoc, APPDEFNAME);


### PR DESCRIPTION
Fixes 
 Exception thrown in GenerateTemporaryTargetAssembly when project name has GB characters in it
Main PR <!-- Link to PR if any that fixed this in the main branch. -->
None
## Description
Bugfix for GB chars, exception thrown when using Load(CurrentProject), when project name has GB characters in it.
Using a filestream instead of using string path to avoid the need to properly compose Uri (which is another way of fixing - but more complicated).
           
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Users will face build error, when building a project which has GB Characters in the project name.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
None
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8151)