### PR TITLE
Fixing SizeConst Build Error

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/NativeDirectoryServicesQueryAPIs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/NativeDirectoryServicesQueryAPIs.cs
@@ -156,7 +156,7 @@ namespace MS.Internal.Documents
             {
                 public Guid clsidNamespace;
                 public UInt32 cItems;
-                [MarshalAs(UnmanagedType.ByValArray)]
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst=1)]
                 public DsObject[] aObjects;
             }
 


### PR DESCRIPTION
Adding `SizeConst` attribute in `NativeDirectoryServicesQueryAPIs.cs` to fix the build error.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8307)