### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -166,6 +166,7 @@ jobs:
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        - task: NuGetAuthenticate@1
 
       # Use utility script to run script command dependent on agent OS.
       - script: eng\scripts\cibuild.cmd

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -147,6 +147,7 @@ jobs:
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        - task: NuGetAuthenticate@1
       # Use utility script to run script command dependent on agent OS
       - script: eng\scripts\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_PublishArgs) $(_SignArgs) $(_OfficialBuildIdArgs) $(_PlatformArgs) $(_InternalRuntimeDownloadArgs)
         displayName: Windows Build / Publish

--- a/eng/wpfautomatedtests.yml
+++ b/eng/wpfautomatedtests.yml
@@ -150,6 +150,7 @@ jobs:
             arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
           env:
             Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        - task: NuGetAuthenticate@1
 
       # Use utility script to run script command dependent on agent OS.
       - script: eng\common\cibuild.cmd


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9176)