### PR TITLE
Adding AppContext Switch for disabling special character ligatures

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/CoreAppContextSwitches.cs
@@ -395,6 +395,21 @@ namespace MS.Internal
 
         #endregion
 
+        #region DisableSpecialCharacterLigature
+
+        internal const string DisableSpecialCharacterLigatureSwitchName = "Switch.System.Windows.DisableSpecialCharacterLigature";
+        private static int _disableSpecialCharacterLigature;
+        public static bool DisableSpecialCharacterLigature
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return LocalAppContext.GetCachedSwitchValue(DisableSpecialCharacterLigatureSwitchName, ref _disableSpecialCharacterLigature);
+            }
+        }
+
+        #endregion
+
     }
 #pragma warning restore 436
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/AppContextDefaultValues.cs
@@ -61,6 +61,7 @@ namespace System
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DoNotUsePresentationDpiCapabilityTier3OrGreaterSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.AllowExternalProcessToBlockAccessToTemporaryFilesSwitchName, false);
             LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.EnableHardwareAccelerationInRdpSwitchName, false);
+            LocalAppContext.DefineSwitchDefault(CoreAppContextSwitches.DisableSpecialCharacterLigatureSwitchName, false);
         }
     }
 #pragma warning restore 436

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -276,6 +276,7 @@ namespace System.Windows.Interop
                 //      DPI_AWARENESS_CONTEXT (DpiAwarenessContext property)
                 //      Window DPI scale (CurrentDpiScale field)
                 InitializeDpiAwarenessAndDpiScales();
+                CheckAndDisableSpecialCharacterLigature();
 
                 _worldTransform = new MatrixTransform(
                     new Matrix(
@@ -309,6 +310,14 @@ namespace System.Windows.Interop
                     VisualTarget_DetachFromHwnd(hwnd);
                 }
             }
+        }
+
+        /// <summary>
+        /// Disables hyphen ligatures if user has exlicitly wants it
+        /// </summary>
+        private void CheckAndDisableSpecialCharacterLigature()
+        {
+            NativeMethodsSetLastError.LsDisableSpecialCharacterLigature(CoreAppContextSwitches.DisableSpecialCharacterLigature);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/NativeMethodsSetLastError.cs
@@ -161,5 +161,8 @@ namespace MS.Internal.Drt
         public static extern IntPtr SetWindowLongPtrWndProc(HandleRef hWnd, int nIndex, NativeMethods.WndProc dwNewLong);
 
 #endif
+
+        [DllImport(PresentationNativeDll, EntryPoint="LsDisableSpecialCharacterLigature")]
+        public static extern void LsDisableSpecialCharacterLigature(bool fDisable);
     }
 }


### PR DESCRIPTION
Contributes to #109 

## Description

Special character ligatures will be included in .NET 9 preview 4. This PR is introducing an AppContext switch to disable the feature.

## Customer Impact

Without this changes customer won't be able to disable the special character ligature.

## Regression

NO

## Testing

DRT + Microsuites + Feature Tests

## Risk

Low. After upgrading to .NET 9 preview 4, WPF applications which have editing features that use special character ligatures may notice some unforeseen issues. For such cases, an AppContext switch (`Switch.System.Windows.DisableSpecialCharacterLigature`) can be set to `true` which will disable the feature.
