### PR TITLE
Add missing System.Memory references

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/UIAutomationClient.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/UIAutomationClient.csproj
@@ -113,6 +113,7 @@
     <NetCoreReference Include="System.Diagnostics.Process" />
     <NetCoreReference Include="System.Diagnostics.StackTrace" />
     <NetCoreReference Include="System.Diagnostics.Tools" />
+    <NetCoreReference Include="System.Memory" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
     <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Resources.ResourceManager" />

--- a/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsFormsIntegration/WindowsFormsIntegration.csproj
@@ -65,6 +65,7 @@
     <NetCoreReference Include="System.Diagnostics.TraceSource" />
     <NetCoreReference Include="System.Drawing" />
     <NetCoreReference Include="System.Drawing.Primitives" />
+    <NetCoreReference Include="System.Memory" />
     <NetCoreReference Include="System.Resources.ResourceManager" />
     <NetCoreReference Include="System.Runtime" />
     <NetCoreReference Include="System.Runtime.Extensions" />


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/wpf/commit/cb1bc77538a0fe02c4af9a364e515d2f77a5be12 & https://github.com/dotnet/wpf/commit/d6b1f4560cb72806a9b55beae86ee5f769ec0960

Found in https://dev.azure.com/dnceng-public/public/_build/results?buildId=682516&view=logs&jobId=9050e078-31bf-5111-d8ec-8b6fa95caf9c&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=523d8a07-ca4d-5c7a-367a-d86c5fc4038b