### PR TITLE
Use ArgumentOutOfRangeException.ThrowIf* across codebase: followups

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
@@ -60,8 +60,9 @@ namespace MS.Internal.FontCache
             Debug.Assert(stream.Position == 0);
             unsafe { _pointer = stream.PositionPointer; }
             long length = stream.Length;
-            if (length < 0 || length > int.MaxValue)
-                throw new ArgumentOutOfRangeException();
+            ArgumentOutOfRangeException.ThrowIfNegative(length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(length, int.MaxValue);
+
             _size = (int)length;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontFaceLayoutInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontFaceLayoutInfo.cs
@@ -737,10 +737,9 @@ namespace MS.Internal.FontCache
                 // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
                 // is 0 the index is not allowed to be equal or greater than the length
                 // (from the MSDN ICollection docs)
-                if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-                {
-                    throw new ArgumentOutOfRangeException("arrayIndex");
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
                 foreach (KeyValuePair<int, ushort> pair in this)
                     array[arrayIndex++] = pair;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontDriver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontDriver.cs
@@ -168,8 +168,8 @@ namespace MS.Internal.FontFace
         {
             if (_technology == FontTechnology.TrueTypeCollection)
             {
-                if (faceIndex < 0 || faceIndex >= _numFaces)
-                    throw new ArgumentOutOfRangeException("faceIndex");
+                ArgumentOutOfRangeException.ThrowIfNegative(faceIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(faceIndex, _numFaces);
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontFamilyIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/FontFamilyIdentifier.cs
@@ -202,8 +202,8 @@ namespace MS.Internal.FontFace
         {
             get
             {
-                if (tokenIndex < 0 || tokenIndex >= Count)
-                    throw new ArgumentOutOfRangeException("tokenIndex");
+                ArgumentOutOfRangeException.ThrowIfNegative(tokenIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(tokenIndex, Count);
 
                 // Have we already been canonicalized?
                 if (_canonicalReferences != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/TypefaceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontFace/TypefaceCollection.cs
@@ -79,10 +79,9 @@ namespace MS.Internal.FontFace
             // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
             // is 0 the index is not allowed to be equal or greater than the length
             // (from the MSDN ICollection docs)
-            if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
             foreach (Typeface t in this)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/PseudoWebRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/IO/Packaging/PseudoWebRequest.cs
@@ -278,9 +278,11 @@ namespace MS.Internal.IO.Packaging
             }
             set
             {
-                // negative time that is not -1 (infinite) is an error case
-                if (value < 0 && value != System.Threading.Timeout.Infinite)
-                    throw new ArgumentOutOfRangeException("value");
+                if (value != System.Threading.Timeout.Infinite)
+                {
+                    // negative time that is not -1 (infinite) is an error case
+                    ArgumentOutOfRangeException.ThrowIfNegative(value);
+                }
 
                 _timeout = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/HuffModule.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/HuffModule.cs
@@ -35,20 +35,15 @@ namespace MS.Internal.Ink.InkSerializedFormat
         /// </summary>
         internal HuffCodec GetDefCodec(uint index)
         {
-            HuffCodec huffCodec = null;
-            if (AlgoModule.DefaultBAACount > index)
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, AlgoModule.DefaultBAACount);
+
+            HuffCodec huffCodec = _defaultHuffCodecs[index];
+            if (huffCodec == null)
             {
-                huffCodec = _defaultHuffCodecs[index];
-                if (huffCodec == null)
-                {
-                    huffCodec = new HuffCodec(index);
-                    _defaultHuffCodecs[index] = huffCodec;
-                }
+                huffCodec = new HuffCodec(index);
+                _defaultHuffCodecs[index] = huffCodec;
             }
-            else
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+
             return huffCodec;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebRequest.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/IO/Packaging/PackWebRequest.cs
@@ -399,9 +399,11 @@ namespace System.IO.Packaging
             }
             set
             {
-                // negative time that is not -1 (infinite) is an error case
-                if (value < 0 && value != System.Threading.Timeout.Infinite)
-                    throw new ArgumentOutOfRangeException("value");
+                if (value != System.Threading.Timeout.Infinite)
+                {
+                    // negative time that is not -1 (infinite) is an error case
+                    ArgumentOutOfRangeException.ThrowIfNegative(value);
+                }
 
                 GetRequest().Timeout = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FreezableCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FreezableCollection.cs
@@ -391,10 +391,8 @@ namespace System.Windows
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -503,10 +501,8 @@ namespace System.Windows
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecorationCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Generated/TextDecorationCollection.cs
@@ -292,10 +292,8 @@ namespace System.Windows
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0 || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -404,10 +402,8 @@ namespace System.Windows
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0 || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusPointCollection.cs
@@ -349,10 +349,8 @@ namespace System.Windows.Input
         /// <returns></returns>
         internal StylusPointCollection Clone(int count)
         {
-            if (count > this.Count || count < 1)
-            {
-                throw new ArgumentOutOfRangeException("count");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, this.Count);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
             return this.Clone(System.Windows.Media.Transform.Identity, this.Description, count);
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/KeyFrames.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/KeyFrames.cs
@@ -141,11 +141,8 @@ namespace System.Windows.Media.Animation
             Boolean baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -285,11 +282,8 @@ namespace System.Windows.Media.Animation
             Byte baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -429,11 +423,8 @@ namespace System.Windows.Media.Animation
             Char baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -573,11 +564,8 @@ namespace System.Windows.Media.Animation
             Color baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -717,11 +705,8 @@ namespace System.Windows.Media.Animation
             Decimal baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -861,11 +846,8 @@ namespace System.Windows.Media.Animation
             Double baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1005,11 +987,8 @@ namespace System.Windows.Media.Animation
             Int16 baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1149,11 +1128,8 @@ namespace System.Windows.Media.Animation
             Int32 baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1293,11 +1269,8 @@ namespace System.Windows.Media.Animation
             Int64 baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1437,11 +1410,8 @@ namespace System.Windows.Media.Animation
             Matrix baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1581,11 +1551,8 @@ namespace System.Windows.Media.Animation
             Object baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1725,11 +1692,8 @@ namespace System.Windows.Media.Animation
             Point baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -1869,11 +1833,8 @@ namespace System.Windows.Media.Animation
             Point3D baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2013,11 +1974,8 @@ namespace System.Windows.Media.Animation
             Quaternion baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2157,11 +2115,8 @@ namespace System.Windows.Media.Animation
             Rotation3D baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2301,11 +2256,8 @@ namespace System.Windows.Media.Animation
             Rect baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2445,11 +2397,8 @@ namespace System.Windows.Media.Animation
             Single baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2589,11 +2538,8 @@ namespace System.Windows.Media.Animation
             Size baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2733,11 +2679,8 @@ namespace System.Windows.Media.Animation
             String baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -2877,11 +2820,8 @@ namespace System.Windows.Media.Animation
             Vector baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }
@@ -3021,11 +2961,8 @@ namespace System.Windows.Media.Animation
             Vector3D baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/Generated/TimelineCollection.cs
@@ -302,10 +302,8 @@ namespace System.Windows.Media.Animation
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -414,10 +412,8 @@ namespace System.Windows.Media.Animation
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Effects/Generated/BitmapEffectCollection.cs
@@ -298,10 +298,8 @@ namespace System.Windows.Media.Effects
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -410,10 +408,8 @@ namespace System.Windows.Media.Effects
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyMapCollection.cs
@@ -268,8 +268,8 @@ namespace System.Windows.Media
                 throw new InvalidOperationException(SR.CompositeFont_TooManyFamilyMaps);
 
             // Validate the index.
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
 
             // PrepareToAddFamilyMap validates the familyName and updates the internal state
             // of the CompositeFontInfo object.
@@ -361,8 +361,8 @@ namespace System.Windows.Media
 
         private void RangeCheck(int index)
         {
-            if (index < 0 || index >= _count)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
         }
 
         private void VerifyChangeable()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FamilyTypefaceCollection.cs
@@ -247,8 +247,8 @@ namespace System.Windows.Media
             VerifyChangeable();
 
             // Validate the index.
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
 
             // We can't have two items with same style, weight, stretch.
             if (FindItem(item) >= 0)
@@ -354,8 +354,8 @@ namespace System.Windows.Media
 
         private void RangeCheck(int index)
         {
-            if (index < 0 || index >= _count)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
         }
 
         private void VerifyChangeable()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Fonts.cs
@@ -332,11 +332,9 @@ namespace System.Windows.Media
                 // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
                 // is 0 the index is not allowed to be equal or greater than the length
                 // (from the MSDN ICollection docs)
-                if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-                {
-                    throw new ArgumentOutOfRangeException("arrayIndex");
-                }
-
+                ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
                 foreach (Typeface t in this)
                 {
                     array[arrayIndex++] = t;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -305,8 +305,8 @@ namespace System.Windows.Media
 
         private int ValidateRange(int startIndex, int count)
         {
-            if (startIndex < 0 || startIndex > _text.Length)
-                throw new ArgumentOutOfRangeException("startIndex");
+            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, _text.Length);
 
             int limit = startIndex + count;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DoubleCollection.cs
@@ -251,10 +251,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -376,10 +374,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/DrawingCollection.cs
@@ -314,10 +314,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -426,10 +424,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeneralTransformCollection.cs
@@ -300,10 +300,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -412,10 +410,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GeometryCollection.cs
@@ -314,10 +314,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -426,10 +424,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/GradientStopCollection.cs
@@ -300,10 +300,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -412,10 +410,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32Collection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/Int32Collection.cs
@@ -251,10 +251,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -376,10 +374,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathFigureCollection.cs
@@ -301,10 +301,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -413,10 +411,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PathSegmentCollection.cs
@@ -300,10 +300,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -412,10 +410,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/PointCollection.cs
@@ -251,10 +251,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -376,10 +374,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TextEffectCollection.cs
@@ -300,10 +300,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -412,10 +410,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/TransformCollection.cs
@@ -314,10 +314,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -426,10 +424,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Generated/VectorCollection.cs
@@ -251,10 +251,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -376,10 +374,8 @@ namespace System.Windows.Media
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphTypeface.cs
@@ -1829,10 +1829,9 @@ namespace System.Windows.Media
                 // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
                 // is 0 the index is not allowed to be equal or greater than the length
                 // (from the MSDN ICollection docs)
-                if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-                {
-                    throw new ArgumentOutOfRangeException("arrayIndex");
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
                 for (ushort i = 0; i < Count; ++i)
                     array[arrayIndex + i] = new KeyValuePair<ushort, double>(i, this[i]);
@@ -1915,10 +1914,9 @@ namespace System.Windows.Media
                     // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
                     // is 0 the index is not allowed to be equal or greater than the length
                     // (from the MSDN ICollection docs)
-                    if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-                    {
-                        throw new ArgumentOutOfRangeException("arrayIndex");
-                    }
+                    ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
                     for (ushort i = 0; i < Count; ++i)
                         array[arrayIndex + i] = _glyphIndexer[i];

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/VisualCollection.cs
@@ -194,11 +194,8 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Collection_BadRank);
             }
 
-            if ((index < 0) ||
-                (array.Length - index < _size))
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _size);
 
             // System.Array does not have a CopyTo method that takes a count. Therefore
             // the loop is programmed here out.
@@ -220,11 +217,8 @@ namespace System.Windows.Media
 
             ArgumentNullException.ThrowIfNull(array);
 
-            if ((index < 0) ||
-                (array.Length - index < _size))
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _size);
 
             // System.Array does not have a CopyTo method that takes a count. Therefore
             // the loop is programmed here out.
@@ -343,7 +337,8 @@ namespace System.Windows.Media
                 // get methods
 
 #pragma warning disable 6503
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index));
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _size);
                 return _items[index];
 #pragma warning restore 6503
             }
@@ -351,7 +346,8 @@ namespace System.Windows.Media
             {
                 VerifyAPIReadWrite(value);
 
-                if (index < 0 || index >= _size) throw new ArgumentOutOfRangeException(nameof(index));
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _size);
 
                 Visual child = _items[index];
 
@@ -709,10 +705,8 @@ namespace System.Windows.Media
         {
             VerifyAPIReadWrite(visual);
 
-            if (index < 0 || index > _size)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _size);
 
             if ((visual != null) &&
                 ((visual._parent != null)   // Only visuals that are not connected to another tree
@@ -761,10 +755,8 @@ namespace System.Windows.Media
         {
             VerifyAPIReadWrite();
 
-            if (index < 0 || index >= _size)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _size);
 
             InternalRemove(_items[index]);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/GeneralTransform3DCollection.cs
@@ -296,10 +296,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -408,10 +406,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/MaterialCollection.cs
@@ -310,10 +310,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -422,10 +420,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Model3DCollection.cs
@@ -310,10 +310,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -422,10 +420,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Point3DCollection.cs
@@ -247,10 +247,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -372,10 +370,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Transform3DCollection.cs
@@ -310,10 +310,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -422,10 +420,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Generated/Vector3DCollection.cs
@@ -247,10 +247,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             _collection.CopyTo(array, index);
         }
@@ -372,10 +370,8 @@ namespace System.Windows.Media.Media3D
             // This will not throw in the case that we are copying
             // from an empty collection.  This is consistent with the
             // BCL Collection implementations. (Windows 1587365)
-            if (index < 0  || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - _collection.Count);
 
             if (array.Rank != 1)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media3D/Visual3DCollection.cs
@@ -105,10 +105,8 @@ namespace System.Windows.Media.Media3D
         /// </summary>
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= InternalCount)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InternalCount);
 
             VerifyAPIReadWrite(_collection[index]);
 
@@ -150,10 +148,9 @@ namespace System.Windows.Media.Media3D
             // The extra "index >= array.Length" check in because even if _collection.Count
             // is 0 the index is not allowed to be equal or greater than the length
             // (from the MSDN ICollection docs)
-            if (index < 0 || index >= array.Length || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, array.Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - Count);
 
             _collection.CopyTo(array, index);
         }
@@ -167,10 +164,9 @@ namespace System.Windows.Media.Media3D
             // The extra "index >= array.Length" check in because even if _collection.Count
             // is 0 the index is not allowed to be equal or greater than the length
             // (from the MSDN ICollection docs)
-            if (index < 0 || index >= array.Length || (index + _collection.Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, array.Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, array.Length - Count);
 
             if (array.Rank != 1)
             {
@@ -263,10 +259,8 @@ namespace System.Windows.Media.Media3D
             }
             set
             {
-                if (index < 0 || index >= InternalCount)
-                {
-                    throw new ArgumentOutOfRangeException("index");
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InternalCount);
 
                 VerifyAPIForAdd(value);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -417,8 +417,8 @@ namespace MS.Internal.Annotations.Anchoring
             ContentLocator realLocator = locator as ContentLocator;
             if (realLocator != null)
             {
-                if (offset < 0 || offset >= realLocator.Parts.Count)
-                    throw new ArgumentOutOfRangeException("offset");
+                ArgumentOutOfRangeException.ThrowIfNegative(offset);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(offset, realLocator.Parts.Count);
             }
 
             return InternalResolveLocator(locator, offset, startNode, false /*skipStartNode*/, out attachmentLevel);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/ObservableDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/ObservableDictionary.cs
@@ -189,8 +189,8 @@ namespace MS.Internal.Annotations
         void ICollection<KeyValuePair<string, string>>.CopyTo(KeyValuePair<string, string>[] target, int startIndex)
         {
             ArgumentNullException.ThrowIfNull(target);
-            if (startIndex < 0 || startIndex > target.Length)
-                throw new ArgumentOutOfRangeException("startIndex");
+            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, target.Length);
 
             ((ICollection<KeyValuePair<string, string>>)_nameValues).CopyTo(target, startIndex);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/InnerItemCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/InnerItemCollectionView.cs
@@ -462,8 +462,8 @@ namespace MS.Internal.Controls
         /// <returns>true if <seealso cref="CollectionView.CurrentItem"/> points to an item within the view.</returns>
         public override bool MoveCurrentToPosition(int position)
         {
-            if (position < -1 || position > ViewCount)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, -1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(position, ViewCount);
 
             if (position != CurrentPosition && OKToChangeCurrent())
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/RBTree.cs
@@ -628,8 +628,8 @@ namespace MS.Internal.Data
 
         void VerifyIndex(int index, int delta = 0)
         {
-            if (index < 0 || index >= Count + delta)
-                throw new ArgumentOutOfRangeException("index");
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count + delta);
         }
 
         #endregion IList<T>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakDictionary.cs
@@ -301,10 +301,7 @@ namespace MS.Internal
                 count++;
             }
 
-            if (count + arrayIndex > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - count);
 
             foreach (KeyValuePair<TKey, TValue> item in this)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakHashSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WeakHashSet.cs
@@ -48,10 +48,7 @@ namespace MS.Internal
                 count++;
             }
 
-            if (count + arrayIndex > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - count);
 
             foreach (T item in this)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -2690,12 +2690,8 @@ namespace MS.Internal.Documents
         private double GetHorizontalOffsetForPage(RowInfo row, int pageNumber)
         {
             ArgumentNullException.ThrowIfNull(row);
-
-            if (pageNumber < row.FirstPage ||
-                pageNumber > row.FirstPage + row.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("pageNumber");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(pageNumber, row.FirstPage);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(pageNumber, row.FirstPage + row.PageCount);
 
             //Rows are centered if the content has varying page sizes,
             //Left-aligned otherwise.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/PageCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/PageCache.cs
@@ -790,10 +790,8 @@ namespace MS.Internal.Documents
         private PageCacheChange UpdateEntry(int index, PageCacheEntry newEntry)
         {
             //Make sure we're in range.
-            if (index >= _cache.Count || index < 0)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _cache.Count);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             Invariant.Assert(newEntry.PageSize != Size.Empty, "Updated entry newEntry has Empty PageSize.");
 
@@ -821,10 +819,8 @@ namespace MS.Internal.Documents
             //Make sure we're in range.
             ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(start, _cache.Count);
 
-            if (start + count > _cache.Count || count < 1)
-            {
-                throw new ArgumentOutOfRangeException("count");
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, _cache.Count - start);
+            ArgumentOutOfRangeException.ThrowIfLessThan(count, 1);
 
             Invariant.Assert(_defaultPageSize != Size.Empty, "Default Page Size is Empty.");
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/RowCache.cs
@@ -243,10 +243,8 @@ namespace MS.Internal.Documents
         /// <returns>The requested row.</returns>
         public RowInfo GetRow(int index)
         {
-            if (index < 0 || index > _rowCache.Count)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _rowCache.Count);
 
             return _rowCache[index];
         }
@@ -259,10 +257,8 @@ namespace MS.Internal.Documents
         /// <returns>The requested row.</returns>
         public RowInfo GetRowForPageNumber(int pageNumber)
         {
-            if (pageNumber < 0 || pageNumber > LastPageInCache)
-            {
-                throw new ArgumentOutOfRangeException("pageNumber");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(pageNumber);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(pageNumber, LastPageInCache);
 
             return _rowCache[GetRowIndexForPageNumber(pageNumber)];
         }
@@ -275,10 +271,8 @@ namespace MS.Internal.Documents
         /// <returns>The requested row index</returns>
         public int GetRowIndexForPageNumber(int pageNumber)
         {
-            if (pageNumber < 0 || pageNumber > LastPageInCache)
-            {
-                throw new ArgumentOutOfRangeException("pageNumber");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(pageNumber);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(pageNumber, LastPageInCache);
 
             //Search our cache for the row that contains the page.
             //NOTE: Future perf item:
@@ -307,10 +301,8 @@ namespace MS.Internal.Documents
         /// <returns>The index of the row that lives at the offset.</returns>
         public int GetRowIndexForVerticalOffset(double offset)
         {
-            if (offset < 0 || offset > ExtentHeight)
-            {
-                throw new ArgumentOutOfRangeException("offset");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, ExtentHeight);
 
             //If we have no rows we'll return 0 (the top of the non-existent document)
             if (_rowCache.Count == 0)
@@ -511,10 +503,9 @@ namespace MS.Internal.Documents
             }
 
             //Throw exception for illegal values
-            if (pivotPage < 0 || pivotPage > PageCache.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("pivotPage");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(pivotPage);
+            //Throw exception for illegal values
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(pivotPage, PageCache.PageCount);
 
             //Can't lay out fewer than 1 column of pages.
             ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
@@ -651,10 +642,8 @@ namespace MS.Internal.Documents
         private int RecalcRowsForDynamicPageSizes(int pivotPage, int columns)
         {
             //Throw exception for illegal values
-            if (pivotPage < 0 || pivotPage >= PageCache.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("pivotPage");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(pivotPage);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(pivotPage, PageCache.PageCount);
 
             //Can't lay out fewer than 1 column of pages.
             ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);
@@ -808,10 +797,8 @@ namespace MS.Internal.Documents
         private int RecalcRowsForFixedPageSizes(int startPage, int columns)
         {
             //Throw exception for illegal values
-            if (startPage < 0 || startPage > PageCache.PageCount)
-            {
-                throw new ArgumentOutOfRangeException("startPage");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(startPage);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startPage, PageCache.PageCount);
 
             //Can't lay out fewer than 1 column of pages.
             ArgumentOutOfRangeException.ThrowIfLessThan(columns, 1);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/UndoManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/UndoManager.cs
@@ -516,10 +516,8 @@ namespace MS.Internal.Documents
                 throw new InvalidOperationException(SR.UndoServiceDisabled);
             }
 
-            if (count > UndoCount || count <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, UndoCount);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
             if (State != UndoState.Normal)
             {
@@ -583,10 +581,8 @@ namespace MS.Internal.Documents
                 throw new InvalidOperationException(SR.UndoServiceDisabled);
             }
 
-            if (count > RedoStack.Count || count <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, RedoStack.Count);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(count);
 
             if (State != UndoState.Normal)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewAutomationPeer.cs
@@ -203,14 +203,10 @@ namespace System.Windows.Automation.Peers
         /// </summary>
         IRawElementProviderSimple IGridProvider.GetItem(int row, int column)
         {
-            if (row < 0 || row >= ((IGridProvider)this).RowCount)
-            {
-                throw new ArgumentOutOfRangeException("row");
-            }
-            if (column < 0 || column >= ((IGridProvider)this).ColumnCount)
-            {
-                throw new ArgumentOutOfRangeException("column");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(row);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(row, ((IGridProvider)this).RowCount);
+            ArgumentOutOfRangeException.ThrowIfNegative(column);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(column, ((IGridProvider)this).ColumnCount);
 
             ListViewItem lvi = _listview.ItemContainerGenerator.ContainerFromIndex(row) as ListViewItem;
             //If item is virtualized, try to de-virtualize it

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/RangeBaseAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/RangeBaseAutomationPeer.cs
@@ -64,10 +64,8 @@ namespace System.Windows.Automation.Peers
         virtual internal void SetValueCore(double val)
         {
             RangeBase owner = (RangeBase)Owner;
-            if (val < owner.Minimum || val > owner.Maximum)
-            {
-                throw new ArgumentOutOfRangeException("val");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(val, owner.Minimum);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(val, owner.Maximum);
 
             owner.Value = (double)val;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/TableAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/TableAutomationPeer.cs
@@ -125,14 +125,10 @@ namespace System.Windows.Automation.Peers
         /// </summary>
         IRawElementProviderSimple IGridProvider.GetItem(int row, int column)
         {
-            if (row < 0 || row >= ((IGridProvider)this).RowCount)
-            {
-                throw new ArgumentOutOfRangeException("row");
-            }
-            if (column < 0 || column >= ((IGridProvider)this).ColumnCount)
-            {
-                throw new ArgumentOutOfRangeException("column");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(row);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(row, ((IGridProvider)this).RowCount);
+            ArgumentOutOfRangeException.ThrowIfNegative(column);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(column, ((IGridProvider)this).ColumnCount);
 
             int currentRow = 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
@@ -2150,10 +2150,8 @@ namespace System.Windows.Controls
                 return;
             }
 
-            if (index < 0 || index >= parentDataGrid.Columns.Count)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, parentDataGrid.Columns.Count);
 
             // if the column widths aren't known, try again when they are
             if (parentDataGrid.InternalColumns.ColumnWidthsComputationPending)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/GridViewColumnCollection.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;   // ObservableCollection<T>
 using System.Collections.Specialized;   // NotifyCollectionChangedEventHandler
 using System.ComponentModel;            // DesignerSerializationVisibility
 using System.Diagnostics;               // Debug
+using System.Runtime.CompilerServices;
 using System.Windows.Data;              // Binding.IndexerName
 
 using MS.Internal;                      // Helper
@@ -242,8 +243,8 @@ namespace System.Windows.Controls
         {
             Debug.Assert(oldIndex != newIndex, "oldIndex==newIndex when perform move action.");
 
-            VerifyIndexInRange(oldIndex, "oldIndex");
-            VerifyIndexInRange(newIndex, "newIndex");
+            VerifyIndexInRange(oldIndex);
+            VerifyIndexInRange(newIndex);
 
             int actualIndex = _actualIndices[oldIndex];
 
@@ -292,7 +293,7 @@ namespace System.Windows.Controls
 
         private GridViewColumnCollectionChangedEventArgs RemoveAtPreprocess(int index)
         {
-            VerifyIndexInRange(index, "index");
+            VerifyIndexInRange(index);
 
             int actualIndex = _actualIndices[index];
             GridViewColumn column = _columns[actualIndex];
@@ -352,10 +353,8 @@ namespace System.Windows.Controls
         private GridViewColumnCollectionChangedEventArgs InsertPreprocess(int index, GridViewColumn column)
         {
             int count = _columns.Count;
-            if (index < 0 || index > count)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, count);
 
             ValidateColumnForInsert(column);
 
@@ -400,7 +399,7 @@ namespace System.Windows.Controls
         // This[index] = newColumn
         private GridViewColumnCollectionChangedEventArgs SetPreprocess(int index, GridViewColumn newColumn)
         {
-            VerifyIndexInRange(index, "index");
+            VerifyIndexInRange(index);
 
             GridViewColumn oldColumn = this[index];
 
@@ -420,12 +419,10 @@ namespace System.Windows.Controls
             return null;
         }
 
-        private void VerifyIndexInRange(int index, string indexName)
+        private void VerifyIndexInRange(int index, [CallerArgumentExpression(nameof(index))] string indexName = null)
         {
-            if (index < 0 || index >= _actualIndices.Count)
-            {
-                throw new ArgumentOutOfRangeException(indexName);
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index, indexName);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _actualIndices.Count, indexName);
         }
 
         // Throw if column is null or already existed in a GVCC

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemCollection.cs
@@ -532,8 +532,8 @@ namespace System.Windows.Controls
             {
                 CheckIsUsingInnerView();
 
-                if (index < 0 || index >= _internalView.Count)
-                    throw new ArgumentOutOfRangeException("index");
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _internalView.Count);
 
                 _internalView[index] = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MultipleCopiesCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/MultipleCopiesCollection.cs
@@ -282,15 +282,11 @@ namespace System.Windows.Controls
         {
             get
             {
-                if ((index >= 0) && (index < RepeatCount))
-                {
-                    Debug.Assert(_item != null, "_item should be non-null.");
-                    return _item;
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("index");
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, RepeatCount);
+
+                Debug.Assert(_item != null, "_item should be non-null.");
+                return _item;
             }
 
             set

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextBox.cs
@@ -235,10 +235,8 @@ namespace System.Windows.Controls
                 return -1;
             }
 
-            if (lineIndex < 0 || lineIndex >= LineCount)
-            {
-                throw new ArgumentOutOfRangeException("lineIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, LineCount);
 
             TextPointer textPointer = GetStartPositionOfLine(lineIndex);
 
@@ -261,10 +259,8 @@ namespace System.Windows.Controls
                 return -1;
             }
 
-            if (charIndex < 0 || charIndex > this.TextContainer.SymbolCount)
-            {
-                throw new ArgumentOutOfRangeException("charIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(charIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(charIndex, this.TextContainer.SymbolCount);
 
             int line;
             TextPointer position = this.TextContainer.CreatePointerAtOffset(charIndex, LogicalDirection.Forward);
@@ -294,10 +290,8 @@ namespace System.Windows.Controls
                 return -1;
             }
 
-            if (lineIndex < 0 || lineIndex >= LineCount)
-            {
-                throw new ArgumentOutOfRangeException("lineIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, LineCount);
 
             TextPointer textPointerStart = GetStartPositionOfLine(lineIndex);
             TextPointer textPointerEnd = GetEndPositionOfLine(lineIndex);
@@ -372,10 +366,8 @@ namespace System.Windows.Controls
                 return;
             }
 
-            if (lineIndex < 0 || lineIndex >= LineCount)
-            {
-                throw new ArgumentOutOfRangeException("lineIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, LineCount);
 
             TextPointer textPointer = GetStartPositionOfLine(lineIndex);
             Rect rect;
@@ -402,10 +394,8 @@ namespace System.Windows.Controls
                 return null; // sentinel value
             }
 
-            if (lineIndex < 0 || lineIndex >= LineCount)
-            {
-                throw new ArgumentOutOfRangeException("lineIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(lineIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(lineIndex, LineCount);
 
             startOfLine = GetStartPositionOfLine(lineIndex);
             endOfLine = GetEndPositionOfLine(lineIndex);
@@ -441,10 +431,8 @@ namespace System.Windows.Controls
         /// <returns>leading or trailing edge rectangle of the given character, or Rect.Empty if no layout information is available.</returns>
         public Rect GetRectFromCharacterIndex(int charIndex, bool trailingEdge)
         {
-            if (charIndex < 0 || charIndex > this.TextContainer.SymbolCount)
-            {
-                throw new ArgumentOutOfRangeException("charIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(charIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(charIndex, this.TextContainer.SymbolCount);
 
             // Start by moving to an insertion position in backward direction.
             // This ensures that when the character at charIndex is part of a surrogate pair or multi-byte character,
@@ -487,10 +475,8 @@ namespace System.Windows.Controls
         /// </remarks>
         public SpellingError GetSpellingError(int charIndex)
         {
-            if (charIndex < 0 || charIndex > this.TextContainer.SymbolCount)
-            {
-                throw new ArgumentOutOfRangeException("charIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(charIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(charIndex, this.TextContainer.SymbolCount);
 
             TextPointer position = this.TextContainer.CreatePointerAtOffset(charIndex, LogicalDirection.Forward);
             SpellingError spellingError = this.TextEditor.GetSpellingErrorAtPosition(position, LogicalDirection.Forward);
@@ -560,10 +546,8 @@ namespace System.Windows.Controls
         /// </remarks>
         public int GetNextSpellingErrorCharacterIndex(int charIndex, LogicalDirection direction)
         {
-            if (charIndex < 0 || charIndex > this.TextContainer.SymbolCount)
-            {
-                throw new ArgumentOutOfRangeException("charIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(charIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(charIndex, this.TextContainer.SymbolCount);
 
             if (this.TextContainer.SymbolCount == 0)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizedCellInfoCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizedCellInfoCollection.cs
@@ -383,12 +383,10 @@ namespace System.Windows.Controls
         {
             get
             {
-                if ((index >= 0) && (index < Count))
-                {
-                    return GetCellInfoFromIndex(_owner, _regions, index);
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
-                throw new ArgumentOutOfRangeException("index");
+                return GetCellInfoFromIndex(_owner, _regions, index);
             }
 
             set

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -1693,8 +1693,8 @@ namespace System.Windows.Controls
         /// <param name="itemIndex">index into the children of this panel</param>
         private void BringContainerIntoView(ItemsControl itemsControl, int itemIndex)
         {
-            if (itemIndex < 0 || itemIndex >= ItemCount)
-                throw new ArgumentOutOfRangeException("itemIndex");
+            ArgumentOutOfRangeException.ThrowIfNegative(itemIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, ItemCount);
 
             UIElement child;
             IItemContainerGenerator generator = Generator;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/BindingListCollectionView.cs
@@ -106,8 +106,8 @@ namespace System.Windows.Data
         {
             VerifyRefreshNotDeferred();
 
-            if (position < -1 || position > InternalCount)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, -1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(position, InternalCount);
 
             _MoveTo(position);
             return IsCurrentInView;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/CollectionView.cs
@@ -545,8 +545,8 @@ namespace System.Windows.Data
         {
             VerifyRefreshNotDeferred();
 
-            if (position < -1 || position > Count)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, -1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(position, Count);
 
             // ignore request to move onto the placeholder
             IEditableCollectionView ecv = this as IEditableCollectionView;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Data/ListCollectionView.cs
@@ -199,8 +199,8 @@ namespace System.Windows.Data
         {
             VerifyRefreshNotDeferred();
 
-            if (position < -1 || position > InternalCount)
-                throw new ArgumentOutOfRangeException("position");
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, -1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(position, InternalCount);
 
 
             if (position != CurrentPosition || !IsCurrentInSync)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/FigureLength.cs
@@ -120,17 +120,19 @@ namespace System.Windows
             {
                 throw new ArgumentException(SR.Format(SR.InvalidCtorParameterUnknownFigureUnitType, "type"));
             }
-            if(value > 1.0 && (type == FigureUnitType.Content || type == FigureUnitType.Page))
+            if (type is FigureUnitType.Content or FigureUnitType.Page)
             {
-                throw new ArgumentOutOfRangeException("value");
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 1.0);
             }
-            if (value > maxColumns && type == FigureUnitType.Column)
+
+            if (type == FigureUnitType.Column)
             {
-                throw new ArgumentOutOfRangeException("value");
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxColumns);
             }
-            if (value > maxPixel && type == FigureUnitType.Pixel)
+
+            if (type == FigureUnitType.Pixel)
             {
-                throw new ArgumentOutOfRangeException("value");
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, maxPixel);
             }
 
             _unitValue = (type == FigureUnitType.Auto) ? 0.0 : value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/SharedStream.cs
@@ -166,15 +166,9 @@ namespace System.Windows.Baml2006
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            if (offset < 0 || offset >= buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
-
-            if ((offset + count) > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(offset, buffer.Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, buffer.Length - count);
 
             CheckDisposed();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlStream.cs
@@ -184,20 +184,14 @@ namespace System.Windows.Markup
         /// <param name="position">Absolute position in the stream</param>
         internal void UpdateReaderLength(long position)
         {
-            if(!(ReadLength <= position))
-            {
-                throw new ArgumentOutOfRangeException( "position" );
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(position, ReadLength);
 #if DEBUG
             Debug.Assert(!WriteComplete,"UpdateReaderLength called after close");
 #endif
 
             ReadLength = position;
 
-            if(!(ReadLength <= WriteLength))
-            {
-                throw new ArgumentOutOfRangeException( "position" );
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(position, WriteLength);
 
             // safe for them to check and remove unused buffers.
             CheckIfCanRemoveFromArrayList(position,WriterBufferArrayList,
@@ -228,10 +222,7 @@ namespace System.Windows.Markup
         /// <returns></returns>
         internal int Read(byte[] buffer, int offset, int count)
         {
-            if(!(count  + ReadPosition <= ReadLength))
-            {
-                throw new ArgumentOutOfRangeException( "count" );
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, ReadLength - ReadPosition);
             int bufferOffset;
             int bufferIndex;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/KeyFrames.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Media/Animation/Generated/KeyFrames.cs
@@ -140,11 +140,8 @@ namespace System.Windows.Media.Animation
             Thickness baseValue, 
             double keyFrameProgress)
         {
-            if (   keyFrameProgress < 0.0
-                || keyFrameProgress > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("keyFrameProgress");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(keyFrameProgress);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(keyFrameProgress, 1.0);
 
             return InterpolateValueCore(baseValue, keyFrameProgress);
         }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PTConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PTConverter.cs
@@ -80,11 +80,8 @@ namespace System.Printing.Interop
             ArgumentNullException.ThrowIfNull(deviceName);
 
             // Check if we can support the schema version client has requested
-            if ((clientPrintSchemaVersion > MaxPrintSchemaVersion) ||
-                (clientPrintSchemaVersion <= 0))
-            {
-                throw new ArgumentOutOfRangeException(nameof(clientPrintSchemaVersion));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(clientPrintSchemaVersion, MaxPrintSchemaVersion);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(clientPrintSchemaVersion);
 
             // Instantiate the provider object this converter instance will use.
             // PTProvider constructor throws exception if it fails for any reason.

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PTManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PTManager.cs
@@ -216,11 +216,8 @@ namespace System.Printing
             ArgumentNullException.ThrowIfNull(deviceName);
 
             // Check if we can support the schema version client has requested
-            if ((clientPrintSchemaVersion > MaxPrintSchemaVersion) ||
-                (clientPrintSchemaVersion <= 0))
-            {
-                throw new ArgumentOutOfRangeException("clientPrintSchemaVersion");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(clientPrintSchemaVersion);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(clientPrintSchemaVersion, MaxPrintSchemaVersion);
 
             // Instantiate a new PTProvider instance. PTProvider constructor throws exception if it fails for any reason.
             _ptProvider = PTProviderBase.Create(deviceName,

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -332,8 +332,8 @@ namespace MS.Internal.IO.Packaging
         internal static Stream CreateUserScopedIsolatedStorageFileStreamWithRandomName(int retryCount, out String fileName)
         {
             // negative is illegal and place an upper limit of 100
-            if (retryCount < 0 || retryCount > 100)
-                throw new ArgumentOutOfRangeException("retryCount");
+            ArgumentOutOfRangeException.ThrowIfNegative(retryCount);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(retryCount, 100);
 
             Stream s = null;
             fileName = null;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Ink/BitStream.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Ink/BitStream.cs
@@ -45,10 +45,9 @@ namespace MS.Internal.Ink
         {
             Debug.Assert(buffer != null);
 
-            if (startIndex < 0 || startIndex >= buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException("startIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startIndex, buffer.Length);
+
             _byteArray = buffer;
             _byteArrayIndex = startIndex;
             _bufferLengthInBits = (uint)(buffer.Length - startIndex) * (uint)Native.BitsPerByte;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SequentialUshortCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SequentialUshortCollection.cs
@@ -63,10 +63,9 @@ namespace MS.Internal
             // The extra "arrayIndex >= array.Length" check in because even if _collection.Count
             // is 0 the index is not allowed to be equal or greater than the length
             // (from the MSDN ICollection docs)
-            if (arrayIndex < 0 || arrayIndex >= array.Length || (arrayIndex + Count) > array.Length)
-            {
-                throw new ArgumentOutOfRangeException("arrayIndex");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(arrayIndex, array.Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length - Count);
 
             for (ushort i = 0; i < _count; ++i)
                 array[arrayIndex + i] = i;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -308,15 +308,10 @@ namespace MS.Utility
         public override void RemoveAt(int index)
         {
             // Wipe out the info at index
-            if (0 == index)
-            {
-                _loneEntry = default(T);
-                --_count;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(index, 0);
+
+            _loneEntry = default(T);
+            --_count;
         }
 
         public override T EntryAt(int index)
@@ -366,14 +361,10 @@ namespace MS.Utility
 
         private void SetCount(int value)
         {
-            if ((value >= 0) && (value <= SIZE))
-            {
-                _count = value;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, SIZE);
+
+            _count = value;
         }
 
         private const int SIZE = 1;
@@ -692,14 +683,10 @@ namespace MS.Utility
 
         private void SetCount(int value)
         {
-            if ((value >= 0) && (value <= SIZE))
-            {
-                _count = value;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, SIZE);
+
+            _count = value;
         }
 
         private const int SIZE = 3;
@@ -1255,14 +1242,10 @@ namespace MS.Utility
 
         private void SetCount(int value)
         {
-            if ((value >= 0) && (value <= SIZE))
-            {
-                _count = value;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, SIZE);
+
+            _count = value;
         }
 
         private const int SIZE = 6;
@@ -1509,14 +1492,10 @@ namespace MS.Utility
 
         private void SetCount(int value)
         {
-            if ((value >= 0) && (value <= _entries.Length))
-            {
-                _count = value;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, _entries.Length);
+
+            _count = value;
         }
 
         // MINSIZE and GROWTH chosen to minimize memory footprint
@@ -1860,25 +1839,22 @@ namespace MS.Utility
 
         public void EnsureIndex(int index)
         {
-            if (index >= 0)
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+            int delta = (index + 1) - Count;
+            if (delta > 0)
             {
-                int delta = (index + 1) - Count;
-                if (delta > 0)
+                // Grow the store
+                Capacity = index + 1;
+
+                T filler = default(T);
+
+                // Insert filler structs or objects
+                for (int i = 0; i < delta; ++i)
                 {
-                    // Grow the store
-                    Capacity = index + 1;
-
-                    T filler = default(T);
-
-                    // Insert filler structs or objects
-                    for (int i = 0; i < delta; ++i)
-                    {
-                        _listStore.Add(filler);
-                    }
+                    _listStore.Add(filler);
                 }
-                return;
             }
-            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public T[] ToArray()
@@ -2238,25 +2214,22 @@ namespace MS.Utility
 
         public void EnsureIndex(int index)
         {
-            if (index >= 0)
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+            int delta = (index + 1) - Count;
+            if (delta > 0)
             {
-                int delta = (index + 1) - Count;
-                if (delta > 0)
+                // Grow the store
+                Capacity = index + 1;
+
+                T filler = default(T);
+
+                // Insert filler structs or objects
+                for (int i = 0; i < delta; ++i)
                 {
-                    // Grow the store
-                    Capacity = index + 1;
-
-                    T filler = default(T);
-
-                    // Insert filler structs or objects
-                    for (int i = 0; i < delta; ++i)
-                    {
-                        _listStore.Add(filler);
-                    }
+                    _listStore.Add(filler);
                 }
-                return;
             }
-            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         public T[] ToArray()

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeaderItemsControl.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonTabHeaderItemsControl.cs
@@ -131,10 +131,8 @@ namespace Microsoft.Windows.Controls.Ribbon
         /// <param name="index"></param>
         internal void ScrollIntoView(int index)
         {
-            if (index < 0 || index >= Items.Count)
-            {
-                throw new ArgumentOutOfRangeException("index");
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
 
             if (ItemContainerGenerator.Status == GeneratorStatus.ContainersGenerated)
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/Misc.cs
@@ -185,15 +185,6 @@ namespace MS.Internal.Automation
             }
         }
 
-        // Check that specified condition is true; if not, throw exception
-        internal static void ValidateArgumentInRange(bool cond, string argName)
-        {
-            if (!cond)
-            {
-                throw new ArgumentOutOfRangeException(argName);
-            }
-        }
-
         // Called by the patterns before accessing .Cache
         internal static void ValidateCached(bool cached)
         {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Text/TextRange.cs
@@ -290,7 +290,7 @@ namespace System.Windows.Automation.Text
         /// <returns>The text of the range possibly truncated to the specified limit.</returns>
         public string GetText(int maxLength)
         {
-            Misc.ValidateArgumentInRange(maxLength >= -1, "maxLength");
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxLength, -1);
             return UiaCoreApi.TextRange_GetText(_hTextRange, maxLength);
         }
 


### PR DESCRIPTION
Follow-up to #8403

## Description

Another step towards using ArgumentOutOfRangeException.ThrowIf* across codebase. This PR addresses the cases not solved by CA1512.
This PR also removes the internal helper `Misc.ValidateArgumentInRange` in `UIAutomationClient`

## Customer Impact

Potentially slightly better perf and better error messages

## Regression

No

## Testing

CI

## Risk

Low. For the most part, we use the IDE to break down if clauses into multiple parts or invert them, then apply CA1512

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8464)