### PR TITLE
Use Volatile.Read/Write instead of Thread.VolatileRead/Write

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeBits.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/TypeBits.cs
@@ -76,7 +76,7 @@ namespace System.Xaml
         {
             get
             {
-                object value = Thread.VolatileRead(ref _value);
+                object value = Volatile.Read(ref _value);
                 return !(value is null);
             }
         }
@@ -100,7 +100,7 @@ namespace System.Xaml
         public void SetVolatile(T value)
         {
             object newValue = value is null ? s_NullSentinel : value;
-            Thread.VolatileWrite(ref _value, newValue);
+            Volatile.Write(ref _value, newValue);
         }
     }
 }


### PR DESCRIPTION
### Fixes 
Build failure: https://github.com/dotnet/wpf/pull/8888

### Description
[Thread.VolatileRead](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatileread?view=net-8.0) and [Thread.VolatileWrite](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.volatilewrite?view=net-8.0) are legacy APIs and have been replaced by [Volatile.Read](https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile.read?view=net-8.0) and [Volatile.Write](https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile.write?view=net-8.0).



### Risk

N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8890)