### PR TITLE
Use ArgumentOutOfRangeException.ThrowIf* across codebase

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/GorillaCodec.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/GorillaCodec.cs
@@ -377,10 +377,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
             {
                 throw new ArgumentNullException(StrokeCollectionSerializer.ISFDebugMessage("input or compressed data was null in Compress"));
             }
-            if (bitCount < 0)
-            {
-                throw new ArgumentOutOfRangeException("bitCount");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
 
             if (bitCount == 0)
             {
@@ -428,14 +425,8 @@ namespace MS.Internal.Ink.InkSerializedFormat
             {
                 throw new ArgumentNullException(StrokeCollectionSerializer.ISFDebugMessage("reader or compressedData was null in compress"));
             }
-            if (bitCount < 0)
-            {
-                throw new ArgumentOutOfRangeException("bitCount");
-            }
-            if (unitsToEncode < 0)
-            {
-                throw new ArgumentOutOfRangeException("unitsToEncode");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
+            ArgumentOutOfRangeException.ThrowIfNegative(unitsToEncode);
 
             if (bitCount == 0)
             {
@@ -518,20 +509,11 @@ namespace MS.Internal.Ink.InkSerializedFormat
         internal uint Uncompress(int bitCount, byte[] input, int inputIndex, DeltaDelta dtxf, int[] outputBuffer, int outputBufferIndex)
         {
             ArgumentNullException.ThrowIfNull(input);
-            if (inputIndex >= input.Length)
-            {
-                throw new ArgumentOutOfRangeException("inputIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(inputIndex, input.Length);
             ArgumentNullException.ThrowIfNull(outputBuffer);
-            if (outputBufferIndex >= outputBuffer.Length)
-            {
-                throw new ArgumentOutOfRangeException("outputBufferIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(outputBufferIndex, outputBuffer.Length);
 
-            if (bitCount < 0)
-            {
-                throw new ArgumentOutOfRangeException("bitCount");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
 
             // Adjust bit count if 0 passed in
             if (bitCount == 0)
@@ -603,14 +585,8 @@ namespace MS.Internal.Ink.InkSerializedFormat
         internal byte[] Uncompress(int bitCount, BitStreamReader reader, GorillaEncodingType encodingType, int unitsToDecode)
         {
             ArgumentNullException.ThrowIfNull(reader);
-            if (bitCount < 0)
-            {
-                throw new ArgumentOutOfRangeException("bitCount");
-            }
-            if (unitsToDecode < 0)
-            {
-                throw new ArgumentOutOfRangeException("unitsToDecode");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
+            ArgumentOutOfRangeException.ThrowIfNegative(unitsToDecode);
 
             int bitsToWrite = 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MultiByteCodec.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MultiByteCodec.cs
@@ -112,10 +112,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
         internal uint SignDecode(byte[] input, int inputIndex, ref int data)
         {
             Debug.Assert(input != null); //already validated at the AlgoModule level
-            if (inputIndex >= input.Length)
-            {
-                throw new ArgumentOutOfRangeException("inputIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(inputIndex, input.Length);
             uint xfData = 0;
             uint cb = Decode(input, inputIndex, ref xfData);
             data = (0 != (0x01 & xfData)) ? -(int)(xfData >> 1) : (int)(xfData >> 1);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/PartialArray.cs
@@ -145,10 +145,7 @@ namespace MS.Internal
                     "array");                
             }
 
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             if (arrayIndex >= array.Length)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/Factory.cs
@@ -206,10 +206,7 @@ namespace MS.Internal.Text.TextInterface
                                  &hr
                                  ))
             {
-                if (faceIndex >= numberOfFaces)
-                {
-                    throw new ArgumentOutOfRangeException("faceIndex");
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(faceIndex, numberOfFaces);
 
                 byte dwriteFontSimulationsFlags = DWriteTypeConverter.Convert(fontSimulationFlags);
                 IDWriteFontFace* dwriteFontFace = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealDoubles.cs
@@ -187,10 +187,7 @@ namespace MS.Internal.TextFormatting
                     "array");                
             }
 
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             if (arrayIndex >= array.Length)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/ThousandthOfEmRealPoints.cs
@@ -130,10 +130,7 @@ namespace MS.Internal.TextFormatting
                     "array");                
             }
 
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             if (arrayIndex >= array.Length)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -252,7 +252,10 @@ namespace System.Windows.Interop
         {
             WritePreamble();
 
-            ArgumentOutOfRangeException.ThrowIfEqual(timeout, Duration.Automatic);
+            if (timeout == Duration.Automatic)
+            {
+                throw new ArgumentOutOfRangeException("timeout");
+            }
 
             return LockImpl(timeout);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -252,10 +252,7 @@ namespace System.Windows.Interop
         {
             WritePreamble();
 
-            if (timeout == Duration.Automatic)
-            {
-                throw new ArgumentOutOfRangeException("timeout");
-            }
+            ArgumentOutOfRangeException.ThrowIfEqual(timeout, Duration.Automatic);
 
             return LockImpl(timeout);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CharacterMetricsDictionary.cs
@@ -133,8 +133,7 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(array);
 
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
@@ -191,8 +190,7 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(array);
 
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/CultureSpecificStringDictionary.cs
@@ -122,8 +122,7 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(array);
 
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));
@@ -157,8 +156,7 @@ namespace System.Windows.Media
         {
             ArgumentNullException.ThrowIfNull(array);
 
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length)
                 throw new ArgumentException(SR.Format(SR.Collection_CopyTo_IndexGreaterThanOrEqualToArrayLength, "index", "array"));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
@@ -794,18 +794,9 @@ namespace System.Windows.Media
             VerifyAPIReadWrite();
 
             // Do we really need this extra check index >= _size.
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
-            if (_size - index < count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, _size - index);
 
             if (count > 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewProxy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewProxy.cs
@@ -351,8 +351,7 @@ namespace MS.Internal.Data
         public override object GetItemAt(int index)
         {
             // only check lower bound because Count could be expensive
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
             return EnumerableWrapper[index];
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CompositeCollectionView.cs
@@ -198,8 +198,7 @@ namespace MS.Internal.Data
         /// </exception>
         public override object GetItemAt(int index)
         {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             int positionX, positionY;
             object item = GetItem(index, out positionX, out positionY);
@@ -313,8 +312,7 @@ namespace MS.Internal.Data
         /// </exception>
         public override bool MoveCurrentToPosition(int position)
         {
-            if (position < -1)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, -1);
 
             int newPositionX, newPositionY;
             object item = GetItem(position, out newPositionX, out newPositionY);
@@ -325,10 +323,7 @@ namespace MS.Internal.Data
                 {
                     item = null;
                     // check upper-bound only after GetItem() to avoid unnecessary pre-counting
-                    if (position > Count)
-                    {
-                        throw new ArgumentOutOfRangeException("position");
-                    }
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(position, Count);
                 }
 
                 if (OKToChangeCurrent())

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/IndexedEnumerable.cs
@@ -218,11 +218,7 @@ namespace MS.Internal.Data
                     return value;
                 }
 
-                if (index < 0)
-                {
-#pragma warning suppress 6503   // "Property get methods should not throw exceptions."
-                    throw new ArgumentOutOfRangeException("index"); // validating the index argument
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
 
                 int moveBy = (index - _cachedIndex);
                 if (moveBy < 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
@@ -575,8 +575,7 @@ namespace MS.Internal.Data
         public void CopyTo(T[] array, int arrayIndex)
         {
             ArgumentNullException.ThrowIfNull(array);
-            if (arrayIndex < 0)
-                throw new ArgumentOutOfRangeException("arrayIndex");
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
             if (arrayIndex + Count > array.Length)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakDictionary.cs
@@ -292,10 +292,7 @@ namespace MS.Internal
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
             ArgumentNullException.ThrowIfNull(array);
 
             int count = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakHashSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakHashSet.cs
@@ -39,10 +39,7 @@ namespace MS.Internal
 
         public void CopyTo(T[] array, int arrayIndex)
         {
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
             ArgumentNullException.ThrowIfNull(array);
 
             int count = 0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Projections/IReadOnlyList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Projections/IReadOnlyList.cs
@@ -88,8 +88,7 @@ namespace MS.Internal.WindowsRuntime.ABI.System.Collections.Generic
 
             private T Indexer_Get(int index)
             {
-                if (index < 0)
-                    throw new ArgumentOutOfRangeException(nameof(index));
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
 
                 try
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -428,10 +428,7 @@ namespace MS.Internal.Documents
         {
             if (!DoubleUtil.AreClose(scale, Scale))
             {
-                if (scale <= 0.0)
-                {
-                    throw new ArgumentOutOfRangeException("scale");
-                }
+                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(scale, 0.0);
 
                 if (!Helper.IsDoubleValid(scale))
                 {
@@ -448,10 +445,7 @@ namespace MS.Internal.Documents
         /// <param name="columns"></param>
         public void SetColumns(int columns)
         {
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Perf Tracing - Mark Layout Change Start
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXPS, EventTrace.Event.WClientDRXLayoutBegin);
@@ -465,10 +459,7 @@ namespace MS.Internal.Documents
         /// <param name="columns"></param>
         public void FitColumns(int columns)
         {
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Perf Tracing - Mark Layout Change Start
             EventTrace.EasyTraceEvent(EventTrace.Keyword.KeywordXPS, EventTrace.Event.WClientDRXLayoutBegin);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/PageCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/PageCache.cs
@@ -696,15 +696,8 @@ namespace MS.Internal.Documents
         /// <param name="count"></param>
         private void ValidatePaginationArgs(int start, int count)
         {
-            if (start < 0)
-            {
-                throw new ArgumentOutOfRangeException("start");
-            }
-
-            if (count <= 0)
-            {
-                throw new ArgumentOutOfRangeException("count");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(start);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
         }
 
         /// <summary>
@@ -762,15 +755,8 @@ namespace MS.Internal.Documents
         private PageCacheChange AddRange(int start, int count)
         {
             //Make sure we're in range.
-            if (start < 0)
-            {
-                throw new ArgumentOutOfRangeException("start");
-            }
-
-            if (count < 1)
-            {
-                throw new ArgumentOutOfRangeException("count");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(start);
+            ArgumentOutOfRangeException.ThrowIfLessThan(count, 1);
 
             Invariant.Assert(_defaultPageSize != Size.Empty, "Default Page Size is Empty.");
 
@@ -833,10 +819,7 @@ namespace MS.Internal.Documents
         private PageCacheChange DirtyRange(int start, int count)
         {
             //Make sure we're in range.
-            if (start >= _cache.Count)
-            {
-                throw new ArgumentOutOfRangeException("start");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(start, _cache.Count);
 
             if (start + count > _cache.Count || count < 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
@@ -399,10 +399,7 @@ namespace MS.Internal.Documents
             startRowIndex = 0;
             rowCount = 0;
 
-            if (endOffset < startOffset)
-            {
-                throw new ArgumentOutOfRangeException("endOffset");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(endOffset, startOffset);
 
             //If the offsets we're given are out of range we'll just return now
             //because we have no rows to find at this offset.
@@ -520,10 +517,7 @@ namespace MS.Internal.Documents
             }
 
             //Can't lay out fewer than 1 column of pages.
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Store off the requested layout parameters.
             _layoutColumns = columns;
@@ -663,10 +657,7 @@ namespace MS.Internal.Documents
             }
 
             //Can't lay out fewer than 1 column of pages.
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Adjust the pivot page as necessary so that the to-be-computed layout has the specified number
             //of columns on the row.
@@ -744,10 +735,7 @@ namespace MS.Internal.Documents
         /// <returns></returns>
         private RowInfo CreateDynamicRow(int startPage, double rowWidth, bool createForward)
         {
-            if (startPage >= PageCache.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("startPage");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startPage, PageCache.PageCount);
 
             //Given a starting page for this row, and the specified
             //width for each row, figure out how many pages will fit on this row
@@ -826,10 +814,7 @@ namespace MS.Internal.Documents
             }
 
             //Can't lay out fewer than 1 column of pages.
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Since all pages in the document have been determined to be
             //the same size, we can use a simple algorithm to create our row layout.
@@ -857,15 +842,9 @@ namespace MS.Internal.Documents
         /// <returns></returns>
         private RowInfo CreateFixedRow(int startPage, int columns)
         {
-            if (startPage >= PageCache.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("startPage");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startPage, PageCache.PageCount);
 
-            if (columns < 1)
-            {
-                throw new ArgumentOutOfRangeException("columns");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
 
             //Given a starting page for this row and the number of columns in the row
             //calculate the width & height and return the resulting RowInfo struct

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -551,10 +551,7 @@ namespace System.Windows.Controls
         /// </summary>
         protected override Visual GetVisualChild(int index)
         {
-            if (index >= this.VisualChildrenCount)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, this.VisualChildrenCount);
 
             return _visualChildren[index];
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewColumnHeaderAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewColumnHeaderAutomationPeer.cs
@@ -90,14 +90,8 @@ namespace System.Windows.Automation.Peers
             if (!IsEnabled())
                 throw new ElementNotEnabledException();
 
-            if (width < 0)
-            {
-                throw new ArgumentOutOfRangeException("width");
-            }
-            if (height < 0)
-            {
-                throw new ArgumentOutOfRangeException("height");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(width);
+            ArgumentOutOfRangeException.ThrowIfNegative(height);
 
             GridViewColumnHeader header = Owner as GridViewColumnHeader;
             if (header != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
@@ -297,8 +297,7 @@ namespace System.Windows.Controls
             ArgumentNullException.ThrowIfNull(array);
             if (array.Rank > 1)
                 throw new ArgumentException(SR.BadTargetArray, "array"); // array is multidimensional.
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             // use the view instead of the collection, because it may have special sort/filter
             if (!EnsureCollectionView())
@@ -340,23 +339,21 @@ namespace System.Windows.Controls
         /// </exception>
         public override object GetItemAt(int index)
         {
-                // only check lower bound because Count could be expensive
-                if (index < 0)
-                    throw new ArgumentOutOfRangeException("index");
+            // only check lower bound because Count could be expensive
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
-                VerifyRefreshNotDeferred();
+            VerifyRefreshNotDeferred();
 
-                if (!EnsureCollectionView())
-                    throw new InvalidOperationException(SR.ItemCollectionHasNoCollection);
+            if (!EnsureCollectionView())
+                throw new InvalidOperationException(SR.ItemCollectionHasNoCollection);
 
-                if (_collectionView == _internalView)
-                {
-                    // check upper bound here because we know it's not expensive
-                    if (index >= _internalView.Count)
-                        throw new ArgumentOutOfRangeException("index");
-                }
+            if (_collectionView == _internalView)
+            {
+                // check upper bound here because we know it's not expensive
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _internalView.Count);
+            }
 
-                return _collectionView.GetItemAt(index);
+            return _collectionView.GetItemAt(index);
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -662,8 +662,7 @@ namespace System.Windows.Data
         public virtual object GetItemAt(int index)
         {
             // only check lower bound because Count could be expensive
-            if (index < 0)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             return EnumerableWrapper[index];
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextElementCollection.cs
@@ -605,10 +605,7 @@ namespace System.Windows.Documents
                 throw new ArgumentException("array");
             }
 
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             if (arrayIndex > array.Length)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
@@ -49,15 +49,9 @@ namespace System.Windows.Baml2006
                 throw new ArgumentException("can\u2019t seek on baseStream");
             }
 
-            if (offset < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
 
-            if (length < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(length));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(length);
 
             SharedStream subStream = baseStream as SharedStream;
             if (subStream != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/StyleHelper.cs
@@ -5443,10 +5443,7 @@ namespace System.Windows
                 return null;
             }
 
-            if (childIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException("childIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(childIndex);
 
             DependencyObject child = styledChildren[childIndex - 1];
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PartialList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PartialList.cs
@@ -151,8 +151,7 @@ namespace MS.Internal
 
         public void CopyTo(T[] array, int arrayIndex)
         {
-            if (arrayIndex < 0)
-                throw new ArgumentOutOfRangeException("arrayIndex");
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             for (int i = 0; i < _count; ++i)
                 array[arrayIndex + i] = this[i];

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SizeLimitedCache.cs
@@ -40,10 +40,7 @@ namespace MS.Internal
         /// </param>
         public SizeLimitedCache(int maximumItems)
         {
-            if (maximumItems <= 0)
-            {
-                throw new ArgumentOutOfRangeException("maximumItems");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumItems);
 
             _maximumItems = maximumItems;
             _permanentCount = 0;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/HwndProxyElementProvider.cs
@@ -402,8 +402,7 @@ namespace MS.Internal.Automation
 
         bool IWindowProvider.WaitForInputIdle( int milliseconds )
         {
-           if( milliseconds < 0 )
-               throw new ArgumentOutOfRangeException( "milliseconds" );
+            ArgumentOutOfRangeException.ThrowIfNegative(milliseconds);
 
             // Implementation note:  This method is usually used in response to handling a WindowPattern.WindowOpenedEvent.
             // In this case it works for both legacy and WCP windows. This is because the WindowOpenedEvent uses a private

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStream.cs
@@ -99,8 +99,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         {
             CheckDisposed();
 
-            if (newLength < 0)
-                throw new ArgumentOutOfRangeException("newLength");
+            ArgumentOutOfRangeException.ThrowIfNegative(newLength);
 
             _versionOwner.WriteAttempt();
             _stream.SetLength(newLength);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/VersionedStreamOwner.cs
@@ -105,8 +105,7 @@ namespace MS.Internal.IO.Packaging.CompoundFile
         /// </summary>
         public override void SetLength(long newLength)
         {
-            if (newLength < 0)
-                throw new ArgumentOutOfRangeException("newLength");
+            ArgumentOutOfRangeException.ThrowIfNegative(newLength);
 
             WriteAttempt();
             checked { BaseStream.SetLength(newLength + _dataOffset); }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompressEmulationStream.cs
@@ -259,8 +259,7 @@ namespace MS.Internal.IO.Packaging
         /// another wrapper Stream class.</remarks>
         internal CompressEmulationStream(Stream baseStream, Stream tempStream, long position, IDeflateTransform transformer)
         {
-            if (position < 0)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfNegative(position);
 
             ArgumentNullException.ThrowIfNull(baseStream);
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/SparseMemoryStream.cs
@@ -82,13 +82,10 @@ namespace MS.Internal.IO.Packaging
         {
             CheckDisposed();
 
-            if (newLength < 0)
-            {
-                throw new ArgumentOutOfRangeException("newLength");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(newLength);
 
 #if DEBUG
-    DebugAssertConsistentArrayStructure();
+            DebugAssertConsistentArrayStructure();
 #endif
 
             if (_currentStreamLength != newLength)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Security/RightsManagement/Grant.cs
@@ -61,10 +61,7 @@ namespace System.Security.RightsManagement
                 throw new ArgumentOutOfRangeException("right");                
             }
 
-            if (validFrom > validUntil)
-            {
-                throw new ArgumentOutOfRangeException("validFrom");                
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(validFrom, validUntil);
 
             _user = user;
             _right = right;


### PR DESCRIPTION
## Description

Use `ArgumentOutOfRangeException.ThrowIf*` across codebase.  A lot of potential use cases are not covered yet because CA1512 cannot automatically take care of them though

## Regression

No

## Testing

CI

## Risk

Low. We use fixer CA1512


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8403)