### PR TITLE
Enabling Hardware Acceleration by default in RDP

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
@@ -60,7 +60,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.ShouldNotRenderInNonInteractiveWindowStationSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotUsePresentationDpiCapabilityTier3OrGreaterSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.AllowExternalProcessToBlockAccessToTemporaryFilesSwitchName, false);
-            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.EnableHardwareAccelerationInRdpSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.EnableHardwareAccelerationInRdpSwitchName, true);
         }
     }
 #pragma warning restore 436


### PR DESCRIPTION
## Description

Hardware acceleration in RDP will be enabled by default and the users who do not wish to enable it can opt-out by setting AppContext Switch (`Switch.System.Windows.Media.EnableHardwareAccelerationInRdp`) to `false`.

## Customer Impact

Hardware acceleration in RDP will be enabled by default.

## Regression

No

## Testing

in progress

## Risk

NA

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8829)