### PR TITLE
Replace ArrayList in DataFormats with List<DataFormat> and refactor the class

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -14,22 +14,12 @@ using MS.Win32;
 
 namespace System.Windows
 {
-    #region DataFormats class
-
     /// <summary>
     /// Translates between Windows Design text-based formats and
     /// 32-bit signed integer-based clipboard formats.
     /// </summary>
     public static class DataFormats
     {
-        //------------------------------------------------------
-        //
-        //  Public Methods
-        //
-        //------------------------------------------------------
-
-        #region Public Methods
-
         /// <summary>
         /// Gets the data format with the Windows Clipboard numeric ID and name for the specified ID.
         /// </summary>
@@ -39,16 +29,6 @@ namespace System.Windows
         /// Gets the data format with the Windows Clipboard numeric ID and name for the specified data format.
         /// </summary>
         public static DataFormat GetDataFormat(string format) => DataFormatsImpl.GetDataFormat(format);
-
-        #endregion Public Methods
-
-        //------------------------------------------------------
-        //
-        //  Public Fields
-        //
-        //------------------------------------------------------
-
-        #region Public Fields
 
         /// <summary>
         /// Specifies the standard ANSI text format. This field is read-only.
@@ -185,15 +165,7 @@ namespace System.Windows
         /// Specifies a data format as Xaml Package. This field is read-only.
         /// </summary>
         public static readonly string XamlPackage = "XamlPackage";
-        #endregion Public Fields
 
-        //------------------------------------------------------
-        //
-        //  Internal Fields
-        //
-        //------------------------------------------------------
-
-        #region Internal Fields
         /// <summary>
         /// Specifies a data format as ApplicationTrust which is used to block
         /// paste from partial trust to full trust applications. The intent of this 
@@ -204,16 +176,6 @@ namespace System.Windows
 
         internal const string FileName = "FileName";
         internal const string FileNameW = "FileNameW";
-
-        #endregion  Internal Fields
-
-        //------------------------------------------------------
-        //
-        //  Internal Methods
-        //
-        //------------------------------------------------------
-
-        #region Internal Methods
 
         /// <summary>
         /// Convert TextDataFormat to Dataformats.
@@ -244,29 +206,11 @@ namespace System.Windows
             _ => false
         };
 
-        #endregion Internal Methods
-
-        //------------------------------------------------------
-        //
-        //  Data Formats Implementation
-        //
-        //------------------------------------------------------
-
-        #region Data Formats Implementation Class
-
         /// <summary>
         /// Static class containing the internal format list and associated lookup methods.
         /// </summary>
         private static class DataFormatsImpl
         {
-            //------------------------------------------------------
-            //
-            //  Static constructor
-            //
-            //------------------------------------------------------
-
-            #region Static constructor
-
             /// <summary>
             /// Ensures that the Win32 predefined formats are setup in our format list.
             /// This is called anytime we need to search the list.
@@ -310,16 +254,6 @@ namespace System.Windows
                 if (inkServicesFrameworkFormatId != 0)
                     formatList.Add(new(StrokeCollection.InkSerializedFormat, inkServicesFrameworkFormatId));
             }
-
-            #endregion Static Constructor
-
-            //------------------------------------------------------
-            //
-            //  Private Methods
-            //
-            //------------------------------------------------------
-
-            #region Private Methods
 
             /// <summary>
             /// Allows a new format name to be specified if the requested format is not in the list.
@@ -395,28 +329,16 @@ namespace System.Windows
                 }
             }
 
-            #endregion Private Methods
-
-            //------------------------------------------------------
-            //
-            //  Private Fields
-            //
-            //------------------------------------------------------
-
-            #region Private Fields
-
-            // The registered data format list.
+            /// <summary>
+            /// List of all registered <see cref="DataFormat"/> that we're aware of.
+            /// </summary>
             private static readonly List<DataFormat> formatList;
-            // This object is for locking the _formatList to access safe in the multi-thread.
+
+            /// <summary>
+            /// Lock specially used for access to <see cref="formatList"/> field.
+            /// </summary>
             private static readonly object _formatListlock = new();
 
-            #endregion Private Fields
-
         }
-
-        #endregion Data Formats Implementation Class
-
     }
-
-    #endregion DataFormats class
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -8,6 +8,7 @@
 
 using MS.Internal.PresentationCore;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows.Ink;
 using System.Threading;
 using System.Text;
@@ -244,19 +245,19 @@ namespace System.Windows
 
                 int xamlFormatId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.Xaml);
                 if (xamlFormatId != 0)
-                    s_formatList.Add(new(DataFormats.Xaml, xamlFormatId));
+                    s_formatList.Add(new DataFormat(DataFormats.Xaml, xamlFormatId));
 
                 // This is the format to store trust boundary information. Essentially this is accompalished by storing 
                 // the permission set of the source application where the content comes from. During paste we compare this to
                 // the permission set of the target application.
                 int applicationTrustFormatId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.ApplicationTrust);
                 if (applicationTrustFormatId != 0)
-                    s_formatList.Add(new(DataFormats.ApplicationTrust, applicationTrustFormatId));
+                    s_formatList.Add(new DataFormat(DataFormats.ApplicationTrust, applicationTrustFormatId));
 
                 // RegisterClipboardFormat returns 0 on failure
                 int inkServicesFrameworkFormatId = UnsafeNativeMethods.RegisterClipboardFormat(StrokeCollection.InkSerializedFormat);
                 if (inkServicesFrameworkFormatId != 0)
-                    s_formatList.Add(new(StrokeCollection.InkSerializedFormat, inkServicesFrameworkFormatId));
+                    s_formatList.Add(new DataFormat(StrokeCollection.InkSerializedFormat, inkServicesFrameworkFormatId));
             }
 
             /// <summary>
@@ -268,8 +269,6 @@ namespace System.Windows
                 lock (s_formatListlock)
                 {
                     DataFormat formatItem;
-                    StringBuilder sb;
-
                     for (int i = 0; i < s_formatList.Count; i++)
                     {
                         formatItem = s_formatList[i];
@@ -280,18 +279,16 @@ namespace System.Windows
                             return formatItem;
                     }
 
-                    sb = new StringBuilder(NativeMethods.MAX_PATH);
-
-                    // This can happen if windows adds a standard format that we don't know about,
-                    // so we should play it safe.
-                    if (UnsafeNativeMethods.GetClipboardFormatName(id, sb, sb.Capacity) == 0)
+                    // This can happen if windows adds a standard format that we don't know about, so we should play it safe.
+                    StringBuilder stringBuilder = new(NativeMethods.MAX_PATH);
+                    if (UnsafeNativeMethods.GetClipboardFormatName(id, stringBuilder, stringBuilder.Capacity) == 0)
                     {
-                        sb.Length = 0; // Same as Clear()
-                        sb.Append("Format").Append(id);
+                        stringBuilder.Length = 0; // Same as Clear()
+                        stringBuilder.Append("Format").Append(id);
                     }
 
                     // Create a new format and store it
-                    formatItem = new(sb.ToString(), id);
+                    formatItem = new DataFormat(stringBuilder.ToString(), id);
                     s_formatList.Add(formatItem);
 
                     return formatItem;
@@ -323,7 +320,7 @@ namespace System.Windows
                     int formatId = UnsafeNativeMethods.RegisterClipboardFormat(format);
 
                     if (formatId == 0)
-                        throw new System.ComponentModel.Win32Exception();
+                        throw new Win32Exception();
 
                     // Create a new format and store it
                     DataFormat newFormat = new(format, formatId);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -30,6 +30,8 @@ namespace System.Windows
         /// </summary>
         public static DataFormat GetDataFormat(string format) => DataFormatsImpl.GetDataFormat(format);
 
+#pragma warning disable IDE1006 // Naming rule violation (Static fields without s_* prefix)
+
         /// <summary>
         /// Specifies the standard ANSI text format. This field is read-only.
         /// </summary>
@@ -155,7 +157,6 @@ namespace System.Windows
         /// </summary>
         public static readonly string Serializable = "PersistentObject";
 
-
         /// <summary>
         /// Specifies a data format as Xaml. This field is read-only.
         /// </summary>
@@ -165,6 +166,8 @@ namespace System.Windows
         /// Specifies a data format as Xaml Package. This field is read-only.
         /// </summary>
         public static readonly string XamlPackage = "XamlPackage";
+
+#pragma warning restore IDE1006 // Naming rule violation (Static fields without s_* prefix)
 
         /// <summary>
         /// Specifies a data format as ApplicationTrust which is used to block

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -3,22 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 //
-//
-// Description: Manage the data formats.
-//
 // See spec at http://avalon/uis/Data%20Transfer%20clipboard%20dragdrop/Avalon%20Data%20Transfer%20Object.htm
 //
-//
 
-using MS.Win32;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using MS.Internal.PresentationCore;
+using System.Collections.Generic;
 using System.Windows.Ink;
-using SecurityHelper = MS.Internal.SecurityHelper;
+using System.Text;
+using MS.Win32;
 
 namespace System.Windows
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -38,17 +38,13 @@ namespace System.Windows
         #region Public Methods
 
         /// <summary>
-        /// Gets an object with the Windows Clipboard numeric
-        /// ID and name for the specified ID.
+        /// Gets the data format with the Windows Clipboard numeric ID and name for the specified ID.
         /// </summary>
         public static DataFormat GetDataFormat(int id) => InternalGetDataFormat(id);
 
         /// <summary>
         /// Gets the data format with the Windows Clipboard numeric ID and name for the specified data format.
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UnmanagedCode permission to call this API.
-        /// </remarks>
         public static DataFormat GetDataFormat(string format)
         {
             ArgumentNullException.ThrowIfNull(format);
@@ -380,7 +376,7 @@ namespace System.Windows
 
                 // This is the format to store trust boundary information. Essentially this is accompalished by storing 
                 // the permission set of the source application where the content comes from. During paste we compare this to
-                // the permissio set of the target application.
+                // the permission set of the target application.
                 int applicationTrustFormatId = UnsafeNativeMethods.RegisterClipboardFormat(DataFormats.ApplicationTrust);
                 if (applicationTrustFormatId != 0)
                     _formatList.Add(new(ApplicationTrust, applicationTrustFormatId));

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DataFormats.cs
@@ -62,16 +62,6 @@ namespace System.Windows
             // Lock the data format list to obtain the mutual-exclusion.
             lock (_formatListlock)
             {
-                // It is much faster to do a case sensitive search here. So do
-                // the case sensitive compare first, then the expensive one.
-                for (int i = 0; i < _formatList.Count; i++)
-                {
-                    DataFormat formatItem = _formatList[i];
-
-                    if (formatItem.Name.Equals(format))
-                        return formatItem;
-                }
-
                 for (int i = 0; i < _formatList.Count; i++)
                 {
                     DataFormat formatItem = _formatList[i];
@@ -317,7 +307,7 @@ namespace System.Windows
             // Ensures the predefined Win32 data formats into our format list.
             EnsurePredefined();
 
-            // Lock the data format list to obtains the mutual-exclusion.
+            // Lock the data format list to obtain the mutual-exclusion.
             lock (_formatListlock)
             {
                 DataFormat formatItem;
@@ -357,7 +347,7 @@ namespace System.Windows
         /// </summary>
         private static void EnsurePredefined()
         {
-            // Lock the data format list to obtains the mutual-exclusion.
+            // Lock the data format list to obtain the mutual-exclusion.
             lock (_formatListlock)
             {
                 if (_formatList is not null)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -153,10 +153,10 @@ namespace MS.Win32
         [DllImport(ExternDll.Gdi32, EntryPoint="SelectObject", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern IntPtr CriticalSelectObject(HandleRef hdc, IntPtr obj);
 
-        [DllImport(ExternDll.User32, CharSet = System.Runtime.InteropServices.CharSet.Auto, BestFitMapping = false, SetLastError = true)]
-        public static extern int GetClipboardFormatName(int format, StringBuilder lpString, int cchMax);
+        [DllImport(ExternDll.User32, CharSet = CharSet.Auto, BestFitMapping = false, SetLastError = true)]
+        public static unsafe extern int GetClipboardFormatName(int format, char* lpString, int cchMax);
 
-        [DllImport(ExternDll.User32, SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, BestFitMapping = false)]
+        [DllImport(ExternDll.User32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
         public static extern int RegisterClipboardFormat(string format);
 
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]


### PR DESCRIPTION
## Description
`DataFormats` is one of those classes that still use `ArrayList` instead of generic `List<DataFormat>`.

There are no functional changes besides removing the `Ordinal` -> `OrdinalIgnoreCase` compare and just using case-insensitive one by default as in .NET 8 this path is vectorized and I believe decreasing the code-size outweights the now immeasurable benefit of two subsequent compares (not to mention, should such a case occur, this solution will come on top) as this isn't a hot path regularly.

While refactoring, I've also removed obsolete CAS remarks and fixed some grammar mistakes.

As a last step, I removed the unnecessary double lock on `InternalGetDataFormat`/`GetDataFormat` methods by creating an internal static class, running the initialization of predefined formats in the static constructor, saving all the unnecessary overhead (the internal static class and the formats are not initialized if only the fields are used, as `beforefieldinit` is set, so there's no regression in that sense as well.)

### Benchmark for id `16` and `"locale"` string

| Method          | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|---------------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original_int    |   33.11 ns |   0.230 ns |    0.204 ns |         684 B |             - |
| Original_string |   91.79 ns |   0.635 ns |    0.594 ns |       1,064 B |             - |
| PR_EDIT_int     | 12.31 ns |   0.089 ns |    0.079 ns |         465 B |             - |
| PR_EDIT_string  |   26.76 ns |   0.171 ns |    0.151 ns |         617 B |             - |

## Customer Impact
This will increase performance 3x and almost 4x times increase can be observed should you query data formats with wrong casing input (which shall not be the case of WPF itself but if used externally, it might).

## Regression
No.

## Risk

I believe there are none as the static collection is used internally as a storage and access is done via defined `GetDataFormat` overloads.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9199)