### PR TITLE
Fix TabStripPlacement not Respected in Tabcontrol

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/TabControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/TabControl.xaml
@@ -7,55 +7,194 @@
 
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <!-- Styles when TabItems are on the Top -->
+    <ControlTemplate x:Key="DefaultTopTabControlStyle" TargetType="{x:Type TabControl}">
+        <Grid KeyboardNavigation.TabNavigation="Local">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TabPanel
+                x:Name="HeaderPanel"
+                Grid.Row="0"
+                Margin="0"
+                Panel.ZIndex="1"
+                Background="Transparent"
+                IsItemsHost="True"
+                KeyboardNavigation.TabIndex="1" />
+
+            <Border
+                x:Name="Border"
+                Grid.Row="1"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="0,1,0,0"
+                CornerRadius="0,4,4,4"
+                KeyboardNavigation.DirectionalNavigation="Contained"
+                KeyboardNavigation.TabIndex="2"
+                KeyboardNavigation.TabNavigation="Local">
+                <ContentPresenter
+                    x:Name="PART_SelectedContentHost"
+                    Margin="0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ContentSource="SelectedContent"
+                    TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Border>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Disabled" />
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Grid>
+    </ControlTemplate>
+
+    <!-- Styles when TabItems are placed Bottom -->
+    <ControlTemplate x:Key="DefaultBottomTabControlStyle" TargetType="{x:Type TabControl}">
+        <Grid KeyboardNavigation.TabNavigation="Local">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TabPanel
+                x:Name="HeaderPanel"
+                Grid.Row="1"
+                Margin="0"
+                Panel.ZIndex="1"
+                Background="Transparent"
+                IsItemsHost="True"
+                KeyboardNavigation.TabIndex="1" />
+
+            <Border
+                x:Name="Border"
+                Grid.Row="0"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="0,0,0,1"
+                CornerRadius="0,4,4,4"
+                KeyboardNavigation.DirectionalNavigation="Contained"
+                KeyboardNavigation.TabIndex="2"
+                KeyboardNavigation.TabNavigation="Local">
+                <ContentPresenter
+                    x:Name="PART_SelectedContentHost"
+                    Margin="0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ContentSource="SelectedContent"
+                    TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Border>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Disabled" />
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Grid>
+    </ControlTemplate>
+
+    <!-- Styles when TabItems are placed to the Left -->
+    <ControlTemplate x:Key="DefaultLeftTabControlStyle" TargetType="{x:Type TabControl}">
+        <Grid KeyboardNavigation.TabNavigation="Local">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TabPanel
+                x:Name="HeaderPanel"
+                Grid.Column="0"
+                Margin="0"
+                Panel.ZIndex="1"
+                Background="Transparent"
+                IsItemsHost="True"
+                KeyboardNavigation.TabIndex="1" />
+
+            <Border
+                x:Name="Border"
+                Grid.Column="1"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="1,0,0,0"
+                CornerRadius="0,4,4,4"
+                KeyboardNavigation.DirectionalNavigation="Contained"
+                KeyboardNavigation.TabIndex="2"
+                KeyboardNavigation.TabNavigation="Local">
+                <ContentPresenter
+                    x:Name="PART_SelectedContentHost"
+                    Margin="0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ContentSource="SelectedContent"
+                    TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Border>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Disabled" />
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Grid>
+    </ControlTemplate>
+
+    <!-- Styles when TabItems are placed to the Right -->
+    <ControlTemplate x:Key="DefaultRightTabControlStyle" TargetType="{x:Type TabControl}">
+        <Grid KeyboardNavigation.TabNavigation="Local">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TabPanel
+                x:Name="HeaderPanel"
+                Grid.Column="1"
+                Margin="0"
+                Panel.ZIndex="1"
+                Background="Transparent"
+                IsItemsHost="True"
+                KeyboardNavigation.TabIndex="1" />
+
+            <Border
+                x:Name="Border"
+                Grid.Column="0"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="0,0,1,0"
+                CornerRadius="0,4,4,4"
+                KeyboardNavigation.DirectionalNavigation="Contained"
+                KeyboardNavigation.TabIndex="2"
+                KeyboardNavigation.TabNavigation="Local">
+                <ContentPresenter
+                    x:Name="PART_SelectedContentHost"
+                    Margin="0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ContentSource="SelectedContent"
+                    TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Border>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Disabled" />
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Grid>
+    </ControlTemplate>
+
     <Style TargetType="{x:Type TabControl}">
         <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TabControl}">
-                    <Grid KeyboardNavigation.TabNavigation="Local">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <TabPanel
-                            x:Name="HeaderPanel"
-                            Grid.Row="0"
-                            Margin="0"
-                            Panel.ZIndex="1"
-                            Background="Transparent"
-                            IsItemsHost="True"
-                            KeyboardNavigation.TabIndex="1" />
-                        <Border
-                            x:Name="Border"
-                            Grid.Row="1"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="0,1,0,0"
-                            CornerRadius="0,4,4,4"
-                            KeyboardNavigation.DirectionalNavigation="Contained"
-                            KeyboardNavigation.TabIndex="2"
-                            KeyboardNavigation.TabNavigation="Local">
-                            <ContentPresenter
-                                x:Name="PART_SelectedContentHost"
-                                Margin="0"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                ContentSource="SelectedContent"
-                                TextElement.Foreground="{TemplateBinding Foreground}" />
-                        </Border>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Disabled" />
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
+            <Style.Triggers>
+                <Trigger Property="TabStripPlacement" Value="Bottom">
+                    <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+                </Trigger>
+
+                <Trigger Property="TabStripPlacement" Value="Left">
+                    <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+                </Trigger>
+
+                <Trigger Property="TabStripPlacement" Value="Right">
+                    <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+                </Trigger>
+            </Style.Triggers>
     </Style>
 
     <Style TargetType="{x:Type TabItem}">
@@ -92,12 +231,10 @@
                                 ContentSource="Header"
                                 RecognizesAccessKey="True" />
                         </Border>
-
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="SelectionStates">
                                 <VisualState x:Name="Unselected" />
                                 <VisualState x:Name="Selected" />
-
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -122,6 +259,30 @@
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource TabViewSelectedItemBorderBrush}" />
                             <Setter Property="Foreground" Value="{DynamicResource TabViewItemForegroundSelected}" />
                         </Trigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Bottom" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Border" Property="BorderThickness" Value="1,0,1,1" />
+                            <Setter TargetName="Border" Property="CornerRadius" Value="0,0,8,8" />
+                        </MultiDataTrigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Left" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="Border" Property="CornerRadius" Value="8,0,0,8" />
+                        </MultiDataTrigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}" Value="Right" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Border" Property="BorderThickness" Value="1,1,0,1" />
+                            <Setter TargetName="Border" Property="CornerRadius" Value="0,8,8,0" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Fixes #8606


## Description
The `TabControl` does not respect the property `TabStripPlacement` when using Windows 11 Themes. 

## Customer Impact
The new themes won't support layout designed to have Tab Items Placed on Right, Left or Bottom.

## Regression
_None_

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8654)