### PR TITLE
Update translation state for ScrollBar_ContextMenu_Top resource

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -4820,7 +4820,7 @@ Chcete ho nahradit?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -4820,7 +4820,7 @@ Möchten Sie das Element ersetzen?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -4820,7 +4820,7 @@ Voulez-vous le remplacer ?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -4820,7 +4820,7 @@ Sostituirlo?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -4820,7 +4820,7 @@ Czy chcesz go zastąpić?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -4820,7 +4820,7 @@ Deseja substituí-lo?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -4820,7 +4820,7 @@ Değiştirmek istiyor musunuz?</target>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -4820,7 +4820,7 @@ Do you want to replace it?</source>
       </trans-unit>
       <trans-unit id="ScrollBar_ContextMenu_Top">
         <source>Top</source>
-        <target state="translated">Top</target>
+        <target state="needs-translation">Top</target>
         <note />
       </trans-unit>
       <trans-unit id="ScrollViewer_CannotBeNaN">


### PR DESCRIPTION
Fixes #8292  <!-- Issue Number -->

## Description
Updated the translation state for ScrollBar_ContextMenu_Top resource from __translated__ to __needs-translation__ to kick off the OneLocBuild localization task and get the resources translated.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Context menu for users using ScrollBar will be correctly translated for different languages.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
--
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
--
<!-- What kind of testing has been done with the fix. -->

## Risk
NA
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8295)