### PR TITLE
Fix for tab grid error

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -2930,7 +2930,7 @@ namespace System.Windows.Data
         // SortDescription was added/removed, refresh CollectionView
         private void SortDescriptionsChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (IsAddingNew || IsEditingItem)
+            if ((IsAddingNew || IsEditingItem) && e.Action != NotifyCollectionChangedAction.Reset)
                 throw new InvalidOperationException(SR.Format(SR.MemberNotAllowedDuringAddOrEdit, "Sorting"));
 
             // adding to SortDescriptions overrides custom sort


### PR DESCRIPTION
Fixes #2662

## Description

Fix for program crashing with a framework exception when we have a TabControl using a DataTemplate with DataGrids in it, and first we sort a DataGrid column and then try to edit a cell in that column, and then try to change tabs in the TabControl

## Customer Impact

Program crashing with a framework exception

## Regression

None

## Testing

Done, no new failures encountered. 

## Risk

None



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8259)