### PR TITLE
TextEditorTyping ignore space commands

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextEditorTyping.cs
@@ -68,7 +68,6 @@ namespace System.Windows.Documents
             }
 
             var onEnterBreak = new ExecutedRoutedEventHandler(OnEnterBreak);
-            var onSpace = new ExecutedRoutedEventHandler(OnSpace);
             var onQueryStatusNYI = new CanExecuteRoutedEventHandler(OnQueryStatusNYI);
             var onQueryStatusEnterBreak = new CanExecuteRoutedEventHandler(OnQueryStatusEnterBreak);
             
@@ -84,8 +83,6 @@ namespace System.Windows.Documents
             CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.EnterLineBreak       , onEnterBreak                                           , onQueryStatusEnterBreak           , KeyGesture.CreateFromResourceStrings(KeyEnterLineBreak,   nameof(SR.KeyEnterLineBreakDisplayString)         ));
             CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.TabForward           , new ExecutedRoutedEventHandler(OnTabForward)           , new CanExecuteRoutedEventHandler(OnQueryStatusTabForward)           , KeyGesture.CreateFromResourceStrings(KeyTabForward,       nameof(SR.KeyTabForwardDisplayString)             ));
             CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.TabBackward          , new ExecutedRoutedEventHandler(OnTabBackward)          , new CanExecuteRoutedEventHandler(OnQueryStatusTabBackward)          , KeyGesture.CreateFromResourceStrings(KeyTabBackward,      nameof(SR.KeyTabBackwardDisplayString)            ));
-            CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.Space                , onSpace                                                , onQueryStatusNYI                  , KeyGesture.CreateFromResourceStrings(KeySpace,            nameof(SR.KeySpaceDisplayString)                  ));
-            CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.ShiftSpace           , onSpace                                                , onQueryStatusNYI                  , KeyGesture.CreateFromResourceStrings(KeyShiftSpace,       nameof(SR.KeyShiftSpaceDisplayString)             ));
 
             CommandHelpers.RegisterCommandHandler(controlType, EditingCommands.Backspace            , new ExecutedRoutedEventHandler(OnBackspace)            , onQueryStatusNYI                  , KeyGesture.CreateFromResourceStrings(KeyBackspace,        SR.KeyBackspaceDisplayString),   KeyGesture.CreateFromResourceStrings(KeyShiftBackspace, SR.KeyShiftBackspaceDisplayString) );
         }
@@ -1258,46 +1255,6 @@ namespace System.Windows.Documents
                 }
                 ((TextSelection)This.Selection).UpdateCaretState(CaretScrollMethod.Simple);
             }
-        }
-
-        // ...........................................................................
-        //
-        // In some controls, Space and Shift+Space keys are mapped to
-        // scroll down and scroll up commands respectively.
-        // In TextEditor, we handle them as text input.
-        // Using the command system allows controls to override the existing default behavior.
-        // ...........................................................................
-
-        // Space, Shift+Space handler
-        private static void OnSpace(object sender, ExecutedRoutedEventArgs e)
-        {
-            TextEditor This = TextEditor._GetTextEditor(sender);
-
-            if (This == null || !This._IsEnabled || This.IsReadOnly || !This._IsSourceInScope(e.OriginalSource))
-            {
-                return;
-            }
-
-            // If this event is our Cicero TextStore composition, we always handles through ITextStore::SetText.
-            if (This.TextStore != null && This.TextStore.IsComposing)
-            {
-                return;
-            }
-
-            if (This.ImmComposition != null && This.ImmComposition.IsComposition)
-            {
-                return;
-            }
-
-            // Consider event handled
-            e.Handled = true;
-
-            if (This.TextView != null)
-            {
-                This.TextView.ThrottleBackgroundTasksForUserInput();
-            }
-
-            ScheduleInput(This, new TextInputItem(This, " ", /*isInsertKeyToggled:*/!This._OvertypeMode));
         }
 
         // ...........................................................................


### PR DESCRIPTION
Fixes #8249

## Description

When typing in a text box, <kbd>Space</kbd> and <kbd>Shift</kbd>+<kbd>Space</kbd> are artificially treated as commands that produce the space character, irrespectively of what they current keyboard layout outputs when the space key is pressed.

This is incosistent with Win32 behavior and breaks several keyboard layouts shipping with Windows:
* **Khmer** (should output KHMER SIGN COENG on <kbd>Space</kbd>)
* **Lao** (should output ZWS on <kbd>Shift</kbd>+<kbd>Space</kbd>)
* **Sinhala** (should output NBSP on <kbd>Shift</kbd>+<kbd>Space</kbd>)
* **Dzongkha** (should output TIBETAN MARK INTERSYLLABIC TSHEG on <kbd>Space</kbd>)
* **Khmer (NIDA)** (should output ZWS on <kbd>Space</kbd>)
* **French (Standard, BÉPO)** (should output NARROW NBSP on <kbd>Shift</kbd>+<kbd>Space</kbd>)
* **Persian (Standard)** (should output ZWNJ on <kbd>Shift</kbd>+<kbd>Space</kbd>)
* **Phags-pa** (should output THIN SPACE on <kbd>Shift</kbd>+<kbd>Space</kbd>)

Unlike in other key combinations of interest, the `TextEditorTyping` class does nothing else other than inject the space character. If something unusual is happening, like a composition in progress or disabled or read-only control, it simply ignores the command.

There is no need to emit the space character manually. The command can be ignored in all cases and the input system will type the space correctly as expected. This PR fixes the issue by making the `TextEditorTypeing` not handle the `EditingCommands.Space` and `EditingCommands.ShiftSpace` commands.

## Customer Impact

Not taking this fix will leave customers using the above listed (and other, user-installed) keyboards unable to type characters specified by the layout on the space bar. This makes it impossible to predictably enter masked text such as passwords.

## Regression

No.

## Testing

Compiled and run using .NET 8.0.100-preview.7.23376.3. Verified the issue in #8249 repros for Sinhala and Persian (Standard) layouts but does not repro in a with the fix (using `TextBox`). I also run the DRT tests and did not see any failures related to this fix, and there does not seem to be any tests concerning these two commands. However, the DRT need to be run in a known environment to verify any of the space injecting code did not get affected (in which case most likely the test would need to be updated).

## Risk

There is a behavioral change by design - controls based on TextBoxBase would mark `EditingCommands.Space` and `EditingCommands.ShiftSpace` as handled, which will be no longer the case after the fix. However, there were already cases when this happened as noted above and where the input would go through the normal input stack (i.e. during composition).

