### PR TITLE
chore: Standardize digit representation in FullValueSource by updating IsCoercedWithCurrentValue initialization

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/EffectiveValueEntry.cs
@@ -603,7 +603,7 @@ namespace System.Windows
         IsCoerced           = 0x0040,
         IsPotentiallyADeferredReference = 0x0080,
         HasExpressionMarker = 0x0100,
-        IsCoercedWithCurrentValue = 0x200,
+        IsCoercedWithCurrentValue = 0x0200,
     }
 
     // Note that these enum values are arranged in the reverse order of


### PR DESCRIPTION
## Description

In this PR, I have updated the initialization of `IsCoercedWithCurrentValue` in `FullValueSource` to use a 4-digit representation. This change does not alter any code behavior and is purely for the sake of code consistency. 

Previously, all other member definitions in `FullValueSource` were using a 4-digit representation, with `IsCoercedWithCurrentValue` being the only exception with a 3-digit representation. I have made this change to unify the digit representation across all members in `FullValueSource` to 4 digits.


## Customer Impact

None.

## Regression

None.

## Testing

None.

## Risk

None. I do not change any of the code behavior.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8471)