### PR TITLE
Remove hand cursor in Win11 style

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -93,7 +93,6 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Margin" Value="{StaticResource ComboBoxItemMargin}" />
         <Setter Property="Padding" Value="{StaticResource ComboBoxItemContentMargin}" />
-        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
@@ -30,7 +30,6 @@
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
-        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />


### PR DESCRIPTION
Fixes #9150


## Description

Combobox items and radiobuttons shouldn't have a hand cursor. They don't have a hand cursor in Windows 11 settings as well.

## Customer Impact

None

## Regression

I guess so

## Testing

Irrelevant

## Risk

None

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9160)