### PR TITLE
Disable CA2022 error

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -189,22 +189,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
 
                     byte[] data = new byte[ropSize];
-#if NET7_0_OR_GREATER
-                stream.ReadExactly(data, 0, (int)ropSize);
-#else
-                int readCount =  (int)ropSize;
-                int totalRead = 0;
-                while(totalRead < readCount)
-                {
-                    int read = stream.Read(data, totalRead, readCount - totalRead);
-                    if (read <= 0)
-                    {
-                        throw new EndOfStreamException();
-                    }
-                    totalRead += read;
-                }
-                
-#endif
+                    stream.ReadExactly(data);
 
                     if (data != null && data.Length > 0)
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -189,8 +189,9 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
 
                     byte[] data = new byte[ropSize];
+                    #pragma warning disable CA2022
                     stream.Read (data, 0, (int)ropSize);
-
+                    #pragma warning restore CA2022
                     if (data != null && data.Length > 0)
                     {
                         //data[0] holds the allowable values of 0-255

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/DrawingAttributeSerializer.cs
@@ -189,9 +189,23 @@ namespace MS.Internal.Ink.InkSerializedFormat
                     }
 
                     byte[] data = new byte[ropSize];
-                    #pragma warning disable CA2022
-                    stream.Read (data, 0, (int)ropSize);
-                    #pragma warning restore CA2022
+#if NET7_0_OR_GREATER
+                stream.ReadExactly(data, 0, (int)ropSize);
+#else
+                int readCount =  (int)ropSize;
+                int totalRead = 0;
+                while(totalRead < readCount)
+                {
+                    int read = stream.Read(data, totalRead, readCount - totalRead);
+                    if (read <= 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+                    totalRead += read;
+                }
+                
+#endif
+
                     if (data != null && data.Length > 0)
                     {
                         //data[0] holds the allowable values of 0-255

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1586,9 +1586,23 @@ namespace System.Windows
 
                         byte[] buffer = new byte[NativeMethods.IntPtrToInt32(size)];
                         inkStream.Position = 0;
-                        #pragma warning disable CA2022
-                        inkStream.Read(buffer, 0, NativeMethods.IntPtrToInt32(size));
-                        #pragma warning restore CA2022
+#if NET7_0_OR_GREATER
+                inkStream.ReadExactly(buffer, 0, NativeMethods.IntPtrToInt32(size));
+#else
+                int readCount =  NativeMethods.IntPtrToInt32(size);
+                int totalRead = 0;
+                while(totalRead < readCount)
+                {
+                    int read = inkStream.Read(bytes, totalRead, readCount - totalRead);
+                    if (read <= 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+                    totalRead += read;
+                }
+                
+#endif
+
                         istream.Write(buffer, NativeMethods.IntPtrToInt32(size), IntPtr.Zero);
                         hr = NativeMethods.S_OK;
                     }
@@ -1726,9 +1740,22 @@ namespace System.Windows
 
                 bytes = new byte[NativeMethods.IntPtrToInt32(size)];
                 stream.Position = 0;
-                #pragma warning disable CA2022
-                stream.Read(bytes, 0, NativeMethods.IntPtrToInt32(size));
-                #pragma warning restore CA2022
+#if NET7_0_OR_GREATER
+                stream.ReadExactly(bytes, 0, NativeMethods.IntPtrToInt32(size));
+#else
+                int readCount =  NativeMethods.IntPtrToInt32(size);
+                int totalRead = 0;
+                while(totalRead < readCount)
+                {
+                    int read = stream.Read(bytes, totalRead, readCount - totalRead);
+                    if (read <= 0)
+                    {
+                        throw new EndOfStreamException();
+                    }
+                    totalRead += read;
+                }
+                
+#endif
                 Marshal.Copy(bytes, 0, ptr, NativeMethods.IntPtrToInt32(size));
             }
             finally

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1586,22 +1586,7 @@ namespace System.Windows
 
                         byte[] buffer = new byte[NativeMethods.IntPtrToInt32(size)];
                         inkStream.Position = 0;
-#if NET7_0_OR_GREATER
-                inkStream.ReadExactly(buffer, 0, NativeMethods.IntPtrToInt32(size));
-#else
-                int readCount =  NativeMethods.IntPtrToInt32(size);
-                int totalRead = 0;
-                while(totalRead < readCount)
-                {
-                    int read = inkStream.Read(bytes, totalRead, readCount - totalRead);
-                    if (read <= 0)
-                    {
-                        throw new EndOfStreamException();
-                    }
-                    totalRead += read;
-                }
-                
-#endif
+                        inkStream.ReadExactly(buffer);
 
                         istream.Write(buffer, NativeMethods.IntPtrToInt32(size), IntPtr.Zero);
                         hr = NativeMethods.S_OK;
@@ -1740,22 +1725,7 @@ namespace System.Windows
 
                 bytes = new byte[NativeMethods.IntPtrToInt32(size)];
                 stream.Position = 0;
-#if NET7_0_OR_GREATER
-                stream.ReadExactly(bytes, 0, NativeMethods.IntPtrToInt32(size));
-#else
-                int readCount =  NativeMethods.IntPtrToInt32(size);
-                int totalRead = 0;
-                while(totalRead < readCount)
-                {
-                    int read = stream.Read(bytes, totalRead, readCount - totalRead);
-                    if (read <= 0)
-                    {
-                        throw new EndOfStreamException();
-                    }
-                    totalRead += read;
-                }
-                
-#endif
+                stream.ReadExactly(bytes);
                 Marshal.Copy(bytes, 0, ptr, NativeMethods.IntPtrToInt32(size));
             }
             finally

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -1586,8 +1586,9 @@ namespace System.Windows
 
                         byte[] buffer = new byte[NativeMethods.IntPtrToInt32(size)];
                         inkStream.Position = 0;
+                        #pragma warning disable CA2022
                         inkStream.Read(buffer, 0, NativeMethods.IntPtrToInt32(size));
-
+                        #pragma warning restore CA2022
                         istream.Write(buffer, NativeMethods.IntPtrToInt32(size), IntPtr.Zero);
                         hr = NativeMethods.S_OK;
                     }
@@ -1725,7 +1726,9 @@ namespace System.Windows
 
                 bytes = new byte[NativeMethods.IntPtrToInt32(size)];
                 stream.Position = 0;
+                #pragma warning disable CA2022
                 stream.Read(bytes, 0, NativeMethods.IntPtrToInt32(size));
+                #pragma warning restore CA2022
                 Marshal.Copy(bytes, 0, ptr, NativeMethods.IntPtrToInt32(size));
             }
             finally


### PR DESCRIPTION
 Fix build failure: https://github.com/dotnet/wpf/pull/9163
Replacing System.IO.Stream.Read with System.IO.Stream.ReadExactly, to resolve the CA2022 error.