### PR TITLE
Address CS0656 with latest compiler

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System.Windows.Input.Manipulations.csproj
@@ -40,6 +40,7 @@
     <NetCoreReference Include="System.Collections" />
     <NetCoreReference Include="System.Diagnostics.Debug" />
     <NetCoreReference Include="System.Diagnostics.Tools" />
+    <NetCoreReference Include="System.Memory" />
     <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Resources.ResourceManager" />

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationTypes/UIAutomationTypes.csproj
@@ -94,6 +94,7 @@
     <NetCoreReference Include="netstandard" />
     <NetCoreReference Include="Microsoft.Win32.Primitives" />
     <NetCoreReference Include="System" />
+    <NetCoreReference Include="System.Memory" />
     <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
     <NetCoreReference Include="System.Runtime.InteropServices" />


### PR DESCRIPTION
The latest compiler fails to build WPF with
```
CSC : error CS0656: Missing compiler required member 'System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan' [D:\a\_work\1\vmr\src\wpf\src\Microsoft.DotNet.Wpf\src\System.Windows.Input.Manipulations\System.Windows.Input.Manipulations.csproj]
CSC : error CS0656: Missing compiler required member 'System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan' [D:\a\_work\1\vmr\src\wpf\src\Microsoft.DotNet.Wpf\src\UIAutomation\UIAutomationTypes\UIAutomationTypes.csproj]
```

Adding a reference to System.Memory to avoid this.  I believe this is due to use of collection expressions taking advantage of this API
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9135)