### PR TITLE
Fix MenuBar Hover Highlighting in High Contrast Theme

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/Dark.xaml
@@ -497,6 +497,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SubtleFillColorTertiary}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SubtleFillColorTertiary}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SolidBackgroundFillColorBase}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HC1.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HC1.xaml
@@ -387,6 +387,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SystemColorHighlightTextColor}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HC2.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HC2.xaml
@@ -386,6 +386,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SystemColorHighlightTextColor}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HCBlack.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HCBlack.xaml
@@ -386,6 +386,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SystemColorHighlightTextColor}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HCWhite.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/HCWhite.xaml
@@ -386,6 +386,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="Transparent" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SystemColorButtonFaceColor}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource SystemColorWindowColor}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SystemColorHighlightTextColor}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SystemColorWindowColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/Theme/Light.xaml
@@ -497,6 +497,7 @@
     <SolidColorBrush x:Key="MenuBarBackground" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="MenuBarItemBackgroundSelected" Color="{StaticResource SubtleFillColorTertiary}" />
     <SolidColorBrush x:Key="MenuBarItemBorderBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="MenuBarItemBackgroundMousePointer" Color="{StaticResource SubtleFillColorTertiary}" />
 
     <!--  MessageDialog  -->
     <SolidColorBrush x:Key="MessageBoxBackground" Color="{StaticResource SolidBackgroundFillColorBase}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Styles/MenuItem.xaml
@@ -530,6 +530,9 @@
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
             </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundMousePointer}" />
+            </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Foreground">
                     <Setter.Value>
@@ -592,6 +595,9 @@
         <ControlTemplate.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundMousePointer}" />
             </Trigger>
             <Trigger Property="Icon" Value="{x:Null}">
                 <Setter TargetName="IconElement" Property="Visibility" Value="Collapsed" />
@@ -658,6 +664,7 @@
                     FontSize="16" />
 
                 <ContentPresenter
+                    x:Name="ItemSource"
                     Grid.Column="3"
                     ContentSource="Header"
                     RecognizesAccessKey="True"
@@ -677,6 +684,9 @@
         <ControlTemplate.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
                 <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundMousePointer}" />
             </Trigger>
             <Trigger Property="Icon" Value="{x:Null}">
                 <Setter TargetName="IconElement" Property="Visibility" Value="Collapsed" />
@@ -793,6 +803,9 @@
             </Trigger>
             <Trigger Property="IsHighlighted" Value="true">
                 <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundSelected}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource MenuBarItemBackgroundMousePointer}" />
             </Trigger>
             <!--<Trigger SourceName="Popup" Property="AllowsTransparency" Value="True">
                 <Setter TargetName="SubmenuBorder" Property="CornerRadius" Value="4" />


### PR DESCRIPTION
Sample Fix for [8747](https://github.com/dotnet/wpf/issues/8747) 

## Description
The MenuItems are not highlighted when hovered over in high contrast theme. Added a brush in all the themes to support highlighting of MenuItems.

## Regression
_None_

## Testing
Local Build Pass
Demo Application Testing

## Risk
_None_

## Additional Remarks
- These changes are like template to be ported to other controls that are not supporting this highlighting of controls.
- The brushes added here in HC1, HC2, HCLight and HCBlack are in accordance to highlighting of a button. We might have to change the value of these brushes based on benchmark highlighting of each control.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8748)