### PR TITLE
Changed x:Class attribute value for win11 ContextMenu control styles

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/ContextMenu.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/ContextMenu.xaml
@@ -6,7 +6,7 @@
 -->
 
 <ResourceDictionary
-    x:Class="Wpf.Ui.Styles.Controls.ContextMenu"
+    x:Class="PresentationFramework.Win11.Styles.ContextMenu"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:ClassModifier="public">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/ContextMenu.xaml.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/ContextMenu.xaml.cs
@@ -1,0 +1,52 @@
+﻿// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file, You can obtain one at https://opensource.org/licenses/MIT.
+// Copyright (C) Leszek Pomianowski and WPF UI Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace PresentationFramework.Win11.Styles
+{
+    /// <summary>
+    /// Overwrites ContextMenu-Style for some UIElements (like RichTextBox) that don't take the default ContextMenu-Style by default.
+    /// <para>The code inside this CodeBehind-Class forces this ContextMenu-Style on these UIElements through Reflection (because it is only accessible through Reflection it is also only possible through CodeBehind and not XAML)</para>
+    /// </summary>
+    // This Code is based on a StackOverflow-Answer: https://stackoverflow.com/a/56736232/9759874
+    partial class ContextMenu : ResourceDictionary
+    {
+        /// <summary>
+        /// Registers editing <see cref="ContextMenu"/> styles with <see cref="Dispatcher"/>.
+        /// </summary>
+        public ContextMenu()
+        {
+            // Run OnResourceDictionaryLoaded asynchronously to ensure other ResourceDictionary are already loaded before adding new entries
+            Dispatcher
+                .CurrentDispatcher
+                .BeginInvoke(DispatcherPriority.Normal, new Action(OnResourceDictionaryLoaded));
+        }
+
+        private void OnResourceDictionaryLoaded()
+        {
+            var currentAssembly = typeof(Application).Assembly;
+
+            AddEditorContextMenuDefaultStyle(currentAssembly);
+        }
+
+        private void AddEditorContextMenuDefaultStyle(Assembly currentAssembly)
+        {
+            var contextMenuStyle = this["UiContextMenu"] as Style;
+            var editorContextMenuType = Type.GetType(
+                "System.Windows.Documents.TextEditorContextMenu+EditorContextMenu, " + currentAssembly
+            );
+
+            if (editorContextMenuType == null || contextMenuStyle == null)
+                return;
+
+            var editorContextMenuStyle = new Style(editorContextMenuType, contextMenuStyle);
+            Add(editorContextMenuType, editorContextMenuStyle);
+        }
+    }
+}


### PR DESCRIPTION
Main PR #8590 

## Description

Changed x:Class attribute value for win11 ContextMenu control styles and added ContextMenu.xaml.cs

## Regression

NA

## Testing

Build Pass.
Verified the visual appearance changes of controls in a sample application.

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8607)