### PR TITLE
Fix comment typo in Stroke2.cs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke2.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Ink/Stroke2.cs
@@ -503,7 +503,7 @@ namespace System.Windows.Ink
 
             bool geometricallyEqual = DrawingAttributes.GeometricallyEqual(drawingAttributes, this.DrawingAttributes);
 
-            // need to recalculate the PathGemetry if the DA passed in is "geometrically" different from
+            // need to recalculate the PathGeometry if the DA passed in is "geometrically" different from
             // this DA, or if the cached PathGeometry is dirty.
             if (false == geometricallyEqual || (true == geometricallyEqual && null == _cachedGeometry))
             {


### PR DESCRIPTION
## Description

Just fix the comment typo.

## Customer Impact

None.

## Regression

None.

## Testing

None.

## Risk

None.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8566)