### PR TITLE
Disable nullability in System.Xaml unit test to fix build

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/AcceptedMarkupExtensionExpressionTypeAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/AcceptedMarkupExtensionExpressionTypeAttributeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using Xunit;
 
 #pragma warning disable 0618

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ArrayExtensionTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ArrayExtensionTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using System.Collections;
 using System.Collections.Generic;
 using Xunit;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ConstructorArgumentAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ConstructorArgumentAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ContentPropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ContentPropertyAttributeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ContentWrapperAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ContentWrapperAttributeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using System.Collections.Generic;
 using Xunit;
 
@@ -18,18 +19,18 @@ public class ContentWrapperAttributeTests
         Assert.Equal(contentWrapper, attribute.ContentWrapper);
     }
 
-    public static IEnumerable<object?[]> Equals_TestData()
+    public static IEnumerable<object[]> Equals_TestData()
     {
         var attribute = new ContentWrapperAttribute(typeof(int));
-        yield return new object?[] { attribute, attribute, true };
-        yield return new object?[] { attribute, new ContentWrapperAttribute(typeof(int)), true };
-        yield return new object?[] { attribute, new ContentWrapperAttribute(typeof(string)), false };
-        yield return new object?[] { attribute, new ContentWrapperAttribute(null), false };
-        yield return new object?[] { new ContentWrapperAttribute(null), new ContentWrapperAttribute(null), true };
-        yield return new object?[] { new ContentWrapperAttribute(null), new ContentWrapperAttribute(typeof(int)), false };
+        yield return new object[] { attribute, attribute, true };
+        yield return new object[] { attribute, new ContentWrapperAttribute(typeof(int)), true };
+        yield return new object[] { attribute, new ContentWrapperAttribute(typeof(string)), false };
+        yield return new object[] { attribute, new ContentWrapperAttribute(null), false };
+        yield return new object[] { new ContentWrapperAttribute(null), new ContentWrapperAttribute(null), true };
+        yield return new object[] { new ContentWrapperAttribute(null), new ContentWrapperAttribute(typeof(int)), false };
 
-        yield return new object?[] { attribute, new object(), false };
-        yield return new object?[] { attribute, null, false };
+        yield return new object[] { attribute, new object(), false };
+        yield return new object[] { attribute, null, false };
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DateTimeValueSerializerTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DateTimeValueSerializerTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
@@ -10,11 +10,11 @@ namespace System.Windows.Markup.Tests;
 
 public class DateTimeValueSerializerTests
 {
-    public static IEnumerable<object?[]> CanConvertFrom_TestData()
+    public static IEnumerable<object[]> CanConvertFrom_TestData()
     {
-        yield return new object?[] { new DateTime(), true };
-        yield return new object?[] { new object(), false };
-        yield return new object?[] { null, false };
+        yield return new object[] { new DateTime(), true };
+        yield return new object[] { new object(), false };
+        yield return new object[] { null, false };
     }
 
     [Theory]

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DependsOnAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DependsOnAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DictionaryKeyPropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/DictionaryKeyPropertyAttributeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/MarkupExtensionReturnTypeAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/MarkupExtensionReturnTypeAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 #pragma warning disable 0618

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/NameReferenceConverterTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/NameReferenceConverterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
@@ -119,13 +120,13 @@ public class NameReferenceConverterTests
         Assert.Throws<InvalidOperationException>(() => converter.ConvertFrom(context, null, value));
     }
 
-    public static IEnumerable<object?[]> CanConvertTo_TestData()
+    public static IEnumerable<object[]> CanConvertTo_TestData()
     {
-        yield return new object?[] { null, null, false };
-        yield return new object?[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => null! }, typeof(string), false };
-        yield return new object?[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new object() }, typeof(string), false };
-        yield return new object?[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new CustomXamlNameProvider() }, typeof(int), false };
-        yield return new object?[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new CustomXamlNameProvider() }, typeof(string), true };
+        yield return new object[] { null, null, false };
+        yield return new object[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => null! }, typeof(string), false };
+        yield return new object[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new object() }, typeof(string), false };
+        yield return new object[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new CustomXamlNameProvider() }, typeof(int), false };
+        yield return new object[] { new CustomTypeDescriptorContext { GetServiceAction = serviceType => new CustomXamlNameProvider() }, typeof(string), true };
     }
 
     [Theory]
@@ -201,7 +202,7 @@ public class NameReferenceConverterTests
 
         public PropertyDescriptor PropertyDescriptor => throw new NotImplementedException();
 
-        public Func<Type, object>? GetServiceAction { get; set; }
+        public Func<Type, object> GetServiceAction { get; set; }
 
         public object GetService(Type serviceType)
         {
@@ -222,7 +223,7 @@ public class NameReferenceConverterTests
     {
         public bool IsFixupTokenAvailable => throw new NotImplementedException();
 
-        public Func<string, object>? ResolveAction { get; set; }
+        public Func<string, object> ResolveAction { get; set; }
 
         public object Resolve(string name)
         {
@@ -238,7 +239,7 @@ public class NameReferenceConverterTests
 
         public object GetFixupToken(IEnumerable<string> names) => throw new NotImplementedException();
 
-        public Func<IEnumerable<string>, bool, object>? GetFixupTokenAction { get; set; }
+        public Func<IEnumerable<string>, bool, object> GetFixupTokenAction { get; set; }
         
         public object GetFixupToken(IEnumerable<string> names, bool canAssignDirectly)
         {
@@ -262,7 +263,7 @@ public class NameReferenceConverterTests
 
     private class CustomXamlNameProvider : IXamlNameProvider
     {
-        public Func<object, string>? GetNameAction { get; set; }
+        public Func<object, string> GetNameAction { get; set; }
         
         public string GetName(object value)
         {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/NameScopePropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/NameScopePropertyAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ReferenceTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/ReferenceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using System.Collections.Generic;
 using System.Xaml;
 using Xunit;
@@ -95,7 +96,7 @@ public class ReferenceTests
     
     private class CustomServiceProvider : IServiceProvider
     {
-        public Func<Type, object>? ServiceAction { get; set; }
+        public Func<Type, object> ServiceAction { get; set; }
 
         public object GetService(Type serviceType)
         {
@@ -113,7 +114,7 @@ public class ReferenceTests
     {
         public bool IsFixupTokenAvailable => throw new NotImplementedException();
 
-        public Func<string, object>? ResolveAction { get; set; }
+        public Func<string, object> ResolveAction { get; set; }
 
         public object Resolve(string name)
         {
@@ -129,7 +130,7 @@ public class ReferenceTests
 
         public object GetFixupToken(IEnumerable<string> names) => throw new NotImplementedException();
 
-        public Func<IEnumerable<string>, bool, object>? GetFixupTokenAction { get; set; }
+        public Func<IEnumerable<string>, bool, object> GetFixupTokenAction { get; set; }
         
         public object GetFixupToken(IEnumerable<string> names, bool canAssignDirectly)
         {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/RootNamespaceAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/RootNamespaceAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/RuntimeNamePropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/RuntimeNamePropertyAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/StaticExtensionTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/StaticExtensionTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Linq;
@@ -246,7 +246,7 @@ public class StaticExtensionTests
     
     private class CustomServiceProvider : IServiceProvider
     {
-        public Func<Type, object>? ServiceAction { get; set; }
+        public Func<Type, object> ServiceAction { get; set; }
 
         public object GetService(Type serviceType)
         {
@@ -261,7 +261,7 @@ public class StaticExtensionTests
 
     private class CustomXamlTypeResolver : IXamlTypeResolver
     {
-        public Func<string, Type>? ResolveAction { get; set; }
+        public Func<string, Type> ResolveAction { get; set; }
         
         public Type Resolve(string qualifiedTypeName)
         {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/StringValueSerializerTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/StringValueSerializerTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/TypeExtensionTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/TypeExtensionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Linq;
@@ -207,7 +208,7 @@ public class TypeExtensionTests
 
     private class CustomServiceProvider : IServiceProvider
     {
-        public Func<Type, object>? ServiceAction { get; set; }
+        public Func<Type, object> ServiceAction { get; set; }
 
         public object GetService(Type serviceType)
         {
@@ -222,7 +223,7 @@ public class TypeExtensionTests
 
     private class CustomXamlTypeResolver : IXamlTypeResolver
     {
-        public Func<string, Type>? ResolveAction { get; set; }
+        public Func<string, Type> ResolveAction { get; set; }
 
         public Type Resolve(string qualifiedTypeName)
         {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/UidPropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/UidPropertyAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XDataTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XDataTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using System.IO;
 using System.Xml;
 using Xunit;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XamlSetMarkupExtensionAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XamlSetMarkupExtensionAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XamlSetTypeConverterAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XamlSetTypeConverterAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XmlLangPropertyAttributeTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System/Windows/Markup/XmlLangPropertyAttributeTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
+#nullable disable
 using Xunit;
 
 namespace System.Windows.Markup.Tests;


### PR DESCRIPTION
Disable nullability in System.Xaml unit test to fix build of https://github.com/dotnet/wpf/pull/8695
Will revert these changes when nullability is completed for System.Xaml

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8700)