### PR TITLE
Fix spelling error in `ISpellerSegment`

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerInteropBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerInteropBase.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Documents
             IReadOnlyList<string> Suggestions { get; }
 
             /// <summary>
-            /// Returns true if the segment has no spelling erorrs
+            /// Returns true if the segment has no spelling errors
             /// </summary>
             bool IsClean { get; }
 


### PR DESCRIPTION
## Description

Simple typo fix.

## Customer Impact

None.

## Regression

Not applicable.

## Testing

Not applicable.

## Risk

Not applicable.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8610)