### PR TITLE
Treat CSystemMemoryBitmap stride as unsigned

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WpfGfx/common/scanop/systembitmap.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/WpfGfx/common/scanop/systembitmap.cpp
@@ -167,7 +167,7 @@ HRESULT CSystemMemoryBitmap::Lock(
 
         void *pvPixels = static_cast<BYTE*>(m_pPixels) +
             (static_cast<int>(nBitLeft) / 8) +
-            rcLock.top * static_cast<int>(m_nStride);
+            rcLock.top * m_nStride;
 
         if (nBitPosition == 0)
         {


### PR DESCRIPTION
Fixes #5125

## Description

When acquiring lock for a bitmap rectangle, the stride of the bitmap is casted to signed integer. With sufficient large bitmaps, this will result in integer overflow, miscalculation of pixel data offsets and subsequently access violation exception when trying to access the bogus pointer.

This PR removes the cast from UINT to integer, so that the the data offset to the rectangle's top does not overflow to negative numbers.

## Customer Impact

Customers not taking this fix will continue experiencing access violation exceptions when manipulating bitmaps where height*stride > int.Max. 

## Regression

No.

## Testing

Compiled x64 wpfgfx_cor3.dll using MSVC 14.39.33519 and WinSDK 10.0.22621.0, replaced the existing one in .NET 8 and verified the issue in #5125 reproduces before the fix and works after fix on .NET 8.

## Risk

Low. The caller already has the bitmap memory allocated and the rectangle bounds are checked, so the maximum value cannot overflow the available pointer space. Furthermore, similar calculation with UINT stride is already performed elsewhere:

https://github.com/dotnet/wpf/blob/623680775b59a17d730d1c3bfb0f2c558f7a9550/src/Microsoft.DotNet.Wpf/src/WpfGfx/core/sw/swlib/swsurfrt.cpp#L1734-L1736

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8787)