### PR TITLE
Fix for Radio Button Behavior in WPF Across Disconnected Windows

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RadioButton.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Controls
                         else
                         {
                             // Uncheck all checked RadioButtons different from the current one
-                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb))
+                            if (rb != this && (rb.IsChecked == true) && rootScope == KeyboardNavigation.GetVisualRoot(rb) && rootScope != null)
                                 rb.UncheckRadioButton();
                             i++;
                         }


### PR DESCRIPTION
## Fixes <!-- Issue Number -->
**RadioButtons with the same GroupName will affect each other over windows if window is closed** https://github.com/dotnet/wpf/issues/2995

## Description
Radio buttons with the same group name across disconnected windows were not being immediately garbage collected, leading to unexpected interactions between closed or disconnected windows. This code change addresses the issue by implementing a validation mechanism to ensure that the current window is connected to the application's visual tree before radio button interactions are processed. This helps prevent unintended interactions between radio buttons across multiple closed or disconnected windows.

## Customer Impact
Unknown

## Regression
None

## Testing
Tested the changes with scenarios involving multiple disconnected windows and radio buttons in same group name. Verified that issue no longer occurs.
