### PR TITLE
Simplify IncludePackageReferencesDuringMarkupCompilation

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
-            if (string.Compare(IncludePackageReferencesDuringMarkupCompilation, "false", StringComparison.OrdinalIgnoreCase) != 0)
+            if (IncludePackageReferencesDuringMarkupCompilation)
             {
                 return ExecuteGenerateTemporaryTargetAssemblyWithPackageReferenceSupport();
             }
@@ -516,8 +516,8 @@ namespace Microsoft.Build.Tasks.Windows
         /// Set this property to 'false' to use the .NET Core 3.0 behavior for this task. 
         ///
         /// </summary>
-        public string IncludePackageReferencesDuringMarkupCompilation 
-        { get; set; }
+        public bool IncludePackageReferencesDuringMarkupCompilation
+        { get; set; } = true;
 
         /// <summary>
         /// TemporaryTargetAssemblyProjectName 


### PR DESCRIPTION
## Description

This was used as an optional bool, which is representable in MSBuild
as a non-Required bool with a default value; MSBuild handles coercing
strings to bool.

## Customer Impact

None--improved maintainability only.

## Regression

No.

## Testing

Automated tests.

## Risk

Low but nonzero--the task will now error if given a string that doesn't cleanly coerce to `true` or `false`.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8379)