### PR TITLE
Fix the automation for merged/closed PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -217,7 +217,8 @@ configuration:
           branch: main
       - and:
         - isAction:
-            action: Null
+            action: Closed
+        - isMerged
         - not:
             titleContains:
               pattern: '[main] Update dependencies'
@@ -406,4 +407,4 @@ configuration:
           label: Community Contribution
       description: Label community PRs with `community contribution` label
 onFailure: 
-onSuccess: 
+onSuccess:


### PR DESCRIPTION
This is follow-up to #8767. Automation related to closed/merged PRs was not working because of an issue in the migration where there wasn't a condition for checking if a PR was merged. The 'merged' action was carried over as 'Null' in the previous PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8791)