### PR TITLE
Closing the bitmapstream for UnknownBitMapDecoder

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1202,6 +1202,7 @@ namespace System.Windows.Media.Imaging
             }
             catch
             {
+                bitmapStream.Close();
                 #pragma warning disable 6500
 
                 decoderHandle = null;
@@ -1212,7 +1213,6 @@ namespace System.Windows.Media.Imaging
             finally
             {
                 UnsafeNativeMethods.MILUnknown.ReleaseInterface(ref comStream);
-                bitmapStream.Close();
             }
 
             string decoderMimeTypes;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapDecoder.cs
@@ -1212,6 +1212,7 @@ namespace System.Windows.Media.Imaging
             finally
             {
                 UnsafeNativeMethods.MILUnknown.ReleaseInterface(ref comStream);
+                bitmapStream.Close();
             }
 
             string decoderMimeTypes;


### PR DESCRIPTION
Fixes #2881

Main PR <!-- Link to PR if any that fixed this in the main branch. -->
None
## Description
If an exception is thrown during the creation of BitmapDecoder, the FileStream used internally does not seem to be released.
BitmapStream wasn't closed and due to which the file wasn't being able to be modified or deleted.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
The file will be locked for editing/deletion.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
None
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local.
<!-- What kind of testing has been done with the fix. -->

## Risk
Low. 
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8174)