### PR TITLE
Do not count invisible UI elements towards size of/position in set

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -338,12 +338,29 @@ namespace System.Windows.Automation.Peers
         {
             int position = AutomationProperties.AutomationPositionInSetDefault;
             ItemCollection itemCollection = itemsControl.Items;
-            position = itemCollection.IndexOf(item);
 
             if (itemsControl.IsGrouping)
             {
                 int sizeOfGroup;
                 position = FindPositionInGroup(itemCollection.Groups, position, out sizeOfGroup);
+            }
+            else
+            {
+                position = itemCollection.IndexOf(item);
+
+                // Some items may not be visible, so we don't want to count
+                foreach (var child in (itemCollection.CollectionView))
+                {
+                    if (item == child)
+                    {
+                        break;
+                    }
+
+                    if (child is not UIElement element || element.Visibility != Visibility.Visible)
+                    {
+                        position -= 1;
+                    }
+                }
             }
 
             return position + 1;
@@ -362,6 +379,15 @@ namespace System.Windows.Automation.Peers
             else
             {
                 size = itemCollection.Count;
+
+                // Some items may not be visible, so we don't want to count
+                foreach (var child in (itemCollection.CollectionView))
+                {
+                    if (child is not UIElement element || element.Visibility != Visibility.Visible)
+                    {
+                        size -= 1;
+                    }
+                }
             }
 
             return size;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemAutomationPeer.cs
@@ -348,15 +348,15 @@ namespace System.Windows.Automation.Peers
             {
                 position = itemCollection.IndexOf(item);
 
-                // Some items may not be visible, so we don't want to count
-                foreach (var child in (itemCollection.CollectionView))
+                // Some items may not be visible, so we don't want to count them
+                foreach (var child in itemCollection.CollectionView)
                 {
                     if (item == child)
                     {
                         break;
                     }
 
-                    if (child is not UIElement element || element.Visibility != Visibility.Visible)
+                    if (child is UIElement element && element.Visibility != Visibility.Visible)
                     {
                         position -= 1;
                     }
@@ -380,10 +380,10 @@ namespace System.Windows.Automation.Peers
             {
                 size = itemCollection.Count;
 
-                // Some items may not be visible, so we don't want to count
-                foreach (var child in (itemCollection.CollectionView))
+                // Some items may not be visible, so we don't want to count them
+                foreach (var child in itemCollection.CollectionView)
                 {
-                    if (child is not UIElement element || element.Visibility != Visibility.Visible)
+                    if (child is UIElement element && element.Visibility != Visibility.Visible)
                     {
                         size -= 1;
                     }


### PR DESCRIPTION
Fixes #8642

## Description

PositionInSet and SizeOfSet for items currently count all items in their container, resulting in potentially incorrect information. This PR updates the logic to exclude non-visible UI elements from these counts.

## Customer Impact

Screen readers may report incorrect information with the current implementation.

## Testing

I tested this patched PresentationFramework.dll against the repro mentioned in #8642 and confirmed Windows Narrator reads the expected values.

## Risk

These changes only effect non-grouping paths. I am not familiar with how the grouped collections calculate set size/position, so those values may still be inaccurate.