### PR TITLE
Use span in ContentType

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -110,7 +110,7 @@ namespace MS.Internal
                 {
                     // Parse content type similar to - type/subtype ; param1=value1 ; param2=value2 ; param3="value3"
                     ParseTypeAndSubType(contentType.AsSpan(0, semiColonIndex));
-                    ParseParameterAndValue(contentType.Substring(semiColonIndex));
+                    ParseParameterAndValue(contentType.AsSpan(semiColonIndex));
                 }
             }
 


### PR DESCRIPTION
## Description
Change Substring for AsSpan for a method that already accepts a span. It looks like it was missed in dotnet/wpf#6268 when ParseParameterAndValue was changed to accept a span.

## Customer Impact
Better perf

## Regression
No

## Testing
Local build + CI

## Risk
Low
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9061)