### PR TITLE
Fix for GetXmlNamespaceMaps and SetXmlNamespaceMaps exception

### DIFF
--- a/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationFramework-ref-Net48.baseline.txt
+++ b/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/PresentationFramework-ref-Net48.baseline.txt
@@ -33,4 +33,6 @@ TypesMustExist : Type 'System.Windows.Interop.DocObjHost' does not exist in the 
 CannotRemoveAttribute : Attribute 'System.ComponentModel.TypeConverterAttribute' exists on 'System.Windows.Markup.StaticExtension' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.ComponentModel.TypeConverterAttribute' exists on 'System.Windows.Markup.TypeExtension' in the contract but not the implementation.
 CannotRemoveBaseTypeOrInterface : Type 'System.Windows.Markup.XamlParseException' does not implement interface 'System.Runtime.InteropServices._Exception' in the implementation but it does in the contract.
-Total Issues: 34
+MembersMustExist : Member 'public System.String System.Windows.Markup.XmlAttributeProperties.GetXmlNamespaceMaps(System.Windows.DependencyObject)' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'public void System.Windows.Markup.XmlAttributeProperties.SetXmlNamespaceMaps(System.Windows.DependencyObject, System.String)' does not exist in the implementation but it does exist in the contract.
+Total Issues: 36

--- a/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/System.Windows.Controls.Ribbon-ref-Net48.baseline.txt
+++ b/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/System.Windows.Controls.Ribbon-ref-Net48.baseline.txt
@@ -1,2 +1,1 @@
-Compat issues with assembly System.Windows.Controls.Ribbon:
 Total Issues: 0

--- a/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/UIAutomationProvider-ref.baseline.txt
+++ b/src/Microsoft.DotNet.Wpf/ApiCompat/Baselines/UIAutomationProvider-ref.baseline.txt
@@ -11,7 +11,6 @@ CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeA
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IRawElementProviderFragment' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IRawElementProviderFragmentRoot' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IRawElementProviderHwndOverride' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IRawElementProviderSimple' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IScrollItemProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IScrollProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ISelectionItemProvider' in the contract but not the implementation.
@@ -20,10 +19,9 @@ CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeA
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ITableItemProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ITableProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ITextProvider' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ITextRangeProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IToggleProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.ITransformProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IValueProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IVirtualizedItemProvider' in the contract but not the implementation.
 CannotRemoveAttribute : Attribute 'System.Runtime.InteropServices.InterfaceTypeAttribute' exists on 'System.Windows.Automation.Provider.IWindowProvider' in the contract but not the implementation.
-Total Issues: 27
+Total Issues: 25

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -11485,7 +11485,7 @@ namespace System.Windows.Markup
         public static readonly System.Windows.DependencyProperty XmlSpaceProperty;
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
-        public static string GetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject) { throw null; }
+        public static System.Collections.Hashtable GetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject) { throw null; }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
         [System.Windows.Markup.DesignerSerializationOptionsAttribute(System.Windows.Markup.DesignerSerializationOptions.SerializeAsAttribute)]

--- a/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/cycle-breakers/PresentationFramework/PresentationFramework.cs
@@ -11496,7 +11496,7 @@ namespace System.Windows.Markup
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
         [System.Windows.Markup.DesignerSerializationOptionsAttribute(System.Windows.Markup.DesignerSerializationOptions.SerializeAsAttribute)]
         public static string GetXmlSpace(System.Windows.DependencyObject dependencyObject) { throw null; }
-        public static void SetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject, string value) { }
+        public static void SetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject, System.Collections.Hashtable value) { }
         public static void SetXmlnsDefinition(System.Windows.DependencyObject dependencyObject, string value) { }
         public static void SetXmlnsDictionary(System.Windows.DependencyObject dependencyObject, System.Windows.Markup.XmlnsDictionary value) { }
         public static void SetXmlSpace(System.Windows.DependencyObject dependencyObject, string value) { }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
@@ -296,14 +296,14 @@ namespace System.Windows.Markup
         /// </remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
-        public static System.Collections.Hashtable GetXmlNamespaceMaps(DependencyObject dependencyObject)
+        public static Hashtable GetXmlNamespaceMaps(DependencyObject dependencyObject)
         {
             if (dependencyObject == null)
             {
                 throw new ArgumentNullException( "dependencyObject" );
             }
 
-            return (System.Collections.Hashtable)dependencyObject.GetValue(XmlNamespaceMapsProperty);
+            return (Hashtable)dependencyObject.GetValue(XmlNamespaceMapsProperty);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace System.Windows.Markup
         /// <remarks>
         /// XmlNamespaceMaps map xml namespace uri to Assembly/CLR namespaces
         /// </remarks>
-        public static void SetXmlNamespaceMaps(DependencyObject dependencyObject, string value)
+        public static void SetXmlNamespaceMaps(DependencyObject dependencyObject, Hashtable value)
         {
             if (dependencyObject == null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XmlAttributeProperties.cs
@@ -296,14 +296,14 @@ namespace System.Windows.Markup
         /// </remarks>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
-        public static string GetXmlNamespaceMaps(DependencyObject dependencyObject)
+        public static System.Collections.Hashtable GetXmlNamespaceMaps(DependencyObject dependencyObject)
         {
             if (dependencyObject == null)
             {
                 throw new ArgumentNullException( "dependencyObject" );
             }
 
-            return (string)dependencyObject.GetValue(XmlNamespaceMapsProperty);
+            return (System.Collections.Hashtable)dependencyObject.GetValue(XmlNamespaceMapsProperty);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -11505,7 +11505,7 @@ namespace System.Windows.Markup
         public static readonly System.Windows.DependencyProperty XmlSpaceProperty;
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
-        public static string GetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject) { throw null; }
+        public static System.Collections.Hashtable GetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject) { throw null; }
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
         [System.Windows.Markup.DesignerSerializationOptionsAttribute(System.Windows.Markup.DesignerSerializationOptions.SerializeAsAttribute)]

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -11516,7 +11516,7 @@ namespace System.Windows.Markup
         [System.Windows.AttachedPropertyBrowsableForTypeAttribute(typeof(System.Windows.DependencyObject))]
         [System.Windows.Markup.DesignerSerializationOptionsAttribute(System.Windows.Markup.DesignerSerializationOptions.SerializeAsAttribute)]
         public static string GetXmlSpace(System.Windows.DependencyObject dependencyObject) { throw null; }
-        public static void SetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject, string value) { }
+        public static void SetXmlNamespaceMaps(System.Windows.DependencyObject dependencyObject, System.Collections.Hashtable value) { }
         public static void SetXmlnsDefinition(System.Windows.DependencyObject dependencyObject, string value) { }
         public static void SetXmlnsDictionary(System.Windows.DependencyObject dependencyObject, System.Windows.Markup.XmlnsDictionary value) { }
         public static void SetXmlSpace(System.Windows.DependencyObject dependencyObject, string value) { }


### PR DESCRIPTION
Fixes #1583 

## Description
`XmlAttributeProperties.GetXmlNamespaceMaps` and `XmlAttributeProperties.SetXmlNamespaceMaps` were throwing `System.InvalidCastException`, as it was not able to cast object of type `System.Collections.Hashtable` to type `System.String`.

Tests updated : [Test PR](https://github.com/dotnet/wpf-test/pull/264)
Documentation updated : [Documentation PR](https://github.com/dotnet/dotnet-api-docs/pull/9582)

## Regression

NA

## Testing

Tests have been modified to work correctly.

## Risk

Low


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8510)