### PR TITLE
Prepare System.Xaml for nullable reference type annotations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/SR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/SR.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Resources;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CriticalExceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/CriticalExceptions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 
 #if PBTCOMPILER

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FriendAccessAllowedAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FriendAccessAllowedAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 // Description: Implementation of a FriendAccessAllowedAttribute attribute that is used to mark internal metadata
 //              that is allowed to be accessed from friend assemblies.
 
@@ -10,7 +12,7 @@ using System;
 #if WINDOWS_BASE
 namespace MS.Internal.WindowsBase
 #elif PRESENTATION_CORE
-namespace MS.Internal.PresentationCore 
+namespace MS.Internal.PresentationCore
 #elif PRESENTATIONFRAMEWORK
 namespace MS.Internal.PresentationFramework
 #elif PRESENTATION_CFF_RASTERIZER

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 // Purpose:  Helper functions that require elevation but are safe to use.
 
 using System;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityCriticalDataForSet.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityCriticalDataForSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 // Description:
 //              This is a helper class to facilate the storage of data that's Critical for set.
 //              The data itself is not information disclosure but the value controls a critical
@@ -10,7 +12,7 @@
 //              For example a filepath variable might control what part of the file system the
 //              code gets access to.
 
-using System ; 
+using System ;
 using System.Security ;
 
 #if WINDOWS_BASE
@@ -43,11 +45,11 @@ namespace MS.Internal
     internal struct SecurityCriticalDataForSet<T>
     {
         internal SecurityCriticalDataForSet(T value)
-        { 
-            _value = value; 
+        {
+            _value = value;
         }
 
-        internal T Value 
+        internal T Value
         {
         #if DEBUG
             [System.Diagnostics.DebuggerStepThrough]

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlContextStack.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -111,7 +113,7 @@ namespace MS.Internal.Xaml.Context
             Debug.Assert(CurrentFrame.Depth == Depth);
         }
 
-        //Consumers of this stack call PopScope, and we'll move the currentFrame from the main 
+        //Consumers of this stack call PopScope, and we'll move the currentFrame from the main
         // linked list to the recylced linked list and call .Reset
         public void PopScope()
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Context/XamlFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -28,8 +30,8 @@ namespace MS.Internal.Xaml.Context
         public virtual XamlFrame Clone()
         {
             // Clone should only be overridden for the classes that really need it
-            // ObjectWriterFrame overrides this so we can reuse the context for 
-            // Templates.  
+            // ObjectWriterFrame overrides this so we can reuse the context for
+            // Templates.
             throw new NotImplementedException();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Xaml/Parser/SpecialBracketCharacters.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 //  Description: Data model for the Bracket characters specified on a Markup Extension property.
 
 using System;
@@ -13,7 +15,7 @@ using System.Text;
 namespace MS.Internal.Xaml.Parser
 {
     /// <summary>
-    /// Class that provides helper functions for the parser/Xaml Reader 
+    /// Class that provides helper functions for the parser/Xaml Reader
     /// to process Bracket Characters specified on a Markup Extension Property
     /// </summary>
     internal class SpecialBracketCharacters : ISupportInitialize
@@ -24,7 +26,7 @@ namespace MS.Internal.Xaml.Parser
         private bool _initializing;
         private StringBuilder _startCharactersStringBuilder;
         private StringBuilder _endCharactersStringBuilder;
-        
+
         internal SpecialBracketCharacters()
         {
             BeginInit();
@@ -59,7 +61,7 @@ namespace MS.Internal.Xaml.Parser
                 foreach (char openingBracket in attributeList.Keys)
                 {
                     char closingBracket = attributeList[openingBracket];
-                    string errorMessage = string.Empty; 
+                    string errorMessage = string.Empty;
                     if (IsValidBracketCharacter(openingBracket, closingBracket))
                     {
                         _startCharactersStringBuilder.Append(openingBracket);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Collections;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 //
 //
 //
@@ -50,16 +52,16 @@ namespace System.Xaml
         // System.Reflection.MetadataLoadContext instance
         private static MetadataLoadContext _metadataLoadContext = null;
 
-        // MetadataLoadContext Assembly cache 
-        private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssemblies = null; 
-        private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssembliesByNameNoExtension = null; 
+        // MetadataLoadContext Assembly cache
+        private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssemblies = null;
+        private static Dictionary<string, Assembly> _cachedMetadataLoadContextAssembliesByNameNoExtension = null;
 
         // The local assembly that contains the baml.
         private static string _localAssemblyName = string.Empty;
 
         internal static void Initialize(IEnumerable<string> assemblyPaths)
-        { 
-            // System.Reflection.MetadataLoadContext Assembly cache 
+        {
+            // System.Reflection.MetadataLoadContext Assembly cache
             _cachedMetadataLoadContextAssemblies = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
             _cachedMetadataLoadContextAssembliesByNameNoExtension = new Dictionary<string, Assembly>(StringComparer.OrdinalIgnoreCase);
             _metadataLoadContext = new MetadataLoadContext(new PathAssemblyResolver(assemblyPaths), MscorlibReflectionAssemblyName);
@@ -168,7 +170,7 @@ namespace System.Xaml
         {
 #if PBTCOMPILER
             Assembly reflectionAssembly = LoadAssembly(assemblyName, null);
-    
+
             if (reflectionAssembly != null)
             {
                 type = reflectionAssembly.GetType(type.FullName);
@@ -209,7 +211,7 @@ namespace System.Xaml
                 return ictp.GetCustomType();
         }
 #endif
-        
+
 #endregion Type
 
         #region Attributes
@@ -534,13 +536,13 @@ namespace System.Xaml
         // For a given assembly name and its full path, Reflection-Only load the assembly directly
         // from the file in disk or load the file to memory and then create assembly instance from
         // memory buffer data.
-        // 
+        //
         private static Assembly ReflectionOnlyLoadAssembly(string assemblyName, string fullPathToAssembly)
         {
-            Assembly assembly = null; 
+            Assembly assembly = null;
 
-            // If the assembly path is empty, try to load assembly by name. LoadFromAssemblyName 
-            // will result in a MetadataLoadContext.Resolve event that will contain more information about the 
+            // If the assembly path is empty, try to load assembly by name. LoadFromAssemblyName
+            // will result in a MetadataLoadContext.Resolve event that will contain more information about the
             // requested assembly.
             if (String.IsNullOrEmpty(fullPathToAssembly))
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/Replacements/TypeUriConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
@@ -23,7 +25,7 @@ namespace System.Xaml.Replacements
 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            return 
+            return
                 destinationType == typeof(InstanceDescriptor) ||
                 destinationType == typeof(string) ||
                 destinationType == typeof(Uri);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/RuntimeIdentifierPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 // Description:
 //   This attribute is placed on a class to identify the property that will
 //   function as an Name for the given class

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/TypeConverterHelper.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 //  Description: Specifies that the whitespace surrounding an element should be trimmed.
 
 using System;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlCompatibilityReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Xml;
 using System.Collections;
@@ -170,7 +172,7 @@ namespace System.Windows.Markup
 
             bool more = Reader.Read(); //passed as ref arg to ReadStartElement and ReadEndElement
             bool result = false;
-          
+
             while (more)
             {
                 switch (Reader.NodeType)
@@ -279,7 +281,7 @@ namespace System.Windows.Markup
                 }
             }
 
-            // if the element is empty (e.g. "<a ... />" and we pushed a scope then we need to set a flag 
+            // if the element is empty (e.g. "<a ... />" and we pushed a scope then we need to set a flag
             // to get rid of the scope when we hit the next element.
             // We also need to store the current elementDepth.
             if (isEmpty)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/XmlWrappingReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Xml;
 using System.Xml.Schema;
@@ -13,7 +15,7 @@ namespace MS.Internal.Markup
 #elif SYSTEM_XAML
 namespace System.Xaml
 #else
-namespace System.Windows.Markup 
+namespace System.Windows.Markup
 #endif
 {
     internal class XmlWrappingReader : XmlReader, IXmlLineInfo, IXmlNamespaceResolver {
@@ -23,8 +25,8 @@ namespace System.Windows.Markup
         protected XmlReader               _reader;
         protected IXmlLineInfo            _readerAsIXmlLineInfo;
         protected IXmlNamespaceResolver   _readerAsResolver;
-    
-// 
+
+//
 // Constructor
 //
         internal XmlWrappingReader( XmlReader baseReader ) {
@@ -105,7 +107,7 @@ namespace System.Windows.Markup
         public override void Close() {
             _reader.Close();
         }
-        
+
         public override void Skip() {
             _reader.Skip();
         }
@@ -160,7 +162,7 @@ namespace System.Windows.Markup
             }
         }
 
-        public virtual int LinePosition { 
+        public virtual int LinePosition {
             get {
                 return ( _readerAsIXmlLineInfo == null ) ? 0 : _readerAsIXmlLineInfo.LinePosition;
             }
@@ -181,5 +183,5 @@ namespace System.Windows.Markup
         }
     }
 }
-    
+
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/GlobalSuppressions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/GlobalSuppressions.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// This file is used by Code Analysis to maintain SuppressMessage 
+#nullable disable
+
+#nullable disable// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
+// Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/OtherAssemblyAttrs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/OtherAssemblyAttrs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 //
 // This file specifies various assembly level attributes.
 //

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <ProjectGuid>{9AC36357-34B7-40A1-95CA-FE9F46D089A7}</ProjectGuid>
     <AssemblyName>System.Xaml</AssemblyName>
-    
+
     <Platforms>AnyCPU;x64;arm64</Platforms>
     <NoWarn>$(NoWarn);0618;NU5125;0618</NoWarn>
     <DefineConstants>$(DefineConstants);OLDRESOURCES;SYSTEM_XAML</DefineConstants>
     <EnableAnalyzers>true</EnableAnalyzers>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/AcceptedMarkupExtensionExpressionTypeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/AcceptedMarkupExtensionExpressionTypeAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     [Obsolete("This is not used by the XAML parser. Please look at XamlSetMarkupExtensionAttribute.")]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/AmbientAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/AmbientAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ArrayExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ArrayExtension.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -24,7 +26,7 @@ namespace System.Windows.Markup
         public ArrayExtension()
         {
         }
-        
+
         /// <summary>
         /// Constructor that takes one parameter. This initializes the type of the array.
         /// </summary>
@@ -56,7 +58,7 @@ namespace System.Windows.Markup
         /// Called to Add a text as a new array item. This will append the
         /// object to the end of the array.
         /// </summary>
-        /// <param name="text">Text to Add to the end of the array.</param> 
+        /// <param name="text">Text to Add to the end of the array.</param>
         public void AddText(string text) => AddChild(text);
 
         ///<summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ConstructorArgumentAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ConstructorArgumentAttribute.cs
@@ -2,18 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
     /// <summary>
-    /// Attribute to declare that this associated property can be initialized by a 
+    /// Attribute to declare that this associated property can be initialized by a
     /// constructor parameter and should be ignored for serialization if the constructor
-    /// with an argument of the supplied name is used to construct the instance. 
+    /// with an argument of the supplied name is used to construct the instance.
     /// </summary>
     [TypeForwardedFrom("WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    public sealed class ConstructorArgumentAttribute : Attribute 
+    public sealed class ConstructorArgumentAttribute : Attribute
     {
         /// <summary>
         /// Constructor for an ConstructorArgumentAttribute

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ContentPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ContentPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ContentWrapperAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ContentWrapperAttribute.cs
@@ -2,21 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
     /// <summary>
-    /// Can be specified on a collection type to indicate which 
-    /// types are used to wrap content foreign content such as 
-    /// strings in a strongly type Collection. 
+    /// Can be specified on a collection type to indicate which
+    /// types are used to wrap content foreign content such as
+    /// strings in a strongly type Collection.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
     [TypeForwardedFrom("WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
     public sealed class ContentWrapperAttribute : Attribute
     {
         /// <summary>
-        /// Declares the given type as being a content wrapper for the collection 
+        /// Declares the given type as being a content wrapper for the collection
         /// type this attribute is declared on.
         /// </summary>
         /// <param name="contentWrapper"></param>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DependsOnAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DependsOnAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DictionaryKeyPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DictionaryKeyPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IComponentConnector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IComponentConnector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/INameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/INameScope.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/INameScopeDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/INameScopeDictionary.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IProvideValueTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IProvideValueTarget.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IQueryAmbient.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IQueryAmbient.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     public interface IQueryAmbient

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IUriContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IUriContext.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
-namespace System.Windows.Markup 
+namespace System.Windows.Markup
 {
     ///<summary>
     /// The IUriContext interface allows elements (like Frame, PageViewer) and type

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IValueSerializerContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IValueSerializerContext.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace System.Windows.Markup 
+namespace System.Windows.Markup
 {
     /// <summary>
     /// Context provided to ValueSerializer that can be used to special case serialization
@@ -25,7 +27,7 @@ namespace System.Windows.Markup
         /// Get a value serializer for the given property descriptor. A property can
         /// override the value serializer that  is to be used to serialize the property
         /// by specifing either a ValueSerializerAttribute or a TypeConverterAttribute.
-        /// This method takes these attributes into account when determining the value 
+        /// This method takes these attributes into account when determining the value
         /// serializer.
         /// </summary>
         /// <param name="descriptor">The property descriptor for whose property value is being converted</param>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IXamlTypeResolver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/IXamlTypeResolver.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtension.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtensionBracketCharactersAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtensionBracketCharactersAttribute.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     /// <summary>
     /// Attribute to declare that this associated property will have special parsing rules
-    /// for any text that is enclosed between these special characters. 
+    /// for any text that is enclosed between these special characters.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
     public sealed class MarkupExtensionBracketCharactersAttribute : Attribute

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtensionReturnTypeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MarkupExtensionReturnTypeAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MemberDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/MemberDefinition.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     public abstract class MemberDefinition

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NameReferenceConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NameReferenceConverter.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Xaml;
 
 namespace System.Windows.Markup
 {
-    public class NameReferenceConverter: TypeConverter 
+    public class NameReferenceConverter: TypeConverter
     {
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
@@ -23,7 +25,7 @@ namespace System.Windows.Markup
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
             ArgumentNullException.ThrowIfNull(context);
-            
+
             var nameResolver = (IXamlNameResolver)context.GetService(typeof(IXamlNameResolver));
             if (nameResolver == null)
             {
@@ -57,7 +59,7 @@ namespace System.Windows.Markup
             }
 
             return base.CanConvertTo(context, destinationType);
-            
+
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
@@ -70,7 +72,7 @@ namespace System.Windows.Markup
                 throw new InvalidOperationException(SR.MissingNameProvider);
             }
 
-            return nameProvider.GetName(value);            
+            return nameProvider.GetName(value);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NameScopePropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NameScopePropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NullExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/NullExtension.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/PropertyDefinition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/PropertyDefinition.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xaml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/Reference.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/Reference.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Xaml;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/RootNamespaceAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/RootNamespaceAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtension.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtensionsToInstanceDescriptorsConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/StaticExtensionsToInstanceDescriptorsConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TrimSurroundingWhitespaceAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TrimSurroundingWhitespaceAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtension.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -63,7 +65,7 @@ namespace System.Windows.Markup
             }
 
             // Get the IXamlTypeResolver from the service provider
-            ArgumentNullException.ThrowIfNull(serviceProvider);            
+            ArgumentNullException.ThrowIfNull(serviceProvider);
 
             IXamlTypeResolver xamlTypeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
             if( xamlTypeResolver == null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtensionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/TypeExtensionConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UidPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
@@ -36,5 +38,5 @@ namespace System.Windows.Markup
         /// The name of the property that is designated to accept the x:Uid value
         /// </summary>
         public string Name { get; }
-    }    
+    }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UsableDuringInitializationAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/UsableDuringInitializationAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/ValueSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -15,12 +17,12 @@ using MS.Internal.Serialization;
 namespace System.Windows.Markup
 {
     /// <summary>
-    /// ValueSerializer allows a type to declare a serializer to control how the type is serialized to and from strings. 
-    /// If a TypeConverter is declared for a type that converts to and from a string, a default value serializer will 
-    /// be created for the type. The string values must be loss-less (i.e. converting to and from a string doesn't loose 
-    /// data) and must be stable (i.e. returns the same string for the same value). If a type converter doesn't  meet 
-    /// these requirements, a custom ValueSerializer must be declared that meet the requirements or associate a null 
-    /// ValueSerializer with the type to indicate the type converter should be ignored. Implementation of ValueSerializer 
+    /// ValueSerializer allows a type to declare a serializer to control how the type is serialized to and from strings.
+    /// If a TypeConverter is declared for a type that converts to and from a string, a default value serializer will
+    /// be created for the type. The string values must be loss-less (i.e. converting to and from a string doesn't loose
+    /// data) and must be stable (i.e. returns the same string for the same value). If a type converter doesn't  meet
+    /// these requirements, a custom ValueSerializer must be declared that meet the requirements or associate a null
+    /// ValueSerializer with the type to indicate the type converter should be ignored. Implementation of ValueSerializer
     /// should avoid throwing exceptions. Any exceptions thrown could possibly terminate serialization.
     /// </summary>
     [TypeForwardedFrom("WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
@@ -85,7 +87,7 @@ namespace System.Windows.Markup
         /// a value serializer for System.Type, any types it asks to convert should be supplied in the returned
         /// enumeration. This allows a serializer to ensure a de-serializer has enough information about the types
         /// this serializer converts.
-        /// 
+        ///
         /// Since a value serializer doesn't exist by default, it is important the value serializer be requested from
         /// the IValueSerializerContext, not ValueSerializer.GetSerializerFor. This allows a serializer to encode
         /// context information (such as xmlns definitions) to the System.Type converter (for example, which prefix
@@ -167,7 +169,7 @@ namespace System.Windows.Markup
         public static ValueSerializer GetSerializerFor(PropertyDescriptor descriptor)
         {
             ArgumentNullException.ThrowIfNull(descriptor);
-            
+
             ValueSerializerAttribute serializerAttribute = descriptor.Attributes[typeof(ValueSerializerAttribute)] as ValueSerializerAttribute;
             if (serializerAttribute != null)
             {
@@ -212,7 +214,7 @@ namespace System.Windows.Markup
 
         /// <summary>
         /// Get the value serializer declared for the given property. ValueSerializer can be overriden by an attribute
-        /// on the property declaration. This version should be called whenever the caller has a 
+        /// on the property declaration. This version should be called whenever the caller has a
         /// IValueSerializerContext to ensure that the correct value serializer is returned for the given context.
         /// </summary>
         /// <param name="descriptor">PropertyDescriptor for the property to be serialized</param>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/WhitespaceSignificantCollectionAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/WhitespaceSignificantCollectionAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XData.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.IO;
 using System.Xml;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlDeferLoadAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlDeferLoadAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetMarkupExtensionAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetMarkupExtensionAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
     [AttributeUsage(AttributeTargets.Class, Inherited=true, AllowMultiple=false)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetMarkupExtensionEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetMarkupExtensionEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Xaml;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetTypeConverterAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetTypeConverterAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Markup
 {
    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetTypeConverterEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetTypeConverterEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Xaml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetValueEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XamlSetValueEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Xaml;
 
 namespace System.Windows.Markup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlLangPropertyAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlLangPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
@@ -24,7 +26,7 @@ namespace System.Windows.Markup
     public sealed class XmlLangPropertyAttribute : Attribute
     {
         /// <summary>
-        /// Creates a new XmlLangPropertyAttribute with the given string 
+        /// Creates a new XmlLangPropertyAttribute with the given string
         /// as the property name.
         /// </summary>
         public XmlLangPropertyAttribute(string name)
@@ -36,5 +38,5 @@ namespace System.Windows.Markup
         /// The name of the property that is designated to accept the xml:lang value
         /// </summary>
         public string Name { get; }
-    }    
+    }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsCompatibleWithAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsCompatibleWithAttribute.cs
@@ -2,20 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
     /// <summary>
-    /// This attribute allows an assembly to declare that previously published 
+    /// This attribute allows an assembly to declare that previously published
     /// XmlnsDefinitions are subsumed by a new version.
-    /// 
-    /// Such as 
-    /// 
-    ///    "http://schemas.example.com/2003/mynamespace" 
-    /// 
-    /// is changed to 
-    /// 
+    ///
+    /// Such as
+    ///
+    ///    "http://schemas.example.com/2003/mynamespace"
+    ///
+    /// is changed to
+    ///
     ///    "http://schemas.example.com/2005/mynamespace"
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsDefinitionAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsDefinitionAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
@@ -9,25 +11,25 @@ namespace System.Windows.Markup
     /// <summary>
     /// XmlnsDefinitionAttribute keeps a mapping between Xml namespace and CLR namespace in an Assembly.
     /// The Xml namespace can be used in a Xaml Markup file.
-    /// 
-    ///  
-    /// To find the appropriate types for element and attribute in xaml file, xaml processors MUST 
-    /// search each referenced assembly for XmlnsDefinitionAttribute. If the xmlns for element tag 
+    ///
+    ///
+    /// To find the appropriate types for element and attribute in xaml file, xaml processors MUST
+    /// search each referenced assembly for XmlnsDefinitionAttribute. If the xmlns for element tag
     /// or attribute matches with the XmlNamespace in this XmlnsDefinitionAttibute, the Xaml processor
-    /// then takes use of the ClrNamespace and AssemblyName stored in this Attibute instance to check 
+    /// then takes use of the ClrNamespace and AssemblyName stored in this Attibute instance to check
     /// if the element or attribute matches any type inside this namespace in the Assembly.
-    /// 
+    ///
     /// For a WinFX assembly, it can set this attibute like below:
-    /// 
+    ///
     /// [assembly:XmlnsDefinition("http://schemas.fabrikam.com/mynamespace", "fabrikam.myproduct.mycategory1")]
     /// [assembly:XmlnsDefinition("http://schemas.fabrikam.com/mynamespace", "fabrikam.myproduct.mycategory2")]
-    /// 
+    ///
     /// [assembly:XmlnsDefinition("xmlnamsspace", "clrnamespace", AssemblyName="myassembly or full assemblyname")]
-    /// 
-    /// If fabrikam.myproduct.mycategory namespace in this assembly contains a UIElement such as "MyButton", the 
+    ///
+    /// If fabrikam.myproduct.mycategory namespace in this assembly contains a UIElement such as "MyButton", the
     /// xaml file could use it like below:
-    /// 
-    ///   Page xmlns:myns="http://schemas.fabrikam.com/mynamespace" .... 
+    ///
+    ///   Page xmlns:myns="http://schemas.fabrikam.com/mynamespace" ....
     ///      myns:MyButton ...../myns:MyButton
     ///   /Page
     /// </summary>
@@ -52,25 +54,25 @@ namespace System.Windows.Markup
 
         /// <summary>
         /// XmlNamespace which can be used in Markup file.
-        /// such as XmlNamespace is set to 
+        /// such as XmlNamespace is set to
         /// "http://schemas.fabrikam.com/mynamespace".
-        /// 
+        ///
         /// The markup file can have definition like
-        /// xmlns:myns="http://schemas.fabrikam.com/mynamespace" 
+        /// xmlns:myns="http://schemas.fabrikam.com/mynamespace"
         /// </summary>
         public string XmlNamespace { get; }
 
         /// <summary>
         /// ClrNamespace which map to XmlNamespace.
-        /// This ClrNamespace should contain some types which are used 
+        /// This ClrNamespace should contain some types which are used
         /// by Xaml markup file.
         /// </summary>
         public string ClrNamespace { get; }
 
         /// <summary>
         /// The name of Assembly that contains some types inside CLRNamespace.
-        /// If the assemblyName is not set, the code should take the assembly 
-        /// for which the instance of this attribute is created. 
+        /// If the assemblyName is not set, the code should take the assembly
+        /// for which the instance of this attribute is created.
         /// </summary>
         public string AssemblyName { get; set; }
    }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsPrefixAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/XmlnsPrefixAttribute.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Markup
 {
     /// <summary>
     /// This attribute allows an assembly to recommend a prefix to be used when writing elements and
-    /// attributes in a xaml file. 
-    /// 
+    /// attributes in a xaml file.
+    ///
     /// For a WinFX assembly, it can set the attributes as follows:
     ///
     /// <code>
@@ -17,8 +19,8 @@ namespace System.Windows.Markup
     /// [assembly:XmlnsDefinition("http://schemas.fabrikam.com/mynamespace", "fabrikam.myproduct.mycategory2")]
     /// [assembly:XmlnsPrefix("http://schemas.fabrikam.com/mynamespace", "myns")]
     /// </code>
-    /// 
-    /// If fabrikam.myproduct.mycategory namespace in this assembly contains a UIElement such as "MyButton", the 
+    ///
+    /// If fabrikam.myproduct.mycategory namespace in this assembly contains a UIElement such as "MyButton", the
     /// xaml file could use it like below:
     ///   <code>
     ///   &lt;Page xmlns:myns="http://schemas.fabrikam.com/mynamespace" .... &gt;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class AttachableMemberIdentifier : IEquatable<AttachableMemberIdentifier>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachablePropertyServices.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -235,7 +237,7 @@ namespace System.Xaml
                 return false;
             }
         }
-#else        
+#else
         //***********************************************WARNING************************************************************
         // In CLR4.0 there is ConditionalWeakTable.  This implementation is for 3.5 and uses a WeakKey dictionary.
         //  This implementation does not handle the problem where a key is rooted in a value (or graph of a value).
@@ -244,7 +246,7 @@ namespace System.Xaml
         //******************************************************************************************************************
         sealed class DefaultAttachedPropertyStore
         {
-            Lazy<WeakDictionary<object, Dictionary<AttachableMemberIdentifier, object>>> instanceStorage = 
+            Lazy<WeakDictionary<object, Dictionary<AttachableMemberIdentifier, object>>> instanceStorage =
                 new Lazy<WeakDictionary<object, Dictionary<AttachableMemberIdentifier, object>>>(
                     () => new WeakDictionary<object, Dictionary<AttachableMemberIdentifier, object>>(), LazyInitMode.AllowMultipleThreadSafeExecution);
 
@@ -347,7 +349,7 @@ namespace System.Xaml
                 where K : class
                 where V : class
             {
-                // Optimally this would be a _real_ dictionary implementation that when it ran across WeakKey's that had 
+                // Optimally this would be a _real_ dictionary implementation that when it ran across WeakKey's that had
                 //  gone out of scope would immediately at least clear their value and from time to time schedule a real
                 //  cleanup.
                 Dictionary<WeakKey, V> storage;
@@ -507,7 +509,7 @@ namespace System.Xaml
                     }
                 }
 
-                // This cleanup token will be immediately thrown away and as a result it will 
+                // This cleanup token will be immediately thrown away and as a result it will
                 //  (a couple of GCs later) make it into the finalization queue and when finalized
                 //  will kick off a thread-pool job to cleanup the dictionary.
 
@@ -535,7 +537,7 @@ namespace System.Xaml
                         Justification = "The point of this method is to create one of these and let it float away... To be finalized...")]
                     public static void CreateCleanupToken(WeakDictionary<K, V> storage)
                     {
-                        // Create one of these, the work is done when it is finalized which 
+                        // Create one of these, the work is done when it is finalized which
                         //  will be at some indeterminate point in the future...
                         WeakDictionaryCleanupToken token = new WeakDictionaryCleanupToken(storage);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ContextServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ContextServices.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Windows.Markup;
 using System.Xaml;
@@ -24,7 +26,7 @@ namespace MS.Internal.Xaml.Context
 
             XamlMember parentProperty = xamlContext.ParentProperty;
             //
-            // We should never have a null ParentProperty here but 
+            // We should never have a null ParentProperty here but
             // protect against null refs since we are going to dereference it
             if (parentProperty == null)
             {
@@ -34,16 +36,16 @@ namespace MS.Internal.Xaml.Context
             if (parentProperty.IsAttachable)
             {
                 //
-                // IPVT returns the static Set method for attached properties in 3.0 
+                // IPVT returns the static Set method for attached properties in 3.0
                 return parentProperty.Setter;
             }
             else
             {
                 //
-                // This branch cover regular property (will return non null) 
+                // This branch cover regular property (will return non null)
                 // and items in a collection/diction (will return null - IPVT returns null in 3.0 for collections/dictionaries).
                 return parentProperty.UnderlyingMember;
             }
-        }        
+        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ICheckIfInitialized.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ICheckIfInitialized.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace MS.Internal.Xaml.Context
 {
     // This interface allows ObjectWriterContext to call into ObjectWriter to get the live initialization

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupGraph.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupGraph.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,7 +15,7 @@ using System.Xaml.Schema;
 namespace MS.Internal.Xaml.Context
 {
     // Graph of unresolved forward references, and the objects that depend on them.
-    // The nodes are objects and names. The edges (NameFixupTokens) are dependencies from an object to 
+    // The nodes are objects and names. The edges (NameFixupTokens) are dependencies from an object to
     // a set of unresolved names, or from an object to another object that has unresolved dependencies.
     internal class NameFixupGraph
     {
@@ -56,7 +58,7 @@ namespace MS.Internal.Xaml.Context
             // Need to special case a deferred ProvideValue at the root, because it has no parent
             if (fixupToken.Target.Property == null)
             {
-                Debug.Assert(fixupToken.Target.Instance == null && 
+                Debug.Assert(fixupToken.Target.Instance == null &&
                     fixupToken.Target.InstanceType == null &&
                     fixupToken.FixupType == FixupType.MarkupExtensionFirstRun);
                 Debug.Assert(_deferredRootProvideValue == null);
@@ -91,7 +93,7 @@ namespace MS.Internal.Xaml.Context
                 foreach (string name in fixupToken.NeededNames)
                 {
                     AddToMultiDict(_dependenciesByName, name, fixupToken);
-                }   
+                }
             }
         }
 
@@ -182,7 +184,7 @@ namespace MS.Internal.Xaml.Context
                 while (i < nameDependencies.Count)
                 {
                     token = nameDependencies[i];
-                    
+
                     // The same name can occur in multiple namescopes, so we need to make sure that
                     // this named object is visible in the scope of the token.
                     object resolvedName = token.ResolveName(name);
@@ -420,7 +422,7 @@ namespace MS.Internal.Xaml.Context
             }
             alreadyTraversed.Add(inEdge);
             FrugalObjectList<NameFixupToken> outEdges;
-            if (inEdge.ReferencedObject == null || 
+            if (inEdge.ReferencedObject == null ||
                 !_dependenciesByParentObject.TryGetValue(inEdge.ReferencedObject, out outEdges))
             {
                 // No dependencies, we're done with this subgraph

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupToken.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/NameFixupToken.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -156,7 +158,7 @@ namespace MS.Internal.Xaml.Context
         {
             get { return _nameScopeDictionaryList; }
         }
-        
+
         public List<String> NeededNames
         {
             get { return _names; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -26,7 +28,7 @@ namespace MS.Internal.Xaml.Context
         XamlObjectWriterSettings _settings;
         List<NameScopeInitializationCompleteSubscriber> _nameScopeInitializationCompleteSubscribers;
 
-        public ObjectWriterContext(XamlSavedContext savedContext, 
+        public ObjectWriterContext(XamlSavedContext savedContext,
             XamlObjectWriterSettings settings, XAML3.INameScope rootNameScope, XamlRuntime runtime)
             : base(savedContext.SchemaContext)
         {
@@ -63,7 +65,7 @@ namespace MS.Internal.Xaml.Context
                 }
 
                 // Push an extra frame to ensure that the template NameScope is
-                // not part of the saved context.  Otherwise, the namescope 
+                // not part of the saved context.  Otherwise, the namescope
                 // will hold things alive as long as the template is alive
                 _stack.PushScope();
                 _savedDepth = _stack.Depth;
@@ -269,7 +271,7 @@ namespace MS.Internal.Xaml.Context
 
         // ----- methods to support the Service Providers
 
-        internal ServiceProviderContext ServiceProviderContext    
+        internal ServiceProviderContext ServiceProviderContext
         {
             get
             {
@@ -489,7 +491,7 @@ namespace MS.Internal.Xaml.Context
         {
             _stack.PopScope();
         }
-        
+
         /// <summary>
         /// Total depth of the stack SavedDepth+LiveDepth
         /// </summary>
@@ -660,7 +662,7 @@ namespace MS.Internal.Xaml.Context
         {
             get { return _settings != null ? _settings.SourceBamlUri : null; }
         }
-        
+
         // This specifically stores the start line number for a start object for consistency
         public int LineNumber_StartObject { get; set; }
 
@@ -893,7 +895,7 @@ namespace MS.Internal.Xaml.Context
                     nameScopeDictionary = new NameScopeDictionary(nameScope);
                 }
             }
-            
+
             // If the root instance isn't a name scope
             // then perhaps it designated a property as the name scope.
             if (nameScopeDictionary == null)
@@ -929,7 +931,7 @@ namespace MS.Internal.Xaml.Context
                 }
             }
 
-            if (nameScopeDictionary == null && _settings != null 
+            if (nameScopeDictionary == null && _settings != null
                 && _settings.RegisterNamesOnExternalNamescope)
             {
                 ObjectWriterFrame frameZero = (ObjectWriterFrame)rootFrame.Previous;
@@ -961,7 +963,7 @@ namespace MS.Internal.Xaml.Context
             }
 
             // Clone the stack
-            var newStack = new XamlContextStack<ObjectWriterFrame>(_stack, true);            
+            var newStack = new XamlContextStack<ObjectWriterFrame>(_stack, true);
             XamlSavedContext savedContext = new XamlSavedContext(savedContextType, this, newStack);
             return savedContext;
         }
@@ -1090,7 +1092,7 @@ namespace MS.Internal.Xaml.Context
 
             public event EventHandler OnNameScopeInitializationComplete
             {
-                // at this point all name scopes have been completed, and we will 
+                // at this point all name scopes have been completed, and we will
                 // not raise any event for subscriptions that come after this.
                 add
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,7 +29,7 @@ namespace MS.Internal.Xaml.Context
         public ObjectWriterFrame(ObjectWriterFrame source)
             : base(source)
         {
-            // Calling the getter will instantiate new Dictionaries. 
+            // Calling the getter will instantiate new Dictionaries.
             // So we just check the field instead to verify that it isn't
             // being used.
             if (source._preconstructionPropertyValues != null)
@@ -81,7 +83,7 @@ namespace MS.Internal.Xaml.Context
 
         public object Instance { get; set; }
         public object Collection { get; set; }
-        
+
         public bool WasAssignedAtCreation
         {
             get { return GetFlag(ObjectWriterFrameFlags.WasAssignedAtCreation); }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/SavedContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/SavedContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using MS.Internal.Xaml.Context;
 
 namespace System.Xaml

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ServiceProviderContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlCommonFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlCommonFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Xaml;
 
@@ -20,7 +22,7 @@ namespace MS.Internal.Xaml.Context
                 return _namespaces;
             }
         }
-        
+
         public XamlCommonFrame() : base()
         {
         }
@@ -45,7 +47,7 @@ namespace MS.Internal.Xaml.Context
                 _namespaces.Clear();
             }
         }
-        
+
         public XamlType XamlType { get; set; }
         public XamlMember Member { get; set; }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -87,7 +89,7 @@ namespace MS.Internal.Xaml
             }
             XamlType rootTagType = tagIsRoot ? tagType : null;
 
-            // If we have <foo x:TA="" foo.bar=""/> we want foo in foo.bar to match the tag 
+            // If we have <foo x:TA="" foo.bar=""/> we want foo in foo.bar to match the tag
             // type since there is no way to specify generic syntax in dotted property notation
             // If that fails, then we fall back to the non-generic case below.
             bool ownerTypeMatchesGenericTagType = false;
@@ -251,7 +253,7 @@ namespace MS.Internal.Xaml
             return GetXamlType(typeName, returnUnknownTypesOnFailure, false);
         }
 
-        internal XamlType GetXamlType(XamlTypeName typeName, bool returnUnknownTypesOnFailure, 
+        internal XamlType GetXamlType(XamlTypeName typeName, bool returnUnknownTypesOnFailure,
             bool skipVisibilityCheck)
         {
             Debug.Assert(typeName != null, "typeName cannot be null and should have been checked before now");
@@ -292,7 +294,7 @@ namespace MS.Internal.Xaml
             }
         }
 
-        private string ResolveXamlNameNS(XamlName name) 
+        private string ResolveXamlNameNS(XamlName name)
         {
             return name.Namespace ?? FindNamespaceByPrefix(name.Prefix);
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlObjectWriterFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlObjectWriterFactory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Xaml;
 
 namespace MS.Internal.Xaml.Context
@@ -30,6 +32,6 @@ namespace MS.Internal.Xaml.Context
         }
 
         #endregion
-   
+
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -125,7 +127,7 @@ namespace MS.Internal.Xaml.Context
             {
                 return true;
             }
-            
+
             // If the property setter is not visible, but the property getter is, treat the property
             // as if it were read-only
             if (member.IsReadOnly || (member.Type != null && member.Type.IsUsableAsReadOnly))

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/XamlParserFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Reflection;
 using System.Xaml;
@@ -25,7 +27,7 @@ namespace MS.Internal.Xaml.Context
             EscapeCharacterMapForMarkupExtension = null;
             BracketModeParseParameters = null;
         }
-        
+
         public XamlType PreviousChildType { get; set; }
         public int CtorArgCount { get; set; }
         public bool ForcedToUseConstructor { get; set; }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Xaml.Schema;
@@ -10,8 +12,8 @@ namespace System.Xaml
 {
     internal class EventConverter : TypeConverter
     {
-        // CanConvertTo and ConvertTo are not implemented here because it is not possible to convert 
-        // an event/delegate to string in the general case, because 
+        // CanConvertTo and ConvertTo are not implemented here because it is not possible to convert
+        // an event/delegate to string in the general case, because
         // 1. an event's getter is private.
         // 2. we currently do not have a syntax for writing down a multi-cast delegate
         // 3. we currently do not have a syntax to write down a method not on the root object.
@@ -44,12 +46,12 @@ namespace System.Xaml
 
         internal static void GetRootObjectAndDelegateType(ITypeDescriptorContext context, out object rootObject, out Type delegateType)
         {
-            rootObject = null; 
+            rootObject = null;
             delegateType = null;
 
-            if (context == null) 
+            if (context == null)
             {
-                return; 
+                return;
             }
 
             IRootObjectProvider rootObjectService = context.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/EventConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Globalization;
 using System.Xaml.Schema;
@@ -18,7 +16,7 @@ namespace System.Xaml
         // 2. we currently do not have a syntax for writing down a multi-cast delegate
         // 3. we currently do not have a syntax to write down a method not on the root object.
 
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             if (sourceType == typeof(string))
             {
@@ -27,14 +25,11 @@ namespace System.Xaml
             return base.CanConvertFrom(context, sourceType);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
-            string valueString = value as string;
-            if (valueString != null)
+            if (value is string valueString)
             {
-                object rootObject = null;
-                Type delegateType = null;
-                GetRootObjectAndDelegateType(context, out rootObject, out delegateType);
+                GetRootObjectAndDelegateType(context, out object? rootObject, out Type? delegateType);
 
                 if (rootObject != null && delegateType != null)
                 {
@@ -44,7 +39,7 @@ namespace System.Xaml
             return base.ConvertFrom(context, culture, value);
         }
 
-        internal static void GetRootObjectAndDelegateType(ITypeDescriptorContext context, out object rootObject, out Type delegateType)
+        internal static void GetRootObjectAndDelegateType(ITypeDescriptorContext? context, out object? rootObject, out Type? delegateType)
         {
             rootObject = null;
             delegateType = null;
@@ -54,14 +49,14 @@ namespace System.Xaml
                 return;
             }
 
-            IRootObjectProvider rootObjectService = context.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;
+            IRootObjectProvider? rootObjectService = context.GetService(typeof(IRootObjectProvider)) as IRootObjectProvider;
             if (rootObjectService == null)
             {
                 return;
             }
             rootObject = rootObjectService.RootObject;
 
-            IDestinationTypeProvider targetService = context.GetService(typeof(IDestinationTypeProvider)) as IDestinationTypeProvider;
+            IDestinationTypeProvider? targetService = context.GetService(typeof(IDestinationTypeProvider)) as IDestinationTypeProvider;
             if (targetService == null)
             {
                 return;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Events/XamlObjectEventArgs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Events/XamlObjectEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class XamlObjectEventArgs : EventArgs

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAmbientProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace System.Xaml

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAttachedPropertyStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IAttachedPropertyStore.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IDestinationTypeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IDestinationTypeProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IDestinationTypeProvider

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/INamespacePrefixLookup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/INamespacePrefixLookup.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface INamespacePrefixLookup

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IRootObjectProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IRootObjectProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IRootObjectProvider

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlLineInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlLineInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlLineInfo
@@ -11,5 +13,5 @@ namespace System.Xaml
         int LineNumber { get; }
         int LinePosition { get; }
     }
-    
+
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlLineInfoConsumer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlLineInfoConsumer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlLineInfoConsumer

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNameProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNameProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlNameProvider

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNameResolver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNameResolver.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace System.Xaml

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNamespaceResolver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlNamespaceResolver.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace System.Xaml
@@ -9,6 +11,6 @@ namespace System.Xaml
     public interface IXamlNamespaceResolver
     {
         string GetNamespace(string prefix);
-        IEnumerable<NamespaceDeclaration> GetNamespacePrefixes(); 
+        IEnumerable<NamespaceDeclaration> GetNamespacePrefixes();
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlObjectWriterFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlObjectWriterFactory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlObjectWriterFactory

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlSchemaContextProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/IXamlSchemaContextProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlSchemaContextProvider

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/DeferredWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using MS.Internal.Xaml.Context;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.Xaml
@@ -20,7 +22,7 @@ namespace System.Xaml
 
     internal delegate void XamlNodeAddDelegate(XamlNodeType nodeType, object data);
     internal delegate void XamlLineInfoAddDelegate(int lineNumber, int linePosition);
-    internal delegate XamlNode XamlNodeNextDelegate();     
+    internal delegate XamlNode XamlNodeNextDelegate();
     internal delegate XamlNode XamlNodeIndexDelegate(int idx);
 
     [DebuggerDisplay("{ToString()}")]
@@ -34,7 +36,7 @@ namespace System.Xaml
 
         public XamlNodeType NodeType
         {
-            get { return _nodeType; } 
+            get { return _nodeType; }
         }
 
         public XamlNode(XamlNodeType nodeType)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriterSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriterSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Markup;
 using System.Xaml.Permissions;
 
@@ -52,7 +54,7 @@ namespace System.Xaml
 
         /// <summary>
         /// SourceBamlUri will be used by XamlObjectWriter in BeginInitHandler's SourceBamlUri property, in place of the actual BaseUri.
-        /// This is only useful to give the correct info in that handler, while keeping runtime behavior fully compatible. 
+        /// This is only useful to give the correct info in that handler, while keeping runtime behavior fully compatible.
         /// </summary>
         public Uri SourceBamlUri { get; set; }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlReaderSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlReaderSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Reflection;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -339,7 +341,7 @@ namespace System.Xaml
             // Namespace is known
             // http://schemas.microsoft.com/winfx/2006/xaml/presentation/options
             // We're inside of a XmlDataIsland
-            
+
             // First, substitute in the LocalAssembly if needed
             if (_mergedSettings.LocalAssembly != null)
             {
@@ -359,7 +361,7 @@ namespace System.Xaml
                 newXmlNamespace = string.Empty;
             }
 
-            
+
             // we need to treat all namespaces inside of XmlDataIslands as Supported.
             // we need to tree Freeze as known, if it is around... don't hardcode.
             //else if (xmlNamespace == XamlReaderHelper.PresentationOptionsNamespaceURI)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReaderSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlXmlReaderSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 
 namespace System.Xaml

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/LineInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/LineInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     internal class LineInfo
@@ -27,7 +29,7 @@ namespace System.Xaml
 
         public int LinePosition
         {
-            get { return _linePosition; }            
+            get { return _linePosition; }
         }
         #endregion
     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/AssemblyNamespacePair.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Reflection;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml.MS.Impl
 {
     internal static class KnownStrings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/PositionalParameterDescriptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/PositionalParameterDescriptor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml.MS.Impl
 {
     internal class PositionalParameterDescriptor

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -212,7 +214,7 @@ namespace System.Xaml.MS.Impl
                 xmlNamespaceList.Add(nsDef.XmlNamespace);
             }
 
-            string assemblyName = _fullyQualifyAssemblyName ? 
+            string assemblyName = _fullyQualifyAssemblyName ?
                 assembly.FullName : XamlSchemaContext.GetAssemblyShortName(assembly);
             foreach (KeyValuePair<string, IList<string>> clrToXmlNs in result)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScope.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScope.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Used to store mapping information for names occuring 
+#nullable disable
+
+// Used to store mapping information for names occuring
 // within the logical tree section.
 
 using System.Collections;
@@ -13,13 +15,13 @@ using System.Windows.Markup;
 namespace System.Xaml
 {
     /// <summary>
-    /// Used to store mapping information for names occuring 
+    /// Used to store mapping information for names occuring
     /// within the logical tree section.
     /// </summary>
     internal class NameScope : INameScopeDictionary
-    {        
+    {
         /// <summary>
-        /// Register Name-Object Map 
+        /// Register Name-Object Map
         /// </summary>
         /// <param name="name">name to be registered</param>
         /// <param name="scopedElement">object mapped to name</param>
@@ -54,12 +56,12 @@ namespace System.Xaml
                 else if (scopedElement != nameContext)
                 {
                     throw new ArgumentException(SR.Format(SR.NameScopeDuplicateNamesNotAllowed, name));
-                }   
+                }
             }
         }
 
         /// <summary>
-        /// Unregister Name-Object Map 
+        /// Unregister Name-Object Map
         /// </summary>
         /// <param name="name">name to be registered</param>
         public void UnregisterName(string name)
@@ -93,7 +95,7 @@ namespace System.Xaml
 
             return _nameMap[name];
         }
-        
+
         // This is a HybridDictionary of Name-Object maps
         private HybridDictionary _nameMap;
 
@@ -253,7 +255,7 @@ namespace System.Xaml
         private class Enumerator : IEnumerator<KeyValuePair<string, object>>
         {
             private IDictionaryEnumerator _enumerator;
-            
+
             public Enumerator(HybridDictionary nameMap)
             {
                 _enumerator = nameMap?.GetEnumerator();

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameScopeDictionary.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -12,7 +14,7 @@ namespace System.Xaml
 {
     //
     // The implementation for this class is taken directly from the source of NameScope, including the use
-    // of HybridDictionary to match the performance semantics of 3.0 for the time being 
+    // of HybridDictionary to match the performance semantics of 3.0 for the time being
     // Note that the IEnumerable<T> uses KeyValuePair<string, object>
     // This means that we need to create KeyValuePairs on the fly
     // The other option would be to just use IEnumerable (or change the HybridDictionary to Dictionary<K,V>)
@@ -22,7 +24,7 @@ namespace System.Xaml
         private HybridDictionary _nameMap;
         private INameScope _underlyingNameScope;
         private FrugalObjectList<string> _names;
-        
+
         public NameScopeDictionary()
         {
         }
@@ -130,7 +132,7 @@ namespace System.Xaml
             HybridDictionary _nameMap;
             INameScope _underlyingNameScope;
             FrugalObjectList<string> _names;
-            
+
             public Enumerator(NameScopeDictionary nameScopeDictionary)
             {
                 _nameMap = nameScopeDictionary._nameMap;
@@ -285,7 +287,7 @@ namespace System.Xaml
 
         #region IDictionary<string, object> methods
         object IDictionary<string, object>.this[string key]
-        { 
+        {
             get
             {
                 throw new NotImplementedException();

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameValidationHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NameValidationHelper.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Used to store mapping information for names occuring 
+#nullable disable
+
+// Used to store mapping information for names occuring
 // within the logical tree section.
 
 using System.Globalization;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NamespaceDeclaration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/NamespaceDeclaration.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.Xaml
@@ -10,7 +12,7 @@ namespace System.Xaml
     public class NamespaceDeclaration
     {
         private string prefix;
-        
+
         private string ns;
 
         public NamespaceDeclaration(string ns, string prefix)
@@ -26,7 +28,7 @@ namespace System.Xaml
                 return prefix;
             }
         }
-        
+
         public string Namespace
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameParser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -154,7 +156,7 @@ namespace MS.Internal.Xaml.Parser
             {
                 P_RepeatingSubscript();
             }
-            
+
             Callout_EndOfType();
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/GenericTypeNameScanner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xaml.MS.Impl;
@@ -138,7 +140,7 @@ namespace MS.Internal.Xaml.Parser
             }
             while (pos < subscript.Length);
             //unterminated string
-            return 0; 
+            return 0;
         }
 
         // strips the subscript off the end of typeName, and returns it

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MePullParser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -29,7 +31,7 @@ namespace MS.Internal.Xaml.Parser
         }
 
         // MarkupExtension ::= '{' TYPENAME Arguments? '}'
-        //    Arguments    ::= (PositionalArgs ( ',' NamedArgs)?) | NamedArgs 
+        //    Arguments    ::= (PositionalArgs ( ',' NamedArgs)?) | NamedArgs
         //    NamedArgs    ::= NamedArg ( ',' NamedArg )*
         //    NamedArg     ::= PROPERTYNAME '=' (STRING | QUOTEDMARKUPEXTENSION | MarkupExtension)
         //  PositionalArgs ::= (Value (',' PositionalArgs)?) | NamedArg
@@ -144,18 +146,18 @@ namespace MS.Internal.Xaml.Parser
         }
 
         ////////////////////////////////
-        // Arguments ::= (PositionalArgs ( ',' NamedArgs)?) | NamedArgs 
+        // Arguments ::= (PositionalArgs ( ',' NamedArgs)?) | NamedArgs
         //
         private IEnumerable<XamlNode> P_Arguments(Found f)
         {
             Found f2 = new Found();
-            // Arguments ::= @ (PositionalArgs ( ',' NamedArgs)?) | NamedArgs 
+            // Arguments ::= @ (PositionalArgs ( ',' NamedArgs)?) | NamedArgs
             switch (_tokenizer.Token)
             {
             case MeTokenType.Close:  // not found
                 break;
 
-            // Arguments ::= (@ PositionalArgs ( ',' NamedArgs)?) | NamedArgs 
+            // Arguments ::= (@ PositionalArgs ( ',' NamedArgs)?) | NamedArgs
             case MeTokenType.String:
             case MeTokenType.QuotedMarkupExtension:
             case MeTokenType.Open:
@@ -172,13 +174,13 @@ namespace MS.Internal.Xaml.Parser
                     }
                 }
 
-                // Arguments ::= (PositionalArgs @ ( ',' NamedArgs)?) | NamedArgs 
+                // Arguments ::= (PositionalArgs @ ( ',' NamedArgs)?) | NamedArgs
                 while (_tokenizer.Token == MeTokenType.Comma)
                 {
-                    // Arguments ::= (PositionalArgs ( @ ',' NamedArgs)?) | NamedArgs 
+                    // Arguments ::= (PositionalArgs ( @ ',' NamedArgs)?) | NamedArgs
                     NextToken();
 
-                    // Arguments ::= (PositionalArgs ( ',' @ NamedArgs)?) | NamedArgs 
+                    // Arguments ::= (PositionalArgs ( ',' @ NamedArgs)?) | NamedArgs
                     foreach (XamlNode node in P_NamedArgs(f2))
                     {
                         yield return node;
@@ -186,7 +188,7 @@ namespace MS.Internal.Xaml.Parser
                 }
                 break;
 
-            // Arguments ::= (PositionalArgs ( ',' NamedArgs)?) | @ NamedArgs 
+            // Arguments ::= (PositionalArgs ( ',' NamedArgs)?) | @ NamedArgs
             case MeTokenType.PropertyName:
                 foreach (XamlNode node in P_NamedArgs(f2))
                 {
@@ -200,7 +202,7 @@ namespace MS.Internal.Xaml.Parser
                 break;
             }
         }
-    
+
         ////////////////////////////////
         //  PositionalArgs ::= (Value (',' PositionalArgs)?) | NamedArg
         //

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/MeScanner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -35,7 +37,7 @@ namespace MS.Internal.Xaml.Parser
     // 3) All strings are trimmed of whitespace front and back unless they were quoted.
     // 4) Quote characters can only appear at the start and end of strings.
     // 5) TypeNames cannot be quoted.
-    
+
     internal class MeScanner
     {
         public const char Space = ' ';
@@ -204,8 +206,8 @@ namespace MS.Internal.Xaml.Parser
 
             if(readString)
             {
-                if (_context.CurrentType.IsMarkupExtension 
-                    && _context.CurrentBracketModeParseParameters != null 
+                if (_context.CurrentType.IsMarkupExtension
+                    && _context.CurrentBracketModeParseParameters != null
                     && _context.CurrentBracketModeParseParameters.IsConstructorParsingMode)
                 {
                     int currentCtrParam = _context.CurrentBracketModeParseParameters.CurrentConstructorParam;
@@ -241,8 +243,8 @@ namespace MS.Internal.Xaml.Parser
             if (value.StartsWith("{}", StringComparison.OrdinalIgnoreCase))
             {
                 value = value.Substring(2);
-            } 
-            
+            }
+
             if (!value.Contains(Backslash))
             {
                 return value;
@@ -288,15 +290,15 @@ namespace MS.Internal.Xaml.Parser
             {
                 throw new XamlParseException(this, error);
             }
-            
+
             // In curly form, we search for TypeName + 'Extension' before TypeName
             string bareTypeName = typeName.Name;
             typeName.Name = typeName.Name + KnownStrings.Extension;
             XamlType xamlType = _context.GetXamlType(typeName, false);
             // This would be cleaner if we moved the Extension fallback logic out of XSC
-            if (xamlType == null || 
+            if (xamlType == null ||
                 // Guard against Extension getting added twice
-                (xamlType.UnderlyingType != null && 
+                (xamlType.UnderlyingType != null &&
                  KS.Eq(xamlType.UnderlyingType.Name, typeName.Name + KnownStrings.Extension)))
             {
                 typeName.Name = bareTypeName;
@@ -374,7 +376,7 @@ namespace MS.Internal.Xaml.Parser
                     }
                 }
                 // If we are inside of MarkupExtensionBracketCharacters for a particular property or position parameter,
-                // scoop up everything inside one by one, and keep track of nested Bracket Characters in the stack. 
+                // scoop up everything inside one by one, and keep track of nested Bracket Characters in the stack.
                 else if (_context.CurrentBracketModeParseParameters != null && _context.CurrentBracketModeParseParameters.IsBracketEscapeMode)
                 {
                     Stack<char> bracketCharacterStack = _context.CurrentBracketModeParseParameters.BracketCharacterStack;
@@ -551,7 +553,7 @@ namespace MS.Internal.Xaml.Parser
 
             if (ch == KnownStrings.WhitespaceChars[0] ||
                 ch == KnownStrings.WhitespaceChars[1] ||
-                ch == KnownStrings.WhitespaceChars[2] || 
+                ch == KnownStrings.WhitespaceChars[2] ||
                 ch == KnownStrings.WhitespaceChars[3] ||
                 ch == KnownStrings.WhitespaceChars[4])
             {
@@ -588,7 +590,7 @@ namespace MS.Internal.Xaml.Parser
         private SpecialBracketCharacters GetBracketCharacterForProperty(string propertyName)
         {
             SpecialBracketCharacters bracketCharacters = null;
-            if (_context.CurrentEscapeCharacterMapForMarkupExtension != null && 
+            if (_context.CurrentEscapeCharacterMapForMarkupExtension != null &&
                 _context.CurrentEscapeCharacterMapForMarkupExtension.ContainsKey(propertyName))
             {
                 bracketCharacters = _context.CurrentEscapeCharacterMapForMarkupExtension[propertyName];

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Xaml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -653,18 +655,18 @@ namespace MS.Internal.Xaml
             Debug.Assert(length1 > 0 && length2 > 0);
 
             ReorderInfo[] temp = new ReorderInfo[length1];
-            
+
             // Copy first half into temp storage.
             //             srcArray,      srcIdx, destArray, destIdx, length
             Array.Copy(_sortingInfoArray, beginning, temp,       0,      length1);
 
             // Copy second half up where the first half was.
             //             srcArray,      srcIdx,    destArray,     destIdx,  length
-            Array.Copy(_sortingInfoArray, middle, _sortingInfoArray, beginning,  length2); 
+            Array.Copy(_sortingInfoArray, middle, _sortingInfoArray, beginning,  length2);
 
             // Copy first half out of temp storage in after the first half
             //        srcArray, srcIdx, destArray,        destIdx,         length
-            Array.Copy(temp,      0,  _sortingInfoArray, beginning + length2, length1); 
+            Array.Copy(temp,      0,  _sortingInfoArray, beginning + length2, length1);
         }
 
         private bool AdvanceTo(int start, XamlNodeType nodeType, int searchDepth, out int end)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/ScannerNodeType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/ScannerNodeType.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace MS.Internal.Xaml.Parser
 {
     internal enum ScannerNodeType

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Xaml;
@@ -94,7 +96,7 @@ namespace MS.Internal.Xaml.Parser
         }
 
 
-        // FxCop says this is not called 
+        // FxCop says this is not called
         //public bool IsXamlNsDefinition
         //{
         //    get { return (!String.IsNullOrEmpty(_xmlnsDefinitionUri)); }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlName.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 
 namespace MS.Internal.Xaml.Parser

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 
 namespace MS.Internal.Xaml.Parser

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPullParser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -40,7 +42,7 @@ namespace MS.Internal.Xaml.Parser
         // Attribute and Directive values can be markup extensions.
 
         ///////////////////////////
-        //  XamlPullParser Exception Strings 
+        //  XamlPullParser Exception Strings
         //
         private const string ElementRuleException = "Element ::= . EmptyElement | ( StartElement ElementBody ).";
         private const string EmptyElementRuleException = "EmptyElement ::= . EMPTYELEMENT DIRECTIVE* ATTRIBUTE*.";

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlQualifiedName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlQualifiedName.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 
 namespace MS.Internal.Xaml.Parser

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScanner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -784,7 +786,7 @@ namespace MS.Internal.Xaml.Parser
 
             // (GetFixedDocumentSequence raises Exception "UnicodeString property does not
             // contain enough characters to correspond to the contents of Indices property.")
-            // 
+            //
             // XamlText.Paste normally converts CRLF to LF, even in attribute values.
             // When the property is Glyphs.UnicodeString, disable this;
             // the length of the string must correspond to the number of entries in

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Xaml;
 using System.Xml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlScannerStack.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xaml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlText.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Diagnostics;
 using System.Text;
@@ -82,7 +84,7 @@ namespace MS.Internal.Xaml.Parser
                 {
                     // (GetFixedDocumentSequence raises Exception "UnicodeString property does not contain
                     // enough characters to correspond to the contents of Indices property.")
-                    // 
+                    //
                     // Convert CRLF into just LF.  Including attribute text values.
                     // Attribute text is internal set to "preserve" to prevent (other) processing.
                     // We processing attribute values in this way because 3.x did it.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderBaseDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderBaseDelegate.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     // This is the base class for the simplest implementation of a
@@ -19,7 +21,7 @@ namespace System.Xaml
 
         protected ReaderBaseDelegate(XamlSchemaContext schemaContext)
         {
-            _schemaContext = schemaContext ?? throw new ArgumentNullException(nameof(schemaContext));            
+            _schemaContext = schemaContext ?? throw new ArgumentNullException(nameof(schemaContext));
         }
 
         public override XamlNodeType NodeType
@@ -73,7 +75,7 @@ namespace System.Xaml
 
         public int LineNumber
         {
-            get 
+            get
             {
                 if (_currentLineInfo != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderDelegate.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     // This is the simplest implementation of a Node based XamlReader.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderMultiIndexDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/ReaderMultiIndexDelegate.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public interface IXamlIndexingReader

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/RefOnly/LooseTypeExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Reflection;
 using System.Windows.Markup;
 
@@ -97,7 +99,7 @@ namespace System.Xaml
                 }
             }
 
-            return true;            
+            return true;
         }
 
         static bool LooselyImplementInterface(Type t, Type interfaceType)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeConverter2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeConverter2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Markup;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeOffsetConverter2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/DateTimeOffsetConverter2.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/TypeListConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/TypeListConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Markup;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/TypeTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Replacements/TypeTypeConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Markup;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -330,7 +332,7 @@ namespace MS.Internal.Xaml.Runtime
 
         public override IList<object> GetCollectionItems(object collection, XamlType collectionType)
         {
-            List<object> result; 
+            List<object> result;
             IEnumerator enumerator = GetItems(collection, collectionType);
             try
             {
@@ -358,7 +360,7 @@ namespace MS.Internal.Xaml.Runtime
             {
                 // Dictionaries are required to either give us an either:
                 // - an IDictionaryEnumerator,
-                // - an IEnumerator<KeyValuePair<K,V>>, or 
+                // - an IEnumerator<KeyValuePair<K,V>>, or
                 // - an IEnumerator that returns DictionaryEntrys
                 IDictionaryEnumerator dictionaryEnumerator = enumerator as IDictionaryEnumerator;
                 if (dictionaryEnumerator != null)
@@ -652,7 +654,7 @@ namespace MS.Internal.Xaml.Runtime
                 //let the value passthrough (to be set as the property value later).
                 obj = value;
             }
-            
+
             return obj;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -28,9 +30,9 @@ namespace MS.Internal.Xaml.Runtime
 
     internal class DynamicMethodRuntime : ClrObjectRuntime
     {
-        const BindingFlags BF_AllInstanceMembers = 
+        const BindingFlags BF_AllInstanceMembers =
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-        const BindingFlags BF_AllStaticMembers = 
+        const BindingFlags BF_AllStaticMembers =
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
 
         static MethodInfo s_GetTypeFromHandleMethod;
@@ -44,7 +46,7 @@ namespace MS.Internal.Xaml.Runtime
         Assembly _localAssembly;
 
         Type _localType;
-        
+
         XamlSchemaContext _schemaContext;
 
         // We cache based on MemberInfo instead of XamlMember for two reasons:
@@ -285,7 +287,7 @@ namespace MS.Internal.Xaml.Runtime
             // We have to emit an indirect call through reflection to avoid the helper getting
             // inlined into the dynamic method, and potentially executing without access to private
             // members on the target type.
-            Emit_LateBoundInvoke(ilGenerator, targetType, KnownStrings.CreateDelegateHelper, 
+            Emit_LateBoundInvoke(ilGenerator, targetType, KnownStrings.CreateDelegateHelper,
                 helperFlags | BindingFlags.InvokeMethod, 1, 0, 2);
             Emit_CastTo(ilGenerator, typeof(Delegate));
             ilGenerator.Emit(OpCodes.Ret);
@@ -303,7 +305,7 @@ namespace MS.Internal.Xaml.Runtime
             ilGenerator.Emit(OpCodes.Ldarg_1);
             ilGenerator.Emit(OpCodes.Ldarg_2);
             MethodInfo method = typeof(Delegate).GetMethod(KnownStrings.CreateDelegate,
-                BindingFlags.Static | BindingFlags.Public, null, 
+                BindingFlags.Static | BindingFlags.Public, null,
                 new Type[] { typeof(Type), typeof(object), typeof(string) }, null);
             ilGenerator.Emit(OpCodes.Call, method);
             ilGenerator.Emit(OpCodes.Ret);
@@ -313,7 +315,7 @@ namespace MS.Internal.Xaml.Runtime
 
         private FactoryDelegate CreateFactoryDelegate(ConstructorInfo ctor)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(ctor.DeclaringType.Name + "Ctor", 
+            DynamicMethod dynamicMethod = CreateDynamicMethod(ctor.DeclaringType.Name + "Ctor",
                 typeof(object), typeof(object[]));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -321,16 +323,16 @@ namespace MS.Internal.Xaml.Runtime
             ilGenerator.Emit(OpCodes.Newobj, ctor);
             UnloadArguments(ilGenerator, locals);
             ilGenerator.Emit(OpCodes.Ret);
-            
+
             return (FactoryDelegate)dynamicMethod.CreateDelegate(typeof(FactoryDelegate));
         }
 
         private FactoryDelegate CreateFactoryDelegate(MethodInfo factory)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(factory.Name + "Factory", 
+            DynamicMethod dynamicMethod = CreateDynamicMethod(factory.Name + "Factory",
                 typeof(object), typeof(object[]));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
-            
+
             LocalBuilder[] locals = LoadArguments(ilGenerator, factory);
             ilGenerator.Emit(OpCodes.Call, factory);
             Emit_BoxIfValueType(ilGenerator, factory.ReturnType);
@@ -350,7 +352,7 @@ namespace MS.Internal.Xaml.Runtime
             }
 
             // We need to handle vararg matches (and optional parameters?)
-            
+
             ParameterInfo[] parameters = method.GetParameters();
             Type[] paramTypes = new Type[parameters.Length];
             LocalBuilder[] locals = new LocalBuilder[paramTypes.Length];
@@ -401,18 +403,18 @@ namespace MS.Internal.Xaml.Runtime
         }
 
         // The methods below don't properly handle non-Runtime reflection classes
-        
+
         // Note that CreateGetDelegate fails verification for value types (and probably shouldn't)
         private PropertyGetDelegate CreateGetDelegate(MethodInfo getter)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(getter.Name + "Getter", 
+            DynamicMethod dynamicMethod = CreateDynamicMethod(getter.Name + "Getter",
                 typeof(object), typeof(object));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
             Type targetType = getter.IsStatic ? getter.GetParameters()[0].ParameterType : GetTargetType(getter);
             ilGenerator.Emit(OpCodes.Ldarg_0);
             Emit_CastTo(ilGenerator, targetType);
-            
+
             Emit_Call(ilGenerator, getter);
             Emit_BoxIfValueType(ilGenerator, getter.ReturnType);
             ilGenerator.Emit(OpCodes.Ret);
@@ -423,7 +425,7 @@ namespace MS.Internal.Xaml.Runtime
         // Note that CreateSetDelegate fails verification for value types (and probably shouldn't)
         private PropertySetDelegate CreateSetDelegate(MethodInfo setter)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(setter.Name + "Setter", 
+            DynamicMethod dynamicMethod = CreateDynamicMethod(setter.Name + "Setter",
                 typeof(void), typeof(object), typeof(object));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -551,7 +553,7 @@ namespace MS.Internal.Xaml.Runtime
             BindingFlags bindingFlags, short targetArgNum, params short[] paramArgNums)
         {
             //Emits: typeof(targetType).InvokeMember(
-            //           methodName, bindingFlags, null, ldarg_targetArgNum, 
+            //           methodName, bindingFlags, null, ldarg_targetArgNum,
             //           new object[] { ldarg_paramArgNums });
 
             Emit_TypeOf(ilGenerator, targetType);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/PartialTrustTolerantRuntime.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,7 +17,7 @@ using System.Xaml.Schema;
 namespace MS.Internal.Xaml.Runtime
 {
     // Perf notes
-    // - Need a perf test to decide whether it's faster to check for public visibility, or just always 
+    // - Need a perf test to decide whether it's faster to check for public visibility, or just always
     //   fall through to the elevated case once we've determined we don't have MemberAccess permission.
     // - Consider checking ctor visibility in CreateInstance
     // - Consider checking method visibility in CreateWithFactoryMethod

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/XamlRuntimeSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/XamlRuntimeSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace MS.Internal.Xaml.Runtime
 {
     internal class XamlRuntimeSettings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/AllowedMemberLocations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/AllowedMemberLocations.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml.Schema
 {
     [Flags]

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/BuiltInValueConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
@@ -189,7 +191,7 @@ namespace System.Xaml.Schema
                     {
                         // There is a built-in TypeConverter available. Very likely, System.UriTypeConverter, but this was not naturally
                         // discovered. this is probably due to the fact that System.Uri does not have [TypeConverterAttribute(typeof(UriConverter))]
-                        // in the .NET Core codebase. 
+                        // in the .NET Core codebase.
                         // Since a default converter was discovered, just use that instead of our own (very nearly equivalent) implementation.
                         s_Uri = new BuiltInValueConverter<TypeConverter>(stdConverter.GetType(), () => TypeDescriptor.GetConverter(typeof(Uri)));
                     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Xaml.MS.Impl;
 
 namespace System.Xaml.Schema
@@ -21,7 +23,7 @@ namespace System.Xaml.Schema
 
             // xmlns:foo="clr-namespace:System.Windows;assembly=myassemblyname"
             // xmlns:bar="clr-namespace:MyAppsNs"
-            // xmlns:spam="clr-namespace:MyAppsNs;assembly="  
+            // xmlns:spam="clr-namespace:MyAppsNs;assembly="
 
             int colonIdx = KS.IndexOf(uriInput, ':');
             if (colonIdx == -1)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/CollectionReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/CollectionReflector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -36,7 +38,7 @@ namespace System.Xaml.Schema
                 return XamlCollectionKind.Array;
             }
 
-            // Dictionaries and Collections must implement IEnumerable or have method 
+            // Dictionaries and Collections must implement IEnumerable or have method
             // GetEnumerator() where return type is assignable to IEnumerator
             bool isIEnumerable = typeof(IEnumerable).IsAssignableFrom(type);
             if (!isIEnumerable && LookupEnumeratorMethod(type) == null)
@@ -344,7 +346,7 @@ namespace System.Xaml.Schema
 
         private static MethodInfo GetPublicMethod(Type type, string name, int argCount)
         {
-            foreach (MemberInfo mi in type.GetMember(name, MemberTypes.Method, 
+            foreach (MemberInfo mi in type.GetMember(name, MemberTypes.Method,
                 BindingFlags.Instance | BindingFlags.Public))
             {
                 MethodInfo method = (MethodInfo)mi;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/MemberReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/MemberReflector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ReferenceEqualityComparer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ReferenceEqualityComparer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/SafeReflectionInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/SafeReflectionInvoker.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeBits.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeBits.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Threading;
 
 namespace System.Xaml
@@ -49,7 +51,7 @@ namespace System.Xaml
         False,
         True
     }
-	
+
     // Thread safety: it's important that this structure remain word-sized, so that reads and
     // writes to it are atomic
     internal struct NullableReference<T> where T : class

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeReflector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -74,7 +76,7 @@ namespace System.Xaml.Schema
             _nonAttachableMemberCache.IsComplete = true;
             _attachableMemberCache = new ThreadSafeDictionary<string, XamlMember>();
             _attachableMemberCache.IsComplete = true;
-            
+
             _baseType.Value = XamlLanguage.Object;
             _boolTypeBits = (int)BoolTypeBits.Default | (int)BoolTypeBits.Unknown | (int)BoolTypeBits.WhitespaceSignificantCollection | (int)BoolTypeBits.AllValid;
             _collectionKind = XamlCollectionKind.None;
@@ -617,7 +619,7 @@ namespace System.Xaml.Schema
         private void PickAttachablePropertyAccessors(List<MethodInfo> getters,
             List<MethodInfo> setters, out MethodInfo getter, out MethodInfo setter)
         {
-            List<KeyValuePair<MethodInfo, MethodInfo>> candidates = 
+            List<KeyValuePair<MethodInfo, MethodInfo>> candidates =
                 new List<KeyValuePair<MethodInfo, MethodInfo>>();
 
             if (setters != null && getters != null)
@@ -642,7 +644,7 @@ namespace System.Xaml.Schema
             // check "IsAssignableFrom" to find the most derived type/property, etc.
             // OR ... we can use the undocumented fact that the most derived
             // type/properties appear to be returned first.
-            // This is for cases where there are multiple overloaded get/set pairs 
+            // This is for cases where there are multiple overloaded get/set pairs
             // for the same attached property name (or multiple overloaded setters with no getter, or multiple adders for an event).
             if (candidates.Count > 0)
             {
@@ -706,7 +708,7 @@ namespace System.Xaml.Schema
             return PickAttachableEventAdder(adders);
         }
 
-        private void LookupAllStaticAccessors(out Dictionary<string, List<MethodInfo>> getters, 
+        private void LookupAllStaticAccessors(out Dictionary<string, List<MethodInfo>> getters,
             out Dictionary<string, List<MethodInfo>> setters, out Dictionary<string, List<MethodInfo>> adders)
         {
             getters = new Dictionary<string,List<MethodInfo>>();
@@ -814,7 +816,7 @@ namespace System.Xaml.Schema
                             preferredAccessors = new List<MethodInfo>();
                         }
                         preferredAccessors.Add(accessor);
-                    }   
+                    }
                 }
             }
         }
@@ -825,7 +827,7 @@ namespace System.Xaml.Schema
             {
                 return IsAttachableEventAdder(accessor);
             }
-            
+
             if (isGetter)
             {
                 return IsAttachablePropertyGetter(accessor);
@@ -915,7 +917,7 @@ namespace System.Xaml.Schema
 
         private bool IsAttachablePropertySetter(MethodInfo mi)
         {
-            // Static Setter has two arguments 
+            // Static Setter has two arguments
             ParameterInfo[] pmi = mi.GetParameters();
             return (pmi.Length == 2);
         }
@@ -931,7 +933,7 @@ namespace System.Xaml.Schema
             {
                 return false;
             }
-            name = mi.Name.Substring(KnownStrings.Add.Length, 
+            name = mi.Name.Substring(KnownStrings.Add.Length,
                 mi.Name.Length - KnownStrings.Add.Length - KnownStrings.Handler.Length);
             return true;
         }
@@ -962,7 +964,7 @@ namespace System.Xaml.Schema
             return result;
         }
 
-        private void GetOrCreateAttachableProperties(XamlSchemaContext schemaContext, List<XamlMember> result, 
+        private void GetOrCreateAttachableProperties(XamlSchemaContext schemaContext, List<XamlMember> result,
             Dictionary<string, List<MethodInfo>> getters, Dictionary<string, List<MethodInfo>> setters)
         {
             foreach (KeyValuePair<string, List<MethodInfo>> nameAndSetterList in setters)
@@ -973,7 +975,7 @@ namespace System.Xaml.Schema
                 {
                     List<MethodInfo> getterList;
                     getters.TryGetValue(name, out getterList);
-                    
+
                     // removing the current entry from getters dictionary because it is not needed anymore
                     getters.Remove(name);
                     MethodInfo getter, setter;
@@ -1003,7 +1005,7 @@ namespace System.Xaml.Schema
             }
         }
 
-        private void GetOrCreateAttachableEvents(XamlSchemaContext schemaContext, 
+        private void GetOrCreateAttachableEvents(XamlSchemaContext schemaContext,
             List<XamlMember> result, Dictionary<string, List<MethodInfo>> adders)
         {
             foreach (KeyValuePair<string, List<MethodInfo>> nameAndAdderList in adders)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlCollectionKind.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlCollectionKind.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml.Schema
 {
     public enum XamlCollectionKind:byte

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -17,7 +19,7 @@ namespace System.Xaml
         private readonly ReadOnlyCollection<string> _xamlNamespaces;
 
         internal XamlDirective(ReadOnlyCollection<string> immutableXamlNamespaces, string name, AllowedMemberLocations allowedLocation, MemberReflector reflector)
-            : base(name, reflector) 
+            : base(name, reflector)
         {
 #if DEBUG
             Debug.Assert(immutableXamlNamespaces is not null);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlMemberInvoker.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Security;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -61,7 +63,7 @@ namespace System.Xaml.Schema
             {
                 return TryGetXamlType(typeName) ?? TryGetXamlType(GetTypeExtensionName(typeName));
             }
-            
+
             Type[] clrTypeArgs = ConvertArrayOfXamlTypesToTypes(typeArgs);
             return TryGetXamlType(typeName, clrTypeArgs) ?? TryGetXamlType(GetTypeExtensionName(typeName), clrTypeArgs);
         }
@@ -263,7 +265,7 @@ namespace System.Xaml.Schema
         // This method should only be called inside SchemaContext._syncExaminingAssemblies lock
         internal void AddAssemblyNamespacePair(AssemblyNamespacePair pair)
         {
-            // To allow the list to be read by multiple threads, we create a new list, add the pair, 
+            // To allow the list to be read by multiple threads, we create a new list, add the pair,
             // then assign it back to the original variable.  Assignments are assured to be atomic.
 
             List<AssemblyNamespacePair> assemblyNamespacesCopy;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeTypeConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Threading;
 
 namespace System.Xaml.Schema
 {
-    public class XamlValueConverter<TConverterBase> : IEquatable<XamlValueConverter<TConverterBase>> 
+    public class XamlValueConverter<TConverterBase> : IEquatable<XamlValueConverter<TConverterBase>>
         where TConverterBase : class
     {
         // Assignment should be idempotent

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/WriterDelegate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/WriterDelegate.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     // This is the simplest implementation of a Node based XamlWriter.
@@ -13,7 +15,7 @@ namespace System.Xaml
         XamlNodeAddDelegate _addDelegate;
         XamlLineInfoAddDelegate _addLineInfoDelegate;
         XamlSchemaContext _schemaContext;
-        
+
         public WriterDelegate(XamlNodeAddDelegate add, XamlLineInfoAddDelegate addlineInfoDelegate, XamlSchemaContext xamlSchemaContext)
         {
             _addDelegate = add;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlBackgroundReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Threading;
 
@@ -31,7 +33,7 @@ namespace System.Xaml
         bool _wrappedReaderHasLineInfo;
         int _lineNumber;
         int _linePosition;
-        
+
         Thread _thread;
         Exception _caughtException;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferringLoader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlDeferringLoader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     // Implemented by templates and any other processors of deferred content.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.Serialization;
 using System.Security;
 using MS.Internal.Xaml.Parser;
@@ -99,7 +101,7 @@ namespace System.Xaml
 
         internal XamlParseException(int lineNumber, int linePosition, string message)
             : base(message, null, lineNumber, linePosition) { }
-        
+
         // FxCop required these.
         public XamlParseException() { }
 
@@ -141,7 +143,7 @@ namespace System.Xaml
     {
         public XamlMember DuplicateMember { get; set; }
         public XamlType ParentType { get; set; }
-        
+
         public XamlDuplicateMemberException() { }
 
         public XamlDuplicateMemberException(XamlMember member, XamlType type)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlLanguage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlLanguage.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -123,7 +125,7 @@ namespace System.Xaml
             new Lazy<XamlDirective>(() => GetXamlDirective(x_AsyncRecords,
                 String, BuiltInValueConverter.Int32, AllowedMemberLocations.Attribute), true);
         private static Lazy<XamlDirective> s_arguments =
-            new Lazy<XamlDirective>(() => GetXamlDirective(x_Arguments, 
+            new Lazy<XamlDirective>(() => GetXamlDirective(x_Arguments,
                 s_listOfObject.Value, null, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_class =
             new Lazy<XamlDirective>(() => GetXamlDirective(x_Class));
@@ -132,21 +134,21 @@ namespace System.Xaml
         private static Lazy<XamlDirective> s_code =
             new Lazy<XamlDirective>(() => GetXamlDirective(x_Code));
         private static Lazy<XamlDirective> s_connectionId =
-            new Lazy<XamlDirective>(() => GetXamlDirective(x_ConnectionId, 
+            new Lazy<XamlDirective>(() => GetXamlDirective(x_ConnectionId,
                 s_string.Value, BuiltInValueConverter.Int32, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_factoryMethod =
-            new Lazy<XamlDirective>(() => GetXamlDirective(x_FactoryMethod, 
+            new Lazy<XamlDirective>(() => GetXamlDirective(x_FactoryMethod,
                 s_string.Value, BuiltInValueConverter.String, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_fieldModifier =
             new Lazy<XamlDirective>(() => GetXamlDirective(x_FieldModifier));
         private static Lazy<XamlDirective> s_items =
-            new Lazy<XamlDirective>(() => GetXamlDirective(x_Items, 
+            new Lazy<XamlDirective>(() => GetXamlDirective(x_Items,
                 s_listOfObject.Value, null, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_initialization =
             new Lazy<XamlDirective>(() => GetXamlDirective(x_Initialization,
                 s_object.Value, null, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_key =
-            new Lazy<XamlDirective>(() => GetXamlDirective(x_Key, 
+            new Lazy<XamlDirective>(() => GetXamlDirective(x_Key,
                 s_object.Value, BuiltInValueConverter.String, AllowedMemberLocations.Any), true);
         private static Lazy<XamlDirective> s_members =
             new Lazy<XamlDirective>(() => GetXamlDirective(x_Members,
@@ -197,7 +199,7 @@ namespace System.Xaml
         public static XamlType Int32 { get { return s_int32.Value; } }
         public static XamlType Boolean { get { return s_boolean.Value; } }
         public static XamlType XData { get { return s_xDataHolder.Value; } }
-        
+
         public static XamlType Object { get { return s_object.Value; } }
         public static XamlType Char { get { return s_char.Value; } }
         public static XamlType Single { get { return s_single.Value; } }
@@ -370,7 +372,7 @@ namespace System.Xaml
         }
 
         // The XAML names of MemberDefinition and PropertyDefinition don't match their CLR type names.
-        // LookupXamlType will still find them in the XAML namespace, but they won't be found through 
+        // LookupXamlType will still find them in the XAML namespace, but they won't be found through
         // clr-namespace lookup. This method handles that special case.
         internal static Type LookupClrNamespaceType(AssemblyNamespacePair nsPair, string typeName)
         {
@@ -388,7 +390,7 @@ namespace System.Xaml
             }
             return null;
         }
-        
+
         internal static XamlDirective LookupXmlDirective(string name)
         {
             switch (name)
@@ -414,7 +416,7 @@ namespace System.Xaml
         {
             XamlDirective[] result = new XamlDirective[]
                 { Arguments, AsyncRecords, Class, Code, ClassModifier, ConnectionId, FactoryMethod, FieldModifier,
-                    Key, Initialization, Items, Members, ClassAttributes, Name, PositionalParameters, Shared, Subclass, 
+                    Key, Initialization, Items, Members, ClassAttributes, Name, PositionalParameters, Shared, Subclass,
                     SynchronousMode, TypeArguments, Uid, UnknownContent, Base, Lang, Space};
             return new ReadOnlyCollection<XamlDirective>(result);
         }
@@ -424,7 +426,7 @@ namespace System.Xaml
             // System.Xaml and WindowsBase
             Assembly[] assemblies = new Assembly[]
                 { typeof(XamlLanguage).Assembly, typeof(MarkupExtension).Assembly };
-            XamlSchemaContextSettings settings = 
+            XamlSchemaContextSettings settings =
                 new XamlSchemaContextSettings { SupportMarkupExtensionsWithDuplicateArity = true };
             XamlSchemaContext result = new XamlSchemaContext(assemblies, settings);
             return result;
@@ -462,7 +464,7 @@ namespace System.Xaml
     }
 
 
-#if TARGETTING35SP1   
+#if TARGETTING35SP1
     public delegate T Initializer<T>();
 
     public struct Lazy<T> where T : class

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -498,7 +500,7 @@ namespace System.Xaml
             MethodInfo setter = Setter;
             if (setter != null)
             {
-                return MemberReflector.GenericArgumentsAreVisibleTo(setter, accessingAssembly, SchemaContext) && 
+                return MemberReflector.GenericArgumentsAreVisibleTo(setter, accessingAssembly, SchemaContext) &&
                     (MemberReflector.IsInternalVisibleTo(setter, accessingAssembly, SchemaContext) ||
                     MemberReflector.IsProtectedVisibleTo(setter, accessingType, SchemaContext));
             }
@@ -833,7 +835,7 @@ namespace System.Xaml
                     ICustomAttributeProvider attrProvider = LookupCustomAttributeProvider();
                     if (attrProvider == null)
                     {
-                        // Set the member that _reflector will use. Note this also ensures that 
+                        // Set the member that _reflector will use. Note this also ensures that
                         // _underlyingMember is initialized, so it's safe to access the field directly below.
                         _reflector.UnderlyingMember = UnderlyingMember;
                     }
@@ -863,8 +865,8 @@ namespace System.Xaml
             if (!_reflector.DefaultValueIsSet)
             {
                 DefaultValueAttribute defaultValueAttrib = null;
-                // Unlike other component-model attributes, DefaultValueAttribute is unsealed, and the 
-                // Value property is virtual. So we cannot reliably process DefaultValueAttribute in ROL. 
+                // Unlike other component-model attributes, DefaultValueAttribute is unsealed, and the
+                // Value property is virtual. So we cannot reliably process DefaultValueAttribute in ROL.
                 // The DefaultValue property is internal and is only called from XamlObjectReader, so it
                 // is safe to use live reflection.
                 if (AreAttributesAvailable)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeList.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -9,7 +11,7 @@ namespace System.Xaml
 {
     // provides a place to Write a list of Xaml nodes
     // and Read them back.  W/o exposing the 'XamlNode' type.
-    
+
     // Single Writer, multiple reader.
     // Must complete writing and Close, before reading.
 
@@ -106,7 +108,7 @@ namespace System.Xaml
             }
             return _nodeList[idx];
         }
-              
+
         public void Clear()
         {
             _nodeList.Clear();

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeQueue.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlNodeQueue.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -28,7 +30,7 @@ namespace System.Xaml
             _endOfStreamNode = new XamlNode(XamlNode.InternalNodeType.EndOfStream);
             _writer = new WriterDelegate(Add, AddLineInfo, schemaContext);
         }
-        
+
         public XamlReader Reader
         {
             get
@@ -84,7 +86,7 @@ namespace System.Xaml
                 _reader.HasLineInfo = true;
             }
         }
-        
+
         private XamlNode Next()
         {
             XamlNode node;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -951,7 +953,7 @@ namespace System.Xaml
                     // that read-only properties must be attributed with DesignerSerializationVisibility.Content
                     // to visible. Unless RequireExplicitContentVisibility is set to true, we don't require that
                     // for readonly collection/dictionary/xdata.
-                    return !context.Settings.RequireExplicitContentVisibility || 
+                    return !context.Settings.RequireExplicitContentVisibility ||
                            GetSerializationVisibility(property) == DesignerSerializationVisibility.Content;
                 }
             }
@@ -2091,7 +2093,7 @@ namespace System.Xaml
 
             static bool IsNull(MemberMarkupInfo propertyInfo)
             {
-                return propertyInfo.Children.Count == 1 && 
+                return propertyInfo.Children.Count == 1 &&
                        propertyInfo.Children[0] is ObjectMarkupInfo objectInfo &&
                        objectInfo.XamlNode.XamlType == XamlLanguage.Null;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReaderSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReaderSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class XamlObjectReaderSettings : XamlReaderSettings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlRuntime.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -36,8 +38,8 @@ namespace System.Xaml
         private readonly ReadOnlyCollection<Assembly> _referenceAssemblies;
 
         // take this lock when iterating new assemblies in the AppDomain/RefAssm
-        object _syncExaminingAssemblies;               
-        
+        object _syncExaminingAssemblies;
+
         #endregion
 
         #region Constructors
@@ -183,7 +185,7 @@ namespace System.Xaml
             if (sb.Length > 0)
             {
                 string result = sb.ToString();
-                
+
                 if (KS.Eq(result, XamlLanguage.PreferredPrefix))
                 {
                     // Prevent this algorithm from stealing 'x'
@@ -350,7 +352,7 @@ namespace System.Xaml
         // Laziy init, always access through property
         private ConcurrentDictionary<string, string> _xmlNsCompatDict;
 
-        // Thread-safe cache - always use TryAdd or TryUpdate to write 
+        // Thread-safe cache - always use TryAdd or TryUpdate to write
         private ConcurrentDictionary<string, string> XmlNsCompatDict
         {
             get
@@ -376,11 +378,11 @@ namespace System.Xaml
             {
                 return true;
             }
-            
+
             // Then look for XmlnsCompatAttributes
             UpdateXmlNsInfo();
             compatibleNamespace = GetCompatibleNamespace(xamlNamespace);
-            
+
             // Fall back to just using the requested namespace;
             if (compatibleNamespace == null)
             {
@@ -469,13 +471,13 @@ namespace System.Xaml
         private ConcurrentDictionary<ReferenceEqualityTuple<MemberInfo, MemberInfo>, XamlMember> _masterMemberList;
         private ConcurrentDictionary<XamlType, Dictionary<string,SpecialBracketCharacters> > _masterBracketCharacterCache;
 
-        // Security note: all of these ConcurrentDictionaries use Reference Equality to prevent spoofing of 
+        // Security note: all of these ConcurrentDictionaries use Reference Equality to prevent spoofing of
         // RuntimeTypes/Members by other custom derived descendants of System.Type/MemberInfo.
         // E.g. if a user called GetXamlType(Type) and passed in a custom descendant of System.Type
         // that reported itself as Equal to some real type, then when we went to look up the real
         // type, we would get the spoofed one instead. Using reference equality avoids that.
 
-        // Thread-safe cache - always use TryAdd or TryUpdate to write 
+        // Thread-safe cache - always use TryAdd or TryUpdate to write
         private ConcurrentDictionary<XamlType, Dictionary<string, SpecialBracketCharacters> > MasterBracketCharacterCache
         {
             get
@@ -486,7 +488,7 @@ namespace System.Xaml
             }
         }
 
-        // Thread-safe cache - always use TryAdd or TryUpdate to write 
+        // Thread-safe cache - always use TryAdd or TryUpdate to write
         private ConcurrentDictionary<Type, XamlType> MasterTypeList
         {
             get
@@ -497,7 +499,7 @@ namespace System.Xaml
             }
         }
 
-        // Thread-safe cache - always use TryAdd or TryUpdate to write 
+        // Thread-safe cache - always use TryAdd or TryUpdate to write
         private ConcurrentDictionary<ReferenceEqualityTuple<Type, XamlType, Type>, object> MasterValueConverterList
         {
             get
@@ -508,7 +510,7 @@ namespace System.Xaml
             }
         }
 
-        // Thread-safe cache - always use TryAdd or TryUpdate to write 
+        // Thread-safe cache - always use TryAdd or TryUpdate to write
         private ConcurrentDictionary<ReferenceEqualityTuple<MemberInfo, MemberInfo>, XamlMember> MasterMemberList
         {
             get
@@ -539,7 +541,7 @@ namespace System.Xaml
         }
 
         /// <summary>
-        /// Constructs a cache of all the members in this particular type that have 
+        /// Constructs a cache of all the members in this particular type that have
         /// MarkupExtensionBracketCharactersAttribute set on them. This cache is added to a master
         /// cache which stores the BracketCharacter cache for each type.
         /// </summary>
@@ -556,7 +558,7 @@ namespace System.Xaml
                     bracketCharacterCache = TryAdd(MasterBracketCharacterCache, type, bracketCharacterCache);
                 }
             }
-            
+
             return bracketCharacterCache;
         }
 
@@ -588,7 +590,7 @@ namespace System.Xaml
             }
 
             return map.Count > 0 ? map : null;
-        } 
+        }
 
         protected internal XamlValueConverter<TConverterBase> GetValueConverter<TConverterBase>(
             Type converterType, XamlType targetType)
@@ -694,7 +696,7 @@ namespace System.Xaml
 
         // take this lock when modifying _unexaminedAssemblies or _isGCCallbackPending
         // Acquisition order: If also taking _syncExaminingAssemblies, take it first
-        object _syncAccessingUnexaminedAssemblies;     
+        object _syncAccessingUnexaminedAssemblies;
 
         // This dictionary is also thread-safe for single reads and writes, but if you're
         // iterating them, lock on _syncExaminingAssemblies to ensure consistent results
@@ -844,7 +846,7 @@ namespace System.Xaml
         private void RegisterAssemblyCleanup()
         {
             // Locking around this check prevents multiple threads from redundantly registering
-            // callbacks at the same time. 
+            // callbacks at the same time.
             // We could use either the examining or unexamined lock, since clenaup touches both;
             // we use the unexamined because it has a shorter blocking time.
             lock (_syncAccessingUnexaminedAssemblies)
@@ -897,7 +899,7 @@ namespace System.Xaml
 
             if (XamlLanguage.AllTypes.Contains(type))
             {
-                // We need a read-only list which combines the directive namespace(s) with the 
+                // We need a read-only list which combines the directive namespace(s) with the
                 // the namespaces(s) that this type supports through standard CLR binding rules
                 IList<string> clrBoundNamespaces = GetXmlNsMappings(clrType.Assembly, clrType.Namespace);
                 List<string> combinedList = new List<string>();
@@ -1112,7 +1114,7 @@ namespace System.Xaml
                         if (throwOnError || CriticalExceptions.IsCriticalException(ex))
                         {
                             // The assemblies after the i'th one in unexaminedAssembliesCopy have not been examined (including the i'th assembly).
-                            // So we need to add them back to _unexaminedAssemblies while also keeping the assemblies that might have been added 
+                            // So we need to add them back to _unexaminedAssemblies while also keeping the assemblies that might have been added
                             // to _unexaminedAssemblies in parallel.
                             lock (_syncAccessingUnexaminedAssemblies)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContextSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContextSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class XamlSchemaContextSettings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlServices.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 using System.IO;
 using System.Xml;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSubreader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSubreader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     internal class XamlSubreader : XamlReader, IXamlLineInfo

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlType.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -31,7 +33,7 @@ namespace System.Xaml
         /// Lazy init: NullableReference.IsSet is null when not initialized
         /// </summary>
         private NullableReference<Type> _underlyingType;
-        
+
         // Lazy init: null until initialized
         // Thread safety: idempotent, assignment races are okay; do not assign incomplete values
         ReadOnlyCollection<string> _namespaces;
@@ -53,7 +55,7 @@ namespace System.Xaml
             _schemaContext = schemaContext ?? throw new ArgumentNullException(nameof(schemaContext));
             _typeArguments = GetTypeArguments(typeArguments);
             _reflector = TypeReflector.UnknownReflector;
-        }        
+        }
 
         public XamlType(Type underlyingType, XamlSchemaContext schemaContext)
             :this(underlyingType, schemaContext, null)
@@ -225,7 +227,7 @@ namespace System.Xaml
             get
             {
                 XamlCollectionKind collectionKind = GetCollectionKind();
-                if (collectionKind != XamlCollectionKind.Collection && 
+                if (collectionKind != XamlCollectionKind.Collection &&
                     collectionKind != XamlCollectionKind.Dictionary)
                 {
                     return null;
@@ -233,7 +235,7 @@ namespace System.Xaml
                 Debug.Assert(_reflector != null, "_reflector should have been initialized by GetCollectionKind");
                 if (_reflector.AllowedContentTypes == null)
                 {
-                    _reflector.AllowedContentTypes = LookupAllowedContentTypes() ?? 
+                    _reflector.AllowedContentTypes = LookupAllowedContentTypes() ??
                         EmptyList<XamlType>.Value;
                 }
                 return _reflector.AllowedContentTypes;
@@ -251,7 +253,7 @@ namespace System.Xaml
                 Debug.Assert(_reflector != null, "_reflector should have been initialized by IsCollection");
                 if (_reflector.ContentWrappers == null)
                 {
-                    _reflector.ContentWrappers = LookupContentWrappers() ?? 
+                    _reflector.ContentWrappers = LookupContentWrappers() ??
                         EmptyList<XamlType>.Value;
                 }
                 return _reflector.ContentWrappers;
@@ -364,7 +366,7 @@ namespace System.Xaml
         public XamlMember GetAliasedProperty(XamlDirective directive)
         {
             EnsureReflector();
-            // Perf note: would be nice to optimize this. We currently have to do the same mapping of 
+            // Perf note: would be nice to optimize this. We currently have to do the same mapping of
             // the directive to one of the four known directives 3 times for each type in the hierarchy
             XamlMember result;
             if (!_reflector.TryGetAliasedProperty(directive, out result))
@@ -471,19 +473,19 @@ namespace System.Xaml
             AppendTypeName(sb, false);
             return sb.ToString();
         }
-        
+
         internal bool IsUsableAsReadOnly
         {
             get
             {
                 XamlCollectionKind collectionKind = GetCollectionKind();
-                return 
+                return
                     (collectionKind == XamlCollectionKind.Collection) ||
                     (collectionKind == XamlCollectionKind.Dictionary) ||
                     IsXData;
             }
         }
-       
+
         internal MethodInfo IsReadOnlyMethod
         {
             get
@@ -995,8 +997,8 @@ namespace System.Xaml
             }
 
             EnsureReflector();
-            ICollection<PropertyInfo> properties; 
-            ICollection<EventInfo> events; 
+            ICollection<PropertyInfo> properties;
+            ICollection<EventInfo> events;
             List<XamlMember> result;
             _reflector.LookupAllMembers(out properties, out events, out result);
 
@@ -1535,7 +1537,7 @@ namespace System.Xaml
             {
                 return null;
             }
-            
+
             // Force the list of all members to populate
             ICollection<XamlMember> allMembers = GetAllMembers();
 
@@ -1675,7 +1677,7 @@ namespace System.Xaml
         // This poses a challenge: if the attribute is defined on a base type, and a derived type
         //   shadows the named member, which do we return?
         // v3 returned that derived member. Also, some attribute lookup methods (e.g. TypeDescriptor)
-        //   always coalesce inheritance hierarchy, which would make it difficult to determine 
+        //   always coalesce inheritance hierarchy, which would make it difficult to determine
         //   whether the attribute was defined on a base or derived class.
         // So, for consistency and compat, we coalesce the hierarchy here, so the caller will always
         //   return the derived member.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlTypeName.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -184,7 +186,7 @@ namespace System.Xaml.Schema
             return xamlTypeName;
         }
 
-        internal static IList<XamlTypeName> ParseListInternal(string typeNameList, 
+        internal static IList<XamlTypeName> ParseListInternal(string typeNameList,
             Func<string, string> prefixResolver, out string error)
         {
             GenericTypeNameParser nameParser = new GenericTypeNameParser(prefixResolver);

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public abstract class XamlWriter : IDisposable

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriterSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlWriterSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class XamlWriterSettings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriterSettings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriterSettings.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Xaml
 {
     public class XamlXmlWriterSettings : XamlWriterSettings

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ms/Internal/Markup/StringValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ms/Internal/Markup/StringValueSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Markup;
 
 namespace MS.Internal.Serialization

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ms/Internal/Markup/TypeConverterValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ms/Internal/Markup/TypeConverterValueSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Xaml;
 using System.Windows.Markup;


### PR DESCRIPTION
Contributes to #7563

## Description

We activate the NRT annotations for System.Xaml.csproj, then disable it in all files so that we can annotate them one by one. The second commit annotates one file to showcase the process.

## Customer Impact

None so far

## Testing

CI

## Risk

Very low. Annotations are not really activated so far, except for an internal class.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8520)