### PR TITLE
Use ArgumentOutOfRangeException.ThrowIf* to replace custom error messages

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FullTextLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/FullTextLine.cs
@@ -1498,12 +1498,9 @@ namespace MS.Internal.TextFormatting
                     throw new ObjectDisposedException(SR.TextLineHasBeenDisposed);
                 }
 
-                if(textLength == 0)
-                {
-                    throw new ArgumentOutOfRangeException("textLength", SR.ParameterMustBeGreaterThanZero);
-                }
+                ArgumentOutOfRangeException.ThrowIfZero(textLength);
 
-                if(textLength < 0)
+                if (textLength < 0)
                 {
                     firstTextSourceCharacterIndex += textLength;
                     textLength = -textLength;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/SimpleTextLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/SimpleTextLine.cs
@@ -807,10 +807,7 @@ namespace MS.Internal.TextFormatting
             int     textLength
             )
         {
-            if (textLength == 0)
-            {
-                throw new ArgumentOutOfRangeException("textLength", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfZero(textLength);
 
             if (textLength < 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -497,11 +497,8 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentOutOfRangeException("paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize", SR.Format(SR.ParameterMustBeBetween, 0, realMaxFontRenderingEmSize));
             }
 
-            if (paragraphProperties.Indent > Constants.RealInfiniteWidth)
-                throw new ArgumentOutOfRangeException("paragraphProperties.Indent", SR.Format(SR.ParameterCannotBeGreaterThan, Constants.RealInfiniteWidth));
-
-            if (paragraphProperties.LineHeight > Constants.RealInfiniteWidth)
-                throw new ArgumentOutOfRangeException("paragraphProperties.LineHeight", SR.Format(SR.ParameterCannotBeGreaterThan, Constants.RealInfiniteWidth));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.Indent, Constants.RealInfiniteWidth, "paragraphProperties.Indent");
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.LineHeight, Constants.RealInfiniteWidth, "paragraphProperties.LineHeight");
 
             if (   paragraphProperties.DefaultIncrementalTab < 0
                 || paragraphProperties.DefaultIncrementalTab > Constants.RealInfiniteWidth)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -526,10 +526,7 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentOutOfRangeException("cpFirst", SR.Format(SR.ParameterMustBeBetween, cpFirst, cpFirst + cchLength));
             }
 
-            if (characterHit.TrailingLength < 0)
-            {
-                throw new ArgumentOutOfRangeException("cchLength", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(characterHit.TrailingLength, nameof(cchLength));
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextRunCacheImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextRunCacheImp.cs
@@ -118,10 +118,7 @@ namespace MS.Internal.TextFormatting
 
                 textRun = settings.TextSource.GetTextRun(cpFetch);
 
-                if (textRun.Length < 1)
-                {
-                    throw new ArgumentOutOfRangeException("textRun.Length", SR.ParameterMustBeGreaterThanZero);
-                }
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(textRun.Length, "textRun.Length");
 
                 Plsrun plsrun = TextRunInfo.GetRunType(textRun);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1834,9 +1834,6 @@
   <data name="ParameterMustBeBetween" xml:space="preserve">
     <value>The parameter value must be between '{0}' and '{1}'.</value>
   </data>
-  <data name="ParameterMustBeGreaterThanZero" xml:space="preserve">
-    <value>The parameter value must be greater than zero.</value>
-  </data>
   <data name="ParameterValueCannotBeInfinity" xml:space="preserve">
     <value>The parameter value must be finite.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1822,9 +1822,6 @@
   <data name="PaginatorNegativePageNumber" xml:space="preserve">
     <value>Page number cannot be negative.</value>
   </data>
-  <data name="ParameterCannotBeLessThan" xml:space="preserve">
-    <value>The parameter value cannot be less than '{0}'.</value>
-  </data>
   <data name="ParameterMustBeBetween" xml:space="preserve">
     <value>The parameter value must be between '{0}' and '{1}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1831,9 +1831,6 @@
   <data name="ParameterValueCannotBeNaN" xml:space="preserve">
     <value>The parameter value must be a number.</value>
   </data>
-  <data name="ParameterValueCannotBeNegative" xml:space="preserve">
-    <value>'{0}' parameter value cannot be negative.</value>
-  </data>
   <data name="Parsers_IllegalToken" xml:space="preserve">
     <value>Token is not valid.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1828,9 +1828,6 @@
   <data name="ParameterCannotBeLessThan" xml:space="preserve">
     <value>The parameter value cannot be less than '{0}'.</value>
   </data>
-  <data name="ParameterCannotBeNegative" xml:space="preserve">
-    <value>Parameter must be greater than or equal to zero.</value>
-  </data>
   <data name="ParameterMustBeBetween" xml:space="preserve">
     <value>The parameter value must be between '{0}' and '{1}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1834,9 +1834,6 @@
   <data name="ParameterValueCannotBeNegative" xml:space="preserve">
     <value>'{0}' parameter value cannot be negative.</value>
   </data>
-  <data name="ParameterValueMustBeGreaterThanZero" xml:space="preserve">
-    <value>'{0}' parameter value must be greater than zero.</value>
-  </data>
   <data name="Parsers_IllegalToken" xml:space="preserve">
     <value>Token is not valid.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1822,9 +1822,6 @@
   <data name="PaginatorNegativePageNumber" xml:space="preserve">
     <value>Page number cannot be negative.</value>
   </data>
-  <data name="ParameterCannotBeGreaterThan" xml:space="preserve">
-    <value>The parameter value cannot be greater than '{0}'.</value>
-  </data>
   <data name="ParameterCannotBeLessThan" xml:space="preserve">
     <value>The parameter value cannot be less than '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Hodnota tohoto parametru musí být číslo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">Hodnota parametru {0} nemůže být záporná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Nalezena nesprávná forma {0} při analýze řetězce {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Hodnota tohoto parametru musí být větší než nula.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Hodnota tohoto parametru nesmí být nekonečno.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Číslo stránky nemůže být záporné.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Hodnota tohoto parametru nemůže být větší než {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Hodnota tohoto parametru nemůže být menší než {0}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Hodnota tohoto parametru nemůže být menší než {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Hodnota tohoto parametru musí být větší nebo rovna nule.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Číslo stránky nemůže být záporné.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Hodnota tohoto parametru nemůže být menší než {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Hodnota parametru {0} nemůže být záporná.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">Hodnota parametru {0} musí být větší než nula.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Nalezena nesprávná forma {0} při analýze řetězce {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Die Seitenzahl kann nicht negativ sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Der Parameterwert darf nicht kleiner sein als "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Der Parameterwert "{0}" darf nicht negativ sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">Der Parameterwert "{0}" muss größer Null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Beim Analysieren der Zeichenfolge "{1}" wurde die ungültige Form "{0}" gefunden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Der Parameterwert muss größer Null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Der Parameterwert muss endlich sein.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Der Parameterwert darf nicht kleiner sein als "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Der Parameter muss größer oder gleich null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Der Parameterwert muss eine Zahl sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">Der Parameterwert "{0}" darf nicht negativ sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Beim Analysieren der Zeichenfolge "{1}" wurde die ungültige Form "{0}" gefunden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Die Seitenzahl kann nicht negativ sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Der Parameterwert darf nicht größer sein als "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Der Parameterwert darf nicht kleiner sein als "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">El valor del parámetro debe ser un número.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">El valor del parámetro '{0}' no puede ser negativo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Se encontró un formato incorrecto "{0}" al analizar la cadena "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">El valor del parámetro '{0}' no puede ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">El valor del parámetro '{0}' debe ser mayor que cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Se encontró un formato incorrecto "{0}" al analizar la cadena "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">El valor del parámetro no puede ser menor que '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">El parámetro debe ser mayor que o igual a cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">El número de página no puede ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">El valor del parámetro no puede ser mayor que '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">El valor del parámetro no puede ser menor que '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">El número de página no puede ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">El valor del parámetro no puede ser menor que '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">El valor del parámetro debe ser mayor que cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">El valor del parámetro debe ser finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">La valeur du paramètre '{0}' ne peut pas être négative.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">La valeur du paramètre '{0}' doit être supérieure à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forme '{0}' incorrecte trouvée durant l'analyse de la chaîne '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Le paramètre ne peut pas avoir une valeur inférieure à '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Le paramètre doit être supérieur ou égal à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Le numéro de page ne peut pas être négatif.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Le paramètre ne peut pas avoir une valeur inférieure à '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">La valeur du paramètre doit être numérique.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">La valeur du paramètre '{0}' ne peut pas être négative.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forme '{0}' incorrecte trouvée durant l'analyse de la chaîne '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">La valeur du paramètre doit être supérieure à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">La valeur du paramètre doit être finie.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Le numéro de page ne peut pas être négatif.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Le paramètre ne peut pas avoir une valeur supérieure à '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Le paramètre ne peut pas avoir une valeur inférieure à '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Il valore del parametro deve essere un numero.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">Il valore del parametro '{0}' non può essere negativo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">È stato trovato un formato non corretto '{0}' durante l'analisi della stringa '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Il valore del parametro deve essere maggiore di zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Il valore del parametro deve essere finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Il valore del parametro '{0}' non può essere negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">Il valore del parametro '{0}' deve essere maggiore di zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">È stato trovato un formato non corretto '{0}' durante l'analisi della stringa '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Il numero di pagina non può essere negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Il valore del parametro non può essere minore di '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Il valore del parametro non può essere minore di '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Il valore del parametro deve essere maggiore o uguale a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Il numero di pagina non può essere negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Il valore del parametro non può essere maggiore di '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Il valore del parametro non può essere minore di '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">パラメーター値は、0 より大きい必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">パラメーター値は、有限である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">'{0}' パラメーター値を負の値にすることはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">'{0}' パラメーター値は、0 より大きい必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 文字列の解析中に無効なフォーム '{0}' が見つかりました。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">パラメーター値は、数値である必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">'{0}' パラメーター値を負の値にすることはできません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 文字列の解析中に無効なフォーム '{0}' が見つかりました。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">パラメーター値は、'{0}' 未満にできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">パラメーターは 0 以上でなければなりません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">ページ番号は負の数にできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">パラメーター値は、'{0}' より大きくできません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">パラメーター値は、'{0}' 未満にできません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">ページ番号は負の数にできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">パラメーター値は、'{0}' 未満にできません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">페이지 번호는 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">매개 변수 값이 '{0}'보다 작을 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">매개 변수 값은 숫자여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">'{0}' 매개 변수 값은 음수일 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 문자열을 구문 분석하는 동안 잘못된 '{0}' 형식이 검색되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">매개 변수 값이 '{0}'보다 작을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">매개 변수는 0보다 크거나 같아야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">'{0}' 매개 변수 값은 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">'{0}' 매개 변수 값은 0보다 커야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 문자열을 구문 분석하는 동안 잘못된 '{0}' 형식이 검색되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">매개 변수 값은 0보다 커야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">매개 변수는 유한한 값이어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">페이지 번호는 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">매개 변수 값이 '{0}'보다 클 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">매개 변수 값이 '{0}'보다 작을 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Wartość parametru nie może być mniejsza niż „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametr musi być większy lub równy zeru.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Wartość parametru musi być większa od zera.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Wartość parametru musi być skończona.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Wartość parametru musi być liczbą.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">Wartość parametru „{0}” nie może być ujemna.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Znaleziono nieprawidłową formę „{0}” podczas analizy ciągu „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Numer strony nie może być ujemny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Wartość parametru nie może być większa niż „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Wartość parametru nie może być mniejsza niż „{0}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Wartość parametru „{0}” nie może być ujemna.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">Wartość parametru „{0}” musi być większa niż zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Znaleziono nieprawidłową formę „{0}” podczas analizy ciągu „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Numer strony nie może być ujemny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Wartość parametru nie może być mniejsza niż „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">O valor do parâmetro '{0}' não pode ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">O valor do parâmetro '{0}' deve ser maior que zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forma incorreta de '{0}' encontrada na análise da cadeia de caracteres '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">O número da página não pode ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">O valor do parâmetro não pode ser maior que '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">O valor do parâmetro não pode ser menor que '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">O valor do parâmetro deve ser maior que zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">O valor do parâmetro deve ser finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">O número da página não pode ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">O valor do parâmetro não pode ser menor que '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">O valor do parâmetro não pode ser menor que '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">O parâmetro deve ser maior ou igual a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">O valor do parâmetro deve ser um número.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">O valor do parâmetro '{0}' não pode ser negativo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forma incorreta de '{0}' encontrada na análise da cadeia de caracteres '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Номер страницы не может быть отрицательным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Значение параметра не может быть больше "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Значение параметра не может быть меньше "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Значение параметра должно быть числом.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">Значение параметра "{0}" не может быть отрицательным.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">При синтаксическом анализе строки "{1}" обнаружена неправильная форма "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Номер страницы не может быть отрицательным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Значение параметра не может быть меньше "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Значение параметра должно быть больше 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Значение параметра должно быть конечным.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Значение параметра "{0}" не может быть отрицательным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">Значение параметра "{0}" должно быть больше 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">При синтаксическом анализе строки "{1}" обнаружена неправильная форма "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Значение параметра не может быть меньше "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Значение параметра должно быть больше или равно 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Sayfa numarası negatif olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">Parametre değeri '{0}' değerinden büyük olamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">Parametre değeri '{0}' değerinden küçük olamaz.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">'{0}' parametre değeri negatif olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">'{0}' parametre değeri sıfırdan büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' dizesi ayrıştırılırken yanlış '{0}' biçimi bulundu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">Parametre değeri bir sayı olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">'{0}' parametre değeri negatif olamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' dizesi ayrıştırılırken yanlış '{0}' biçimi bulundu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Sayfa numarası negatif olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">Parametre değeri '{0}' değerinden küçük olamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">Parametre değeri sıfırdan büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Parametre değeri sonlu olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Parametre değeri '{0}' değerinden küçük olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametre sıfıra eşit veya daha büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">参数值必须大于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">参数值必须有限。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">“{0}”参数值不能为负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">“{0}”参数值必须大于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">解析“{1}”字符串时发现格式“{0}”错误。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">参数值不能小于“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">参数必须大于或等于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">页码不能为负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">参数值不能小于“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">页码不能为负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">参数值不能大于“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">参数值不能小于“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">参数值必须是一个数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">“{0}”参数值不能为负数。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">解析“{1}”字符串时发现格式“{0}”错误。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">頁碼不能為負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeLessThan">
-        <source>The parameter value cannot be less than '{0}'.</source>
-        <target state="translated">參數值不能小於 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeGreaterThanZero">
-        <source>The parameter value must be greater than zero.</source>
-        <target state="translated">參數值必須大於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">參數值必須有限制。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">頁碼不能為負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeGreaterThan">
-        <source>The parameter value cannot be greater than '{0}'.</source>
-        <target state="translated">參數值不能大於 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterCannotBeLessThan">
         <source>The parameter value cannot be less than '{0}'.</source>
         <target state="translated">參數值不能小於 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2537,11 +2537,6 @@
         <target state="translated">參數值必須是數字。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNegative">
-        <source>'{0}' parameter value cannot be negative.</source>
-        <target state="translated">'{0}' 參數值不能為負數。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">剖析 '{1}' 字串時發現不正確的格式 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2542,11 +2542,6 @@
         <target state="translated">'{0}' 參數值不能為負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueMustBeGreaterThanZero">
-        <source>'{0}' parameter value must be greater than zero.</source>
-        <target state="translated">'{0}' 參數值必須大於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">剖析 '{1}' 字串時發現不正確的格式 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">參數值不能小於 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">參數必須大於或等於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/D3DImage.cs
@@ -67,17 +67,10 @@ namespace System.Windows.Interop
         /// </summary>
         public D3DImage(double dpiX, double dpiY)
         {
-            
-            if (dpiX < 0)
-            {
-                throw new ArgumentOutOfRangeException("dpiX", SR.ParameterMustBeGreaterThanZero);
-            }
 
-            if (dpiY < 0)
-            {
-                throw new ArgumentOutOfRangeException("dpiY", SR.ParameterMustBeGreaterThanZero);
-            }
-   
+            ArgumentOutOfRangeException.ThrowIfNegative(dpiX);
+            ArgumentOutOfRangeException.ThrowIfNegative(dpiY);
+
             _canWriteEvent = new ManualResetEvent(true);
             _availableCallback = Callback;
             _sendPresentDelegate = SendPresent;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -1275,8 +1275,7 @@ namespace System.Windows.Media
         {
             set
             {
-                if (value < 0)
-                    throw new ArgumentOutOfRangeException("value", SR.ParameterCannotBeNegative);
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
 
                 _defaultParaProps.SetLineHeight(value);
                 InvalidateMetrics();
@@ -1299,8 +1298,7 @@ namespace System.Windows.Media
         {
             set
             {
-                if (value < 0)
-                    throw new ArgumentOutOfRangeException("value", SR.ParameterCannotBeNegative);
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
                 _maxTextWidth = value;
                 InvalidateMetrics();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -290,8 +290,7 @@ namespace System.Windows.Media
 
         private static void ValidateFontSize(double emSize)
         {
-            if (emSize <= 0)
-                throw new ArgumentOutOfRangeException("emSize", SR.ParameterMustBeGreaterThanZero);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(emSize);
 
             if (emSize > MaxFontEmSize)
                 throw new ArgumentOutOfRangeException("emSize", SR.Format(SR.ParameterCannotBeGreaterThan, MaxFontEmSize));
@@ -1376,8 +1375,7 @@ namespace System.Windows.Media
         {
             set
             {
-                if (value <= 0)
-                    throw new ArgumentOutOfRangeException("value", SR.ParameterMustBeGreaterThanZero);
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
                 _maxLineCount = value;
                 InvalidateMetrics();
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -291,9 +291,7 @@ namespace System.Windows.Media
         private static void ValidateFontSize(double emSize)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(emSize);
-
-            if (emSize > MaxFontEmSize)
-                throw new ArgumentOutOfRangeException("emSize", SR.Format(SR.ParameterCannotBeGreaterThan, MaxFontEmSize));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(emSize, MaxFontEmSize);
 
             if (double.IsNaN(emSize))
                 throw new ArgumentOutOfRangeException("emSize", SR.ParameterValueCannotBeNaN);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -456,11 +456,8 @@ namespace System.Windows.Media
                 if (double.IsNaN(renderingEmSize))
                     throw new ArgumentOutOfRangeException("renderingEmSize", SR.ParameterValueCannotBeNaN);
 
-                if (renderingEmSize < 0.0)
-                    throw new ArgumentOutOfRangeException("renderingEmSize", SR.ParameterValueCannotBeNegative);
-
+                ArgumentOutOfRangeException.ThrowIfNegative(renderingEmSize);
                 ArgumentNullException.ThrowIfNull(glyphTypeface);
-
                 ArgumentNullException.ThrowIfNull(glyphIndices);
 
                 if (glyphIndices.Count <= 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSizeOptions.cs
@@ -117,10 +117,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="pixelHeight">Height of the resulting Bitmap</param>
         public static BitmapSizeOptions FromHeight(int pixelHeight)
         {
-            if (pixelHeight <= 0)
-            {
-                throw new System.ArgumentOutOfRangeException("pixelHeight", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions();
 
@@ -138,10 +135,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="pixelWidth">Width of the resulting Bitmap</param>
         public static BitmapSizeOptions FromWidth(int pixelWidth)
         {
-            if (pixelWidth <= 0)
-            {
-                throw new System.ArgumentOutOfRangeException("pixelWidth", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions();
 
@@ -161,15 +155,8 @@ namespace System.Windows.Media.Imaging
         /// <param name="pixelHeight">Height of the resulting Bitmap</param>
         public static BitmapSizeOptions FromWidthAndHeight(int pixelWidth, int pixelHeight)
         {
-            if (pixelWidth <= 0)
-            {
-                throw new System.ArgumentOutOfRangeException("pixelWidth", SR.ParameterMustBeGreaterThanZero);
-            }
-
-            if (pixelHeight <= 0)
-            {
-                throw new System.ArgumentOutOfRangeException("pixelHeight", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
 
             BitmapSizeOptions sizeOptions = new BitmapSizeOptions();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -738,11 +738,8 @@ namespace System.Windows.Media.Imaging
             if (sourceRect.Height <= 0)
                 sourceRect.Height = PixelHeight;
 
-            if (sourceRect.Width > PixelWidth)
-                throw new ArgumentOutOfRangeException("sourceRect.Width", SR.Format(SR.ParameterCannotBeGreaterThan, PixelWidth));
-
-            if (sourceRect.Height > PixelHeight)
-                throw new ArgumentOutOfRangeException("sourceRect.Height", SR.Format(SR.ParameterCannotBeGreaterThan, PixelHeight));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceRect.Width, PixelWidth, "sourceRect.Width");
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceRect.Height, PixelHeight, "sourceRect.Height");
 
             int minStride = checked(((sourceRect.Width * Format.BitsPerPixel) + 7) / 8);
             if (stride < minStride)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -730,8 +730,7 @@ namespace System.Windows.Media.Imaging
             if (buffer == IntPtr.Zero)
                 throw new ArgumentNullException("buffer");
 
-            if (stride <= 0)
-                throw new ArgumentOutOfRangeException("stride", SR.ParameterMustBeGreaterThanZero);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stride);
 
             if (sourceRect.Width <= 0)
                 sourceRect.Width = PixelWidth;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -742,12 +742,10 @@ namespace System.Windows.Media.Imaging
             ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceRect.Height, PixelHeight, "sourceRect.Height");
 
             int minStride = checked(((sourceRect.Width * Format.BitsPerPixel) + 7) / 8);
-            if (stride < minStride)
-                throw new ArgumentOutOfRangeException("stride", SR.Format(SR.ParameterCannotBeLessThan, minStride));
+            ArgumentOutOfRangeException.ThrowIfLessThan(stride, minStride);
 
             int minRequiredDestSize = checked((stride * (sourceRect.Height - 1)) + minStride);
-            if (bufferSize < minRequiredDestSize)
-                throw new ArgumentOutOfRangeException("buffer", SR.Format(SR.ParameterCannotBeLessThan, minRequiredDestSize));
+            ArgumentOutOfRangeException.ThrowIfLessThan(bufferSize, minRequiredDestSize);
 
             lock (_syncObject)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/InteropBitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/InteropBitmapSource.cs
@@ -126,15 +126,8 @@ namespace System.Windows.Interop
         {
 
             _bitmapInit.BeginInit();
-            if (pixelWidth <= 0)
-            {
-                throw new ArgumentOutOfRangeException("pixelWidth", SR.ParameterMustBeGreaterThanZero);
-            }
-
-            if (pixelHeight <= 0)
-            {
-                throw new ArgumentOutOfRangeException("pixelHeight", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
 
             Guid formatGuid = format.Guid;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/RenderTargetBitmap.cs
@@ -61,15 +61,8 @@ namespace System.Windows.Media.Imaging
                         );
             }
 
-            if (pixelWidth <= 0)
-            {
-                throw new ArgumentOutOfRangeException("pixelWidth", SR.ParameterMustBeGreaterThanZero);
-            }
-
-            if (pixelHeight <= 0)
-            {
-                throw new ArgumentOutOfRangeException("pixelHeight", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelWidth);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pixelHeight);
 
             if (dpiX < DoubleUtil.DBL_EPSILON)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -845,17 +845,9 @@ namespace System.Windows.Media.Imaging
             //
             // Sanitize the source rect and assure it will fit within the back buffer.
             //
-            if (sourceRect.X < 0)
-            {
-                Debug.Assert(!backwardsCompat);
-                throw new ArgumentOutOfRangeException("sourceRect", SR.ParameterCannotBeNegative);
-            }
-
-            if (sourceRect.Y < 0)
-            {
-                Debug.Assert(!backwardsCompat);
-                throw new ArgumentOutOfRangeException("sourceRect", SR.ParameterCannotBeNegative);
-            }
+            Debug.Assert(!(backwardsCompat && (sourceRect.X < 0 || sourceRect.Y < 0)));
+            ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.X, nameof(sourceRect));
+            ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.Y, nameof(sourceRect));
 
             if (sourceRect.Width < 0)
             {
@@ -893,18 +885,18 @@ namespace System.Windows.Media.Imaging
                 }
             }
 
-            if (destinationX < 0)
+            if (!backwardsCompat)
             {
-                if (backwardsCompat)
+                ArgumentOutOfRangeException.ThrowIfNegative(destinationX);
+            }
+            else
+            {
+                if (destinationX < 0)
                 {
                     HRESULT.Check((int)WinCodecErrors.WINCODEC_ERR_VALUEOVERFLOW);
                 }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("sourceRect", SR.ParameterCannotBeNegative);
-                }
             }
-        
+
             if (destinationX > _pixelWidth - sourceRect.Width)
             {
                 if (backwardsCompat)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -451,15 +451,8 @@ namespace System.Windows.Media.Imaging
         {
             WritePreamble();
 
-            if (bufferSize < 1)
-            {
-                throw new ArgumentOutOfRangeException("bufferSize", SR.Format(SR.ParameterCannotBeLessThan, 1));
-            }
-
-            if (stride < 1)
-            {
-                throw new ArgumentOutOfRangeException("stride", SR.Format(SR.ParameterCannotBeLessThan, 1));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stride);
 
             if (sourceRect.IsEmpty || sourceRect.Width <= 0 || sourceRect.Height <= 0)
             {
@@ -518,15 +511,8 @@ namespace System.Windows.Media.Imaging
                                     out sourceBufferSize, 
                                     out elementType);
 
-            if (stride < 1)
-            {
-                throw new ArgumentOutOfRangeException("stride", SR.Format(SR.ParameterCannotBeLessThan, 1));
-            }
-
-            if (offset < 0)
-            {
-                throw new ArgumentOutOfRangeException("offset", SR.Format(SR.ParameterCannotBeLessThan, 0));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stride);
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
 
             // We accept arrays of arbitrary value types - but not reference types.
             if (elementType == null || !elementType.IsValueType)
@@ -946,11 +932,8 @@ namespace System.Windows.Media.Imaging
                 throw new ArgumentNullException(backwardsCompat ? "buffer" : "sourceBuffer");
             }
 
-            if (sourceBufferStride < 1)
-            {
-                Debug.Assert(!backwardsCompat);
-                throw new ArgumentOutOfRangeException("sourceBufferStride", SR.Format(SR.ParameterCannotBeLessThan, 1));
-            }
+            Debug.Assert(!(backwardsCompat && sourceBufferStride < 1));
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(sourceBufferStride);
 
             if (sourceRect.Width == 0 || sourceRect.Height == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/TextEffect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/TextEffect.cs
@@ -51,10 +51,7 @@ namespace System.Windows.Media
             int positionCount
             )            
         {
-            if (positionCount < 0)
-            {
-                throw new ArgumentOutOfRangeException("positionCount", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(positionCount);
 
             Transform       = transform;
             Foreground      = foreground;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterBufferReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterBufferReference.cs
@@ -84,10 +84,7 @@ namespace System.Windows.Media.TextFormatting
             int                 offsetToFirstChar
             )
         {
-            if (offsetToFirstChar < 0)
-            {
-                throw new ArgumentOutOfRangeException("offsetToFirstChar", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(offsetToFirstChar);
 
             // maximum offset is one less than CharacterBuffer.Count, except that zero is always a valid offset
             // even in the case of an empty or null character buffer

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterBufferReference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterBufferReference.cs
@@ -89,10 +89,7 @@ namespace System.Windows.Media.TextFormatting
             // maximum offset is one less than CharacterBuffer.Count, except that zero is always a valid offset
             // even in the case of an empty or null character buffer
             int maxOffset = (charBuffer == null) ? 0 : Math.Max(0, charBuffer.Count - 1);
-            if (offsetToFirstChar > maxOffset)
-            {
-                throw new ArgumentOutOfRangeException("offsetToFirstChar", SR.Format(SR.ParameterCannotBeGreaterThan, maxOffset));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offsetToFirstChar, maxOffset);
 
             _charBuffer = charBuffer;
             _offsetToFirstChar = offsetToFirstChar;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterString.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterString.cs
@@ -101,10 +101,7 @@ namespace System.Windows.Media.TextFormatting
                 characterBufferReference.CharacterBuffer.Count - characterBufferReference.OffsetToFirstChar :
                 0;
 
-            if (characterLength > maxLength)
-            {
-                throw new ArgumentOutOfRangeException("characterLength", SR.Format(SR.ParameterCannotBeGreaterThan, maxLength));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(characterLength, maxLength);
 
             _charBufferRef = characterBufferReference;
             _length = characterLength;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterString.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/CharacterString.cs
@@ -95,10 +95,7 @@ namespace System.Windows.Media.TextFormatting
             int                         characterLength
             )
         {
-            if (characterLength < 0)
-            {
-                throw new ArgumentOutOfRangeException("characterLength", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(characterLength);
 
             int maxLength = (characterBufferReference.CharacterBuffer != null) ?
                 characterBufferReference.CharacterBuffer.Count - characterBufferReference.OffsetToFirstChar :

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextCharacters.cs
@@ -115,12 +115,8 @@ namespace System.Windows.Media.TextFormatting
             int                         length,
             TextRunProperties           textRunProperties
             )
-        {        
-            if (length <= 0)
-            {
-                throw new ArgumentOutOfRangeException("length", SR.ParameterMustBeGreaterThanZero);
-            }
-
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
             ArgumentNullException.ThrowIfNull(textRunProperties);
 
             if (textRunProperties.Typeface == null)
@@ -133,10 +129,7 @@ namespace System.Windows.Media.TextFormatting
                 throw new ArgumentNullException("textRunProperties.CultureInfo");
             }
 
-            if (textRunProperties.FontRenderingEmSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException("textRunProperties.FontRenderingEmSize", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(textRunProperties.FontRenderingEmSize, "textRunProperties.FontRenderingEmSize");
 
             _characterBufferReference = characterBufferReference;
             _length = length;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextEndOfLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextEndOfLine.cs
@@ -48,8 +48,7 @@ namespace System.Windows.Media.TextFormatting
             TextRunProperties   textRunProperties
             )
         {
-            if (length <= 0)
-                throw new ArgumentOutOfRangeException("length", SR.ParameterMustBeGreaterThanZero);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
 
             if (textRunProperties != null && textRunProperties.Typeface == null)
                 throw new ArgumentNullException("textRunProperties.Typeface");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextEndOfSegment.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextEndOfSegment.cs
@@ -37,8 +37,7 @@ namespace System.Windows.Media.TextFormatting
         /// <param name="length">number of characters</param>
         public TextEndOfSegment(int length)
         {
-            if (length <= 0)
-                throw new ArgumentOutOfRangeException("length", SR.ParameterMustBeGreaterThanZero);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
 
             _length = length;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextHidden.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextHidden.cs
@@ -38,10 +38,7 @@ namespace System.Windows.Media.TextFormatting
             int     length
             )
         {
-            if (length <= 0)
-            {
-                throw new ArgumentOutOfRangeException("length", SR.ParameterMustBeGreaterThanZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
 
             _length = length;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextSimpleMarkerProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextSimpleMarkerProperties.cs
@@ -57,10 +57,7 @@ namespace System.Windows.Media.TextFormatting
                 else if (TextMarkerSource.IsKnownIndexMarkerStyle(style))
                 {
                     // validate autoNumberingIndex
-                    if (autoNumberingIndex < 1)
-                    {
-                        throw new ArgumentOutOfRangeException("autoNumberingIndex", SR.Format(SR.ParameterCannotBeLessThan, 1));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfNegativeOrZero(autoNumberingIndex);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -4002,9 +4002,6 @@ Do you want to replace it?</value>
   <data name="InvalidPermissionType" xml:space="preserve">
     <value>Permission type is not valid. Expected '{0}'.</value>
   </data>
-  <data name="ParameterCannotBeNegative" xml:space="preserve">
-    <value>Parameter must be greater than or equal to zero.</value>
-  </data>
   <data name="SecurityExceptionForSettingSandboxExternalToTrue" xml:space="preserve">
     <value>Cannot set SandboxExternalContent to true in partial trust.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -3608,11 +3608,6 @@ Chcete ho nahradit?</target>
         <target state="translated">Prvek {0} musí být poskytnut při vytváření instance {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Hodnota tohoto parametru musí být větší nebo rovna nule.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Parametr musí být FrameworkElement nebo FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -3608,11 +3608,6 @@ Möchten Sie das Element ersetzen?</target>
         <target state="translated">"{0}" muss beim Instanziieren von "{1}" bereitgestellt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Der Parameter muss größer oder gleich null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Bei dem Parameter muss es sich um "FrameworkElement" oder "FrameworkContentElement" handeln.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">"{0}" se debe proporcionar al crear la instancia de "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">El parámetro debe ser mayor que o igual a cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">El parámetro debe ser FrameworkElement o FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -3608,11 +3608,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">'{0}' doit être fourni durant l'instanciation de '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Le paramètre doit être supérieur ou égal à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Parameter doit être FrameworkElement ou FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -3608,11 +3608,6 @@ Sostituirlo?</target>
         <target state="translated">È necessario specificare '{0}' quando si crea un'istanza di '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Il valore del parametro deve essere maggiore o uguale a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Il parametro deve essere FrameworkElement o FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">'{1}' をインスタンス化するには、'{0}' が必要です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">パラメーターは 0 以上でなければなりません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">パラメーターは、FrameworkElement または FrameworkContentElement である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">'{1}'의 인스턴스를 만들 때 '{0}'이(가) 제공되어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">매개 변수는 0보다 크거나 같아야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">매개 변수는 FrameworkElement 또는 FrameworkContentElement여야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -3608,11 +3608,6 @@ Czy chcesz go zastąpić?</target>
         <target state="translated">Podczas tworzenia wystąpienia „{1}” należy dostarczyć „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametr musi być większy lub równy zeru.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Parametrem musi być FrameworkElement lub FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -3608,11 +3608,6 @@ Deseja substituí-lo?</target>
         <target state="translated">'{0}' precisa ser fornecido durante a criação de uma instância de '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">O parâmetro deve ser maior ou igual a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">O parâmetro deve ser FrameworkElement ou FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">При создании экземпляра "{1}" необходимо задать "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Значение параметра должно быть больше или равно 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Параметр должен быть FrameworkElement или FrameworkContentElement.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -3608,11 +3608,6 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">'{1}' örneği oluşturulurken '{0}' sağlanmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametre sıfıra eşit veya daha büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">Parametre FrameworkElement veya FrameworkContentElement olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">安装“{1}”时必须提供“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">参数必须大于或等于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">参数必须是 FrameworkElement 或 FrameworkContentElement。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -3608,11 +3608,6 @@ Do you want to replace it?</source>
         <target state="translated">安裝 '{1}' 時必須提供 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">參數必須大於或等於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeLogicalNode">
         <source>Parameter must be FrameworkElement or FrameworkContentElement.</source>
         <target state="translated">參數必須是 FrameworkElement 或 FrameworkContentElement。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/PasswordBox.cs
@@ -1077,15 +1077,8 @@ namespace System.Windows.Controls
             ITextPointer selectionEnd;
 
             //             VerifyAccess();
-            if (start < 0)
-            {
-                throw new ArgumentOutOfRangeException("start", SR.ParameterCannotBeNegative);
-            }
-
-            if (length < 0)
-            {
-                throw new ArgumentOutOfRangeException("length", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(start);
+            ArgumentOutOfRangeException.ThrowIfNegative(length);
 
             // Identify new selection start position
             selectionStart = this.TextContainer.Start.CreatePointer();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
@@ -151,15 +151,8 @@ namespace System.Windows.Controls
         /// </summary>
         public void Select(int start, int length)
         {
-            if (start < 0)
-            {
-                throw new ArgumentOutOfRangeException("start", SR.ParameterCannotBeNegative);
-            }
-
-            if (length < 0)
-            {
-                throw new ArgumentOutOfRangeException("length", SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(start);
+            ArgumentOutOfRangeException.ThrowIfNegative(length);
 
             // Identify new position for selection Start
             int maxStart = TextContainer.SymbolCount;
@@ -825,10 +818,7 @@ namespace System.Windows.Controls
             }
             set
             {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", SR.ParameterCannotBeNegative);
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
 
                 // Identify new position for selection end
                 int maxLength = TextSelectionInternal.Start.GetOffsetToPosition(TextContainer.End);
@@ -869,10 +859,7 @@ namespace System.Windows.Controls
             }
             set
             {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException("value", SR.ParameterCannotBeNegative);
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
 
                 // Store current length of the selection
                 int selectionLength = TextSelectionInternal.Start.GetOffsetToPosition(TextSelectionInternal.End);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Localizer/BamlLocalizationDictionary.cs
@@ -282,14 +282,7 @@ namespace System.Windows.Markup.Localizer
         public void CopyTo(DictionaryEntry[] array, int arrayIndex)
         {
             ArgumentNullException.ThrowIfNull(array);
-
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(
-                    "arrayIndex", 
-                    SR.ParameterCannotBeNegative
-                );
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
 
             if (arrayIndex >= array.Length)
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CharacterBuffer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CharacterBuffer.cs
@@ -387,11 +387,8 @@ namespace MS.Internal
                 throw new ArgumentNullException("characterString");
             }
 
-            if (length <= 0)
-            {
-                throw new ArgumentOutOfRangeException("length", SR.ParameterValueMustBeGreaterThanZero);
-            }
-            
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
+
             _unsafeString = characterString;
             _length = length;
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -747,9 +747,6 @@
   <data name="OpenPropertyInCurrentFrame_SM" space_="preserve">
     <value>XAML Node Stream: Missing EndMember for '{0}.{1}' before StartMember '{2}'.</value>
   </data>
-  <data name="ParameterCannotBeNegative" space_="preserve">
-    <value>Parameter must be greater than or equal to zero.</value>
-  </data>
   <data name="ParentlessPropertyElement" space_="preserve">
     <value>The property element '{0}' is not contained by an object element.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Datový proud uzlu XAML: Nebyla nalezena metoda EndMember pro {0}.{1} před metodou StartMember {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Hodnota tohoto parametru musí být větší nebo rovna nule.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">Element vlastnosti {0} není obsažen v elementu objektu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML-Knotenstream: EndMember für "{0}.{1}" fehlt vor StartMember "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Der Parameter muss größer oder gleich null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">Das Eigenschaftenelement "{0}" ist nicht in einem Objektelement enthalten.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Flujo de nodo XAML: falta EndMember para '{0}.{1}' delante de StartMember '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">El parámetro debe ser mayor que o igual a cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">El elemento de propiedad '{0}' no está contenido en un elemento de objeto.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Flux de nœud XAML : EndMember manquant pour '{0}.{1}' avant StartMember '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Le paramètre doit être supérieur ou égal à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">L'élément de propriété '{0}' n'est pas contenu dans un élément objet.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Flusso del nodo XAML: EndMember mancante per '{0}.{1}' prima di StartMember '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Il valore del parametro deve essere maggiore o uguale a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">L'elemento della proprietà '{0}' non è contenuto da un elemento dell'oggetto.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML ノード ストリーム: StartMember '{2}' の前に '{0}.{1}' の EndMember がありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">パラメーターは 0 以上でなければなりません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">プロパティ要素 '{0}' はオブジェクト要素に含まれていません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML 노드 스트림: StartMember '{2}' 앞에 '{0}.{1}'에 대한 EndMember가 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">매개 변수는 0보다 크거나 같아야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">속성 요소 '{0}'이(가) 개체 요소에서 포함되지 않았습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Strumień węzłów XAML: brak metody EndMember dla elementu {0}.{1} przed metodą StartMember „{2}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametr musi być większy lub równy zeru.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">Element właściwości „{0}” nie jest zawarty w elemencie obiektu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Fluxo do Nó XAML: EndMember ausente para '{0}.{1}' antes de StartMember '{2}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">O parâmetro deve ser maior ou igual a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">O elemento de propriedade '{0}' não está contido em um elemento de objeto.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">Поток узла XAML: отсутствует EndMember для "{0}.{1}" перед StartMember "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Значение параметра должно быть больше или равно 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">Элемент свойства "{0}" не содержится в элементе объекта.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML Düğüm Akışı: StartMember '{2}' öncesinde '{0}.{1}' için EndMember yok.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametre sıfıra eşit veya daha büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">'{0}' özellik öğesi bir nesne öğesinin içinde değil.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML 节点流: StartMember“{2}”前面缺少“{0}.{1}”的 EndMember。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">参数必须大于或等于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">对象元素中未包含属性元素“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1052,11 +1052,6 @@
         <target state="translated">XAML 節點資料流: StartMember '{2}' 前面遺漏 '{0}.{1}' 的 EndMember。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">參數必須大於或等於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentlessPropertyElement">
         <source>The property element '{0}' is not contained by an object element.</source>
         <target state="translated">屬性項目 '{0}' 未包含在物件項目中。</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsButton.cs
@@ -95,11 +95,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             ButtonType type;
             int style;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
@@ -69,11 +69,7 @@ namespace MS.Internal.AutomationProxies
         internal static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsComboBox(hwnd, null, HostedByComboEx(hwnd), idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsContainer.cs
@@ -61,11 +61,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert(idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsContainer(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
@@ -83,11 +83,7 @@ namespace MS.Internal.AutomationProxies
             // AutomationElement.LogicalMapping, BUT user still can get "edit"
             // from Hwnd
             // Something is wrong if idChild is not zero
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsEditBox(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
@@ -49,11 +49,7 @@ namespace MS.Internal.AutomationProxies
         internal static IRawElementProviderSimple Create (IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new FormsLink(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsIPAddress.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsIPAddress.cs
@@ -54,11 +54,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsIPAddress(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsNonControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsNonControl.cs
@@ -45,11 +45,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert(idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsNonControl(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsProgressbar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsProgressbar.cs
@@ -48,11 +48,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsProgressBar(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRebar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRebar.cs
@@ -50,11 +50,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsRebar(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEdit.cs
@@ -63,11 +63,7 @@ namespace MS.Internal.AutomationProxies
         internal static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero
-            if (idChild != 0)
-            {
-                Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsRichEdit(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsScrollBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsScrollBar.cs
@@ -68,11 +68,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsScrollBar(hwnd, null, idChild, NativeMethods.SB_CTL);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSlider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSlider.cs
@@ -54,11 +54,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsSlider(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsSpinner.cs
@@ -54,11 +54,7 @@ namespace MS.Internal.AutomationProxies
         internal static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             IntPtr hwndBuddy;
             try

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStartMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStartMenu.cs
@@ -41,11 +41,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert(idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsStartMenu(hwnd, null, 0);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatic.cs
@@ -59,10 +59,9 @@ namespace MS.Internal.AutomationProxies
         {
             // This proxy should not be created with idChild != 0,
             // unless it is a link label.
-            if (idChild != 0 && !IsLinkLabel(hwnd))
+            if (!IsLinkLabel(hwnd))
             {
-                System.Diagnostics.Debug.Assert(idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
+                ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
             }
 
             StaticType type;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatusBar.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsStatusBar.cs
@@ -55,11 +55,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsStatusBar(hwnd, null, idChild, null);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
@@ -55,11 +55,7 @@ namespace MS.Internal.AutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsTooltip(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsUpDown.cs
@@ -55,11 +55,7 @@ namespace MS.Internal.AutomationProxies
         internal static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsUpDown(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/UnsupportedAutomationProxies/WindowsDateTimePicker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/UnsupportedAutomationProxies/WindowsDateTimePicker.cs
@@ -56,11 +56,7 @@ namespace MS.Internal.UnsupportedAutomationProxies
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
             // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsDateTimePicker(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/UnsupportedAutomationProxies/windowspager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/UnsupportedAutomationProxies/windowspager.cs
@@ -49,12 +49,8 @@ namespace MS.Internal.UnsupportedAutomationProxies
 
         private static IRawElementProviderSimple Create(IntPtr hwnd, int idChild)
         {
-            // Something is wrong if idChild is not zero 
-            if (idChild != 0)
-            {
-                System.Diagnostics.Debug.Assert (idChild == 0, "Invalid Child Id, idChild != 0");
-                throw new ArgumentOutOfRangeException("idChild", idChild, SR.ShouldBeZero);
-            }
+            // Something is wrong if idChild is not zero
+            ArgumentOutOfRangeException.ThrowIfNotEqual(idChild, 0);
 
             return new WindowsPager(hwnd, null, idChild);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/Strings.resx
@@ -330,9 +330,6 @@
   <data name="SetFocusFailed" xml:space="preserve">
     <value>Target element cannot receive focus.</value>
   </data>
-  <data name="ShouldBeZero" xml:space="preserve">
-    <value>Must be zero.</value>
-  </data>
   <data name="ValueReadonly" xml:space="preserve">
     <value>Value is read-only.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.cs.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Cílový element nemůže být vybrán.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Musí mít hodnotu nula.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Hodnota je pouze pro čtení.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.de.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Das Zielelement kann keinen Fokus erhalten.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Muss Null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Der Wert ist schreibgeschützt.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.es.xlf
@@ -357,11 +357,6 @@
         <target state="translated">El elemento de destino no puede recibir el foco.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Debe ser cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">El valor es de solo lectura.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.fr.xlf
@@ -357,11 +357,6 @@
         <target state="translated">L'élément cible ne peut pas recevoir le focus.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Doit être égal à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">La valeur est en lecture seule.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.it.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Impossibile spostare lo stato attivo sull'elemento di destinazione.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Deve essere zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Valore di sola lettura.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ja.xlf
@@ -357,11 +357,6 @@
         <target state="translated">ターゲット要素は、フォーカスを受け取ることができません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">ゼロを指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">値は読み取り専用です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ko.xlf
@@ -357,11 +357,6 @@
         <target state="translated">대상 요소가 포커스를 받을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">0이어야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">값이 읽기 전용입니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.pl.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Nie można ustawić fokusu na elemencie docelowym.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Musi mieć wartość zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Wartość jest tylko do odczytu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.pt-BR.xlf
@@ -357,11 +357,6 @@
         <target state="translated">O elemento de destino não pode receber o foco.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Deve ser zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">O valor é somente leitura.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.ru.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Конечному элементу не удается получить фокус.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Должно быть нулем.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Значение доступно только для чтения.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.tr.xlf
@@ -357,11 +357,6 @@
         <target state="translated">Hedef öğeye odaklanılamıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">Sıfır olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">Değer salt okunur.</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.zh-Hans.xlf
@@ -357,11 +357,6 @@
         <target state="translated">目标元素无法接收焦点。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">必须为零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">值为只读。</target>

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/Resources/xlf/Strings.zh-Hant.xlf
@@ -357,11 +357,6 @@
         <target state="translated">目標項目無法接收焦點。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ShouldBeZero">
-        <source>Must be zero.</source>
-        <target state="translated">必須為零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ValueReadonly">
         <source>Value is read-only.</source>
         <target state="translated">值是唯讀的。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1767,9 +1767,6 @@
   <data name="StringEmpty" xml:space="preserve">
     <value>Parameter cannot be a zero-length string.</value>
   </data>
-  <data name="ParameterCannotBeNegative" xml:space="preserve">
-    <value>Parameter must be greater than or equal to zero.</value>
-  </data>
   <data name="Freezable_CantBeFrozen" xml:space="preserve">
     <value>Specified value of type '{0}' must have IsFrozen set to false to modify.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Zadaný objekt odkazu je v konfliktu s předdefinovaným odkazem specifickým pro balíček.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Hodnota tohoto parametru musí být větší nebo rovna nule.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Das angegebene Verweisobjekt verursacht einen Konflikt mit dem vordefinierten Package-spezifischen Verweis.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Der Parameter muss größer oder gleich null sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">El objeto de referencia especificado entra en conflicto con la referencia específica de paquete predefinida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">El parámetro debe ser mayor que o igual a cero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">L'objet de référence spécifié est en conflit avec la référence prédéfinie spécifique au package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Le paramètre doit être supérieur ou égal à zéro.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">L'oggetto di riferimento specificato è in conflitto con il riferimento predefinito specifico di Package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Il valore del parametro deve essere maggiore o uguale a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定された参照オブジェクトは、定義済みの Package 固有の参照と競合しています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">パラメーターは 0 以上でなければなりません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">지정한 참조 개체가 미리 정의된 Package 특정 참조와 충돌합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">매개 변수는 0보다 크거나 같아야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Określony obiekt odwołania wywołuje konflikt ze wstępnie zdefiniowanym odwołaniem specyficznym dla elementu Package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametr musi być większy lub równy zeru.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">O objeto de referência especificado é conflitante com a referência específica do Pacote predefinida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">O parâmetro deve ser maior ou igual a zero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Указанный эталонный объект конфликтует с предопределенной ссылкой для заданного пакета.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Значение параметра должно быть больше или равно 0.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Belirtilen başvuru nesnesi önceden tanımlı Pakete özgü başvuru ile çakışıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">Parametre sıfıra eşit veya daha büyük olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定的引用对象与预定义的 Package 专属引用冲突。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">参数必须大于或等于零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定的參考物件與預先定義的 Package 專屬參考相衝突。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterCannotBeNegative">
-        <source>Parameter must be greater than or equal to zero.</source>
-        <target state="translated">參數必須大於或等於零。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterMustBeBetween">
         <source>The parameter value must be between '{0}' and '{1}'.</source>
         <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
@@ -79,16 +79,9 @@ namespace System.Windows
         // concerns prevent this until a side-by-side release.
         internal void ValidateForDirtyRect(string paramName, int width, int height)
         {
-            if (_x < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, SR.ParameterCannotBeNegative);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(_x, paramName);
+            ArgumentOutOfRangeException.ThrowIfNegative(_y, paramName);
 
-            if (_y < 0)
-            {
-                throw new ArgumentOutOfRangeException(paramName, SR.ParameterCannotBeNegative);
-            }            
-            
             if (_width < 0 || _width > width)
             {
                 throw new ArgumentOutOfRangeException(paramName, SR.Format(SR.ParameterMustBeBetween, 0, width));


### PR DESCRIPTION
This is a followup to #8403.

## Description

Many error messages can be replaced with messages from the BCL using the new `ArgumentOutOfRangeException` throw helpers.
Here are the messages I removed, each in its own commit:

- ParameterMustBeGreaterThanZero
- ParameterCannotBeNegative
- ParameterCannotBeGreaterThan
- ParameterCannotBeLessThan
- ParameterValueMustBeGreaterThanZero
- ParameterValueCannotBeNegative
- ShouldBeZero

ParameterMustBeBetween would be a good candidate, but this would slightly change the information conveyed by the error message. I still think it's worth it though.
ParameterValueCannotBeInfinity and ParameterValueCannotBeNaN also come to mind.

## Customer Impact

Slight performance improvement, and a bit fewer resources.

## Regression

No

## Testing

CI

## Risk

Low. I manually searched and removed the error messages, and let CA1512 finish the work


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8408)