### PR TITLE
[release/8.0] Migrate to 1ESPT

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,0 +1,91 @@
+# This is a simple wrapper for eng/pipeline.yml to get around the limitation of
+# user-defined variables not being available in yaml template expressions.
+
+# Parameters ARE available in template expressions, and parameters can have default values,
+# so they can be used to control yaml flow.
+#
+
+variables:
+    # clean the local repo on the build agents
+  - name: Build.Repository.Clean
+    value: true
+  - name: _DotNetArtifactsCategory
+    value: WINDOWSDESKTOP
+  - name: _DotNetValidationArtifactsCategory
+    value: WINDOWSDESKTOP
+  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+    - name: PostBuildSign
+      value: false
+  - ${{ else }}:
+    - name: PostBuildSign
+      value: true
+  
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - group: DotNet-Wpf-SDLValidation-Params
+
+
+# This is set in the pipeline directly 
+# When set to false, CI tests will not be enabled in builds. 
+#
+# _ContinuousIntegrationTestsEnabled: false
+
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+#
+# only trigger ci builds for the master and release branches
+trigger:
+  batch: true 
+  branches:
+    include: 
+    - main
+    - release/*
+    - internal/release/*
+    - experimental/*
+  paths:
+    exclude:
+    - Documentation/*
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - main
+    - release/*
+    - internal/release/*
+    - experimental/*
+  paths:
+    exclude:
+    - Documentation/*
+
+# Call the pipeline-pr.yml template, which does the real work
+stages:
+- stage: build
+  displayName: Build 
+  jobs:
+  - template: /eng/pipeline-pr.yml
+    parameters:
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        runAsPublic: false
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      publishingInfraVersion: 3
+      enableSymbolValidation: false
+      enableSigningValidation: false
+      enableNugetValidation: false
+      enableSourceLinkValidation: false
+      # This is to enable SDL runs part of Post-Build Validation Stage
+      SDLValidationParameters:
+        enable: false
+        params: ' -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL $(_TsaInstanceURL)
+        -TsaProjectName $(_TsaProjectName)
+        -TsaNotificationEmail $(_TsaNotificationEmail)
+        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+        -TsaBugAreaPath $(_TsaBugAreaPath)
+        -TsaIterationPath $(_TsaIterationPath)
+        -TsaRepositoryName "wpf"
+        -TsaCodebaseName "wpf"
+        -TsaPublish $True'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,24 +6,21 @@
 #
 
 variables:
-    # clean the local repo on the build agents
-  - name: Build.Repository.Clean
+# clean the local repo on the build agents
+- name: Build.Repository.Clean
+  value: true
+- name: _DotNetArtifactsCategory
+  value: WINDOWSDESKTOP
+- name: _DotNetValidationArtifactsCategory
+  value: WINDOWSDESKTOP
+- ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+  - name: PostBuildSign
+    value: false
+- ${{ else }}:
+  - name: PostBuildSign
     value: true
-  - name: _DotNetArtifactsCategory
-    value: WINDOWSDESKTOP
-  - name: _DotNetValidationArtifactsCategory
-    value: WINDOWSDESKTOP
-  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
-    - name: PostBuildSign
-      value: false
-  - ${{ else }}:
-    - name: PostBuildSign
-      value: true
-  
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-Wpf-SDLValidation-Params
-
-
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - group: DotNet-Wpf-SDLValidation-Params
 # This is set in the pipeline directly 
 # When set to false, CI tests will not be enabled in builds. 
 #
@@ -35,68 +32,49 @@ variables:
 #
 # only trigger ci builds for the master and release branches
 trigger:
-  batch: true 
-  branches:
-    include: 
-    - main
-    - release/3.*
-    - release/5.*
-    - release/6.*
-    - release/7.*
-    - release/8.*
-    - internal/release/5.*
-    - internal/release/6.*
-    - internal/release/7.*
-    - internal/release/8.*
-    - experimental/*
-  paths:
-    exclude:
-    - Documentation/*
-
-pr:
-  autoCancel: true
+  batch: true
   branches:
     include:
     - main
-    - release/3.* 
-    - internal/release/3.*
-    - release/5.*
-    - release/6.*
-    - release/7.*
-    - release/8.*
+    - release/*
+    - internal/release/*
     - experimental/*
   paths:
     exclude:
     - Documentation/*
-
-# Call the pipeline.yml template, which does the real work
-stages:
-- stage: build
-  displayName: Build 
-  jobs:
-  - template: /eng/pipeline.yml
-    parameters:
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        runAsPublic: false
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "wpf"
-        -TsaCodebaseName "wpf"
-        -TsaPublish $True'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    featureFlags:
+      autoBaseline: true
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022-pt
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build
+      jobs:
+      - template: /eng/pipeline.yml@self
+        parameters:
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            runAsPublic: false
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          publishingInfraVersion: 3
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          SDLValidationParameters:
+            enable: false
+            params: ' -SourceToolsList @("policheck","credscan") -TsaInstanceURL $(_TsaInstanceURL) -TsaProjectName $(_TsaProjectName) -TsaNotificationEmail $(_TsaNotificationEmail) -TsaCodebaseAdmin $(_TsaCodebaseAdmin) -TsaBugAreaPath $(_TsaBugAreaPath) -TsaIterationPath $(_TsaIterationPath) -TsaRepositoryName "wpf" -TsaCodebaseName "wpf" -TsaPublish $True'

--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -2,17 +2,21 @@
 # This file should be kept in sync across https://www.github.com/dotnet/wpf and dotnet-wpf-int repos. 
 #
 # 
+
 parameters:
+  # Needed because runAsPublic is used in template expressions, which can't read from user-defined variables
+  # Defaults to true
   runAsPublic: true
   repoName: dotnet/wpf
+
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - template: /eng/common/templates-official/job/onelocbuild.yml@self
+  - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
       MirrorRepo: wpf
       LclSource: lclFilesfromPackage
       LclPackageId: 'LCL-JUNO-PROD-WPF'
-- template: /eng/common/templates-official/jobs/jobs.yml@self
+- template: /eng/common/templates/jobs/jobs.yml
   parameters:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
@@ -32,9 +36,10 @@ jobs:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals windows.vs2022preview.amd64
     helixRepo: $(repoName)
+
     jobs:
     - job: Windows_NT
-      timeoutInMinutes: 120 # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
+      timeoutInMinutes: 120  # how long to run the job before automatically cancelling; see https://github.com/dotnet/wpf/issues/952
       pool:
         # For public jobs, use the hosted pool.  For internal jobs use the internal pool.
         # Will eventually change this to two BYOC pools.
@@ -46,72 +51,78 @@ jobs:
           name: NetCore1ESPool-Internal
           demands: ImageOverride -equals windows.vs2022preview.amd64
       variables:
-      - name: Codeql.Enabled
-        value: true
-      - name: _TeamName
-        value: DotNetCore
-      - name: _SignType
-        value: real
-      - name: _SignArgs
-        value: ''
-      - name: _PublishArgs
-        value: ''
-      - name: _OfficialBuildIdArgs
-        value: ''
-      - name: _Platform
-        value: x86
-      - name: _PlatformArgs
-        value: /p:Platform=$(_Platform)
-      - name: _PublicBuildPipeline # We will run Helix tests when building in the open, but do not repeat when building and publishing again using the internal build-pipeline
-        value: true
-      - name: _TestHelixAgentPool
-        value: 'Windows.10.Amd64.ClientRS5.Open' #Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'; See https://github.com/dotnet/wpf/issues/952
-      - name: _HelixStagingDir
-        value: $(BUILD.STAGINGDIRECTORY)\helix\functests
-      - name: _HelixSource
-        value: ${{ parameters.repoName }}/$(Build.SourceBranch)
-      - name: _HelixToken
-        value: ''
-      - name: _HelixCreator
-        value: ${{ parameters.repoName }}
-      - name: _programfilesx86
-        value: ${Env:ProgramFiles(x86)}/dotnet
-      - name: _programfiles
-        value: ${Env:ProgramFiles}/dotnet
-      - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-        - name: _InternalRuntimeDownloadArgs
-          value: ''
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - group: DotNetBuilds storage account read tokens
-        - group: AzureDevOps-Artifact-Feeds-Pats
-        - name: _InternalRuntimeDownloadArgs
-          value: >-
-            /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-      - ${{ if eq(parameters.runAsPublic, 'false') }}:
-      # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
+        - name: Codeql.Enabled
+          value: true
+        # needed for signing
+        - name: _TeamName
+          value: DotNetCore
         - name: _SignType
           value: real
-        - group: DotNet-HelixApi-Access
+        - name: _SignArgs
+          value: ''
+        - name: _PublishArgs
+          value: ''
+        - name: _OfficialBuildIdArgs
+          value: ''
+        - name: _Platform
+          value: x86
+        - name: _PlatformArgs
+          value: /p:Platform=$(_Platform)
+        - name: _PublicBuildPipeline  # We will run Helix tests when building in the open, but do not repeat when building and publishing again using the internal build-pipeline
+          value: true
+        - name: _TestHelixAgentPool
+          value: 'Windows.10.Amd64.ClientRS5.Open' # Preferred:'Windows.10.Amd64.Open%3bWindows.7.Amd64.Open%3bWindows.10.Amd64.ClientRS5.Open'; See https://github.com/dotnet/wpf/issues/952
+        - name: _HelixStagingDir
+          value: $(BUILD.STAGINGDIRECTORY)\helix\functests
+        - name: _HelixSource
+          value: ${{ parameters.repoName }}/$(Build.SourceBranch)
+        - name: _HelixToken
+          value: ''
+        - name: _HelixCreator
+          value: ${{ parameters.repoName }}
+        - name: _programfilesx86
+          value: ${Env:ProgramFiles(x86)}/dotnet          
+        - name: _programfiles
+          value:  ${Env:ProgramFiles}/dotnet
+        - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+          - name: _InternalRuntimeDownloadArgs
+            value: ''
+        - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - group: DotNetBuilds storage account read tokens
+          - group: AzureDevOps-Artifact-Feeds-Pats
+          - name: _InternalRuntimeDownloadArgs
+            value: >-
+              /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+              /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+
+
+        # Override some values if we're building internally
+        - ${{ if eq(parameters.runAsPublic, 'false') }}:
+          # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
+          - name: _SignType
+            value: real
+          - group: DotNet-HelixApi-Access
 
           # note: Even though they are referenced here, user defined variables (like $(_SignType)) are not resolved 
           # until the agent is running on the machine. They can be overridden any time before they are resolved,
           # like in the job matrix below (see Build_Debug)
-        - name: _SignArgs
-          value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        - name: _PublishArgs
-          value: /p:DotNetPublishUsingPipelines=true
-        - name: _OfficialBuildIdArgs
-          value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-        - name: _PublicBuildPipeline
-          value: false
-        - name: _HelixSource
-          value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
-        - name: _HelixToken
-          value: '$(HelixApiAccessToken)'
-        - name: _HelixCreator
-          value: ''
-        - name: _TestHelixAgentPool
-          value: 'Windows.10.Amd64.ClientRS5'
+          - name: _SignArgs
+            value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
+          - name: _PublishArgs
+            value: /p:DotNetPublishUsingPipelines=true
+          - name: _OfficialBuildIdArgs
+            value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+          - name: _PublicBuildPipeline
+            value: false
+          - name: _HelixSource
+            value: official/${{ parameters.repoName }}/$(Build.SourceBranch)
+          - name: _HelixToken
+            value: '$(HelixApiAccessToken)' # from DotNet-HelixApi-Access group
+          - name: _HelixCreator
+            value: '' #if _HelixToken is set, Creator must be empty
+          - name: _TestHelixAgentPool
+            value: 'Windows.10.Amd64.ClientRS5' # Preferred: 'Windows.10.Amd64%3bWindows.7.Amd64%3bWindows.10.Amd64.ClientRS5'
+
       strategy:
         matrix:
           ${{ if eq(parameters.runAsPublic, 'true') }}:
@@ -146,6 +157,7 @@ jobs:
       # Set VSO Variable(s)
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
+
       - ${{ if ne(variables['System.TeamProject'], 'public') }}:
         - task: PowerShell@2
           displayName: Setup Private Feeds Credentials
@@ -154,8 +166,16 @@ jobs:
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      # Use utility script to run script command dependent on agent OS
-      - script: eng\scripts\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_PublishArgs) $(_SignArgs) $(_OfficialBuildIdArgs) $(_PlatformArgs) $(_InternalRuntimeDownloadArgs)
+
+      # Use utility script to run script command dependent on agent OS.
+      - script: eng\scripts\cibuild.cmd
+          -configuration $(_BuildConfig) 
+          -prepareMachine
+          $(_PublishArgs)
+          $(_SignArgs)
+          $(_OfficialBuildIdArgs)
+          $(_PlatformArgs)
+          $(_InternalRuntimeDownloadArgs)
         displayName: Windows Build / Publish
         # This condition should be kept in sync with the condition for 'Run DRTs' step 
         #   When building on a regular pipeline (!_HelixPipeline), build as usual 
@@ -163,14 +183,23 @@ jobs:
         #   (!_HelixPipeline) ||
         #   (_HelixPipeline && _PublicBuildPipeline && _ContinuousIntegrationTestsEnabled && _BuildConfig == Release)
         condition: or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true')))
-      - script: eng\scripts\ciunittest.cmd -configuration $(_BuildConfig) -prepareMachine $(_PublishArgs) $(_SignArgs) $(_OfficialBuildIdArgs) $(_PlatformArgs) $(_InternalRuntimeDownloadArgs)
-        displayName: Run xUnit Tests
+
+      - script: eng\scripts\ciunittest.cmd
+          -configuration $(_BuildConfig) 
+          -prepareMachine
+          $(_PublishArgs)
+          $(_SignArgs)
+          $(_OfficialBuildIdArgs)
+          $(_PlatformArgs)
+          $(_InternalRuntimeDownloadArgs)
+        displayName: Windows Build / Publish
         condition: and(or(ne(variables['_HelixPipeline'], 'true'), and(eq(variables['_HelixPipeline'], 'true') ,eq(variables['_BuildConfig'], 'Release'), eq(variables['_PublicBuildPipeline'], 'true'), eq(variables['_ContinuousIntegrationTestsEnabled'], 'true'))), ne(variables['_Platform'], 'arm64'))
+
       - task: PublishTestResults@2
         displayName: Publish XUnit Test Results
         inputs:
           testResultsFormat: 'xUnit'
-          testResultsFiles: '*.xml'
+          testResultsFiles: '*.xml' 
           searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
           mergeTestResults: true
         continueOnError: true
@@ -182,30 +211,35 @@ jobs:
           filePath: $(Build.SourcesDirectory)/dotnet-test-install.ps1
           arguments: -InstallDir $(_programfiles) -Architecture $(_Platform) -Runtime dotnet  -Channel 8.0 -Quality daily
           condition: eq(variables['_Platform'], 'x64')
+      
       - task: PowerShell@2
         displayName: Install .NET Core(x86)
         inputs:
           filePath: $(Build.SourcesDirectory)/dotnet-test-install.ps1
           arguments: -InstallDir $(_programfilesx86) -Architecture $(_Platform) -Runtime dotnet  -Channel 8.0 -Quality daily
         condition: eq(variables['_Platform'], 'x86')
+  
       - task: PowerShell@2
         displayName: Install .NET WindowsDesktop
         inputs:
           filePath: $(Build.SourcesDirectory)/dotnet-test-install.ps1
           arguments: -InstallDir $(_programfiles) -Architecture $(_Platform) -Runtime windowsdesktop  -Channel 8.0 -Quality daily
         condition: eq(variables['_Platform'], 'x64')
+     
       - task: PowerShell@2
         displayName: Install .NET WindowsDesktop(x86)
         inputs:
           filePath: $(Build.SourcesDirectory)/dotnet-test-install.ps1
           arguments: -InstallDir $(_programfilesx86) -Architecture $(_Platform) -Runtime windowsdesktop  -Channel 8.0 -Quality daily
-        condition: eq(variables['_Platform'], 'x86')
+        condition: eq(variables['_Platform'], 'x86')  
+
       - task: PowerShell@2
         displayName: Replace WPF binaries
         inputs:
           targetType: 'inline'
           script: '.\eng\copy-wpf.ps1 -testhost -destination .dotnet -$(_BuildConfig) -arch $(_Platform)'
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+
       - task: DownloadPipelineArtifact@2
         displayName: Fetch Test Binaries
         inputs:
@@ -218,6 +252,7 @@ jobs:
           checkDownloadedFiles: true
           artifactName: Tests.$(_BuildConfig).$(_Platform).zip
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+
       - task: ExtractFiles@1
         displayName: Extract Test Bins
         inputs:
@@ -226,6 +261,7 @@ jobs:
           cleanDestinationFolder: true
           overwriteExistingFiles: true
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+
       - task: PowerShell@2
         displayName: Run Tests
         inputs:
@@ -233,6 +269,7 @@ jobs:
           script: '.\CIRunDrts.cmd'
           workingDirectory: '$(System.ArtifactsDirectory)\testbins'
         condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+      
       - task: CopyFiles@2
         inputs:
           SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
@@ -241,6 +278,7 @@ jobs:
           CleanTargetFolder: true
           OverWrite: true
         condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
+        
       - task: CopyFiles@2
         inputs:
           SourceFolder: 'C:\Users\cloudtest\AppData\Roaming\QualityVault\Run\Report\'
@@ -249,16 +287,19 @@ jobs:
           CleanTargetFolder: true
           OverWrite: true
         condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
-      - task: 1ES.PublishPipelineArtifact@1
+
+      - task: PublishPipelineArtifact@1
         inputs:
           artifactName: 'TestResultsX64'
-          targetPath: '$(System.DefaultWorkingDirectory)\Results\'
+          targetPath: '$(System.DefaultWorkingDirectory)\Results\'      
         condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x64'), eq(variables['_BuildConfig'], 'Release'))
-      - task: 1ES.PublishPipelineArtifact@1
+
+      - task: PublishPipelineArtifact@1
         inputs:
           artifactName: 'TestResultsX86'
           targetPath: '$(System.DefaultWorkingDirectory)\ResultsX86\'
         condition: and(eq(variables['System.TeamProject'], 'public'), eq(variables['_Platform'], 'x86'), eq(variables['_BuildConfig'], 'Release'))
+          
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'XUnit'


### PR DESCRIPTION
Related: https://github.com/dotnet/wpf/pull/8892

Test: In progress

Steps:

Ran the migration tool with release/8.0 branch
changed necessary pools, templates, enable auto baselining
Clean-up (pending)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8965)