### PR TITLE
Use 'Scout' images for builds and tests to gain VS 17.8.0 Preview 2

### DIFF
--- a/azure-pipelines1.yml
+++ b/azure-pipelines1.yml
@@ -63,6 +63,6 @@ stages:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
         # runAsPublic is used in expressions, which can't read from user-defined variables
         runAsPublic: false

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -31,10 +31,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
     helixRepo: $(repoName)
 
     jobs:
@@ -46,10 +46,10 @@ jobs:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
       variables:
         - name: Codeql.Enabled
           value: true

--- a/eng/wpfautomatedtests.yml
+++ b/eng/wpfautomatedtests.yml
@@ -25,10 +25,10 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
     helixRepo: $(repoName)
 
     jobs:
@@ -40,10 +40,10 @@ jobs:
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
       variables:
         # needed for signing
         - name: _TeamName


### PR DESCRIPTION
## Description

Adopts the "scout" image names for all pipelines. This will bring in VS 17.8.0 Preview 2, which unblocks [Revert "Workaround a C++/CLI bug involving DIMs (#89253)" by tannergooding · Pull Request #92234 · dotnet/runtime](https://github.com/dotnet/runtime/pull/92234).

Once this is merged, it will need to be backported to `release/8.0` as well. And once VS 17.8.0 Preview 2 lands in the regular images, we can switch back away from the scout images.

## Customer Impact

We have a .NET 8 feature in the core libraries where we [Ensure that INumberBase implements IUtf8SpanFormattable](https://github.com/dotnet/runtime/pull/88840), but that used a default interface methods approach that wasn't handled in C++/CLI. The C++/CLI team made a fix for this that landed in VS 17.8.0 Preview 2. We expected that version of VS to be available to all pipelines by now, but it's still only available in the "scout" images.

We need to merge dotnet/runtime#92234 within the next couple business days to ensure .NET 8 ships with the desired API shape and interface implementations on the core types.

## Testing

This PR will assert that the "scout" images work successfully.

## Risk

This incurs risk for the builds by switching to the scout images for the final builds of .NET 8, but that is lower risk than promoting VS 17.8.0 Preview 2 into the regular images.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8302)