### PR TITLE
Use ArgumentNullException.ThrowIfNull System.Windows.Controls.Ribbon and System.Windows.Input.Manipulations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Automation/Peers/RibbonComboBoxAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Automation/Peers/RibbonComboBoxAutomationPeer.cs
@@ -118,8 +118,7 @@ namespace Microsoft.Windows.Automation.Peers
             if (!owner.IsEnabled)
                 throw new ElementNotEnabledException();
 
-            if (value == null)
-                throw new ArgumentNullException("value");
+            ArgumentNullException.ThrowIfNull(value);
 
             owner.Text = value;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/KeyTipService.cs
@@ -61,10 +61,7 @@ namespace Microsoft.Windows.Controls
         /// </summary>
         public static string GetKeyTip(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(KeyTipProperty);
         }
 
@@ -73,10 +70,7 @@ namespace Microsoft.Windows.Controls
         /// </summary>
         public static void SetKeyTip(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(KeyTipProperty, value);
         }
 
@@ -105,19 +99,13 @@ namespace Microsoft.Windows.Controls
 
         public static bool GetIsKeyTipScope(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(IsKeyTipScopeProperty);
         }
 
         public static void SetIsKeyTipScope(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(IsKeyTipScopeProperty, value);
         }
 
@@ -132,19 +120,13 @@ namespace Microsoft.Windows.Controls
 
         public static Style GetKeyTipStyle(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Style)element.GetValue(KeyTipStyleProperty);
         }
 
         public static void SetKeyTipStyle(DependencyObject element, Style value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(KeyTipStyleProperty, value);
         }
 
@@ -433,19 +415,13 @@ namespace Microsoft.Windows.Controls
 
         internal static IEnumerable<DependencyObject> GetCustomSiblingKeyTipElements(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (IEnumerable<DependencyObject>)element.GetValue(CustomSiblingKeyTipElementsProperty);
         }
 
         internal static void SetCustomSiblingKeyTipElements(DependencyObject element, IEnumerable<DependencyObject> value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CustomSiblingKeyTipElementsProperty, value);
         }
 
@@ -1307,19 +1283,13 @@ namespace Microsoft.Windows.Controls
 
         internal static bool GetCanClipKeyTip(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(CanClipKeyTipProperty);
         }
 
         internal static void SetCanClipKeyTip(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CanClipKeyTipProperty, value);
         }
 
@@ -1336,8 +1306,7 @@ namespace Microsoft.Windows.Controls
         /// </summary>
         static private AdornerLayer GetAdornerLayer(Visual visual, out bool isScrollAdornerLayer)
         {
-            if (visual == null)
-                throw new ArgumentNullException("visual");
+            ArgumentNullException.ThrowIfNull(visual);
 
             isScrollAdornerLayer = false;
             Visual parent = VisualTreeHelper.GetParent(visual) as Visual;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGroupsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGroupsPanel.cs
@@ -54,10 +54,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
         public void RegisterStarLayoutProvider(IProvideStarLayoutInfoBase starLayoutInfoProvider)
         {
-            if (starLayoutInfoProvider == null)
-            {
-                throw new ArgumentNullException("starLayoutInfoProvider");
-            }
+            ArgumentNullException.ThrowIfNull(starLayoutInfoProvider);
             IProvideStarLayoutInfo provider = starLayoutInfoProvider as IProvideStarLayoutInfo;
             if (provider == null)
             {
@@ -72,10 +69,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
         public void UnregisterStarLayoutProvider(IProvideStarLayoutInfoBase starLayoutInfoProvider)
         {
-            if (starLayoutInfoProvider == null)
-            {
-                throw new ArgumentNullException("starLayoutInfoProvider");
-            }
+            ArgumentNullException.ThrowIfNull(starLayoutInfoProvider);
             IProvideStarLayoutInfo provider = starLayoutInfoProvider as IProvideStarLayoutInfo;
             if (provider == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonMenuItemsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonMenuItemsPanel.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
         public void RegisterStarLayoutProvider(IProvideStarLayoutInfoBase starLayoutInfoProvider)
         {
-            if (starLayoutInfoProvider == null)
-            {
-                throw new ArgumentNullException("starLayoutInfoProvider");
-            }
+            ArgumentNullException.ThrowIfNull(starLayoutInfoProvider);
             if (!_registeredStarLayoutProviders.Contains(starLayoutInfoProvider))
             {
                 _registeredStarLayoutProviders.Add(starLayoutInfoProvider);
@@ -45,10 +42,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
         public void UnregisterStarLayoutProvider(IProvideStarLayoutInfoBase starLayoutInfoProvider)
         {
-            if (starLayoutInfoProvider == null)
-            {
-                throw new ArgumentNullException("starLayoutInfoProvider");
-            }
+            ArgumentNullException.ThrowIfNull(starLayoutInfoProvider);
             if (_registeredStarLayoutProviders.Contains(starLayoutInfoProvider))
             {
                 _registeredStarLayoutProviders.Remove(starLayoutInfoProvider);

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLengthConverter.cs
@@ -116,10 +116,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException("destinationType");
-            }
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             if (value != null && value is RibbonControlLength)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlService.cs
@@ -50,10 +50,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static ImageSource GetLargeImageSource(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (ImageSource)element.GetValue(LargeImageSourceProperty);
         }
 
@@ -62,10 +59,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetLargeImageSource(DependencyObject element, ImageSource value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(LargeImageSourceProperty, value);
         }
 
@@ -87,10 +81,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static ImageSource GetSmallImageSource(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (ImageSource)element.GetValue(SmallImageSourceProperty);
         }
 
@@ -99,10 +90,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetSmallImageSource(DependencyObject element, ImageSource value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(SmallImageSourceProperty, value);
         }
 
@@ -128,10 +116,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static string GetLabel(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(LabelProperty);
         }
 
@@ -140,10 +125,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetLabel(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(LabelProperty, value);
         }
 
@@ -168,10 +150,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static string GetToolTipTitle(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(ToolTipTitleProperty);
         }
 
@@ -180,10 +159,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipTitle(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipTitleProperty, value);
         }
 
@@ -199,10 +175,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static string GetToolTipDescription(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(ToolTipDescriptionProperty);
         }
 
@@ -211,10 +184,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipDescription(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipDescriptionProperty, value);
         }
 
@@ -230,10 +200,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static ImageSource GetToolTipImageSource(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (ImageSource)element.GetValue(ToolTipImageSourceProperty);
         }
 
@@ -242,10 +209,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipImageSource(DependencyObject element, ImageSource value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipImageSourceProperty, value);
         }
 
@@ -261,10 +225,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static string GetToolTipFooterTitle(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(ToolTipFooterTitleProperty);
         }
 
@@ -273,10 +234,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipFooterTitle(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipFooterTitleProperty, value);
         }
 
@@ -292,10 +250,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static string GetToolTipFooterDescription(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (string)element.GetValue(ToolTipFooterDescriptionProperty);
         }
 
@@ -304,10 +259,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipFooterDescription(DependencyObject element, string value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipFooterDescriptionProperty, value);
         }
 
@@ -323,10 +275,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static ImageSource GetToolTipFooterImageSource(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (ImageSource)element.GetValue(ToolTipFooterImageSourceProperty);
         }
 
@@ -335,10 +284,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetToolTipFooterImageSource(DependencyObject element, ImageSource value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ToolTipFooterImageSourceProperty, value);
         }
 
@@ -368,10 +314,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Ribbon GetRibbon(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Ribbon)element.GetValue(RibbonProperty);
         }
 
@@ -380,10 +323,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         internal static void SetRibbon(DependencyObject element, Ribbon value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(RibbonPropertyKey, value);
         }
 
@@ -402,10 +342,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetMouseOverBorderBrush(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(MouseOverBorderBrushProperty); 
         }
 
@@ -414,10 +351,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetMouseOverBorderBrush(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(MouseOverBorderBrushProperty, value); 
         }
             
@@ -436,10 +370,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetMouseOverBackground(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(MouseOverBackgroundProperty); 
         }
 
@@ -448,10 +379,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetMouseOverBackground(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(MouseOverBackgroundProperty, value);
         }
 
@@ -470,10 +398,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetPressedBorderBrush(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(PressedBorderBrushProperty); 
         }
 
@@ -482,10 +407,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetPressedBorderBrush(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(PressedBorderBrushProperty, value);
         }
 
@@ -504,10 +426,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetPressedBackground(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(PressedBackgroundProperty);
         }
 
@@ -516,10 +435,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetPressedBackground(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(PressedBackgroundProperty, value);
         }
 
@@ -538,10 +454,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetCheckedBackground(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(CheckedBackgroundProperty);
         }
 
@@ -550,10 +463,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetCheckedBackground(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CheckedBackgroundProperty, value);
         }
 
@@ -572,10 +482,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetCheckedBorderBrush(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(CheckedBorderBrushProperty);
         }
 
@@ -584,10 +491,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetCheckedBorderBrush(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CheckedBorderBrushProperty, value);
         }
 
@@ -606,10 +510,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetFocusedBackground(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(FocusedBackgroundProperty);
         }
 
@@ -618,10 +519,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetFocusedBackground(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(FocusedBackgroundProperty, value);
         }
 
@@ -640,10 +538,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static Brush GetFocusedBorderBrush(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Brush)element.GetValue(FocusedBorderBrushProperty);
         }
 
@@ -652,10 +547,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetFocusedBorderBrush(DependencyObject element, Brush value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(FocusedBorderBrushProperty, value);
         }
 
@@ -676,10 +568,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// <returns></returns>
         public static CornerRadius GetCornerRadius(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (CornerRadius)element.GetValue(CornerRadiusProperty);
         }
 
@@ -690,10 +579,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// <param name="value"></param>
         public static void SetCornerRadius(DependencyObject element, CornerRadius value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CornerRadiusProperty, value);
         }
 
@@ -719,10 +605,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static RibbonControlSizeDefinition GetControlSizeDefinition(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (RibbonControlSizeDefinition)element.GetValue(ControlSizeDefinitionProperty);
         }
 
@@ -731,10 +614,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetControlSizeDefinition(DependencyObject element, RibbonControlSizeDefinition value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ControlSizeDefinitionProperty, value);
         }
 
@@ -771,19 +651,13 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         public static RibbonControlSizeDefinition GetDefaultControlSizeDefinition(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (RibbonControlSizeDefinition)element.GetValue(DefaultControlSizeDefinitionProperty);
         }
 
         public static void SetDefaultControlSizeDefinition(DependencyObject element, RibbonControlSizeDefinition value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(DefaultControlSizeDefinitionProperty, value);
         }
 
@@ -872,10 +746,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static bool GetIsInControlGroup(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(IsInControlGroupProperty);
         }
 
@@ -885,10 +756,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         internal static void SetIsInControlGroup(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(IsInControlGroupPropertyKey, value);
         }
 
@@ -910,19 +778,13 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         public static bool GetCanAddToQuickAccessToolBarDirectly(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(CanAddToQuickAccessToolBarDirectlyProperty);
         }
 
         public static void SetCanAddToQuickAccessToolBarDirectly(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(CanAddToQuickAccessToolBarDirectlyProperty, value);
         }
 
@@ -945,10 +807,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static bool GetIsInQuickAccessToolBar(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(IsInQuickAccessToolBarProperty);
         }
 
@@ -957,10 +816,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         internal static void SetIsInQuickAccessToolBar(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(IsInQuickAccessToolBarPropertyKey, value);
         }
 
@@ -979,10 +835,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static RibbonControlSizeDefinition GetQuickAccessToolBarControlSizeDefinition(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (RibbonControlSizeDefinition)element.GetValue(QuickAccessToolBarControlSizeDefinitionProperty);
         }
 
@@ -991,10 +844,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetQuickAccessToolBarControlSizeDefinition(DependencyObject element, RibbonControlSizeDefinition value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(QuickAccessToolBarControlSizeDefinitionProperty, value);
         }
 
@@ -1014,10 +864,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static object GetQuickAccessToolBarId(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return element.GetValue(QuickAccessToolBarIdProperty);
         }
 
@@ -1026,10 +873,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static void SetQuickAccessToolBarId(DependencyObject element, object value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(QuickAccessToolBarIdProperty, value);
         }
 
@@ -1042,10 +886,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static bool GetShowKeyboardCues(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(ShowKeyboardCuesProperty);
         }
 
@@ -1054,10 +895,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         internal static void SetShowKeyboardCues(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(ShowKeyboardCuesPropertyKey, value);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonHelper.cs
@@ -1521,10 +1521,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         internal static bool ExistsInQAT(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
 
             Ribbon ribbon = (Ribbon)element.GetValue(RibbonControlService.RibbonProperty);
             object qatID = RibbonControlService.GetQuickAccessToolBarId(element);

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonQuickAccessToolBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonQuickAccessToolBar.cs
@@ -281,10 +281,7 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// <returns>The property's value.</returns>
         public static bool GetIsOverflowItem(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(IsOverflowItemProperty);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTwoLineText.cs
@@ -218,19 +218,13 @@ namespace Microsoft.Windows.Controls.Ribbon
 
         public static Geometry GetPathData(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (Geometry)element.GetValue(PathDataProperty);
         }
 
         public static void SetPathData(DependencyObject element, Geometry value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(PathDataProperty, value);
         }
 
@@ -249,19 +243,13 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// </summary>
         public static bool GetHasTwoLines(DependencyObject element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             return (bool)element.GetValue(HasTwoLinesProperty);
         }
 
         public static void SetHasTwoLines(DependencyObject element, bool value)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
             element.SetValue(HasTwoLinesProperty, value);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/StringCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/StringCollectionConverter.cs
@@ -99,15 +99,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// <returns>converted value</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (null == value)
-            {
-                throw new ArgumentNullException("value");
-            }
-
-            if (null == destinationType)
-            {
-                throw new ArgumentNullException("destinationType");
-            }
+            ArgumentNullException.ThrowIfNull(value);
+            ArgumentNullException.ThrowIfNull(destinationType);
 
             StringCollection stringCollectionValue = value as StringCollection;
             if (stringCollectionValue != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
@@ -38,10 +38,7 @@ namespace Microsoft.Windows.Controls
         /// <param name="itemsControl"></param>
         private TextSearchInternal(ItemsControl itemsControl)
         {
-            if (itemsControl == null)
-            {
-                throw new ArgumentNullException("itemsControl");
-            }
+            ArgumentNullException.ThrowIfNull(itemsControl);
 
             _attachedTo = itemsControl;
 
@@ -783,10 +780,7 @@ namespace Microsoft.Windows.Controls
 
         internal static string GetPrimaryText(FrameworkElement element)
         {
-            if (element == null)
-            {
-                throw new ArgumentNullException("element");
-            }
+            ArgumentNullException.ThrowIfNull(element);
 
             string text = (string)element.GetValue(TextSearch.TextProperty);
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/InertiaProcessor2D.cs
@@ -326,7 +326,7 @@ namespace System.Windows.Input.Manipulations
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetParameters(InertiaParameters2D parameters)
         {
-            Validations.CheckNotNull(parameters, "parameters");
+            ArgumentNullException.ThrowIfNull(parameters);
 
             InertiaTranslationBehavior2D translationParameters = parameters as InertiaTranslationBehavior2D;
             if (translationParameters != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationProcessor2D.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/ManipulationProcessor2D.cs
@@ -311,7 +311,7 @@ namespace System.Windows.Input.Manipulations
         EditorBrowsable(EditorBrowsableState.Never)]
         public void SetParameters(ManipulationParameters2D parameters)
         {
-            Validations.CheckNotNull(parameters, "parameters");
+            ArgumentNullException.ThrowIfNull(parameters);
             parameters.Set(this);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/Validations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/Validations.cs
@@ -12,20 +12,6 @@ namespace System.Windows.Input.Manipulations
     internal static class Validations
     {
         /// <summary>
-        /// Throws if an argument is null.
-        /// </summary>
-        /// <param name="value"></param>
-        /// <param name="paramName"></param>
-        public static void CheckNotNull(object value, string paramName)
-        {
-            Debug.Assert(paramName != null);
-            if (value == null)
-            {
-                throw new ArgumentNullException(paramName);
-            }
-        }
-
-        /// <summary>
         /// Gets whether the specified value is finite.
         /// </summary>
         /// <param name="value"></param>


### PR DESCRIPTION
## Description

- Use `ArgumentNullException.ThrowIfNull` in System.Windows.Controls.Ribbon, as in #7181
- Remove internal method `Validations.CheckNotNull` and replace with `ArgumentNullException.ThrowIfNull` in System.Windows.Input.Manipulations

## Regression

No

## Testing

CI

## Risk

Low: the changes from the first commit are mostly mechanic, using fixer CA1510. The ones from the second commit are scarce


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8193)