### PR TITLE
Rename SourceBuild.props to DotNetBuild.props for unified-build

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,5 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- Whenever altering this or other DotNetBuild files, please include @dotnet/source-build-internal as a reviewer. -->
+
 <Project>
 
   <PropertyGroup>


### PR DESCRIPTION
Same as https://github.com/dotnet/winforms/pull/10863