### PR TITLE
Correct PerMonitorV2 DPI for popups without targets

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -3120,7 +3120,7 @@ namespace System.Windows.Controls.Primitives
 
             internal Matrix GetTransformToDevice()
             {
-                CompositionTarget ct = _window.Value.CompositionTarget;
+                CompositionTarget ct = _window?.Value.CompositionTarget;
                 if (ct != null && !ct.IsDisposed)
                 {
                     return ct.TransformToDevice;
@@ -3570,6 +3570,13 @@ namespace System.Windows.Controls.Primitives
                         var screenOrigin = popup._secHelper.ClientToScreen(rootVisual, ptPlacementTargetOrigin);
                         return new NativeMethods.POINT((int)screenOrigin.X, (int)screenOrigin.Y);
                     }
+                }
+                else
+                {
+                    // GetPlacementTargetInterestPoints already returns points in screen-coordinate
+                    Point[] placementTargetInterestPoints = popup.GetPlacementTargetInterestPoints(popup.PlacementInternal);
+                    Point center = placementTargetInterestPoints[(int)InterestPoint.TopLeft];
+                    return new NativeMethods.POINT((int)center.X, (int)center.Y);
                 }
 
                 return null;


### PR DESCRIPTION
Fixes #3874

## Description

When creating a HWND for a popup, it needs to be positioned at the correct monitor to receive its DPI in PerMonitorV2 mode, as noticed and implemented here:

https://github.com/dotnet/wpf/blob/0ef158e08eb7811a7ea83c01b9083f3dc25d881a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs#L1588-L1599

However, when the `PlacemenetTarget` of the popup is `null`, these required steps are not done, since the `GetPlacementTargetOriginInScreenCoordinates` gives up and returns 0,0. The popup is then properly positioned after the window is created, which is too late - the winow is potentially created on the wrong monitor, with consequences as above.

This PR updates `GetPlacementTargetOriginInScreenCoordinates` to estimate the position that would be used later to position the popup when there is no target. This ensures that the window is created on the correct monitor and the popup will receive correct DPI values.

## Customer Impact

Only customers using PerMonitorV2 and monitors with at least two different DPIs are affected. For those customers, not taking this PR would mean that popups opened without setting any `PlacementTarget` will open with the primary's monitor DPI.

## Regression

No.

## Testing

Compiled and run using .NET 8.0.0-preview.7.23375.6 with PerMonitorV2 manifest. Verified that setting `ContextMenu.IsOpen` to `true` exhibits the bug on a monitor with different DPI and does not when the PR is applied, using various popup positioning.

## Risk

I believe this is low, the scenario when the new code executed is very narrow. All of the following must be true:
1. Application opted into per monitor V2 DPI awarenes
2. Apllication is running in a multi-monitor setup with varying DPI configuration
3. The popup does not have any `PlacementTarget` set (this shouldn't be common)
4. The popup is opened programatically (e.g. setting `IsOpen=true`)

Without the PR, the window is created at 0,0 in this case. With the PR, the window is created at a different coordinate. Either way, the window is positioned afterwards to the correct location, so the only observable change is the monitor on which the Win32 window is initially created.