### PR TITLE
Prefer use of interpolated strings in System.Xaml

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/AttachableMemberIdentifier.cs
@@ -76,7 +76,7 @@ namespace System.Xaml
                 return memberName;
             }
 
-            return declaringType.ToString() + "." + memberName;
+            return $"{declaringType}.{memberName}";
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Context/ObjectWriterFrame.cs
@@ -76,8 +76,7 @@ namespace MS.Internal.Xaml.Context
             string prop = (Member == null) ? "-" : Member.Name;
             string inst = (Instance == null) ? "-" : ((Instance is string) ? Instance.ToString() : "*");
             string coll = (Collection == null) ? "-" : "*";
-            string res = KS.Fmt("{0}.{1} inst={2} coll={3}",
-                                 type, prop, inst, coll);
+            string res = string.Create(TypeConverterHelper.InvariantEnglishUS, $"{type}.{prop} inst={inst} coll={coll}");
             return res;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -115,7 +115,7 @@ namespace System.Xaml
 
         public override string ToString()
         {
-            string str = NodeType.ToString(TypeConverterHelper.InvariantEnglishUS);
+            string str = string.Create(TypeConverterHelper.InvariantEnglishUS, $"{NodeType}: ");
             switch(NodeType)
             {
             case XamlNodeType.StartObject:

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlNodes.cs
@@ -115,7 +115,7 @@ namespace System.Xaml
 
         public override string ToString()
         {
-            string str = String.Format(TypeConverterHelper.InvariantEnglishUS, "{0}: ", NodeType);
+            string str = NodeType.ToString(TypeConverterHelper.InvariantEnglishUS);
             switch(NodeType)
             {
             case XamlNodeType.StartObject:
@@ -150,7 +150,7 @@ namespace System.Xaml
                     break;
 
                 case InternalNodeType.LineInfo:
-                    str += "LineInfo: " + LineInfo.ToString();
+                    str += $"LineInfo: {LineInfo}";
                     break;
                 }
                 break;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/InfosetObjects/XamlObjectWriter.cs
@@ -2192,7 +2192,7 @@ namespace System.Xaml
                 string rootNamespace = SchemaContext.GetRootNamespace(rootInstanceType.Assembly);
                 if (!string.IsNullOrEmpty(rootNamespace))
                 {
-                    className = rootNamespace + "." + className;
+                    className = $"{rootNamespace}.{className}";
                 }
                 if (rootInstanceType.FullName != className)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/KnownStrings.cs
@@ -94,10 +94,5 @@ namespace System.Xaml.MS.Impl
         {
             return src.StartsWith(target, StringComparison.Ordinal);
         }
-
-        public static string Fmt(string formatString, params object[] otherArgs)
-        {
-            return string.Format(TypeConverterHelper.InvariantEnglishUS, formatString, otherArgs);
-        }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NamespacePrefixLookup.cs
@@ -28,7 +28,7 @@ namespace MS.Internal.Xaml.Parser
             // we really shouldn't generate extraneous new namespaces
             string newPrefix;
             do {
-                newPrefix = "prefix" + n++;
+                newPrefix = $"prefix{n++}";
             } while (_nsResolver(newPrefix) != null);
             _newNamespaces.Add(new NamespaceDeclaration(ns, newPrefix));
             return newPrefix;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/NodeStreamSorter.cs
@@ -86,7 +86,7 @@ namespace MS.Internal.Xaml
 #if DEBUG
             public override string ToString()
             {
-                return String.Format(TypeConverterHelper.InvariantEnglishUS, "Depth[{0}] {1}", Depth, XamlNodeType);
+                return string.Create(TypeConverterHelper.InvariantEnglishUS, $"Depth[{Depth}] {XamlNodeType}");
             }
 #endif
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlAttribute.cs
@@ -126,7 +126,7 @@ namespace MS.Internal.Xaml.Parser
                 uri = Value;
                 definingPrefix = !Name.IsDotted
                     ? Name.Name
-                    : Name.OwnerName + "." + Name.Name;
+                    : $"{Name.OwnerName}.{Name.Name}";
                 return true;
             }
             // case where:  xmlns="ValueUri"

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlPropertyName.cs
@@ -79,7 +79,7 @@ namespace MS.Internal.Xaml.Parser
             get
             {
                 return IsDotted ?
-                    Owner.ScopedName + "." + Name :
+                    $"{Owner.ScopedName}.{Name}" :
                     Name;
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlQualifiedName.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Parser/XamlQualifiedName.cs
@@ -21,7 +21,7 @@ namespace MS.Internal.Xaml.Parser
             {
                 return string.IsNullOrEmpty(Prefix) ?
                     Name :
-                    Prefix + ":" + Name;
+                    $"{Prefix}:{Name}";
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/ClrObjectRuntime.cs
@@ -90,13 +90,13 @@ namespace MS.Internal.Xaml.Runtime
                     throw;
                 }
 
-                string qMethodName = type.ToString() + "." + methodName;
+                string qMethodName = $"{type}.{methodName}";
                 throw CreateException(SR.Format(SR.MethodInvocation, qMethodName), UnwrapTargetInvocationException(e));
             }
 
             if (instance == null)
             {
-                string qMethodName = type.ToString() + "." + methodName;
+                string qMethodName = $"{type}.{methodName}";
                 throw CreateException(SR.Format(SR.FactoryReturnedNull, qMethodName));
             }
             return instance;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Runtime/DynamicMethodRuntime.cs
@@ -280,7 +280,7 @@ namespace MS.Internal.Xaml.Runtime
                 return _delegateCreatorWithoutHelper;
             }
 
-            DynamicMethod dynamicMethod = CreateDynamicMethod(targetType.Name + "DelegateHelper",
+            DynamicMethod dynamicMethod = CreateDynamicMethod($"{targetType.Name}DelegateHelper",
                 typeof(Delegate), typeof(Type), typeof(object), typeof(string));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -315,7 +315,7 @@ namespace MS.Internal.Xaml.Runtime
 
         private FactoryDelegate CreateFactoryDelegate(ConstructorInfo ctor)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(ctor.DeclaringType.Name + "Ctor",
+            DynamicMethod dynamicMethod = CreateDynamicMethod($"{ctor.DeclaringType.Name}Ctor", 
                 typeof(object), typeof(object[]));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -329,7 +329,7 @@ namespace MS.Internal.Xaml.Runtime
 
         private FactoryDelegate CreateFactoryDelegate(MethodInfo factory)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(factory.Name + "Factory",
+            DynamicMethod dynamicMethod = CreateDynamicMethod($"{factory.Name}Factory", 
                 typeof(object), typeof(object[]));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -407,7 +407,7 @@ namespace MS.Internal.Xaml.Runtime
         // Note that CreateGetDelegate fails verification for value types (and probably shouldn't)
         private PropertyGetDelegate CreateGetDelegate(MethodInfo getter)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(getter.Name + "Getter",
+            DynamicMethod dynamicMethod = CreateDynamicMethod($"{getter.Name}Getter", 
                 typeof(object), typeof(object));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
@@ -425,7 +425,7 @@ namespace MS.Internal.Xaml.Runtime
         // Note that CreateSetDelegate fails verification for value types (and probably shouldn't)
         private PropertySetDelegate CreateSetDelegate(MethodInfo setter)
         {
-            DynamicMethod dynamicMethod = CreateDynamicMethod(setter.Name + "Setter",
+            DynamicMethod dynamicMethod = CreateDynamicMethod($"{setter.Name}Setter",
                 typeof(void), typeof(object), typeof(object));
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/ClrNamespaceUriParser.cs
@@ -12,8 +12,7 @@ namespace System.Xaml.Schema
     {
         public static string GetUri(string clrNs, string assemblyName)
         {
-            return string.Format(TypeConverterHelper.InvariantEnglishUS, KnownStrings.UriClrNamespace + ":{0};" +
-                KnownStrings.UriAssembly + "={1}", clrNs, assemblyName);
+            return $"{KnownStrings.UriClrNamespace}:{clrNs};{KnownStrings.UriAssembly}={assemblyName}";
         }
 
         public static bool TryParseUri(string uriInput, out string clrNs, out string assemblyName)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/Reflector.cs
@@ -105,7 +105,7 @@ namespace System.Xaml.Schema
                 {
                     return ((ConstructorArgumentAttribute)attributes[0]).ArgumentName;
                 }
-                Debug.Fail("Unexpected attribute type requested: " + attributeType.Name);
+                Debug.Fail($"Unexpected attribute type requested: {attributeType.Name}");
                 return null;
             }
             try
@@ -149,7 +149,7 @@ namespace System.Xaml.Schema
                     return new ReadOnlyDictionary<char, char>(bracketCharacterAttributeList);
                 }
 
-                Debug.Fail("Unexpected attribute type requested: " + attributeType.Name);
+                Debug.Fail($"Unexpected attribute type requested: {attributeType.Name}");
                 return null;
             }
 
@@ -180,7 +180,7 @@ namespace System.Xaml.Schema
                     bool result = ((UsableDuringInitializationAttribute)attributes[0]).Usable;
                     return (T)(object)result;
                 }
-                Debug.Fail("Unexpected attribute type requested: " + attributeType.Name);
+                Debug.Fail($"Unexpected attribute type requested: {attributeType.Name}");
                 return null;
             }
             try
@@ -221,7 +221,7 @@ namespace System.Xaml.Schema
                 {
                     return ((ValueSerializerAttribute)attributes[0]).ValueSerializerType;
                 }
-                Debug.Fail("Unexpected attribute type requested: " + attributeType.Name);
+                Debug.Fail($"Unexpected attribute type requested: {attributeType.Name}");
                 return null;
             }
             try
@@ -301,7 +301,7 @@ namespace System.Xaml.Schema
                     return result;
                 }
 
-                Debug.Fail("Unexpected attribute type requested: " + attributeType.Name);
+                Debug.Fail($"Unexpected attribute type requested: {attributeType.Name}");
                 return null;
 
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlDirective.cs
@@ -80,7 +80,7 @@ namespace System.Xaml
         {
             if (_xamlNamespaces.Count > 0)
             {
-                return "{" + _xamlNamespaces[0] + "}" + Name;
+                return $"{{{_xamlNamespaces[0]}}}{Name}";
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlNamespace.cs
@@ -251,7 +251,7 @@ namespace System.Xaml.Schema
                     // This is a dynamic assembly that got unloaded; ignore it
                     continue;
                 }
-                string longName = assemblyNamespacePair.ClrNamespace + "." + shortName;
+                string longName = $"{assemblyNamespacePair.ClrNamespace}.{shortName}";
 
                 Type type = asm.GetType(longName);
                 if (type != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlValueConverter.cs
@@ -95,7 +95,7 @@ namespace System.Xaml.Schema
             {
                 if (TargetType != null)
                 {
-                    return ConverterType.Name + "(" + TargetType.Name + ")";
+                    return $"{ConverterType.Name}({TargetType.Name})";
                 }
 
                 return ConverterType.Name;

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMarkupExtensionWriter.cs
@@ -412,7 +412,7 @@ namespace System.Xaml
                 {
                     writer.sb.Append(Delimiter);
                     WritePrefix(writer, writer.LookupPrefix(property));
-                    string local = property.DeclaringType.Name + "." + property.Name;
+                    string local = $"{property.DeclaringType.Name}.{property.Name}";
                     writer.sb.Append(local);
                 }
                 else

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlMember.cs
@@ -339,7 +339,7 @@ namespace System.Xaml
         public override string ToString()
         {
             Debug.Assert(_declaringType != null, "XamlDirective should not call base.ToString");
-            return _declaringType.ToString() + "." + Name;
+            return $"{_declaringType}.{Name}";
         }
 
         public IList<XamlMember> DependsOn

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -1792,7 +1792,7 @@ namespace System.Xaml
             {
                 string typestring = context.ConvertXamlTypeToString(context.LocalAssemblyAwareGetXamlType(type));
 
-                return typestring + "." + methodName;
+                return $"{typestring}.{methodName}";
             }
 
             static ObjectMarkupInfo ForArray(Array value, SerializerContext context)

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlXmlWriter.cs
@@ -626,7 +626,7 @@ namespace System.Xaml
         {
             string prefix = LookupPrefix(type.GetXamlNamespaces(), out _);
             string typeName = GetTypeName(type);
-            string typeNamePrefixed = string.IsNullOrEmpty(prefix) ? typeName : prefix + ":" + typeName;
+            string typeNamePrefixed = string.IsNullOrEmpty(prefix) ? typeName : $"{prefix}:{typeName}";
 
             // save the subscript
             string subscript;
@@ -812,7 +812,7 @@ namespace System.Xaml
 
                 XamlType xamlType = property.IsAttachable ? property.DeclaringType : type;
                 string prefix = property.IsAttachable || property.IsDirective ? writer.FindPrefix(property.GetXamlNamespaces(), out ns) : writer.FindPrefix(type.GetXamlNamespaces(), out ns);
-                string local = (property.IsDirective) ? property.Name : GetTypeName(xamlType) + "." + property.Name;
+                string local = (property.IsDirective) ? property.Name : $"{GetTypeName(xamlType)}.{property.Name}";
                 writer.output.WriteStartElement(prefix, local, ns);
             }
 
@@ -846,7 +846,7 @@ namespace System.Xaml
                     }
                     else
                     {
-                        local = GetTypeName(property.DeclaringType) + "." + property.Name;
+                        local = $"{GetTypeName(property.DeclaringType)}.{property.Name}";
                     }
                     WriteStartAttribute(writer, prefix, local, ns);
                 }
@@ -1540,7 +1540,7 @@ namespace System.Xaml
                 WriteMemberAsAttribute(writer);
                 if (!writer.deferredValueIsME && StringStartsWithCurly(writer.deferredValue))
                 {
-                    writer.output.WriteValue("{}" + writer.deferredValue);
+                    writer.output.WriteValue($"{{}}{writer.deferredValue}");
                 }
                 else
                 {


### PR DESCRIPTION
See #8519

## Description

We replace as many manual string concatenations and string.Format with interpolated strings. This saves allocations in many instances, and makes for a more readable code.

## Customer Impact

Less allocations

## Regression

No

## Testing

CI

## Risk

Low. Most changes are automated using the IDE


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8615)