### PR TITLE
Use double value as argument in FindMinutes function.

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/GDIExporter/gdiprintcontext.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/GDIExporter/gdiprintcontext.cpp
@@ -38,7 +38,8 @@ int CGDIRenderTarget::StartDocument(String ^ printerName, String^ jobName, Strin
                 // The best fix would be waiting for those jobs to be completed.
                 // Heuristics: Release fonts which are more than 10 minutes old.
                 
-                DateTime cutoffTime = DateTime::Now - TimeSpan::FromMinutes(10);
+                double limit = 10.0;
+                DateTime cutoffTime = DateTime::Now - TimeSpan::FromMinutes(limit);
 
                 int i = 0;
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/GDIExporter/gdiprintcontext.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/CPP/src/GDIExporter/gdiprintcontext.cpp
@@ -38,8 +38,7 @@ int CGDIRenderTarget::StartDocument(String ^ printerName, String^ jobName, Strin
                 // The best fix would be waiting for those jobs to be completed.
                 // Heuristics: Release fonts which are more than 10 minutes old.
                 
-                double limit = 10.0;
-                DateTime cutoffTime = DateTime::Now - TimeSpan::FromMinutes(limit);
+                DateTime cutoffTime = DateTime::Now - TimeSpan::FromMinutes(10.0);
 
                 int i = 0;
 


### PR DESCRIPTION
Fixes # 
Build failure in PR: https://github.com/dotnet/wpf/pull/8863

## Description

In Dotnet/runtime new TimeSpan.From overloads were added for int values. 
PR: https://github.com/dotnet/runtime/pull/98633

In WPF, we are using FromMinutes function from TimeSpan with value 10. 
On addition of new surface API in runtime, C++/CLI reports it as ambiguous (between int and double)

Fixing it by setting the argument value as double

## Risk

N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8864)