### PR TITLE
ItemsCommands

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);CORE_NATIVEMETHODS;PRESENTATION_CORE;COMMONDPS</DefineConstants>
@@ -554,6 +554,7 @@
     <Compile Include="System\Windows\Input\Command\InputGesture.cs" />
     <Compile Include="System\Windows\Input\Command\InputGestureCollection.cs" />
     <Compile Include="System\Windows\Input\Command\ISecureCommand.cs" />
+    <Compile Include="System\Windows\Input\Command\ItemsCommands.cs" />
     <Compile Include="System\Windows\Input\Command\KeyBinding.cs" />
     <Compile Include="System\Windows\Input\Command\KeyGesture.cs" />
     <Compile Include="System\Windows\Input\Command\KeyGestureConverter.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
@@ -277,6 +277,18 @@ MoveFocusForwardKeyDisplayString=Ctrl+Right
 MoveFocusPageUpKeyDisplayString=Ctrl+PageUp
 MoveFocusPageDownKeyDisplayString=Ctrl+PageDown
 
+;ItemsCommands Text
+Sort=Sort
+Group=Group
+
+;ItemsCommands Keys
+Sort=
+Group=
+
+;ItemsCommands Key display strings
+Sort=
+Group=
+
 ; MediaCommands Text
 MediaPlayText=Play
 MediaPauseText=Pause

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1303,6 +1303,24 @@
   <data name="IsfOperationFailed" xml:space="preserve">
     <value>InkSerializedFormat operation failed.</value>
   </data>
+  <data name="ItemsSortKey" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ItemsSortKeyDisplayString" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ItemsSortText" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="ItemsGroupKey" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ItemsGroupKeyDisplayString" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ItemsGroupText" xml:space="preserve">
+    <value>Group</value>
+  </data>
   <data name="KeyboardSinkAlreadyOwned" xml:space="preserve">
     <value>The specified keyboard sink is already owned by a site.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Operace InkSerializedFormat se nezdařila.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Seskupit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Seřadit</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Kombinace klávesy a modifikátoru {0}+{1} není podporována gestem KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Fehler beim InkSerializedFormat-Vorgang.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Gruppieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Sortieren</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Die Kombination aus Taste und Modifizierer "{0}+{1}" wird für KeyGesture nicht unterstützt.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Error de la operación InkSerializedFormat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Agrupar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Ordenar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Combinación de teclas y modificador "{0}+{1}" no admitida por KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Échec de l'opération InkSerializedFormat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Grouper</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Trier</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">La combinaison clé et modificateur '{0}+{1}' n'est pas prise en charge pour KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Operazione InkSerializedFormat non riuscita.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Raggruppa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Ordina</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">La combinazione di tasto e modificatore '{0}+{1}' non è supportata per KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">InkSerializedFormat 処理に失敗しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">グループ化</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">並べ替え</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">'{0}+{1}' キーと修飾子キーの組み合わせは、KeyGesture ではサポートされていません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">InkSerializedFormat 작업이 실패했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">그룹</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">정렬</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">KeyGesture에 '{0}+{1}' 키와 한정자 조합을 사용할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Operacja InkSerializedFormat nie powiodła się.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Grupuj</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Sortuj</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Kombinacja „{0}+{1}” klucza i modyfikatora nie jest obsługiwana dla elementu KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Falha na operação de InkSerializedFormat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Agrupar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Classificar</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Não há suporte para a combinação de teclas e modificador '{0}+{1}' para KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">Не удалось выполнить операцию InkSerializedFormat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Группировать</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Сортировать</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">Сочетание клавиш "{0}+{1}" и модификатора не поддерживается для KeyGesture.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">InkSerializedFormat işlemi başarısız oldu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">Gruplandır</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">Sırala</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">'{0}+{1}' tuş ve değiştirici bileşimi KeyGesture için desteklenmiyor.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">InkSerializedFormat 操作失败。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">创建组</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">排序</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">KeyGesture 尚不支持“{0}+{1}”键和修饰符组合。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -1927,6 +1927,16 @@
         <target state="translated">InkSerializedFormat 操作失敗。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ItemsGroupText">
+        <source>Group</source>
+        <target state="translated">組成群組</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ItemsSortText">
+        <source>Sort</source>
+        <target state="translated">排序</target>
+        <note />
+      </trans-unit>
       <trans-unit id="KeyGesture_Invalid">
         <source>'{0}+{1}' key and modifier combination is not supported for KeyGesture.</source>
         <target state="translated">KeyGesture 不支援 '{0}+{1}' 按鍵與輔助按鍵組合。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/ItemsCommands.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/ItemsCommands.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//
+//
+//
+// Description: The ItemsCommands class defines a standard set of commands that act on collection of items.
+//
+//              See spec at : http://avalon/CoreUI/Specs%20%20Eventing%20and%20Commanding/CommandLibrarySpec.mht
+//
+//
+//
+
+using System;
+using System.Windows;
+using System.Windows.Input;
+using System.Collections;
+using System.ComponentModel;
+
+using SR=MS.Internal.PresentationCore.SR;
+
+namespace System.Windows.Input
+{
+    /// <summary>
+    /// ItemsCommands - Set of Standard Commands
+    /// </summary>
+    public static class ItemsCommands
+    {
+        //------------------------------------------------------
+        //
+        //  Public Methods
+        //
+        //------------------------------------------------------
+#region Public Methods
+
+        /// <summary>
+        /// Play Command
+        /// </summary>
+        public static RoutedUICommand Sort
+        {
+            get { return _EnsureCommand(CommandId.Sort); }
+        }
+
+        /// <summary>
+        /// Pause Command
+        /// </summary>
+        public static RoutedUICommand Group
+        {
+            get { return _EnsureCommand(CommandId.Group); }
+        }
+#endregion Public Methods
+
+        //------------------------------------------------------
+        //
+        //  Private Methods
+        //
+        //------------------------------------------------------
+        #region Private Methods
+        private static string GetPropertyName(CommandId commandId)
+        {
+            string propertyName = String.Empty;
+
+            switch (commandId)
+            {
+                case CommandId.Sort : propertyName = nameof(Sort); break;
+                case CommandId.Group: propertyName = nameof(Group); break;
+        }
+            return propertyName;
+        }
+
+        internal static string GetUIText(byte commandId)
+        {
+            string uiText = String.Empty;
+
+            switch ((CommandId)commandId)
+            {
+                case  CommandId.Sort: uiText = SR.ItemsSortText; break;
+                case  CommandId.Group: uiText = SR.ItemsGroupText; break;
+            }
+            return uiText;
+        }
+
+        internal static InputGestureCollection LoadDefaultGestureFromResource(byte commandId)
+        {
+            InputGestureCollection gestures = new InputGestureCollection();
+
+            //Standard Commands
+            switch ((CommandId)commandId)
+            {
+                case  CommandId.Sort:
+                    KeyGesture.AddGesturesFromResourceStrings(
+                        SR.ItemsSortKey,
+                        SR.ItemsSortKeyDisplayString,
+                        gestures);
+                    break;
+                case  CommandId.Group:
+                    KeyGesture.AddGesturesFromResourceStrings(
+                        SR.ItemsGroupKey,
+                        SR.ItemsGroupKeyDisplayString,
+                        gestures);
+                    break;
+                }
+            return gestures;
+        }
+
+        private static RoutedUICommand _EnsureCommand(CommandId idCommand)
+        {
+            if (idCommand >= 0 && idCommand < CommandId.Last)
+            {
+                lock (_internalCommands.SyncRoot)
+                {
+                    if (_internalCommands[(int)idCommand] == null)
+                    {
+                        RoutedUICommand newCommand = new RoutedUICommand(GetPropertyName(idCommand), typeof(ItemsCommands), (byte)idCommand);
+                        newCommand.AreInputGesturesDelayLoaded = true;
+                        _internalCommands[(int)idCommand] = newCommand;
+                    }
+                }
+                return _internalCommands[(int)idCommand];
+            }
+            return null;
+        }
+        #endregion Private Methods
+
+        //------------------------------------------------------
+        //
+        //  Private Fields
+        //
+        //------------------------------------------------------
+        #region Private Fields
+        // these constants will go away in future, its just to index into the right one.
+        private enum CommandId : byte
+        {
+            // Formatting
+            Sort = 1,
+            Group = 2,
+
+            // Last
+            Last = 3
+        }
+
+        private static RoutedUICommand[] _internalCommands = new RoutedUICommand[(int)CommandId.Last];
+        #endregion Private Fields
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedCommand.cs
@@ -269,6 +269,10 @@ namespace System.Windows.Input
             {
                 return ComponentCommands.LoadDefaultGestureFromResource(_commandId);
             }
+            else if(OwnerType == typeof(ItemsCommands))
+            {
+                return ItemsCommands.LoadDefaultGestureFromResource(_commandId);
+            }
             return new InputGestureCollection();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedUICommand.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/RoutedUICommand.cs
@@ -106,6 +106,10 @@ namespace System.Windows.Input
             {
                 return ComponentCommands.GetUIText(CommandId);
             }
+            else if(OwnerType == typeof(ItemsCommands))
+            {
+                return ItemsCommands.GetUIText(CommandId);
+            }
             return null;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -3600,6 +3600,11 @@ namespace System.Windows.Input
         Text = 4,
         Command = 5,
     }
+    public static partial class ItemsCommands
+    {
+        public static System.Windows.Input.RoutedUICommand Sort { get { throw null; } }
+        public static System.Windows.Input.RoutedUICommand Group { get { throw null; } }
+    }
     public partial class KeyBinding : System.Windows.Input.InputBinding
     {
         public static readonly System.Windows.DependencyProperty KeyProperty;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/Command/CommandConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/Command/CommandConverter.cs
@@ -203,7 +203,8 @@ namespace System.Windows.Input
             commandType == typeof(EditingCommands) ||
             commandType == typeof(NavigationCommands) ||
             commandType == typeof(ComponentCommands) ||
-            commandType == typeof(MediaCommands))
+            commandType == typeof(MediaCommands) ||
+            commandType == typeof(ItemsCommands))
             {
                 return true;
             }
@@ -736,6 +737,19 @@ namespace System.Windows.Input
                 }
             }
 
+            if (ownerType == typeof(ItemsCommands) || ((null == knownCommand) && searchAll))
+            {
+                switch (localName)
+                {
+                    case "Sort":
+                        knownCommand = ItemsCommands.Sort;
+                        break;
+                    case "Group":
+                        knownCommand = ItemsCommands.Group;
+                        break;
+                }
+            }
+
 
             #if DEBUG
             if( knownCommand == null )
@@ -749,6 +763,7 @@ namespace System.Windows.Input
                     VerifyCommandDoesntExist( typeof(MediaCommands), localName );
                     VerifyCommandDoesntExist( typeof(EditingCommands), localName );
                     VerifyCommandDoesntExist( typeof(ComponentCommands), localName );
+                    VerifyCommandDoesntExist( typeof(ItemsCommands), localName );
                 }
 
             }


### PR DESCRIPTION
## Description

This is a new feature introducing built-in set of commands applicable to collection(view) of items.

This will enable controls to implement sorting and grouping using commands, and specially allow `DataGrid` to sustainably handle sorting using keyboard instead of #6873.

This PR implements API proposal #8199.

## Customer Impact

Without taking this PR, developers will need to create custom solutions to for invoking sorting and grouping. These can be user-defined commands, however, these would not be available to built-in controls shipping with WPF.

## Regression

No.

## Testing

Compiled and tested with 8.0.100-preview.7.23376.3, that the commands can be parsed from XAML, bound to keyboard shortcuts and executed on various targets using explicit buttons as well as shortcuts, including modified DataGrid.

## Risk

These are all new classes and members not affecting any existing functionality.