### PR TITLE
More uses of ArgumentOutOfRangeException.ThrowIf* to replace custom error messages

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -482,28 +482,17 @@ namespace MS.Internal.TextFormatting
             if (double.IsInfinity(paragraphWidth))
                 throw new ArgumentOutOfRangeException("paragraphWidth", SR.ParameterValueCannotBeInfinity);
 
-            if (    paragraphWidth < 0
-                || paragraphWidth > Constants.RealInfiniteWidth)
-            {
-                throw new ArgumentOutOfRangeException("paragraphWidth", SR.Format(SR.ParameterMustBeBetween, 0, Constants.RealInfiniteWidth));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(paragraphWidth);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphWidth, Constants.RealInfiniteWidth);
 
             double realMaxFontRenderingEmSize = Constants.RealInfiniteWidth / Constants.GreatestMutiplierOfEm;
 
-            if (    paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize < 0
-                ||  paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize > realMaxFontRenderingEmSize)
-            {
-                throw new ArgumentOutOfRangeException("paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize", SR.Format(SR.ParameterMustBeBetween, 0, realMaxFontRenderingEmSize));
-            }
-
+            ArgumentOutOfRangeException.ThrowIfNegative(paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize, "paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize");
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize, realMaxFontRenderingEmSize, "paragraphProperties.DefaultTextRunProperties.FontRenderingEmSize");
             ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.Indent, Constants.RealInfiniteWidth, "paragraphProperties.Indent");
             ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.LineHeight, Constants.RealInfiniteWidth, "paragraphProperties.LineHeight");
-
-            if (   paragraphProperties.DefaultIncrementalTab < 0
-                || paragraphProperties.DefaultIncrementalTab > Constants.RealInfiniteWidth)
-            {
-                throw new ArgumentOutOfRangeException("paragraphProperties.DefaultIncrementalTab", SR.Format(SR.ParameterMustBeBetween, 0, Constants.RealInfiniteWidth));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(paragraphProperties.DefaultIncrementalTab, "paragraphProperties.DefaultIncrementalTab");
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphProperties.DefaultIncrementalTab, Constants.RealInfiniteWidth, "paragraphProperties.DefaultIncrementalTab");
         }
 
 
@@ -516,11 +505,8 @@ namespace MS.Internal.TextFormatting
             int             cchLength
             )
         {
-            if (    characterHit.FirstCharacterIndex < cpFirst
-                ||  characterHit.FirstCharacterIndex > cpFirst + cchLength)
-            {
-                throw new ArgumentOutOfRangeException("cpFirst", SR.Format(SR.ParameterMustBeBetween, cpFirst, cpFirst + cchLength));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(cpFirst, characterHit.FirstCharacterIndex);
+            ArgumentOutOfRangeException.ThrowIfLessThan(cpFirst, characterHit.FirstCharacterIndex - cchLength);
 
             ArgumentOutOfRangeException.ThrowIfNegative(characterHit.TrailingLength, nameof(cchLength));
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -478,11 +478,8 @@ namespace MS.Internal.TextFormatting
                 throw new ArgumentNullException("paragraphProperties.DefaultTextRunProperties.Typeface");
 
             ArgumentOutOfRangeException.ThrowIfEqual(paragraphWidth, double.NaN);
-
-            if (double.IsInfinity(paragraphWidth))
-                throw new ArgumentOutOfRangeException("paragraphWidth", SR.ParameterValueCannotBeInfinity);
-
             ArgumentOutOfRangeException.ThrowIfNegative(paragraphWidth);
+            ArgumentOutOfRangeException.ThrowIfEqual(paragraphWidth, double.PositiveInfinity);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(paragraphWidth, Constants.RealInfiniteWidth);
 
             double realMaxFontRenderingEmSize = Constants.RealInfiniteWidth / Constants.GreatestMutiplierOfEm;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/TextFormatterImp.cs
@@ -477,8 +477,7 @@ namespace MS.Internal.TextFormatting
             if (paragraphProperties.DefaultTextRunProperties.Typeface == null)
                 throw new ArgumentNullException("paragraphProperties.DefaultTextRunProperties.Typeface");
 
-            if (double.IsNaN(paragraphWidth))
-                throw new ArgumentOutOfRangeException("paragraphWidth", SR.ParameterValueCannotBeNaN);
+            ArgumentOutOfRangeException.ThrowIfEqual(paragraphWidth, double.NaN);
 
             if (double.IsInfinity(paragraphWidth))
                 throw new ArgumentOutOfRangeException("paragraphWidth", SR.ParameterValueCannotBeInfinity);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
@@ -15,7 +15,6 @@ UsesPerPixelOpacityIsObsolete=UsesPerPixelOpacity is obsolete and should not be 
 ParameterMustBeGreaterThanZero=The parameter value must be greater than zero.
 ParameterCannotBeLessThan=The parameter value cannot be less than '{0}'.
 ParameterCannotBeGreaterThan=The parameter value cannot be greater than '{0}'.
-ParameterValueCannotBeInfinity=The parameter value must be finite.
 ParameterValueCannotBeNegative='{0}' parameter value cannot be negative.
 
 ; General

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
@@ -11,12 +11,6 @@ HwndSourceDisposed=Cannot access a disposed HwndSource.
 NullHwnd=Hwnd of zero is not valid.
 UsesPerPixelOpacityIsObsolete=UsesPerPixelOpacity is obsolete and should not be set when using UsesPerPixelTransparency
 
-;ParameterValidation
-ParameterMustBeGreaterThanZero=The parameter value must be greater than zero.
-ParameterCannotBeLessThan=The parameter value cannot be less than '{0}'.
-ParameterCannotBeGreaterThan=The parameter value cannot be greater than '{0}'.
-ParameterValueCannotBeNegative='{0}' parameter value cannot be negative.
-
 ; General
 General_BadType=The object passed to '{0}' is not a valid type.
 General_Expected_Type=Expected object of type '{0}'.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/ExceptionStringTable.txt
@@ -15,7 +15,6 @@ UsesPerPixelOpacityIsObsolete=UsesPerPixelOpacity is obsolete and should not be 
 ParameterMustBeGreaterThanZero=The parameter value must be greater than zero.
 ParameterCannotBeLessThan=The parameter value cannot be less than '{0}'.
 ParameterCannotBeGreaterThan=The parameter value cannot be greater than '{0}'.
-ParameterMustBeBetween=The parameter value must be between '{0}' and '{1}'.
 ParameterValueCannotBeInfinity=The parameter value must be finite.
 ParameterValueCannotBeNegative='{0}' parameter value cannot be negative.
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1822,9 +1822,6 @@
   <data name="PaginatorNegativePageNumber" xml:space="preserve">
     <value>Page number cannot be negative.</value>
   </data>
-  <data name="ParameterMustBeBetween" xml:space="preserve">
-    <value>The parameter value must be between '{0}' and '{1}'.</value>
-  </data>
   <data name="ParameterValueCannotBeInfinity" xml:space="preserve">
     <value>The parameter value must be finite.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1828,9 +1828,6 @@
   <data name="ParameterValueCannotBeInfinity" xml:space="preserve">
     <value>The parameter value must be finite.</value>
   </data>
-  <data name="ParameterValueCannotBeNaN" xml:space="preserve">
-    <value>The parameter value must be a number.</value>
-  </data>
   <data name="Parsers_IllegalToken" xml:space="preserve">
     <value>Token is not valid.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1822,9 +1822,6 @@
   <data name="PaginatorNegativePageNumber" xml:space="preserve">
     <value>Page number cannot be negative.</value>
   </data>
-  <data name="ParameterValueCannotBeInfinity" xml:space="preserve">
-    <value>The parameter value must be finite.</value>
-  </data>
   <data name="Parsers_IllegalToken" xml:space="preserve">
     <value>Token is not valid.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Číslo stránky nemůže být záporné.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Hodnota tohoto parametru nesmí být nekonečno.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Hodnota tohoto parametru nesmí být nekonečno.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Hodnota tohoto parametru musí být číslo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Nalezena nesprávná forma {0} při analýze řetězce {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Číslo stránky nemůže být záporné.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Hodnota tohoto parametru nesmí být nekonečno.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Nalezena nesprávná forma {0} při analýze řetězce {1}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Die Seitenzahl kann nicht negativ sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Der Parameterwert muss endlich sein.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Der Parameterwert muss endlich sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Der Parameterwert muss eine Zahl sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Beim Analysieren der Zeichenfolge "{1}" wurde die ungültige Form "{0}" gefunden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Die Seitenzahl kann nicht negativ sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Der Parameterwert muss endlich sein.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Beim Analysieren der Zeichenfolge "{1}" wurde die ungültige Form "{0}" gefunden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">El número de página no puede ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">El valor del parámetro debe ser finito.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Se encontró un formato incorrecto "{0}" al analizar la cadena "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">El valor del parámetro debe ser finito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">El valor del parámetro debe ser un número.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Se encontró un formato incorrecto "{0}" al analizar la cadena "{1}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">El número de página no puede ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">El valor del parámetro debe ser finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Le numéro de page ne peut pas être négatif.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">La valeur du paramètre doit être finie.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Le numéro de page ne peut pas être négatif.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">La valeur du paramètre doit être finie.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forme '{0}' incorrecte trouvée durant l'analyse de la chaîne '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">La valeur du paramètre doit être finie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">La valeur du paramètre doit être numérique.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forme '{0}' incorrecte trouvée durant l'analyse de la chaîne '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Il valore del parametro deve essere finito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Il valore del parametro deve essere un numero.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">È stato trovato un formato non corretto '{0}' durante l'analisi della stringa '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Il numero di pagina non può essere negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Il valore del parametro deve essere finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Il numero di pagina non può essere negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Il valore del parametro deve essere finito.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">È stato trovato un formato non corretto '{0}' durante l'analisi della stringa '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">ページ番号は負の数にできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">パラメーター値は、有限である必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 文字列の解析中に無効なフォーム '{0}' が見つかりました。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">パラメーター値は、有限である必要があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">パラメーター値は、数値である必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 文字列の解析中に無効なフォーム '{0}' が見つかりました。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">ページ番号は負の数にできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">パラメーター値は、有限である必要があります。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">페이지 번호는 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">매개 변수는 유한한 값이어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">매개 변수는 유한한 값이어야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">매개 변수 값은 숫자여야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 문자열을 구문 분석하는 동안 잘못된 '{0}' 형식이 검색되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">페이지 번호는 음수일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">매개 변수는 유한한 값이어야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' 문자열을 구문 분석하는 동안 잘못된 '{0}' 형식이 검색되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Numer strony nie może być ujemny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Wartość parametru musi być skończona.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Wartość parametru musi być skończona.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Wartość parametru musi być liczbą.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Znaleziono nieprawidłową formę „{0}” podczas analizy ciągu „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Numer strony nie może być ujemny.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Wartość parametru musi być skończona.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Znaleziono nieprawidłową formę „{0}” podczas analizy ciągu „{1}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">O número da página não pode ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">O valor do parâmetro deve ser finito.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">O valor do parâmetro deve ser finito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">O valor do parâmetro deve ser um número.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forma incorreta de '{0}' encontrada na análise da cadeia de caracteres '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">O número da página não pode ser negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">O valor do parâmetro deve ser finito.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">Forma incorreta de '{0}' encontrada na análise da cadeia de caracteres '{1}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Номер страницы не может быть отрицательным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Значение параметра должно быть конечным.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">При синтаксическом анализе строки "{1}" обнаружена неправильная форма "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Значение параметра должно быть конечным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Значение параметра должно быть числом.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">При синтаксическом анализе строки "{1}" обнаружена неправильная форма "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Номер страницы не может быть отрицательным.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Значение параметра должно быть конечным.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">Parametre değeri sonlu olmalıdır.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">Parametre değeri bir sayı olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' dizesi ayrıştırılırken yanlış '{0}' biçimi bulundu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Sayfa numarası negatif olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">Parametre değeri sonlu olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">Sayfa numarası negatif olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">Parametre değeri sonlu olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">'{1}' dizesi ayrıştırılırken yanlış '{0}' biçimi bulundu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">页码不能为负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">参数值必须有限。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">解析“{1}”字符串时发现格式“{0}”错误。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">参数值必须有限。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">参数值必须是一个数。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">解析“{1}”字符串时发现格式“{0}”错误。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">页码不能为负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">参数值必须有限。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">頁碼不能為負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParameterValueCannotBeInfinity">
         <source>The parameter value must be finite.</source>
         <target state="translated">參數值必須有限制。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2522,11 +2522,6 @@
         <target state="translated">頁碼不能為負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeInfinity">
-        <source>The parameter value must be finite.</source>
-        <target state="translated">參數值必須有限制。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">剖析 '{1}' 字串時發現不正確的格式 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2532,11 +2532,6 @@
         <target state="translated">參數值必須有限制。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterValueCannotBeNaN">
-        <source>The parameter value must be a number.</source>
-        <target state="translated">參數值必須是數字。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Parser_BadForm">
         <source>Incorrect form '{0}' found parsing '{1}' string.</source>
         <target state="translated">剖析 '{1}' 字串時發現不正確的格式 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FontStretch.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FontStretch.cs
@@ -43,8 +43,8 @@ namespace System.Windows
         // Important note: when changing this method signature please make sure to update FontStretchConverter accordingly.
         public static FontStretch FromOpenTypeStretch(int stretchValue)
         {
-            if (stretchValue < 1 || stretchValue > 9)
-                throw new ArgumentOutOfRangeException("stretchValue", SR.Format(SR.ParameterMustBeBetween, 1, 9));
+            ArgumentOutOfRangeException.ThrowIfLessThan(stretchValue, 1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(stretchValue, 9);
             return new FontStretch(stretchValue);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FontWeight.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/FontWeight.cs
@@ -41,8 +41,8 @@ namespace System.Windows
         // Important note: when changing this method signature please make sure to update FontWeightConverter accordingly.
         public static FontWeight FromOpenTypeWeight(int weightValue)
         {
-            if (weightValue < 1 || weightValue > 999)
-                throw new ArgumentOutOfRangeException("weightValue", SR.Format(SR.ParameterMustBeBetween, 1, 999));
+            ArgumentOutOfRangeException.ThrowIfLessThan(weightValue, 1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(weightValue, 999);
             return new FontWeight(weightValue);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FormattedText.cs
@@ -292,9 +292,7 @@ namespace System.Windows.Media
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(emSize);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(emSize, MaxFontEmSize);
-
-            if (double.IsNaN(emSize))
-                throw new ArgumentOutOfRangeException("emSize", SR.ParameterValueCannotBeNaN);
+            ArgumentOutOfRangeException.ThrowIfEqual(emSize, double.NaN);
         }
 
         private static void ValidateFlowDirection(FlowDirection flowDirection, string parameterName)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/GlyphRun.cs
@@ -453,9 +453,7 @@ namespace System.Windows.Media
             }
             else
             {
-                if (double.IsNaN(renderingEmSize))
-                    throw new ArgumentOutOfRangeException("renderingEmSize", SR.ParameterValueCannotBeNaN);
-
+                ArgumentOutOfRangeException.ThrowIfEqual(renderingEmSize, double.NaN);
                 ArgumentOutOfRangeException.ThrowIfNegative(renderingEmSize);
                 ArgumentNullException.ThrowIfNull(glyphTypeface);
                 ArgumentNullException.ThrowIfNull(glyphIndices);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/JpegBitmapEncoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/JpegBitmapEncoder.cs
@@ -63,10 +63,8 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 1) || (value > 100))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 1, 100));
-                }
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 100);
 
                 _qualityLevel = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WmpBitmapEncoder.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WmpBitmapEncoder.cs
@@ -63,12 +63,10 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0.0) || (value > 1.0))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0.0, 1.0));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 1);
 
-                _imagequalitylevel= value;
+                _imagequalitylevel = value;
             }
         }
 
@@ -227,10 +225,7 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 1) || (value > 255))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 1, 255));
-                }
+                ArgumentOutOfRangeException.ThrowIfZero(value);
 
                 _qualitylevel = value;
             }
@@ -248,10 +243,7 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 3))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 3));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 3);
 
                 _subsamplinglevel = value;
             }
@@ -269,10 +261,7 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 2))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 2));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 2);
 
                 _overlaplevel = value;
             }
@@ -290,10 +279,8 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 4096))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 4096));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 4096);
 
                 _horizontaltileslices = value;
             }
@@ -311,10 +298,8 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 4096))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 4096));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 4096);
 
                 _verticaltileslices = value;
             }
@@ -362,11 +347,6 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 255))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 255));
-                }
-
                 _alphaqualitylevel = value;
             }
         }
@@ -398,10 +378,7 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 3))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 3));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 3);
 
                 _imagedatadiscardlevel = value;
             }
@@ -419,10 +396,7 @@ namespace System.Windows.Media.Imaging
             }
             set
             {
-                if ((value < 0) || (value > 4))
-                {
-                    throw new System.ArgumentOutOfRangeException("value", SR.Format(SR.ParameterMustBeBetween, 0, 4));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 4);
 
                 _alphadatadiscardlevel = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -831,92 +831,28 @@ namespace System.Windows.Media.Imaging
             //
             // Sanitize the source rect and assure it will fit within the back buffer.
             //
-            Debug.Assert(!(backwardsCompat && (sourceRect.X < 0 || sourceRect.Y < 0)));
+            Debug.Assert(!(backwardsCompat && (sourceRect.X < 0 || sourceRect.Y < 0 || sourceRect.Width < 0 || sourceRect.Height < 0)));
             ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.X, nameof(sourceRect));
             ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.Y, nameof(sourceRect));
-
-            if (sourceRect.Width < 0)
-            {
-                Debug.Assert(!backwardsCompat);
-                throw new ArgumentOutOfRangeException("sourceRect", SR.Format(SR.ParameterMustBeBetween, 0, _pixelWidth));
-            }
-
-            if (sourceRect.Width > _pixelWidth)
-            {
-                if (backwardsCompat)
-                {
-                    HRESULT.Check(MS.Win32.NativeMethods.E_INVALIDARG);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("sourceRect", SR.Format(SR.ParameterMustBeBetween, 0, _pixelWidth));
-                }
-            }
-
-            if (sourceRect.Height < 0)
-            {
-                Debug.Assert(!backwardsCompat);
-                throw new ArgumentOutOfRangeException("sourceRect", SR.Format(SR.ParameterMustBeBetween, 0, _pixelHeight));
-            }
-
-            if (sourceRect.Height > _pixelHeight)
-            {
-                if (backwardsCompat)
-                {
-                    HRESULT.Check(MS.Win32.NativeMethods.E_INVALIDARG);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("sourceRect", SR.Format(SR.ParameterMustBeBetween, 0, _pixelHeight));
-                }
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.Width, nameof(sourceRect));
+            ArgumentOutOfRangeException.ThrowIfNegative(sourceRect.Height, nameof(sourceRect));
 
             if (!backwardsCompat)
             {
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceRect.Width, _pixelWidth, nameof(sourceRect));
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(sourceRect.Height, _pixelHeight, nameof(sourceRect));
                 ArgumentOutOfRangeException.ThrowIfNegative(destinationX);
+                ArgumentOutOfRangeException.ThrowIfNegative(destinationY);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(destinationX, _pixelWidth - sourceRect.Width);
+                ArgumentOutOfRangeException.ThrowIfGreaterThan(destinationY, _pixelHeight - sourceRect.Height);
             }
-            else
+            else if(sourceRect.Width > _pixelWidth || sourceRect.Height > _pixelHeight || destinationX > _pixelWidth - sourceRect.Width || destinationY > _pixelHeight - sourceRect.Height)
             {
-                if (destinationX < 0)
-                {
-                    HRESULT.Check((int)WinCodecErrors.WINCODEC_ERR_VALUEOVERFLOW);
-                }
+                HRESULT.Check(MS.Win32.NativeMethods.E_INVALIDARG);
             }
-
-            if (destinationX > _pixelWidth - sourceRect.Width)
+            else if (destinationX < 0 || destinationY < 0)
             {
-                if (backwardsCompat)
-                {
-                    HRESULT.Check(MS.Win32.NativeMethods.E_INVALIDARG);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("destinationX", SR.Format(SR.ParameterMustBeBetween, 0, _pixelWidth - sourceRect.Width));
-                }
-            }
-
-            if (destinationY < 0)
-            {
-                if (backwardsCompat)
-                {
-                    HRESULT.Check((int)WinCodecErrors.WINCODEC_ERR_VALUEOVERFLOW);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("destinationY", SR.Format(SR.ParameterMustBeBetween, 0, _pixelHeight - sourceRect.Height));
-                }
-            }
-
-            if (destinationY > _pixelHeight - sourceRect.Height)
-            {
-                if (backwardsCompat)
-                {
-                    HRESULT.Check(MS.Win32.NativeMethods.E_INVALIDARG);
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException("destinationY", SR.Format(SR.ParameterMustBeBetween, 0, _pixelHeight - sourceRect.Height));
-                }
+                HRESULT.Check((int)WinCodecErrors.WINCODEC_ERR_VALUEOVERFLOW);
             }
 
             //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaPlayerState.cs
@@ -262,10 +262,8 @@ namespace System.Windows.Media
             set
             {
                 VerifyAPI();
-                if (Double.IsNaN(value))
-                {
-                    throw new ArgumentException(SR.ParameterValueCannotBeNaN, "value");
-                }
+
+                ArgumentOutOfRangeException.ThrowIfEqual(value, double.NaN);
 
                 if (DoubleUtil.GreaterThanOrClose(value, 1))
                 {
@@ -312,10 +310,8 @@ namespace System.Windows.Media
             set
             {
                 VerifyAPI();
-                if (Double.IsNaN(value))
-                {
-                    throw new ArgumentException(SR.ParameterValueCannotBeNaN, "value");
-                }
+
+                ArgumentOutOfRangeException.ThrowIfEqual(value, double.NaN);
 
                 if (DoubleUtil.GreaterThanOrClose(value, 1))
                 {
@@ -932,10 +928,7 @@ namespace System.Windows.Media
             {
                 VerifyAPI();
 
-                if (Double.IsNaN(value))
-                {
-                    throw new ArgumentException(SR.ParameterValueCannotBeNaN, "value");
-                }
+                ArgumentOutOfRangeException.ThrowIfEqual(value, double.NaN);
 
                 HRESULT.Check(MILMedia.SetRate(_nativeMedia, value));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextParagraphCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextParagraphCache.cs
@@ -177,8 +177,7 @@ namespace System.Windows.Media.TextFormatting
         /// </summary>
         private int VerifyMaxLineWidth(double maxLineWidth)
         {
-            if (double.IsNaN(maxLineWidth))
-                throw new ArgumentOutOfRangeException("maxLineWidth", SR.ParameterValueCannotBeNaN);                                        
+            ArgumentOutOfRangeException.ThrowIfEqual(maxLineWidth, double.NaN);
             
             if (maxLineWidth == 0 || double.IsPositiveInfinity(maxLineWidth))
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextParagraphCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/textformatting/TextParagraphCache.cs
@@ -184,12 +184,9 @@ namespace System.Windows.Media.TextFormatting
                 // consider 0 or positive infinity as maximum ideal width
                 return Constants.IdealInfiniteWidth;
             }
-            
-            if (    maxLineWidth < 0 
-                ||  maxLineWidth > Constants.RealInfiniteWidth)
-            {
-                throw new ArgumentOutOfRangeException("maxLineWidth", SR.Format(SR.ParameterMustBeBetween, 0, Constants.RealInfiniteWidth));
-            }
+
+            ArgumentOutOfRangeException.ThrowIfNegative(maxLineWidth);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(maxLineWidth, Constants.RealInfiniteWidth);
 
             // convert real value to ideal value
             return TextFormatterImp.RealToIdeal(maxLineWidth);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CharacterBuffer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CharacterBuffer.cs
@@ -400,8 +400,9 @@ namespace MS.Internal
         public override char this[int characterOffset]
         {
             get {
-                if (characterOffset >= _length || characterOffset < 0)
-                    throw new ArgumentOutOfRangeException("characterOffset", SR.Format(SR.ParameterMustBeBetween,0,_length));
+                ArgumentOutOfRangeException.ThrowIfNegative(characterOffset);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(characterOffset, _length);
+
                 return _unsafeString[characterOffset];
             }
             set { throw new NotSupportedException(); }
@@ -456,15 +457,11 @@ namespace MS.Internal
             )
         {
 
-            if (characterOffset >= _length || characterOffset < 0)
-            {
-                throw new ArgumentOutOfRangeException("characterOffset", SR.Format(SR.ParameterMustBeBetween,0,_length));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(characterOffset);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(characterOffset, _length);
 
-            if (characterLength < 0 || characterOffset + characterLength > _length)
-            {
-                throw new ArgumentOutOfRangeException("characterLength", SR.Format(SR.ParameterMustBeBetween,0, _length - characterOffset));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(characterLength);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(characterLength, _length - characterOffset);
 
             stringBuilder.Append(new string(_unsafeString, characterOffset, characterLength));
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -147,9 +147,6 @@
   <data name="ReferenceIsNull" xml:space="preserve">
     <value>Value cannot be null. Object reference: '{0}'.</value>
   </data>
-  <data name="ParameterMustBeBetween" xml:space="preserve">
-    <value>The parameter value must be between '{0}' and '{1}'.</value>
-  </data>
   <data name="Freezable_UnregisteredHandler" xml:space="preserve">
     <value>Handler has not been registered with this event.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Zadaný objekt odkazu je v konfliktu s předdefinovaným odkazem specifickým pro balíček.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Hodnota tohoto parametru musí být v rozsahu od {0} do {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">K součásti se nedá přistoupit, protože nadřazený balíček se uzavřel.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Das angegebene Verweisobjekt verursacht einen Konflikt mit dem vordefinierten Package-spezifischen Verweis.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Der Parameterwert muss zwischen "{0}" und "{1}" liegen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Auf das Teil kann nicht zugegriffen werden, weil das übergeordnete Paket geschlossen wurde.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">El objeto de referencia especificado entra en conflicto con la referencia específica de paquete predefinida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">El valor del parámetro debe estar comprendido entre "{0}" y "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">No se puede acceder a la parte porque el paquete principal se cerró.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">L'objet de référence spécifié est en conflit avec la référence prédéfinie spécifique au package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">La valeur du paramètre doit être comprise entre '{0}' et '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Impossible d'accéder au composant, car le package parent a été fermé.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">L'oggetto di riferimento specificato è in conflitto con il riferimento predefinito specifico di Package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Il valore del parametro deve essere compreso tra '{0}' e '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Non è possibile accedere alla parte perché il pacchetto padre è stato chiuso.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定された参照オブジェクトは、定義済みの Package 固有の参照と競合しています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">パラメーター値は、'{0}' と '{1}' の間である必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">親パッケージが閉じられたため、パートにアクセスできません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">지정한 참조 개체가 미리 정의된 Package 특정 참조와 충돌합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">매개 변수 값은 '{0}'과(와) '{1}' 사이에 있어야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">부모 패키지가 닫혔으므로 파트에 액세스할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Określony obiekt odwołania wywołuje konflikt ze wstępnie zdefiniowanym odwołaniem specyficznym dla elementu Package.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Wartość parametru musi należeć do przedziału od „{0}” do „{1}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Nie można uzyskać dostępu do części, ponieważ pakiet nadrzędny został zamknięty.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">O objeto de referência especificado é conflitante com a referência específica do Pacote predefinida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">O valor do parâmetro precisa estar entre '{0}' e '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Não é possível acessar a parte porque o pacote pai foi fechado.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Указанный эталонный объект конфликтует с предопределенной ссылкой для заданного пакета.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Параметр должен принимать значения от "{0}" до "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Не удается получить доступ к части, так как родительский пакет был закрыт.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">Belirtilen başvuru nesnesi önceden tanımlı Pakete özgü başvuru ile çakışıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">Parametre değeri '{0}' ile '{1}' arasında olmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">Üst paket kapatıldığından bölüme erişilemiyor.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定的引用对象与预定义的 Package 专属引用冲突。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">参数值必须介于“{0}”到“{1}”之间。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">由于父包已关闭，因此无法访问部分包。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -1292,11 +1292,6 @@
         <target state="translated">指定的參考物件與預先定義的 Package 專屬參考相衝突。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ParameterMustBeBetween">
-        <source>The parameter value must be between '{0}' and '{1}'.</source>
-        <target state="translated">參數值必須介於 '{0}' 到 '{1}' 之間。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ParentContainerClosed">
         <source>Cannot access part because parent package was closed.</source>
         <target state="translated">因為父套件已關閉，所以無法存取組件。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Int32Rect.cs
@@ -81,16 +81,10 @@ namespace System.Windows
         {
             ArgumentOutOfRangeException.ThrowIfNegative(_x, paramName);
             ArgumentOutOfRangeException.ThrowIfNegative(_y, paramName);
-
-            if (_width < 0 || _width > width)
-            {
-                throw new ArgumentOutOfRangeException(paramName, SR.Format(SR.ParameterMustBeBetween, 0, width));
-            }
-
-            if (_height < 0 || _height > height)
-            {
-                throw new ArgumentOutOfRangeException(paramName, SR.Format(SR.ParameterMustBeBetween, 0, height));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(_width, paramName);
+            ArgumentOutOfRangeException.ThrowIfNegative(_height, paramName);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(_width, width, paramName);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(_height, height, paramName);
         }
 
         private readonly static Int32Rect s_empty = new Int32Rect(0,0,0,0);


### PR DESCRIPTION
Follow-up to #8408

## Description

As mentioned in #8408, ParameterMustBeBetween, ParameterValueCannotBeInfinity and ParameterValueCannotBeNaN are good candidates for replacing custom ressources with inbox ones. This PR addresses those two cases, each in its own commit

## Regression

No

## Testing

CI

## Risk

Low. I manually searched and removed the error messages, and let CA1512 finish the work


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8489)