### PR TITLE
Added null check in Textbox control on CanExecuteChanged to avoid exception

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/RelayCommand{T}.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/RelayCommand{T}.cs
@@ -81,7 +81,7 @@ public class RelayCommand<T> : IRelayCommand<T>
     /// <inheritdoc/>
     public void NotifyCanExecuteChanged()
     {
-        CanExecuteChanged.Invoke(this, EventArgs.Empty);
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Main PR #8604 

## Description

Added null check in Textbox control on CanExecuteChanged to avoid exception

## Customer Impact

CanExecuteChanged may throw exception if it is null.

## Regression

NA

## Testing

Build Pass. Verified the visual appearance changes of controls in a sample application with this check.

## Risk

NA


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8619)