### PR TITLE
Adding a Null check for data in SetData function

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -339,6 +339,8 @@ namespace System.Windows
         {
             ArgumentNullException.ThrowIfNull(format);
 
+            ArgumentNullException.ThrowIfNull(data);
+
             if (format == string.Empty)
             {
                 throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -331,20 +331,17 @@ namespace System.Windows
         /// to specify whether the
         /// data can be converted to another format.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(UIPermissionClipboard.AllClipboard) to call this API.
-        /// </remarks>
         [FriendAccessAllowed]
         public void SetData(string format, Object data, bool autoConvert)
         {
             ArgumentNullException.ThrowIfNull(format);
 
-            ArgumentNullException.ThrowIfNull(data);
-
             if (format == string.Empty)
             {
                 throw new ArgumentException(SR.DataObject_EmptyFormatNotAllowed);
             }
+
+            ArgumentNullException.ThrowIfNull(data);
 
             _innerData.SetData(format, data, autoConvert);
         }


### PR DESCRIPTION
## Description
Adding a Null check for Data in ```SetData``` function of ```DataObject ``` class. 
A null check has been overlooked within one of the ```SetData``` functions. Even when we use the constructor to set the data with the same attributes, it still verifies whether the data is null or not.

## Regression

None 


## Testing

Build and local testing passed.

## Risk

Low
It may cause few applications to crash with Null exception, if we try to drag and drop a null object.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8478)