### PR TITLE
Put Unlock method within the finally block to ensure that the Lock and Unlock methods are called in pairs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -1034,7 +1034,7 @@ namespace System.Windows.Media.Imaging
                     }
                     finally
                     {
-                        // The MILUtilities.MILCopyPixelBuffer may throw ArgumentException. We put Unlock method within the finally block to ensure that the Lock and Unlock methods are called in pairs
+                        // MILUtilities.MILCopyPixelBuffer may throw ArgumentException (e.g. for invalid stride)
                         // See https://github.com/dotnet/wpf/issues/8134
                         Unlock();
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/8134



## Description

The MILUtilities.MILCopyPixelBuffer may throw ArgumentException. We put Unlock method within the finally block to ensure that the Lock and Unlock methods are called in pairs


## Customer Impact

See https://github.com/dotnet/wpf/issues/8134

## Regression

None.

## Testing

Just CI and my [demo](https://github.com/lindexi/lindexi_gd/tree/20395cade5a79ed40bdd03acf73320994966c691/HawacearkecallLalarnowhallna)

## Risk

Normal.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8157)