### PR TITLE
Fix Xaml compilation generating an empty InitializeComponent method when App contains a single item

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
@@ -517,7 +517,7 @@ namespace MS.Internal
                         xmlReader.MoveToAttribute(attrName);
                 }
             }
-            else if (!_compiler.IsBamlNeeded && !_compiler.ProcessingRootContext && _compiler.IsCompilingEntryPointClass && xmlReader.Depth > 0)
+            else if (!_compiler.IsBamlNeeded && _compiler.IsCompilingEntryPointClass && xmlReader.Depth > 0)
             {
                 if ((!localName.Equals(MarkupCompiler.CODETAG) &&
                      !localName.Equals($"{MarkupCompiler.CODETAG}Extension")) ||


### PR DESCRIPTION
Fixes dotnet/wpf#2543
Fixes dotnet/wpf#2926
Fixes dotnet/wpf#4457
Fixes dotnet/wpf#4538
Fixes dotnet/wpf#6198

## Description
There were many bug reports of different type that were all caused by the same bug. Xaml compilation generating an empty InitializeComponent method when App contains a single item.

Some context:
When generating App.InitializeComponent for a Xaml where there is only the StartupUri property, it will skip loading Baml in App.InitializeComponent and only set the StartupUri property in the generated code for performance reasons. There is currently a bug when detecting if the StartupUri property is the only property that would be loaded from the Baml.

See https://github.com/dotnet/wpf/pull/8853#discussion_r1507014370 for an explanation of the changes in this PR.

## Customer Impact
Should fix issues linked at the top (Might be more since the bug does not always surface the same way)

## Regression
Yes and no, the bug was not present in non-SDK style .Net Framework projects.

## Testing
Manual testing using the samples provided in the issues and manual testing with my own samples with multiple Xaml combination.

## Risk
Low to medium. Worst case scenario this PR could cause existing project that were not loading Baml to now load Baml which could cause slight perf regression but I wasn't able to cause this in my testing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8853)