### PR TITLE
Fix ItemsControl Automation Again

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -469,6 +469,7 @@
     <Compile Include="System\Windows\Automation\Peers\InkPresenterAutomationPeer.cs" />
     <Compile Include="System\Windows\Automation\Peers\ItemAutomationPeer.cs" />
     <Compile Include="System\Windows\Automation\Peers\ItemsControlAutomationPeer.cs" />
+    <Compile Include="System\Windows\Automation\Peers\ItemsControlElementAutomationPeer.cs" />
     <Compile Include="System\Windows\Automation\Peers\ItemsControlItemAutomationPeer.cs" />
     <Compile Include="System\Windows\Automation\Peers\ItemsControlWrapperAutomationPeer.cs" />
     <Compile Include="System\Windows\Automation\Peers\IViewAutomationPeer.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlElementAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlElementAutomationPeer.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace System.Windows.Automation.Peers
+{
+    // this class is a brother of ItemsControlItemAutomationPeer,
+    internal class ItemsControlElementAutomationPeer : ItemAutomationPeer
+    {
+        private AutomationPeer _elementAutomationPeer;
+
+        public ItemsControlElementAutomationPeer(UIElement element, AutomationPeer peer, ItemsControlWrapperAutomationPeer parent)
+            : base(element, parent)
+        {
+            _elementAutomationPeer = peer;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return _elementAutomationPeer.GetAutomationControlType();
+        }
+
+        protected override string GetClassNameCore()
+        {
+            return _elementAutomationPeer.GetClassName();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlWrapperAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/ItemsControlWrapperAutomationPeer.cs
@@ -21,6 +21,20 @@ namespace System.Windows.Automation.Peers
 
         override protected ItemAutomationPeer CreateItemAutomationPeer(object item)
         {
+            if (item is UIElement element)
+            {
+                // Some UIElements have their own automation peers, so we need to check for that.
+                var peer = element.CreateAutomationPeer();
+                if (peer is not null)
+                {
+                    return new ItemsControlElementAutomationPeer(element, peer, this);
+                }
+
+                // Some other UIElements don't have their own automation peers, so we treat them as ItemsControlItems.
+            }
+
+            // If the item is not a UIElement, or if it is a UIElement that doesn't have its own automation peer,
+            // we create an ItemsControlItemAutomationPeer for it.
             return new ItemsControlItemAutomationPeer(item, this);
         }
 


### PR DESCRIPTION
Fixes #8679

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

The PR #6862 addressed an issue with ItemsControl Automation reported in #6861. However, it inadvertently introduced breaking changes, as reported in #8679. Another PR, #8712, attempts to resolve this issue by partially reverting the changes made in #6862, but this approach does not fundamentally address the problem.

### Why does #8679 occur?

Actually, the button "ItemButton1" does not disappear. Instead, its type is changed from Button to DataItem by the ItemsControlWrapperAutomationPeer.

### How does this PR resolve #8679?

I believe the proper way to fix #8679 is to maintain the original type of the UIElement, rather than reverting the changes of #6862. This is because the ItemsControlWrapperAutomationPeer is designed to present DataItems from ItemsControl to the UIA tree when the ItemsControlDoesNotSupportAutomation switch is off. However, the approach in #8712, which returns null, results in ItemsControl inconsistent behavior: sometimes reports DataItems (as in groups) and other times reports null (as in different scenarios). This inconsistency does not align with the intended function of the ItemsControlDoesNotSupportAutomation switch.

To address this, I have introduced a new type, ItemsControlElementAutomationPeer, as a counterpart to the existing ItemsControlItemAutomationPeer. This preserves the original automation functionality of UIElement. As a result, we can resolve both issues #6862 and #8679, while also adhering to the intended purpose of the ItemsControlDoesNotSupportAutomation switch.

## Customer Impact

Compared to .NET 7 and earlier versions, this change introduces DataItem to the UIA tree for plain lists in ItemsControl, and adds UIA support for grouped items.
Relative to .NET 8, this change alters the UIA type of UIElement within ItemsControl when the UIElement has its own AutomationPeer. This ensures that button-like controls in ItemsControl behave as they did in .NET 7 and earlier versions.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, i.e., a regression? -->

## Testing

I have expanded the existing test code and incorporated the contributions from @Tobiidave in #8679.

<https://github.com/walterlv/Walterlv.WpfIssues.ItemsControlAutomationIssue>

The revised code has been tested and functions correctly.

## Risk

This modification introduces breaking changes to the ItemsControl AutomationPeer. We should discuss this change thoroughly before proceeding with the merge.
