### PR TITLE
Use ArgumentNullException.ThrowIfNull in PresentationUI and Themes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/CommandEnforcer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/CommandEnforcer.cs
@@ -27,10 +27,7 @@ namespace MS.Internal.Documents.Application
         /// <param name="policy">The RMPolicy to be bound to the above Command.</param>
         public PolicyBinding(RoutedUICommand command, RightsManagementPolicy policy)
         {
-            if (command == null)
-            {
-                throw new ArgumentNullException("command");
-            }
+            ArgumentNullException.ThrowIfNull(command);
 
             _command = command;
             _policy = policy;
@@ -91,10 +88,7 @@ namespace MS.Internal.Documents.Application
         /// <param name="bind">The binding to add</param>
         internal void AddBinding(PolicyBinding bind)
         {
-            if (bind == null)
-            {
-                throw new ArgumentNullException("bind");
-            }
+            ArgumentNullException.ThrowIfNull(bind);
 
             _bindings.Add(bind);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentManager.cs
@@ -505,11 +505,8 @@ internal sealed class DocumentManager
     /// <param name="document">The document to validate.</param>
     private static void ThrowIfNull(Document document)
     {
-        if (document == null)
-        {
-            throw new ArgumentNullException("document");
+            ArgumentNullException.ThrowIfNull(document);
         }
-    }
     #endregion Private Methods
 
     #region Private Delegates

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentManager.cs
@@ -505,8 +505,8 @@ internal sealed class DocumentManager
     /// <param name="document">The document to validate.</param>
     private static void ThrowIfNull(Document document)
     {
-            ArgumentNullException.ThrowIfNull(document);
-        }
+        ArgumentNullException.ThrowIfNull(document);
+    }
     #endregion Private Methods
 
     #region Private Delegates

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentProperties.cs
@@ -36,10 +36,7 @@ namespace MS.Internal.Documents.Application
         /// <param name="uri"></param>
         private DocumentProperties(Uri uri)
         {
-            if (uri == null)
-            {
-                throw new ArgumentNullException("uri");
-            }
+            ArgumentNullException.ThrowIfNull(uri);
 
             _uri = new SecurityCriticalData<Uri>(uri);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
@@ -388,9 +388,9 @@ internal sealed class DocumentStream : StreamProxy, IDisposable
     /// <returns>An DocumentStream.</returns>
     internal static DocumentStream Open(Stream existing)
     {
-            ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(existing);
 
-            Trace.SafeWrite(
+        Trace.SafeWrite(
             Trace.File,
             "Opened {0}#{1} as existing stream.",
             existing,
@@ -984,8 +984,8 @@ internal sealed class DocumentStream : StreamProxy, IDisposable
     /// <exception cref="System.InvalidOperationException"/>
     private static void ThrowIfInvalidXpsFileForOpen(Uri location)
     {
-            ArgumentNullException.ThrowIfNull(location);
-            if (!location.IsFile)
+        ArgumentNullException.ThrowIfNull(location);
+        if (!location.IsFile)
         {
             throw new InvalidOperationException(
                 SR.DocumentStreamMustBeFileSource);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/DocumentStream.cs
@@ -388,12 +388,9 @@ internal sealed class DocumentStream : StreamProxy, IDisposable
     /// <returns>An DocumentStream.</returns>
     internal static DocumentStream Open(Stream existing)
     {
-        if (existing == null)
-        {
-            throw new ArgumentNullException("existing");
-        }
+            ArgumentNullException.ThrowIfNull(existing);
 
-        Trace.SafeWrite(
+            Trace.SafeWrite(
             Trace.File,
             "Opened {0}#{1} as existing stream.",
             existing,
@@ -987,11 +984,8 @@ internal sealed class DocumentStream : StreamProxy, IDisposable
     /// <exception cref="System.InvalidOperationException"/>
     private static void ThrowIfInvalidXpsFileForOpen(Uri location)
     {
-        if (location == null)
-        {
-            throw new ArgumentNullException("location");
-        }
-        if (!location.IsFile)
+            ArgumentNullException.ThrowIfNull(location);
+            if (!location.IsFile)
         {
             throw new InvalidOperationException(
                 SR.DocumentStreamMustBeFileSource);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/PageTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/PageTextBox.cs
@@ -398,10 +398,7 @@ namespace MS.Internal.Documents.Application
 
             void IValueProvider.SetValue(string value)
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 if (!IsEnabled())
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RestrictedTransactionalPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RestrictedTransactionalPackage.cs
@@ -46,9 +46,9 @@ internal sealed class RestrictedTransactionalPackage : TransactionalPackage
     /// <exception cref="System.ArgumentException" />
     internal override void MergeChanges(Stream target)
     {
-            ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(target);
 
-            if (TempPackage.Value != null)
+        if (TempPackage.Value != null)
         {
             foreach (PackagePart part in TempPackage.Value.GetParts())
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RestrictedTransactionalPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RestrictedTransactionalPackage.cs
@@ -46,12 +46,9 @@ internal sealed class RestrictedTransactionalPackage : TransactionalPackage
     /// <exception cref="System.ArgumentException" />
     internal override void MergeChanges(Stream target)
     {
-        if (target == null)
-        {
-            throw new ArgumentNullException("target");
-        }
+            ArgumentNullException.ThrowIfNull(target);
 
-        if (TempPackage.Value != null)
+            if (TempPackage.Value != null)
         {
             foreach (PackagePart part in TempPackage.Value.GetParts())
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RightsManagementErrorHandler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/RightsManagementErrorHandler.cs
@@ -69,10 +69,7 @@ namespace MS.Internal.Documents.Application
             RightsManagementOperation operation,
             Exception exception)
         {
-            if (exception == null)
-            {
-                throw new ArgumentNullException("exception");
-            }
+            ArgumentNullException.ThrowIfNull(exception);
 
             Trace.SafeWrite(
                 Trace.Rights,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
@@ -81,9 +81,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <exception cref="System.ArgumentNullException" />
     internal void EnableEditMode(Stream workspace)
     {
-            ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(workspace);
 
-            if (!workspace.CanWrite)
+        if (!workspace.CanWrite)
         {
             throw new ArgumentException(
                 SR.PackagingWriteNotSupported,
@@ -100,9 +100,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <exception cref="System.ArgumentException" />
     internal virtual void MergeChanges(Stream target)
     {
-            ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(target);
 
-            if (!target.CanWrite)
+        if (!target.CanWrite)
         {
             throw new InvalidOperationException();
         }
@@ -147,10 +147,10 @@ internal class TransactionalPackage : Package, IDisposable
 
     internal void Rebind(Stream newOriginal)
     {
-            ArgumentNullException.ThrowIfNull(newOriginal);
+        ArgumentNullException.ThrowIfNull(newOriginal);
 
-            // close this as we will open a new one
-            _originalPackage.Value.Close();
+        // close this as we will open a new one
+        _originalPackage.Value.Close();
         _trashCan.Add(_originalPackage.Value);
         _isDirty = false;
 
@@ -524,9 +524,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <returns>A writeable PackagePart.</returns>
     private PackagePart TempPackagePartFactory(PackagePart packagePart)
     {
-            ArgumentNullException.ThrowIfNull(packagePart);
+        ArgumentNullException.ThrowIfNull(packagePart);
 
-            EnsureTempPackage();
+        EnsureTempPackage();
 
         Uri partUri = packagePart.Uri;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
@@ -64,9 +64,9 @@ internal class TransactionalPackage : Package, IDisposable
     internal TransactionalPackage(Stream original)
         : base(FileAccess.ReadWrite)
     {
-            ArgumentNullException.ThrowIfNull(original);
+        ArgumentNullException.ThrowIfNull(original);
 
-            Package originalPackage = Package.Open(original);
+        Package originalPackage = Package.Open(original);
 
         _originalPackage = new SecurityCriticalDataForSet<Package>(originalPackage);
         _tempPackage = new SecurityCriticalDataForSet<Package>(null);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/TransactionalPackage.cs
@@ -64,12 +64,9 @@ internal class TransactionalPackage : Package, IDisposable
     internal TransactionalPackage(Stream original)
         : base(FileAccess.ReadWrite)
     {
-        if (original == null)
-        {
-            throw new ArgumentNullException("original");
-        }
+            ArgumentNullException.ThrowIfNull(original);
 
-        Package originalPackage = Package.Open(original);
+            Package originalPackage = Package.Open(original);
 
         _originalPackage = new SecurityCriticalDataForSet<Package>(originalPackage);
         _tempPackage = new SecurityCriticalDataForSet<Package>(null);
@@ -84,12 +81,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <exception cref="System.ArgumentNullException" />
     internal void EnableEditMode(Stream workspace)
     {
-        if (workspace == null)
-        {
-            throw new ArgumentNullException("workspace");
-        }
+            ArgumentNullException.ThrowIfNull(workspace);
 
-        if (!workspace.CanWrite)
+            if (!workspace.CanWrite)
         {
             throw new ArgumentException(
                 SR.PackagingWriteNotSupported,
@@ -106,12 +100,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <exception cref="System.ArgumentException" />
     internal virtual void MergeChanges(Stream target)
     {
-        if (target == null)
-        {
-            throw new ArgumentNullException("target");
-        }
+            ArgumentNullException.ThrowIfNull(target);
 
-        if (!target.CanWrite)
+            if (!target.CanWrite)
         {
             throw new InvalidOperationException();
         }
@@ -156,13 +147,10 @@ internal class TransactionalPackage : Package, IDisposable
 
     internal void Rebind(Stream newOriginal)
     {
-        if (newOriginal == null)
-        {
-            throw new ArgumentNullException("newOriginal");
-        }
+            ArgumentNullException.ThrowIfNull(newOriginal);
 
-        // close this as we will open a new one
-        _originalPackage.Value.Close();
+            // close this as we will open a new one
+            _originalPackage.Value.Close();
         _trashCan.Add(_originalPackage.Value);
         _isDirty = false;
 
@@ -536,12 +524,9 @@ internal class TransactionalPackage : Package, IDisposable
     /// <returns>A writeable PackagePart.</returns>
     private PackagePart TempPackagePartFactory(PackagePart packagePart)
     {
-        if (packagePart == null)
-        {
-            throw new ArgumentNullException("packagePart");
-        }
+            ArgumentNullException.ThrowIfNull(packagePart);
 
-        EnsureTempPackage();
+            EnsureTempPackage();
 
         Uri partUri = packagePart.Uri;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandPackagePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandPackagePart.cs
@@ -65,13 +65,11 @@ internal sealed class WriteableOnDemandPackagePart : PackagePart
         WriteablePackagePartFactoryDelegate writeablePartFactory)
         : base(container, readingPart.Uri)
     {
-            ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(readingPart);
+        ArgumentNullException.ThrowIfNull(writeablePartFactory);
 
-            ArgumentNullException.ThrowIfNull(readingPart);
-
-            ArgumentNullException.ThrowIfNull(writeablePartFactory);
-
-            _activePart = readingPart;
+        _activePart = readingPart;
         _getWriteablePartInstance = writeablePartFactory;
     }
     #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandPackagePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandPackagePart.cs
@@ -65,22 +65,13 @@ internal sealed class WriteableOnDemandPackagePart : PackagePart
         WriteablePackagePartFactoryDelegate writeablePartFactory)
         : base(container, readingPart.Uri)
     {
-        if (container == null)
-        {
-            throw new ArgumentNullException("container");
-        }
+            ArgumentNullException.ThrowIfNull(container);
 
-        if (readingPart == null)
-        {
-            throw new ArgumentNullException("readingPart");
-        }
+            ArgumentNullException.ThrowIfNull(readingPart);
 
-        if (writeablePartFactory == null)
-        {
-            throw new ArgumentNullException("writeablePartFactory");
-        }
+            ArgumentNullException.ThrowIfNull(writeablePartFactory);
 
-        _activePart = readingPart;
+            _activePart = readingPart;
         _getWriteablePartInstance = writeablePartFactory;
     }
     #endregion Constructors

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandStream.cs
@@ -52,11 +52,10 @@ internal sealed class WriteableOnDemandStream : Stream
         FileAccess access,
         GetWriteableInstance writeableStreamFactory)
     {
-            ArgumentNullException.ThrowIfNull(readingStream);
+        ArgumentNullException.ThrowIfNull(readingStream);
+        ArgumentNullException.ThrowIfNull(writeableStreamFactory);
 
-            ArgumentNullException.ThrowIfNull(writeableStreamFactory);
-
-            _active = readingStream;
+        _active = readingStream;
         _mode = mode;
         _access = access;
         _writeableStreamFactory = writeableStreamFactory;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/WriteableOnDemandStream.cs
@@ -52,17 +52,11 @@ internal sealed class WriteableOnDemandStream : Stream
         FileAccess access,
         GetWriteableInstance writeableStreamFactory)
     {
-        if (readingStream == null)
-        {
-            throw new ArgumentNullException("readingStream");
-        }
+            ArgumentNullException.ThrowIfNull(readingStream);
 
-        if (writeableStreamFactory == null)
-        {
-            throw new ArgumentNullException("writeableStreamFactory");
-        }
+            ArgumentNullException.ThrowIfNull(writeableStreamFactory);
 
-        _active = readingStream;
+            _active = readingStream;
         _mode = mode;
         _access = access;
         _writeableStreamFactory = writeableStreamFactory;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/ZoomComboBox.cs
@@ -551,10 +551,7 @@ namespace MS.Internal.Documents.Application
 
             void IValueProvider.SetValue(string value)
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 if (!IsEnabled())
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DigitalSignatureProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DigitalSignatureProvider.cs
@@ -38,24 +38,20 @@ namespace MS.Internal.Documents
         /// will manipulate</param>
         public DigitalSignatureProvider(Package package)
         {
-            if (package != null)
+            ArgumentNullException.ThrowIfNull(package);
+
+            XpsDocument = new XpsDocument(package);
+            FixedDocumentSequence = XpsDocument.FixedDocumentSequenceReader;
+            if (FixedDocumentSequence == null)
             {
-                XpsDocument = new XpsDocument(package);
-                FixedDocumentSequence = XpsDocument.FixedDocumentSequenceReader;
-                if (FixedDocumentSequence == null)
-                {
-                    throw new ArgumentException(SR.DigitalSignatureNoFixedDocumentSequence);
-                }
-                // We only want to save the first fixed document since all
-                // XPS Viewer signature definitions will be added to the first
-                // fixed document.
-                FixedDocument =
-                    FixedDocumentSequence.FixedDocuments[0];
+                throw new ArgumentException(SR.DigitalSignatureNoFixedDocumentSequence);
             }
-            else
-            {
-                throw new ArgumentNullException("package");
-            }
+            // We only want to save the first fixed document since all
+            // XPS Viewer signature definitions will be added to the first
+            // fixed document.
+            FixedDocument =
+                FixedDocumentSequence.FixedDocuments[0];
+
         }
         #endregion Constructors
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
@@ -234,15 +234,9 @@ namespace MS.Internal.Documents
         /// <param name="docSigManager">A reference to the DocumentSignatureManager</param>
         public void InitializeUI(DocumentSignatureManager docSigManager, DocumentRightsManagementManager rmManager)
         {
-            if (docSigManager == null)
-            {
-                throw new ArgumentNullException("docSigManager");
-            }
+            ArgumentNullException.ThrowIfNull(docSigManager);
 
-            if (rmManager == null)
-            {
-                throw new ArgumentNullException("rmManager");
-            }
+            ArgumentNullException.ThrowIfNull(rmManager);
 
             // Set DocumentSignatureManager reference.
             _docSigManager = docSigManager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentApplicationDocumentViewer.cs
@@ -235,7 +235,6 @@ namespace MS.Internal.Documents
         public void InitializeUI(DocumentSignatureManager docSigManager, DocumentRightsManagementManager rmManager)
         {
             ArgumentNullException.ThrowIfNull(docSigManager);
-
             ArgumentNullException.ThrowIfNull(rmManager);
 
             // Set DocumentSignatureManager reference.
@@ -1630,16 +1629,11 @@ namespace MS.Internal.Documents
         /// <param name="args"></param>
         private void OnRMPolicyChanged(object sender, DocumentRightsManagementManager.RightsManagementPolicyEventArgs args)
         {
-            if (args != null)
-            {
-                //Invoke the CommandEnforcer to enable/disable commands as appropriate.
-                _rightsManagementPolicy.Value = args.RMPolicy;
-                CommandEnforcer.Enforce();
-            }
-            else
-            {
-                throw new ArgumentNullException("args");
-            }
+            ArgumentNullException.ThrowIfNull(args);
+
+            //Invoke the CommandEnforcer to enable/disable commands as appropriate.
+            _rightsManagementPolicy.Value = args.RMPolicy;
+            CommandEnforcer.Enforce();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
@@ -1095,10 +1095,7 @@ namespace MS.Internal.Documents
         {
             CertificatePriorityStatus certificatePriorityStatus = CertificatePriorityStatus.Corrupted;
 
-            if (digitalSignature == null)
-            {
-                throw new ArgumentNullException("digitalSignature");
-            }
+            ArgumentNullException.ThrowIfNull(digitalSignature);
 
             // Signature requests and invalid signatures with missing certificates
             // both get the certificate status NoCertificate

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/DocumentSignatureManager.cs
@@ -42,14 +42,9 @@ namespace MS.Internal.Documents
         /// </summary>
         private DocumentSignatureManager(IDigitalSignatureProvider digSigProvider)
         {
-            if (digSigProvider != null)
-            {
-                DigitalSignatureProvider = digSigProvider;
-            }
-            else
-            {
-                throw new ArgumentNullException("digSigProvider");
-            }
+            ArgumentNullException.ThrowIfNull(digSigProvider);
+
+            DigitalSignatureProvider = digSigProvider;
 
             _changeLog = new List<ChangeLogEntity>();
 
@@ -1163,20 +1158,15 @@ namespace MS.Internal.Documents
         /// <param name="args"></param>
         private void OnRMPolicyChanged(object sender, DocumentRightsManagementManager.RightsManagementPolicyEventArgs args)
         {
-            if (args != null)
+            ArgumentNullException.ThrowIfNull(args);
+
+            if ((args.RMPolicy & RightsManagementPolicy.AllowSign) == RightsManagementPolicy.AllowSign)
             {
-                if ((args.RMPolicy & RightsManagementPolicy.AllowSign) == RightsManagementPolicy.AllowSign)
-                {
-                    _allowSign.Value = true;
-                }
-                else
-                {
-                    _allowSign.Value = false;
-                }
+                _allowSign.Value = true;
             }
             else
             {
-                throw new ArgumentNullException("args");
+                _allowSign.Value = false;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/PeoplePickerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/PeoplePickerWrapper.cs
@@ -312,10 +312,7 @@ namespace MS.Internal.Documents
             /// <param name="ptrToDsObjectNames">A pointer to a valid DsObjectNames struct</param>
             internal DsObjectNamesWrapper(System.IO.MemoryStream dataStream)
             {
-                if (dataStream == null)
-                {
-                    throw new ArgumentNullException("dataStream");
-                }
+                ArgumentNullException.ThrowIfNull(dataStream);
 
                 //We need to get a pointer to this data for our DsObjectNamesWrapper
                 //to wrap.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs
@@ -636,7 +636,6 @@ namespace MS.Internal.Documents
             private void UpdateRowFromEveryone(DataGridViewRow everyoneRow, DataGridViewRow targetRow)
             {
                 ArgumentNullException.ThrowIfNull(everyoneRow);
-
                 ArgumentNullException.ThrowIfNull(targetRow);
 
                 int ownerColumnIndex = RightsTableColumnToIndex(RightsTableColumn.AllowOwner);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RMPublishingDialog.RightsTable.cs
@@ -614,10 +614,7 @@ namespace MS.Internal.Documents
             /// <param name="everyoneRow">The row containing the Everyone user</param>
             private void UpdateAllRowsFromEveryone(DataGridViewRow everyoneRow)
             {
-                if (everyoneRow == null)
-                {
-                    throw new ArgumentNullException("everyoneRow");
-                }
+                ArgumentNullException.ThrowIfNull(everyoneRow);
 
                 // Update all the non-owner rows from the Everyone row
                 for (int rowIndex = _firstNonOwnerRow; rowIndex < Rows.Count; rowIndex++)
@@ -638,15 +635,9 @@ namespace MS.Internal.Documents
             /// <param name="targetRow">The target row to update</param>
             private void UpdateRowFromEveryone(DataGridViewRow everyoneRow, DataGridViewRow targetRow)
             {
-                if (everyoneRow == null)
-                {
-                    throw new ArgumentNullException("everyoneRow");
-                }
+                ArgumentNullException.ThrowIfNull(everyoneRow);
 
-                if (targetRow == null)
-                {
-                    throw new ArgumentNullException("targetRow");
-                }
+                ArgumentNullException.ThrowIfNull(targetRow);
 
                 int ownerColumnIndex = RightsTableColumnToIndex(RightsTableColumn.AllowOwner);
 
@@ -732,10 +723,7 @@ namespace MS.Internal.Documents
             /// <param name="everyoneRow">The row containing the Everyone user</param>
             private void UpdateAllRowsOnEveryoneRemoval(DataGridViewRow everyoneRow)
             {
-                if (everyoneRow == null)
-                {
-                    throw new ArgumentNullException("everyoneRow");
-                }
+                ArgumentNullException.ThrowIfNull(everyoneRow);
 
                 // Go through all the columns in the Everyone row
                 for (int column = RightsTableColumnToIndex(_leftModifiablePermissionColumn); column < _rightsTableColumnCount; column++)
@@ -766,10 +754,7 @@ namespace MS.Internal.Documents
             /// <param name="row">The row to update.</param>
             private void UpdateAllowOwner(DataGridViewRow row)
             {
-                if (row == null)
-                {
-                    throw new ArgumentNullException("row");
-                }
+                ArgumentNullException.ThrowIfNull(row);
 
                 DataGridViewDisableCheckBoxCell cell =
                     row.Cells[RightsTableColumnToIndex(RightsTableColumn.AllowOwner)]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RequestedSignatureDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RequestedSignatureDialog.cs
@@ -26,15 +26,10 @@ namespace MS.Internal.Documents
         /// </summary>
         internal RequestedSignatureDialog(DocumentSignatureManager docSigManager)
         {
-            if (docSigManager != null)
-            {
-                //Init private fields
-                _documentSignatureManager = docSigManager;
-            }
-            else
-            {
-                throw new ArgumentNullException("docSigManager");
-            }
+            ArgumentNullException.ThrowIfNull(docSigManager);
+
+            //Init private fields
+            _documentSignatureManager = docSigManager;
 
             // Initialize the "Must Sign By:" field
             _dateTimePicker.MinDate = DateTime.Now;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementManager.cs
@@ -44,14 +44,9 @@ namespace MS.Internal.Documents
         /// </summary>
         private DocumentRightsManagementManager(IRightsManagementProvider rmProvider)
         {
-            if (rmProvider != null)
-            {
-                _rmProviderCache.Value = rmProvider;
-            }
-            else
-            {
-                throw new ArgumentNullException("rmProvider");
-            }
+            ArgumentNullException.ThrowIfNull(rmProvider);
+
+            _rmProviderCache.Value = rmProvider;
 
             //Create dictionary for Credential Management
             //used to map between CredManResources and RM Users

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
@@ -448,13 +448,10 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     /// </summary>
     void IRightsManagementProvider.SetDefaultCredentials(RightsManagementUser user)
     {
-        if (user == null)
-        {
-            throw new ArgumentNullException("user");
-        }
+            ArgumentNullException.ThrowIfNull(user);
 
-        //Get AvailableCreds list so we can match new default user.
-        ReadOnlyCollection<RightsManagementUser> users =
+            //Get AvailableCreds list so we can match new default user.
+            ReadOnlyCollection<RightsManagementUser> users =
             ((IRightsManagementProvider)this).GetAvailableCredentials();
 
         int index = users.IndexOf(user);
@@ -485,12 +482,9 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     /// </summary>
     void IRightsManagementProvider.RemoveCredentials(RightsManagementUser user)
     {
-        if (user == null)
-        {
-            throw new ArgumentNullException("user");
-        }
+            ArgumentNullException.ThrowIfNull(user);
 
-        SecureEnvironment.RemoveActivatedUser(user);
+            SecureEnvironment.RemoveActivatedUser(user);
     }
 
     /// <summary>
@@ -647,14 +641,11 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     void IRightsManagementProvider.GenerateUnsignedPublishLicense(
         IList<RightsManagementLicense> licenses)
     {
-        if (licenses == null)
-        {
-            throw new ArgumentNullException("licenses");
-        }
+            ArgumentNullException.ThrowIfNull(licenses);
 
-        // If the document is already protected, only owners can republish it
-        // with different permissions
-        if (IsProtected && !HasPermission(
+            // If the document is already protected, only owners can republish it
+            // with different permissions
+            if (IsProtected && !HasPermission(
             _rmUseLicense.Value, RightsManagementPermissions.AllowOwner))
         {
             throw new InvalidOperationException(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
@@ -452,7 +452,7 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
 
         //Get AvailableCreds list so we can match new default user.
         ReadOnlyCollection<RightsManagementUser> users =
-        ((IRightsManagementProvider)this).GetAvailableCredentials();
+            ((IRightsManagementProvider)this).GetAvailableCredentials();
 
         int index = users.IndexOf(user);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementProvider.cs
@@ -448,11 +448,11 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     /// </summary>
     void IRightsManagementProvider.SetDefaultCredentials(RightsManagementUser user)
     {
-            ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(user);
 
-            //Get AvailableCreds list so we can match new default user.
-            ReadOnlyCollection<RightsManagementUser> users =
-            ((IRightsManagementProvider)this).GetAvailableCredentials();
+        //Get AvailableCreds list so we can match new default user.
+        ReadOnlyCollection<RightsManagementUser> users =
+        ((IRightsManagementProvider)this).GetAvailableCredentials();
 
         int index = users.IndexOf(user);
 
@@ -482,9 +482,9 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     /// </summary>
     void IRightsManagementProvider.RemoveCredentials(RightsManagementUser user)
     {
-            ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(user);
 
-            SecureEnvironment.RemoveActivatedUser(user);
+        SecureEnvironment.RemoveActivatedUser(user);
     }
 
     /// <summary>
@@ -641,11 +641,11 @@ internal class RightsManagementProvider : IRightsManagementProvider, IDisposable
     void IRightsManagementProvider.GenerateUnsignedPublishLicense(
         IList<RightsManagementLicense> licenses)
     {
-            ArgumentNullException.ThrowIfNull(licenses);
+        ArgumentNullException.ThrowIfNull(licenses);
 
-            // If the document is already protected, only owners can republish it
-            // with different permissions
-            if (IsProtected && !HasPermission(
+        // If the document is already protected, only owners can republish it
+        // with different permissions
+        if (IsProtected && !HasPermission(
             _rmUseLicense.Value, RightsManagementPermissions.AllowOwner))
         {
             throw new InvalidOperationException(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
@@ -72,10 +72,7 @@ namespace MS.Internal.Documents
         {
             string accountName = null;
 
-            if (user == null)
-            {
-                throw new ArgumentNullException("user");
-            }
+            ArgumentNullException.ThrowIfNull(user);
 
             switch (user.AuthenticationType)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SigningDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SigningDialog.cs
@@ -33,15 +33,9 @@ namespace MS.Internal.Documents
         /// </summary>
         internal SigningDialog(X509Certificate2 x509Certificate2, DigitalSignature digitalSignatureRequest, DocumentSignatureManager docSigManager)
         {
-            if (x509Certificate2 == null)
-            {
-                throw new ArgumentNullException("x509Certificate2");
-            } 
-            if (docSigManager == null)
-            {
-                throw new ArgumentNullException("docSigManager");
-            }
-            
+            ArgumentNullException.ThrowIfNull(x509Certificate2);
+            ArgumentNullException.ThrowIfNull(docSigManager);
+
             _docSigManager = docSigManager;
             _x509Certificate2 = x509Certificate2;   // setting critical data.
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/Microsoft/Windows/Themes/ScrollChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero/Microsoft/Windows/Themes/ScrollChrome.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Windows.Themes
         /// <returns>The value of the property.</returns>
         public static ScrollGlyph GetScrollGlyph(DependencyObject element)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             return (ScrollGlyph) element.GetValue(ScrollGlyphProperty);
         }
 
@@ -74,8 +74,8 @@ namespace Microsoft.Windows.Themes
         /// <param name="value">The value to attach.</param>
         public static void SetScrollGlyph(DependencyObject element, ScrollGlyph value)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             element.SetValue(ScrollGlyphProperty, value);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Microsoft/Windows/Themes/ScrollChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Microsoft/Windows/Themes/ScrollChrome.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Windows.Themes
         /// <returns>The value of the property.</returns>
         public static ScrollGlyph GetScrollGlyph(DependencyObject element)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             return (ScrollGlyph) element.GetValue(ScrollGlyphProperty);
         }
 
@@ -74,8 +74,8 @@ namespace Microsoft.Windows.Themes
         /// <param name="value">The value to attach.</param>
         public static void SetScrollGlyph(DependencyObject element, ScrollGlyph value)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             element.SetValue(ScrollGlyphProperty, value);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Microsoft/Windows/Themes/ScrollChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.AeroLite/Microsoft/Windows/Themes/ScrollChrome.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Windows.Themes
         /// <returns>The value of the property.</returns>
         public static ScrollGlyph GetScrollGlyph(DependencyObject element)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             return (ScrollGlyph) element.GetValue(ScrollGlyphProperty);
         }
 
@@ -74,8 +74,8 @@ namespace Microsoft.Windows.Themes
         /// <param name="value">The value to attach.</param>
         public static void SetScrollGlyph(DependencyObject element, ScrollGlyph value)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
-            
+            ArgumentNullException.ThrowIfNull(element);
+
             element.SetValue(ScrollGlyphProperty, value);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Microsoft/Windows/Themes/ScrollChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Luna/Microsoft/Windows/Themes/ScrollChrome.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Windows.Themes
         /// <returns>The value of the property.</returns>
         public static ScrollGlyph GetScrollGlyph(DependencyObject element)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
+            ArgumentNullException.ThrowIfNull(element);
 
             return (ScrollGlyph)element.GetValue(ScrollGlyphProperty);
         }
@@ -111,7 +111,7 @@ namespace Microsoft.Windows.Themes
         /// <param name="value">The value to attach.</param>
         public static void SetScrollGlyph(DependencyObject element, ScrollGlyph value)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
+            ArgumentNullException.ThrowIfNull(element);
 
             element.SetValue(ScrollGlyphProperty, value);
         }

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Microsoft/Windows/Themes/ScrollChrome.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Royale/Microsoft/Windows/Themes/ScrollChrome.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Windows.Themes
         /// <returns>The value of the property.</returns>
         public static ScrollGlyph GetScrollGlyph(DependencyObject element)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
+            ArgumentNullException.ThrowIfNull(element);
 
             return (ScrollGlyph)element.GetValue(ScrollGlyphProperty);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.Windows.Themes
         /// <param name="value">The value to attach.</param>
         public static void SetScrollGlyph(DependencyObject element, ScrollGlyph value)
         {
-            if (element == null) { throw new ArgumentNullException("element"); }
+            ArgumentNullException.ThrowIfNull(element);
 
             element.SetValue(ScrollGlyphProperty, value);
         }


### PR DESCRIPTION
## Description

Use ArgumentNullException.ThrowIfNull in `PresentationUI` and `Themes` as in #7181

## Regression

No

## Testing

CI

## Risk

Low: changes are mostly mechanic, using fixer CA1510

Note that many files don't follow indentation conventions, so I had to manually realign what the analyzer changed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8194)