### PR TITLE
Add VMR build file

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,9 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>wpf</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
While this is currently called SourceBuild.props, we plan to later rename this to distinguish between source build and the dotnet build. Especially for wpf which doesn't participate in source-build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8693)