### PR TITLE
Fix ListView/GridView scroll performance when automation peers are created

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewItemAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/GridViewItemAutomationPeer.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Automation.Peers
                     _dataChildren = new Hashtable(rowPresenter.ActualCells.Count);
 
                     List<AutomationPeer> list = new List<AutomationPeer>();
-                    int row = listview.Items.IndexOf(item);
+                    int row = listview.ItemContainerGenerator.IndexFromContainer(lvi);
                     int column = 0;
 
                     foreach (UIElement ele in rowPresenter.ActualCells)


### PR DESCRIPTION
Fixes #9181 

## Description

I was running some tests with ListView (using GridView) and when I loaded `1 000 000` items (yes, an obscure use case but that's why we got virtualization, no?), the scrolling performance would degrade and keyboard scrolling felt almost unusable.

During a quick rundown, I've discovered the culprit is in override of `GetChildrenCore` of `GridViewItemAutomationPeer`, which performs IndexOf (linear) search in the `Items` collection of the underlying `ItemsSource` to find the respective item's Row. 

## Reproduction Steps

The easiest step to reproduce is to add a ListView with GridView plus a ComboBox, after opening the ComboBox's dropdown (clicking it), `Accessibility.dll` gets loaded and the party gets started. You can find a demo repository on [Github - here](https://github.com/h3xds1nz/ListViewPerformance).

## Behavior

The scrolling performance becomes worse to unusable with increasing number of items.

## Known Workarounds

The "workaround" is to subclass `GridView`, overriding `GetAutomationPeer` to return NULL. Not really a solution though.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9182)