### PR TITLE
[TextBoxBase.cs] OnPreviewKeyDown override calls wrong virtual base method

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/TextBoxBase.cs
@@ -1073,7 +1073,7 @@ namespace System.Windows.Controls.Primitives
         /// </summary>
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {
-            base.OnKeyDown(e);
+            base.OnPreviewKeyDown(e);
 
             if (e.Handled)
             {


### PR DESCRIPTION
Fixes # none

Main PR  N/A

## Description

As noted in the title, the `TextBoxBase.OnPreviewKeyDown` override incorrectly calls virtual base method `UIElement.OnKeyDown` instead of `UIElement.OnPreviewKeyDown`.

This type of bug could have been catastrophic (and thus would have been found years ago), but in this case it happens to be benign, since both of those base methods (`UIElement.OnKeyDown` and `UIElement.OnPreviewKeyDown`) are vacuous.

Fixing this typo would mitigate a future problem in the (unlikely) case that code ended up getting added to one or both of the affected virtual base methods.

A more practical concern is that the error could cause false positive errors, diagnoses, and/or reports to occur with static analysis and automated code manipulation tools.

Code readability and principled correctness.

## Customer Impact

Minor, only causes temporary confusion, panic, and wasted time for those who are examining the source code.

## Regression

No

## Testing

Switching virtual base call from one vacuous method (incorrect) to another vacuous method (the correct one) can have no functional effect on runtime behavior.

## Risk

Insignificant risk.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9144)