### PR TITLE
GetPattern Null check supporting columns without Datagridowner

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
@@ -255,7 +255,7 @@ namespace System.Windows.Automation.Peers
             switch (patternInterface)
             {
                 case PatternInterface.Invoke:
-                    if (this.OwningDataGrid!=null && !this.OwningDataGrid.IsReadOnly && !_column.IsReadOnly)
+                    if (this.OwningDataGrid != null && !this.OwningDataGrid.IsReadOnly && !_column.IsReadOnly)
                     {
                         return this;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/DataGridCellItemAutomationPeer.cs
@@ -255,7 +255,7 @@ namespace System.Windows.Automation.Peers
             switch (patternInterface)
             {
                 case PatternInterface.Invoke:
-                    if (!this.OwningDataGrid.IsReadOnly && !_column.IsReadOnly)
+                    if (this.OwningDataGrid!=null && !this.OwningDataGrid.IsReadOnly && !_column.IsReadOnly)
                     {
                         return this;
                     }


### PR DESCRIPTION
Fixes #8476 

## Description
Lack of null check in `DataGridCellAutomationPeer` causes a `NullReferenceException` referencing to `column.DataGridOwner` property. Adding the null check to avoid the same.

## Customer Impact
Crashing applications where `DataGridOwner` of a column is not set.

## Regression
_None_

## Testing
Local build pass and verified that the sample application no longer throws the said exception.

## Risk
_Low_


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8477)