### PR TITLE
Try fix GetHashCode implementation of the Thickness struct is broken for uniform length

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
@@ -95,7 +95,13 @@ namespace System.Windows
         /// <returns>Hash code</returns>
         public override int GetHashCode()
         {
-            return _Left.GetHashCode() ^ _Top.GetHashCode() ^ _Right.GetHashCode() ^ _Bottom.GetHashCode();
+            var hashCode = new System.HashCode();
+            hashCode.Add(_Left);
+            hashCode.Add(_Top);
+            hashCode.Add(_Right);
+            hashCode.Add(_Bottom);
+            var code = hashCode.ToHashCode();
+            return code;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Thickness.cs
@@ -95,13 +95,7 @@ namespace System.Windows
         /// <returns>Hash code</returns>
         public override int GetHashCode()
         {
-            var hashCode = new System.HashCode();
-            hashCode.Add(_Left);
-            hashCode.Add(_Top);
-            hashCode.Add(_Right);
-            hashCode.Add(_Bottom);
-            var code = hashCode.ToHashCode();
-            return code;
+            return System.HashCode.Combine(_Left, _Top, _Right, _Bottom);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/8789

## Description

I change the GetHashCode implementation of the Thickness struct. I use the HashCode to calculate the hash code of Thickness.

I'm not sure I'm doing the right thing.

## Customer Impact

The GetHashCode  of Thickness will be change

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

Just CI.

## Risk

Normal. It's hard to evaluate. Because some logic that depends on the original behavior can break down.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8822)