### PR TITLE
Fixing ally issues in combobox and scroll bar

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -246,7 +246,8 @@
                                             FontSize="{TemplateBinding FontSize}"
                                             Foreground="{TemplateBinding Foreground}"
                                             IsReadOnly="{TemplateBinding IsReadOnly}"
-                                            Style="{StaticResource DefaultComboBoxTextBoxStyle}" />
+                                            Style="{StaticResource DefaultComboBoxTextBoxStyle}"
+                                            AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" />
                                     </Grid>
                                 </Grid>
                                 <Popup

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
@@ -139,6 +139,7 @@
                 Command="ScrollBar.LineUpCommand"
                 Content="{StaticResource CaretUpGlyph}"
                 Opacity="0"
+                AutomationProperties.Name="Scroll Up"
                 Style="{StaticResource ScrollBarLineButtonStyle}" />
             <Track
                 x:Name="PART_Track"
@@ -168,6 +169,7 @@
                 Command="ScrollBar.LineDownCommand"
                 Content="{StaticResource CaretDownGlyph}"
                 Opacity="0"
+                AutomationProperties.Name="Scroll Down"
                 Style="{StaticResource ScrollBarLineButtonStyle}" />
         </Grid>
         <ControlTemplate.Triggers>
@@ -259,6 +261,7 @@
                 Command="ScrollBar.LineLeftCommand"
                 Content="{StaticResource CaretLeftGlyph}"
                 Opacity="0"
+                AutomationProperties.Name="Scroll Left"
                 Style="{StaticResource ScrollBarLineButtonStyle}" />
             <Track
                 x:Name="PART_Track"
@@ -286,6 +289,7 @@
                 Command="ScrollBar.LineRightCommand"
                 Content="{StaticResource CaretRightGlyph}"
                 Opacity="0"
+                AutomationProperties.Name="Scroll Right"
                 Style="{StaticResource ScrollBarLineButtonStyle}" />
         </Grid>
         <ControlTemplate.Triggers>


### PR DESCRIPTION
## Description
The following PR fixes Accessibility issue which occurs due to improper naming of nested controls of scroll bar and editable combo box.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Customers using accessibility tools will find it easier to navigate with the help of narrator and other tools.
<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
The name of scroll bar's repeat button is hard coded to up, down, left or right in the changes. Might need to verify if this conveys the message or do we need to be able to bind it based on its parent name.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
