### PR TITLE
Fix event call in OpenFolderDialog.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/OpenFolderDialog.cs
@@ -247,10 +247,7 @@ namespace Microsoft.Win32
         /// </summary>
         protected override void OnItemOk(CancelEventArgs e)
         {
-            if (FolderOk != null)
-            {
-                FolderOk(this, e);
-            }
+            FolderOk?.Invoke(this, e);
         }
 
         #endregion Protected Methods


### PR DESCRIPTION
(I think I'm using Main PR correct, but I'm unsure?)
Main PR #7244 

## Description

This PR fixes the event handler invoke by guarding against the possibility that the event can be unsubscribed between the null check and the invocation which raises a null reference exception. The pattern this PR uses was introduced in C# 6. Prior to that, you could only guard against this scenario by making a local variable copy of the event delegate and checking that for null+invoke.

## Customer Impact

There's a possibility that someone unsubscribes from the event between the check and invoke, which raises a null reference exception when the event is invoked. This guards against it.

## Regression

No

## Testing

None

## Risk

Unsure


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8299)