### PR TITLE
Keep track of selected TabItem for focus

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TabItem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TabItem.cs
@@ -353,7 +353,22 @@ namespace System.Windows.Controls
 
                                 // If we successfully move focus inside the content then don't set focus to the header
                                 if (success)
+                                {
                                     e.Handled = true;
+
+                                    // However, if the focus got switched to a different focus scope,
+                                    // mark the header as the one last focused in its focus scope. #8293
+                                    if (Keyboard.FocusedElement is DependencyObject focusedElement)
+                                    {
+                                        DependencyObject thisFocusScope = FocusManager.GetFocusScope(this);
+                                        if (thisFocusScope != null && Keyboard.FocusedElement is DependencyObject currentFocus)
+                                        {
+                                            DependencyObject currentFocusScope = FocusManager.GetFocusScope(currentFocus);
+                                            if (currentFocusScope != thisFocusScope && thisFocusScope != null)
+                                                FocusManager.SetFocusedElement(thisFocusScope, this);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #8293

## Description

When a `TabItem` is selected in `TabControl`, it sets focus to its content (unless the `TabItem` itself is focused). If the content gets succesfully focused, then the `TabItem` supresses receiving focus to not steal it from the content back.

When the content is a `Button` in its own focus scope (such as in a `ToolBar`), the `Button` will try to switch back to the main focus scope after pressed (on losing mouse capture).

Finally, when a `TabItem` is focused, the `TabControl` will switch to that tab.

As a result, if a `TabItem` contains `ToolBar` with a `Button`, that `Button` will try to re-focus the previously focused element. However, if the `TabItem` suppressed receiving focus,  then the previously selected tab will still be remembered as the last focused element, and re-focusing it will select it and thus unexpectedly change the displayed tab.

## Customer Impact

Customers not taking this fix will experience undesirable UI behaviour with buttons in their own focus scope inside a `TabItem`. By default that is only the case for buttons inside `ToolBar`, although developers can change that.

Workarounds of the original issue exist, as described in https://github.com/dotnet/wpf/issues/8293#issuecomment-1757974135

## Regression

No. Well technically the `Switch.System.Windows.Controls.TabControl.SelectionPropertiesCanLagBehindSelectionChangedEvent` compatibility switch introduced this issue in .NET 4.7.1. Before that, the `TabItem` would not opt out of receiving focus, so this issue did not happen, but there were even worse problems.

## Testing

Compiled and tested with the repro app in #8293 on .NET 8.0.100-preview.7.23376.3. Verified the issue repros without the fix and does not repro after the fix.

## Risk

This is potentially a higher impact change (focusing behaviour changes) and there is a lot of corner cases that might be difficult to pick up. To minimize the risk as much as possible, the new behavior is executed in a very specific case only:
1. Selecting the tab item did not change the focused element.
2. ~The focused element is another tab item of the same control.~ (in that case the code does not run, so issue does not exist)
3. The tab item succeeded focusing its content and suppressed receiving focus.
4. The newly focused element is in a different focus scope.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8300)