### PR TITLE
Fix missing PasswordBox styles in Windows 11 theme

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/PresentationFramework.Win11.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Win11/Resources/PresentationFramework.Win11.xaml
@@ -31,6 +31,7 @@
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/Menu.xaml" />
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/MenuItem.xaml" />
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/Page.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/PasswordBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/ProgressBar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/RadioButton.xaml" />
         <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Win11;component/Styles/RichTextBox.xaml" />


### PR DESCRIPTION
Fixes #8706

## Description
Adding PasswordBox to ResourceDictionary.

## Testing
Local Build Pass

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/wpf/pull/8751)