### PR TITLE
Update Corner Radius Resource

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Variables.xaml
@@ -16,7 +16,7 @@
 
     <system:Double x:Key="ControlContentThemeFontSize">14</system:Double>
     <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
-    <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
+    <CornerRadius x:Key="OverlayCornerRadius">8,8,8,8</CornerRadius>
     <CornerRadius x:Key="PopupCornerRadius">8,8,8,8</CornerRadius>
 
     <!--


### PR DESCRIPTION
Fixes #9082 

## Description
For top-level containers such as app windows, flyouts, cards and dialogs, WinUI uses the resource `OverlayCornerRadius` with a value set to 8 pixel. Similar resource in WPF is set to 4 pixels and this change updates the value the resource to 8 pixels.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->


## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->

## Risk
_None_
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9119)