### PR TITLE
Use new templates to enable internal sources and runtimes

### DIFF
--- a/eng/pipeline-pr.yml
+++ b/eng/pipeline-pr.yml
@@ -88,7 +88,6 @@ jobs:
           - name: _InternalRuntimeDownloadArgs
             value: ''
         - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          - group: DotNetBuilds storage account read tokens
           - group: AzureDevOps-Artifact-Feeds-Pats
           - name: _InternalRuntimeDownloadArgs
             value: >-
@@ -158,15 +157,8 @@ jobs:
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
 
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - task: NuGetAuthenticate@1
+      - template: /eng/common/templates/steps/enable-internal-sources.yml
+      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
       # Use utility script to run script command dependent on agent OS.
       - script: eng\scripts\cibuild.cmd

--- a/eng/pipeline.yml
+++ b/eng/pipeline.yml
@@ -79,7 +79,6 @@ jobs:
         - name: _InternalRuntimeDownloadArgs
           value: ''
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - group: DotNetBuilds storage account read tokens
         - group: AzureDevOps-Artifact-Feeds-Pats
         - name: _InternalRuntimeDownloadArgs
           value: >-
@@ -139,15 +138,10 @@ jobs:
         clean: true
       - powershell: eng\pre-build.ps1
         displayName: Pre-Build - Set VSO Variables
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - task: NuGetAuthenticate@1
+      
+      - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+      - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
+      
       # Use utility script to run script command dependent on agent OS
       - script: eng\scripts\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_PublishArgs) $(_SignArgs) $(_OfficialBuildIdArgs) $(_PlatformArgs) $(_InternalRuntimeDownloadArgs)
         displayName: Windows Build / Publish


### PR DESCRIPTION
These use WIF to get dSAS tokens for internal runtimes, as well as using NuGetAuthenticate to authenticate to internal feeds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9205)