### PR TITLE
Use generic version of Enum.Parse

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Input
                 {
                     if (text.LastIndexOf('.') == -1)
                     {
-                        CursorType ct = (CursorType)Enum.Parse(typeof(CursorType), text);
+                        CursorType ct = Enum.Parse<CursorType>(text);
 
                         switch (ct)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeNameConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputScopeNameConverter.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Input
                     
                 if (!stringSource.Equals(String.Empty))
                 {
-                    nameValue = (InputScopeNameValue)Enum.Parse(typeof(InputScopeNameValue), stringSource);
+                    nameValue = Enum.Parse<InputScopeNameValue>(stringSource);
                 }
             }
             

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RequestCachePolicyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/RequestCachePolicyConverter.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), "value");
             }
 
-            HttpRequestCacheLevel level = (HttpRequestCacheLevel)Enum.Parse(typeof(HttpRequestCacheLevel), s, true);
+            HttpRequestCacheLevel level = Enum.Parse<HttpRequestCacheLevel>(s, true);
             
             return new HttpRequestCachePolicy(level);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -215,7 +215,7 @@ namespace System.Windows.Input
                         case "PLAY": keyFound = Key.Play; break;
                         case "ZOOM": keyFound = Key.Zoom; break;
                         case "PA1": keyFound = Key.Pa1; break;
-                        default: keyFound = (Key)Enum.Parse(typeof(Key), keyToken, true); break;
+                        default: keyFound = Enum.Parse<Key>(keyToken, true); break;
                     }
 
                     if ((int)keyFound != -1)


### PR DESCRIPTION
## Description
Use generic version of Enum.Parse to improve performance and reduce allocations.

The generic version was introduced in .Net Core 2.0: https://learn.microsoft.com/en-us/dotnet/api/system.enum.parse?view=net-8.0#system-enum-parse-1(system-string)

Benchmark results:
|     Method |    value |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|----------- |--------- |---------:|---------:|---------:|------:|-------:|----------:|
| NonGeneric | SizeNESW | 42.99 ns | 0.807 ns | 0.793 ns |  1.00 | 0.0014 |      24 B |
|    Generic | SizeNESW | 16.38 ns | 0.196 ns | 0.174 ns |  0.38 |      - |         - |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class EnumParseBenchmark
{
    [Benchmark(Baseline = true)]
    [Arguments("SizeNESW")]
    public CursorType NonGeneric(string value)
    {
        return (CursorType)Enum.Parse(typeof(CursorType), value);
    }

    [Benchmark]
    [Arguments("SizeNESW")]
    public CursorType Generic(string value)
    {
        return Enum.Parse<CursorType>(value);
    }
}
  ```
  
</details>

## Customer Impact
Improve performance and reduced allocations.

## Regression
No.

## Testing
Local testing.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9207)