### PR TITLE
Fix TextBlock Foreground and FontIcon Issue

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/TextBlock.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/TextBlock.xaml
@@ -5,11 +5,13 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <Style TargetType="{x:Type TextBlock}">
 
-        <!--<Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>-->
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
 
         <!--  The Display option causes a large aliasing effect  -->
         <!--<Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />-->
@@ -21,5 +23,13 @@
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
     </Style>
+
+    <DataTemplate DataType="{x:Type sys:String}">
+        <TextBlock Text="{Binding}">
+            <TextBlock.Resources>
+                <Style TargetType="{x:Type TextBlock}"/>
+            </TextBlock.Resources>
+        </TextBlock>
+    </DataTemplate>
 
 </ResourceDictionary>


### PR DESCRIPTION
Fixes #8708

Main PR #8744 

## Description
Added the foreground property of a text block to windows 11 styles. Also, updated the data template styles applied to a string to use default Text block styles instead of overriding the new styles.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Regression
_None_

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
_None_

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8745)