### PR TITLE
Minor Performance Optimization by Reducing Calls to `AppDomain.CurrentDomain.FriendlyName`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -95,10 +95,11 @@ namespace MS.Win32
             // Register will fail if the string gets over 255 in length.
             // So limit each part to a reasonable amount.
             string appName;
-            if(null != AppDomain.CurrentDomain.FriendlyName && 128 <= AppDomain.CurrentDomain.FriendlyName.Length)
-                appName = AppDomain.CurrentDomain.FriendlyName.Substring(0, 128);
+            var currentDomainFriendlyName = AppDomain.CurrentDomain.FriendlyName;
+            if (null != currentDomainFriendlyName && 128 <= currentDomainFriendlyName.Length)
+                appName = currentDomainFriendlyName[..128];
             else
-                appName = AppDomain.CurrentDomain.FriendlyName;
+                appName = currentDomainFriendlyName;
 
             string threadName;
             if(null != Thread.CurrentThread.Name && 64 <= Thread.CurrentThread.Name.Length)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndWrapper.cs
@@ -95,7 +95,7 @@ namespace MS.Win32
             // Register will fail if the string gets over 255 in length.
             // So limit each part to a reasonable amount.
             string appName;
-            var currentDomainFriendlyName = AppDomain.CurrentDomain.FriendlyName;
+            string currentDomainFriendlyName = AppDomain.CurrentDomain.FriendlyName;
             if (null != currentDomainFriendlyName && 128 <= currentDomainFriendlyName.Length)
                 appName = currentDomainFriendlyName[..128];
             else


### PR DESCRIPTION
## Description

I have optimized the performance by reducing the number of times `AppDomain.CurrentDomain.FriendlyName` property is accessed. Accessing the FriendlyName property is not cheap and results in some additional performance overhead. By assigning it to a local variable first, I have managed to reduce multiple property accesses, thereby slightly improving performance without altering the existing logic.

```
    public sealed partial class AppDomain : MarshalByRefObject
    {
        public string FriendlyName
        {
            get
            {
                Assembly? assembly = Assembly.GetEntryAssembly();
                return assembly != null ? assembly.GetName().Name! : "DefaultDomain";
            }
        }
   }
```

See https://github.com/dotnet/runtime/blob/222d4c5df0b63edb4dbb75771c6e0f8c1315746e/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs#L65-L72

## Customer Impact

Minor Performance Optimization

## Regression

None.

## Testing

Just CI.

## Risk

Very Low?


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8567)