### PR TITLE
Update _SignType to test for Internal

### DIFF
--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -100,7 +100,7 @@ jobs:
         - ${{ if eq(parameters.runAsPublic, 'false') }}:
           # note: You have to use list syntax here (- name: value) or you will get errors about declaring the same variable multiple times
           - name: _SignType
-            value: real
+            value: test
           - group: DotNet-HelixApi-Access
 
           # note: Even though they are referenced here, user defined variables (like $(_SignType)) are not resolved 


### PR DESCRIPTION
### Description

[Internal pipeline ](https://dev.azure.com/dnceng/internal/_build/results?buildId=2416843&view=results)is failing because it is running on _SignType ```real```.
Updating _SignType in pipeline-pr.yml to ```test``` for internal pipeline.

Test: [Results](https://dev.azure.com/dnceng/internal/_build/results?buildId=2421533&view=results)
CC: @lonitra 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/8980)
 
 