### PR TITLE
Clean-up public and internal pipelines

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -19,9 +19,6 @@ variables:
   - ${{ else }}:
     - name: PostBuildSign
       value: true
-  
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-Wpf-SDLValidation-Params
 
 
 # This is set in the pipeline directly 
@@ -68,25 +65,3 @@ stages:
     parameters:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         runAsPublic: false
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "wpf"
-        -TsaCodebaseName "wpf"
-        -TsaPublish $True'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,8 @@ variables:
 - ${{ else }}:
   - name: PostBuildSign
     value: true
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - group: DotNet-Wpf-SDLValidation-Params
+- group: DotNet-Wpf-SDLValidation-Params
+
 trigger:
   batch: true
   branches:
@@ -52,16 +52,15 @@ extends:
       jobs:
       - template: /eng/pipeline.yml@self
         parameters:
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             runAsPublic: false
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: /eng/common/templates-official/post-build/post-build.yml@self
-        parameters:
-          publishingInfraVersion: 3
-          enableSymbolValidation: false
-          enableSigningValidation: false
-          enableNugetValidation: false
-          enableSourceLinkValidation: false
-          SDLValidationParameters:
-            enable: false
-            params: ' -SourceToolsList @("policheck","credscan") -TsaInstanceURL $(_TsaInstanceURL) -TsaProjectName $(_TsaProjectName) -TsaNotificationEmail $(_TsaNotificationEmail) -TsaCodebaseAdmin $(_TsaCodebaseAdmin) -TsaBugAreaPath $(_TsaBugAreaPath) -TsaIterationPath $(_TsaIterationPath) -TsaRepositoryName "wpf" -TsaCodebaseName "wpf" -TsaPublish $True'
+
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        publishingInfraVersion: 3
+        enableSymbolValidation: false
+        enableSigningValidation: false
+        enableNugetValidation: false
+        enableSourceLinkValidation: false
+        SDLValidationParameters:
+          enable: false
+          params: ' -SourceToolsList @("policheck","credscan") -TsaInstanceURL $(_TsaInstanceURL) -TsaProjectName $(_TsaProjectName) -TsaNotificationEmail $(_TsaNotificationEmail) -TsaCodebaseAdmin $(_TsaCodebaseAdmin) -TsaBugAreaPath $(_TsaBugAreaPath) -TsaIterationPath $(_TsaIterationPath) -TsaRepositoryName "wpf" -TsaCodebaseName "wpf" -TsaPublish $True'

--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -10,12 +10,7 @@ parameters:
   repoName: dotnet/wpf
 
 jobs:
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - template: /eng/common/templates/job/onelocbuild.yml
-    parameters:
-      MirrorRepo: wpf
-      LclSource: lclFilesfromPackage
-      LclPackageId: 'LCL-JUNO-PROD-WPF'
+
 - template: /eng/common/templates/jobs/jobs.yml
   parameters:
     enableMicrobuild: true
@@ -29,27 +24,19 @@ jobs:
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       binlogPath: artifacts/log/Debug/x86/Build.binlog
       pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2022preview.amd64.Open
     helixRepo: $(repoName)
 
     jobs:
     - job: Windows_NT
       timeoutInMinutes: 120  # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
       pool:
-        # For public jobs, use the hosted pool.  For internal jobs use the internal pool.
+        # For public jobs, use the hosted pool. 
         # Will eventually change this to two BYOC pools.
         # agent pool can't be read from a user-defined variable (Azure DevOps limitation)
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2022preview.amd64.Open
       variables:
         - name: Codeql.Enabled
           value: true
@@ -84,69 +71,35 @@ jobs:
           value: ${Env:ProgramFiles(x86)}/dotnet          
         - name: _programfiles
           value:  ${Env:ProgramFiles}/dotnet
-        - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-          - name: _InternalRuntimeDownloadArgs
-            value: ''
-        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - group: DotNetBuilds storage account read tokens
-          - group: AzureDevOps-Artifact-Feeds-Pats
-          - name: _InternalRuntimeDownloadArgs
-            value: >-
-              /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-              /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
-
-        # Override some values if we're building internally
-        - ${{ if eq(parameters.runAsPublic, 'false') }}:
-          # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
-          - name: _SignType
-            value: real
-          - group: DotNet-HelixApi-Access
-
-          # note: Even though they are referenced here, user defined variables (like $(_SignType)) are not resolved 
-          # until the agent is running on the machine. They can be overridden any time before they are resolved,
-          # like in the job matrix below (see Build_Debug)
-          - name: _SignArgs
-            value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-          - name: _PublishArgs
-            value: /p:DotNetPublishUsingPipelines=true
-          - name: _OfficialBuildIdArgs
-            value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          - name: _PublicBuildPipeline
-            value: false
-          - name: _HelixSource
-            value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
-          - name: _HelixToken
-            value: '$(HelixApiAccessToken)' # from DotNet-HelixApi-Access group
-          - name: _HelixCreator
-            value: '' #if _HelixToken is set, Creator must be empty
-          - name: _TestHelixAgentPool
-            value: 'Windows.10.Amd64.ClientRS5' # Preferred: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
+        - name: _InternalRuntimeDownloadArgs
+          value: ''
 
       strategy:
-        matrix:
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_x86:
-              _BuildConfig: Debug
-              # override some variables for debug
-              # _SignType has to be real for package publishing to succeed - do not override to test.
+        matrix: 
+          Build_Debug_x86:
+            _BuildConfig: Debug
+            # override some variables for debug
+            # _SignType has to be real for package publishing to succeed - do not override to test.
+
           Build_Release_x86:
             _BuildConfig: Release
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_x64:
-              _BuildConfig: Debug
-              # override some variables for debug
-              # _SignType has to be real for package publishing to succeed - do not override to test.
-              _Platform: x64
+
+          Build_Debug_x64:
+            _BuildConfig: Debug
+            # override some variables for debug
+            # _SignType has to be real for package publishing to succeed - do not override to test.
+            _Platform: x64
+
           Build_Release_x64:
             _BuildConfig: Release
             _Platform: x64
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_arm64:
-              _BuildConfig: Debug
-              # override some variables for debug
-              # _SignType has to be real for package publishing to succeed - do not override to test.
-              _Platform: arm64
+          
+          Build_Debug_arm64:
+            _BuildConfig: Debug
+            # override some variables for debug
+            # _SignType has to be real for package publishing to succeed - do not override to test.
+            _Platform: arm64
+
           Build_Release_arm64:
             _BuildConfig: Release
             _Platform: arm64
@@ -157,15 +110,6 @@ jobs:
       # Set VSO Variable(s)
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
-
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
       # Use utility script to run script command dependent on agent OS.
       - script: eng\scripts\cibuild.cmd

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -25,23 +25,15 @@ jobs:
       condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
       binlogPath: artifacts/log/Debug/x86/Build.binlog
       pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2022preview.amd64
     helixRepo: $(repoName)
     jobs:
     - job: Windows_NT
       timeoutInMinutes: 120 # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
       pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2022preview.amd64
       variables:
       - name: Codeql.Enabled
         value: true
@@ -75,62 +67,48 @@ jobs:
         value: ${Env:ProgramFiles(x86)}/dotnet
       - name: _programfiles
         value: ${Env:ProgramFiles}/dotnet
-      - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - group: DotNetBuilds storage account read tokens
-        - group: AzureDevOps-Artifact-Feeds-Pats
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-      - ${{ if eq(parameters.runAsPublic, 'false') }}:
-      # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
-        - name: _SignType
-          value: real
-        - group: DotNet-HelixApi-Access
+      - group: DotNetBuilds storage account read tokens
+      - group: AzureDevOps-Artifact-Feeds-Pats
+      - name: _InternalRuntimeDownloadArgs
+        value: >-
+          /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+      
 
-          # note: Even though they are referenced here, user defined variables (like $(_SignType)) are not resolved 
-          # until the agent is running on the machine. They can be overridden any time before they are resolved,
-          # like in the job matrix below (see Build_Debug)
-        - name: _SignArgs
-          value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        - name: _PublishArgs
-          value: /p:DotNetPublishUsingPipelines=true
-        - name: _OfficialBuildIdArgs
-          value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        - name: _PublicBuildPipeline
-          value: false
-        - name: _HelixSource
-          value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
-        - name: _HelixToken
-          value: '$(HelixApiAccessToken)'
-        - name: _HelixCreator
-          value: ''
-        - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.ClientRS5'
+      # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
+      - name: _SignType
+        value: real
+      - group: DotNet-HelixApi-Access
+
+        # note: Even though they are referenced here, user defined variables (like $(_SignType)) are not resolved 
+        # until the agent is running on the machine. They can be overridden any time before they are resolved,
+        # like in the job matrix below (see Build_Debug)
+      - name: _SignArgs
+        value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+      - name: _PublishArgs
+        value: /p:DotNetPublishUsingPipelines=true
+      - name: _OfficialBuildIdArgs
+        value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+      - name: _PublicBuildPipeline
+        value: false
+      - name: _HelixSource
+        value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
+      - name: _HelixToken
+        value: '$(HelixApiAccessToken)'
+      - name: _HelixCreator
+        value: ''
+      - name: _TestHelixAgentPool
+        value: 'Windows.10.Amd64.ClientRS5'
+      
       strategy:
         matrix:
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_x86:
-              _BuildConfig: Debug
-              # override some variables for debug
-              # _SignType has to be real for package publishing to succeed - do not override to test.
+          
           Build_Release_x86:
             _BuildConfig: Release
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_x64:
-              _BuildConfig: Debug
-              # override some variables for debug
-              # _SignType has to be real for package publishing to succeed - do not override to test.
-              _Platform: x64
+          
           Build_Release_x64:
             _BuildConfig: Release
             _Platform: x64
-          ${{ if eq(parameters.runAsPublic, 'true') }}:
-            Build_Debug_arm64:
-              _BuildConfig: Debug
-              _Platform: arm64
+         
           Build_Release_arm64:
             _BuildConfig: Release
             _Platform: arm64


### PR DESCRIPTION
### Description
We have separated the public and internal pipelines, so we can remove the conditions throughout that are checking internal vs. public to make things more readable.