### PR TITLE
Use generic version of Enum.GetName

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Cursor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Cursor.cs
@@ -339,7 +339,7 @@ namespace System.Windows.Input
             else
             {
                 // Get the string representation fo the cursor type enumeration.
-                return Enum.GetName(typeof(CursorType), _cursorType);
+                return Enum.GetName(_cursorType);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeConverter.cs
@@ -156,7 +156,7 @@ namespace System.Windows.Input
             {
                 if (destinationType == typeof(string))
                 {
-                    return Enum.GetName(typeof(InputScopeNameValue), ((InputScopeName)inputScope.Names[0]).NameValue);
+                    return Enum.GetName(((InputScopeName)inputScope.Names[0]).NameValue);
                 }
             }
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeNameConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeNameConverter.cs
@@ -138,7 +138,7 @@ namespace System.Windows.Input
             {
                 if (destinationType == typeof(string))
                 {
-                    return Enum.GetName(typeof(InputScopeNameValue), inputScopeName.NameValue);
+                    return Enum.GetName(inputScopeName.NameValue);
                 }
             }
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemKeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemKeyConverter.cs
@@ -252,7 +252,7 @@ namespace System.Windows.Markup
                 ((SystemResourceKeyID.GridViewScrollViewerStyle <= id) &&
                  (id <= SystemResourceKeyID.GridViewItemContainerStyle)))
             {
-                return $"{Enum.GetName(typeof(SystemResourceKeyID), id)}Key";
+                return $"{Enum.GetName(id)}Key";
             }
             else if (SystemResourceKeyID.MenuItemSeparatorStyle == id ||
                      SystemResourceKeyID.StatusBarSeparatorStyle == id)
@@ -262,7 +262,7 @@ namespace System.Windows.Markup
             else if ((SystemResourceKeyID.ToolBarButtonStyle <= id) &&
                      (id <= SystemResourceKeyID.ToolBarMenuStyle))
             {
-                string propName = $"{Enum.GetName(typeof(SystemResourceKeyID), id)}Key";
+                string propName = $"{Enum.GetName(id)}Key";
                 return propName.Remove(0, 7); // Remove the "ToolBar" prefix
             }
 
@@ -274,7 +274,7 @@ namespace System.Windows.Markup
             if ((SystemResourceKeyID.InternalSystemColorsStart < id) &&
                 (id < SystemResourceKeyID.InternalSystemColorsExtendedEnd))
             {
-                return Enum.GetName(typeof(SystemResourceKeyID), id);
+                return Enum.GetName(id);
             }
 
             return String.Empty;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
@@ -138,7 +138,7 @@ namespace MS.Internal.Documents
                 {
                     // Determine resource name.
                     string resourceName = "PUIRMStatus"
-                        + Enum.GetName(typeof(RightsManagementStatus), status)
+                        + Enum.GetName(status)
                         + "BrushKey";
 
                     // Acquire reference to the brush.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureResourceHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureResourceHelper.cs
@@ -165,7 +165,7 @@ namespace MS.Internal.Documents
                 {
                     // Determine resource name.
                     string resourceName = "PUISignatureStatus"
-                        + Enum.GetName(typeof(SignatureStatus), sigStatus)
+                        + Enum.GetName(sigStatus)
                         + "BrushKey";
 
                     // Acquire reference to the brush.


### PR DESCRIPTION
## Description
Use generic version of Enum.GetName to improve performance and reduce allocations.

The generic version was introduced in .Net 5: https://learn.microsoft.com/en-us/dotnet/api/system.enum.getname?view=net-8.0#system-enum-getname-1(-0)

Benchmark results:
|     Method | knownColor |      Mean |     Error |    StdDev |    Median | Ratio |  Gen 0 | Allocated |
|----------- |----------- |----------:|----------:|----------:|----------:|------:|-------:|----------:|
| NonGeneric |  ScrollAll | 14.631 ns | 0.2646 ns | 0.2346 ns | 14.626 ns |  1.00 | 0.0014 |      24 B |
|    Generic |  ScrollAll |  3.018 ns | 0.0764 ns | 0.1526 ns |  2.959 ns |  0.21 |      - |         - |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class EnumGetNameBenchmark
{
    [Benchmark(Baseline = true)]
    [Arguments(CursorType.ScrollAll)]
    public string NonGeneric(CursorType knownColor)
    {
        return Enum.GetName(typeof(CursorType), knownColor);
    }

    [Benchmark]
    [Arguments(CursorType.ScrollAll)]
    public string Generic(CursorType knownColor)
    {
        return Enum.GetName(knownColor);
    }
}
  ```
  
</details>

## Customer Impact
Improve performance and reduced allocations.

## Regression
No.

## Testing
Local testing.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9206)