### PR TITLE
Fix draft PR automation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -54,6 +54,8 @@ configuration:
           hour: 4
       filters:
       - isDraftPullRequest
+      - isNotLabeledWith:
+          label: draft
       actions:
       - addLabel:
           label: draft
@@ -63,6 +65,8 @@ configuration:
           hour: 4
       filters:
       - isNotDraftPullRequest
+      - hasLabel:
+          label: draft
       actions:
       - removeLabel:
           label: draft


### PR DESCRIPTION
## Description
I noticed that draft PRs were getting "updated" without any changes (See [recently updated PRs](https://github.com/dotnet/wpf/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aopen)). That started recently and I think this was caused by #8767.

I found that for the draft automation, it wasn't checking whether or not the label was already applied before adding it (Or the opposite). There are other places where we already do this check which leads me to believe that it might be the cause for this small bug.

Note: I don't know how to test this so the change might not be correct and/or might not fix this small bug.

/cc ­@jeffhandley (Since you touched this file in #8791)

## Customer Impact
None.

## Regression
No.

## Testing
None.

## Risk
None.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8815)