### PR TITLE
Added Themes folder with Generic.xaml under net5.0 and net6.0 folders.

### DIFF
--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -25,18 +25,4 @@
     <PackagingContent Include="useSharedDesignerContext.txt" SubFolder="root" />
     <PackagingContent Include="content\**\*" SubFolder="root\%(RecursiveDir)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackagingContent Remove="content\WpfCustomControlLibrary-CSharp\net5.0\Themes\Generic.xaml" />
-    <PackagingContent Remove="content\WpfCustomControlLibrary-CSharp\net6.0\Themes\Generic.xaml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="content\WpfCustomControlLibrary-CSharp\net5.0\Themes\Generic.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
-    <None Update="content\WpfCustomControlLibrary-CSharp\net6.0\Themes\Generic.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
-  </ItemGroup>
 </Project>

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/Microsoft.DotNet.Wpf.ProjectTemplates.ArchNeutral.csproj
@@ -25,4 +25,18 @@
     <PackagingContent Include="useSharedDesignerContext.txt" SubFolder="root" />
     <PackagingContent Include="content\**\*" SubFolder="root\%(RecursiveDir)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackagingContent Remove="content\WpfCustomControlLibrary-CSharp\net5.0\Themes\Generic.xaml" />
+    <PackagingContent Remove="content\WpfCustomControlLibrary-CSharp\net6.0\Themes\Generic.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="content\WpfCustomControlLibrary-CSharp\net5.0\Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+    <None Update="content\WpfCustomControlLibrary-CSharp\net6.0\Themes\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+  </ItemGroup>
 </Project>

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/net5.0/Themes/Generic.xaml
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/net5.0/Themes/Generic.xaml
@@ -1,0 +1,17 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:Company.WpfCustomControlLibrary">
+    <Style TargetType="{x:Type local:CustomControl1}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:CustomControl1}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/net6.0/Themes/Generic.xaml
+++ b/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfCustomControlLibrary-CSharp/net6.0/Themes/Generic.xaml
@@ -1,0 +1,17 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:Company.WpfCustomControlLibrary">
+    <Style TargetType="{x:Type local:CustomControl1}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:CustomControl1}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
Fixes #8773 

## Description

Added Themes folder with Generic.xaml under net5.0 and net6.0 folders so that when a user creates a WPF Custom Control Library project (NOT the .NET Framework version) it will include a Themes folder that in turn will contain Generic.xaml.

## Testing
I created a new WPF Custom Control Library project (NOT the .NET Framework version) and it has a Themes folder that in turn contains Generic.xaml.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8868)