### PR TITLE
Fixing 'AuthenticationManager' is obsolete Build Error

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/CustomCredentialPolicy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/CustomCredentialPolicy.cs
@@ -59,10 +59,13 @@ namespace MS.Internal.AppModel
                         // We do not want to overwrite the application's setting. 
                         // Check whether it is already set before setting it. 
                         // The default of this property is null. It demands ControlPolicy permission to be set.
+
+#pragma warning disable SYSLIB0009
                         if (AuthenticationManager.CredentialPolicy == null)
                         {
                             AuthenticationManager.CredentialPolicy = new CustomCredentialPolicy();
                         }
+#pragma warning restore SYSLIB0009
                         _initialized = true;
                     }
                 }


### PR DESCRIPTION
Disabled the `SYSLIB0009` warning to by pass the 'AuthenticationManager' is obsolete error

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8308)