### PR TITLE
Add IsClosing property to the Window class

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -7989,6 +7989,18 @@ namespace System.Windows
     }
     #endregion Enums
 
+    #region Public Fields
+    
+    /// <summary>
+    ///     Is the window closing
+    /// </summary>
+    public bool IsClosing
+    {
+        get=>_isClosing;
+    }
+
+    #endregion
+
     internal class SingleChildEnumerator : IEnumerator
     {
         internal SingleChildEnumerator(object Child)


### PR DESCRIPTION
IsClosing property has been added to the Window class

Fixes #9152

## Description

I add IsClosing property to the Window class

## Regression

None

## Testing

Local Build Pass
Sample Application Testing

## Risk

None
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9153)