### PR TITLE
Enabling UnitTests for .NET 9

### DIFF
--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -184,26 +184,26 @@ jobs:
         #   (_HelixPipeline && _PublicBuildPipeline && _ContinuousIntegrationTestsEnabled && _BuildConfig == Release)
         condition: or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')))
 
-      # - script: eng\scripts\ciunittest.cmd
-      #     -configuration $(_BuildConfig) 
-      #     -prepareMachine
-      #     $(_PublishArgs)
-      #     $(_SignArgs)
-      #     $(_OfficialBuildIdArgs)
-      #     $(_PlatformArgs)
-      #     $(_InternalRuntimeDownloadArgs)
-      #   displayName: Run xUnit Tests
-      #   condition: and(or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))), ne(variables['_Platform'], 'arm64'))
+      - script: eng\scripts\ciunittest.cmd
+          -configuration $(_BuildConfig) 
+          -prepareMachine
+          $(_PublishArgs)
+          $(_SignArgs)
+          $(_OfficialBuildIdArgs)
+          $(_PlatformArgs)
+          $(_InternalRuntimeDownloadArgs)
+        displayName: Run xUnit Tests
+        condition: and(or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))), ne(variables['_Platform'], 'arm64'))
 
-      # - task: PublishTestResults@2
-      #   displayName: Publish XUnit Test Results
-      #   inputs:
-      #     testResultsFormat: 'xUnit'
-      #     testResultsFiles: '*.xml' 
-      #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-      #     mergeTestResults: true
-      #   continueOnError: true
-      #   condition: and(eq(variables['_BuildConfig'], 'Release'), ne(variables['_Platform'], 'arm64'))     
+      - task: PublishTestResults@2
+        displayName: Publish XUnit Test Results
+        inputs:
+          testResultsFormat: 'xUnit'
+          testResultsFiles: '*.xml' 
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          mergeTestResults: true
+        continueOnError: true
+        condition: and(eq(variables['_BuildConfig'], 'Release'), ne(variables['_Platform'], 'arm64'))     
 
       - task: PowerShell@2
         displayName: Install .NET Core


### PR DESCRIPTION
Fixes #8260 

## Description
Uncommenting the unit tests that were disabled.

## Customer Impact
_None_

## Regression
_None_

## Testing
Local build pass. Checked that all 334 unit tests ran and passed.

## Risk
_None_


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8317)