### PR TITLE
Use generic version of Enum.GetValues

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Knowncolors.cs
@@ -172,7 +172,7 @@ namespace System.Windows.Media
 
         static KnownColors()
         {
-            Array knownColorValues = Enum.GetValues(typeof(KnownColor));
+            KnownColor[] knownColorValues = Enum.GetValues<KnownColor>();
             foreach (KnownColor colorValue in knownColorValues)
             {
                 string aRGBString = String.Format("#{0,8:X8}", (uint)colorValue);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/StickyNote/StickyNoteAnnotations.cs
@@ -78,7 +78,7 @@ namespace MS.Internal.Controls.StickyNote
             s_xmlTokeFullNames = new Dictionary<XmlToken, string>();
 
             // Fill in the name dictionary.
-            foreach (XmlToken val in Enum.GetValues(typeof(XmlToken)))
+            foreach (XmlToken val in Enum.GetValues<XmlToken>())
             {
                 AddXmlTokenNames(val);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Tracing/SpellerCOMActionTraceLogger.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Tracing/SpellerCOMActionTraceLogger.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Documents.Tracing
                         NumCallsMeasured = new Dictionary<Actions, long>()
                     };
 
-                    foreach (Actions a in Enum.GetValues(typeof(Actions)))
+                    foreach (Actions a in Enum.GetValues<Actions>())
                     {
                         instanceInfo.CumulativeCallTime100Ns.Add(a, 0);
                         instanceInfo.NumCallsMeasured.Add(a, 0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/RightsManagementResourceHelper.cs
@@ -116,7 +116,7 @@ namespace MS.Internal.Documents
             if (_brushResources == null)
             {
                 // Get the entire list of RightsManagementStatus values.
-                Array statusList = Enum.GetValues(typeof(RightsManagementStatus));
+                RightsManagementStatus[] statusList = Enum.GetValues<RightsManagementStatus>();
 
                 // Construct the array to hold brush references.
                 _brushResources = new DrawingBrush[statusList.Length];

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureResourceHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/SignatureResourceHelper.cs
@@ -143,7 +143,7 @@ namespace MS.Internal.Documents
             if (_brushResources == null)
             {
                 // Get the entire list of SignatureStatus values.
-                Array statusList = Enum.GetValues(typeof(SignatureStatus));
+                SignatureStatus[] statusList = Enum.GetValues<SignatureStatus>();
 
                 // Construct the array to hold brush references.
                 _brushResources = new DrawingBrush[statusList.Length];

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/PrintSchema.cs
@@ -1986,7 +1986,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string DocumentCollate = "DocumentCollate";
 
                 internal static string[] CollationNames = Enum.GetNames(typeof(Collation));
-                internal static int[] CollationEnums = (int[])Enum.GetValues(typeof(Collation));
+                internal static int[] CollationEnums = (int[])(Array)Enum.GetValues<Collation>();
             }
 
             internal class DuplexKeys
@@ -1996,7 +1996,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string JobDuplex = "JobDuplexAllDocumentsContiguously";
 
                 internal static string[] DuplexNames = Enum.GetNames(typeof(Duplexing));
-                internal static int[] DuplexEnums = (int[])Enum.GetValues(typeof(Duplexing));
+                internal static int[] DuplexEnums = (int[])(Array)Enum.GetValues<Duplexing>();
             }
 
             internal class NUpKeys
@@ -2008,7 +2008,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string PresentationDirection = "PresentationDirection";
 
                 internal static string[] DirectionNames = Enum.GetNames(typeof(PagesPerSheetDirection));
-                internal static int[] DirectionEnums = (int[])Enum.GetValues(typeof(PagesPerSheetDirection));
+                internal static int[] DirectionEnums = (int[])(Array)Enum.GetValues<PagesPerSheetDirection>();
             }
 
             internal class StapleKeys
@@ -2018,7 +2018,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string JobStaple = "JobStapleAllDocuments";
 
                 internal static string[] StaplingNames = Enum.GetNames(typeof(Stapling));
-                internal static int[] StaplingEnums = (int[])Enum.GetValues(typeof(Stapling));
+                internal static int[] StaplingEnums = (int[])(Array)Enum.GetValues<Stapling>();
             }
 
             internal class PageDeviceFontSubstitutionKeys
@@ -2028,7 +2028,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PageDeviceFontSubstitution";
 
                 internal static string[] SubstitutionNames = Enum.GetNames(typeof(DeviceFontSubstitution));
-                internal static int[] SubstitutionEnums = (int[])Enum.GetValues(typeof(DeviceFontSubstitution));
+                internal static int[] SubstitutionEnums = (int[])(Array)Enum.GetValues<DeviceFontSubstitution>();
             }
 
             internal class PageMediaSizeKeys
@@ -2047,7 +2047,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string CustomMediaSizeHeight =       "CustomMediaSizeHeight";
 
                 internal static string[] MediaSizeNames = Enum.GetNames(typeof(PageMediaSizeName));
-                internal static int[] MediaSizeEnums = (int[])Enum.GetValues(typeof(PageMediaSizeName));
+                internal static int[] MediaSizeEnums = (int[])(Array)Enum.GetValues<PageMediaSizeName>();
             }
 
             internal class PageImageableSizeKeys
@@ -2073,7 +2073,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self =         "PageMediaType";
 
                 internal static string[] MediaTypeNames = Enum.GetNames(typeof(PageMediaType));
-                internal static int[] MediaTypeEnums = (int[])Enum.GetValues(typeof(PageMediaType));
+                internal static int[] MediaTypeEnums = (int[])(Array)Enum.GetValues<PageMediaType>();
             }
 
             internal class PageOrientationKeys
@@ -2083,7 +2083,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PageOrientation";
 
                 internal static string[] OrientationNames = Enum.GetNames(typeof(PageOrientation));
-                internal static int[] OrientationEnums = (int[])Enum.GetValues(typeof(PageOrientation));
+                internal static int[] OrientationEnums = (int[])(Array)Enum.GetValues<PageOrientation>();
             }
 
             internal class PageOutputColorKeys
@@ -2093,7 +2093,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self =   "PageOutputColor";
 
                 internal static string[] ColorNames = Enum.GetNames(typeof(OutputColor));
-                internal static int[] ColorEnums = (int[])Enum.GetValues(typeof(OutputColor));
+                internal static int[] ColorEnums = (int[])(Array)Enum.GetValues<OutputColor>();
             }
 
             internal class PageResolutionKeys
@@ -2106,7 +2106,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string QualitativeResolution = "QualitativeResolution";
 
                 internal static string[] QualityNames = Enum.GetNames(typeof(PageQualitativeResolution));
-                internal static int[] QualityEnums = (int[])Enum.GetValues(typeof(PageQualitativeResolution));
+                internal static int[] QualityEnums = (int[])(Array)Enum.GetValues<PageQualitativeResolution>();
             }
 
             internal class PageScalingKeys
@@ -2119,7 +2119,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string CustomSquareScale  = "Scale";
 
                 internal static string[] ScalingNames = Enum.GetNames(typeof(PageScaling));
-                internal static int[] ScalingEnums = (int[])Enum.GetValues(typeof(PageScaling));
+                internal static int[] ScalingEnums = (int[])(Array)Enum.GetValues<PageScaling>();
             }
 
             internal class PageTrueTypeFontModeKeys
@@ -2129,7 +2129,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PageTrueTypeFontMode";
 
                 internal static string[] ModeNames = Enum.GetNames(typeof(TrueTypeFontMode));
-                internal static int[] ModeEnums = (int[])Enum.GetValues(typeof(TrueTypeFontMode));
+                internal static int[] ModeEnums = (int[])(Array)Enum.GetValues<TrueTypeFontMode>();
             }
 
             internal class JobPageOrderKeys
@@ -2139,7 +2139,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "JobPageOrder";
 
                 internal static string[] PageOrderNames = Enum.GetNames(typeof(PageOrder));
-                internal static int[] PageOrderEnums = (int[])Enum.GetValues(typeof(PageOrder));
+                internal static int[] PageOrderEnums = (int[])(Array)Enum.GetValues<PageOrder>();
             }
 
             internal class PagePhotoPrintingIntentKeys
@@ -2149,7 +2149,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PagePhotoPrintingIntent";
 
                 internal static string[] PhotoIntentNames = Enum.GetNames(typeof(PhotoPrintingIntent));
-                internal static int[] PhotoIntentEnums = (int[])Enum.GetValues(typeof(PhotoPrintingIntent));
+                internal static int[] PhotoIntentEnums = (int[])(Array)Enum.GetValues<PhotoPrintingIntent>();
             }
 
             internal class PageBorderlessKeys
@@ -2159,7 +2159,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PageBorderless";
 
                 internal static string[] BorderlessNames = Enum.GetNames(typeof(PageBorderless));
-                internal static int[] BorderlessEnums = (int[])Enum.GetValues(typeof(PageBorderless));
+                internal static int[] BorderlessEnums = (int[])(Array)Enum.GetValues<PageBorderless>();
             }
 
             internal class PageOutputQualityKeys
@@ -2169,7 +2169,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string Self = "PageOutputQuality";
 
                 internal static string[] OutputQualityNames = Enum.GetNames(typeof(OutputQuality));
-                internal static int[] OutputQualityEnums = (int[])Enum.GetValues(typeof(OutputQuality));
+                internal static int[] OutputQualityEnums = (int[])(Array)Enum.GetValues<OutputQuality>();
             }
 
             internal class InputBinKeys
@@ -2181,7 +2181,7 @@ namespace MS.Internal.Printing.Configuration
                 internal const string PageInputBin = "PageInputBin";
 
                 internal static string[] InputBinNames = Enum.GetNames(typeof(InputBin));
-                internal static int[] InputBinEnums = (int[])Enum.GetValues(typeof(InputBin));
+                internal static int[] InputBinEnums = (int[])(Array)Enum.GetValues<InputBin>();
             }
 
             internal class ParameterProps

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextHandle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/DpiAwarenessContext/DpiAwarenessContextHandle.cs
@@ -132,7 +132,7 @@ namespace MS.Utility
         /// <param name="dpiAwarenessContextHandle">Handle being converted</param>
         public static explicit operator DpiAwarenessContextValue(DpiAwarenessContextHandle dpiAwarenessContextHandle)
         {
-            foreach (DpiAwarenessContextValue dpiContextValue in Enum.GetValues(typeof(DpiAwarenessContextValue)))
+            foreach (DpiAwarenessContextValue dpiContextValue in Enum.GetValues<DpiAwarenessContextValue>())
             {
                 if (dpiContextValue != DpiAwarenessContextValue.Invalid)
                 {


### PR DESCRIPTION
## Description
Use generic version of Enum.GetValues to improve performance and reduce allocations.

The generic version was introduced in .Net 5: https://learn.microsoft.com/en-us/dotnet/api/system.enum.getvalues?view=net-8.0#system-enum-getvalues-1

Benchmark results:
|     Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Allocated |
|----------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|
| NonGeneric | 63.97 ns | 1.292 ns | 2.581 ns |  1.00 |    0.00 | 0.0353 | 0.0001 |     592 B |
|    Generic | 33.34 ns | 0.672 ns | 0.690 ns |  0.50 |    0.02 | 0.0353 | 0.0001 |     592 B |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class EnumGetValuesBenchmark
{
    [Benchmark(Baseline = true)]
    public Array NonGeneric()
    {
        return Enum.GetValues(typeof(KnownColor));
    }

    [Benchmark]
    public KnownColor[] Generic()
    {
        return Enum.GetValues<KnownColor>();
    }
}
  ```
  
</details>

Some code also uses the non-generic version of the array enumerator which incurred boxing.
Benchmark results:
|     Method |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Allocated |
|----------- |----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|
| NonGeneric | 12.861 us | 0.2253 us | 0.2410 us |  1.00 |    0.00 | 1.9989 | 0.3662 |     33 KB |
|    Generic |  8.484 us | 0.1668 us | 0.2338 us |  0.65 |    0.02 | 1.7853 | 0.3204 |     29 KB |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
public class EnumGetValuesForEachBenchmark
{
    [Benchmark(Baseline = true)]
    public Dictionary<string, KnownColor> NonGeneric()
    {
        Dictionary<string, KnownColor> knownArgbColors = new Dictionary<string, KnownColor>();

        Array knownColorValues = Enum.GetValues(typeof(KnownColor));
        foreach (KnownColor colorValue in knownColorValues)
        {
            string aRGBString = String.Format("#{0,8:X8}", (uint)colorValue);
            knownArgbColors[aRGBString] = colorValue;
        }

        return knownArgbColors;
    }

    [Benchmark]
    public Dictionary<string, KnownColor> Generic()
    {
        Dictionary<string, KnownColor> knownArgbColors = new Dictionary<string, KnownColor>();

        KnownColor[] knownColorValues = Enum.GetValues<KnownColor>();
        foreach (KnownColor colorValue in knownColorValues)
        {
            string aRGBString = String.Format("#{0,8:X8}", (uint)colorValue);
            knownArgbColors[aRGBString] = colorValue;
        }

        return knownArgbColors;
    }
}
  ```
  
</details>

Some code were also casting the resulting array to an int array. Now we need to cast to `Array` before casting to an in array but it is still faster.
Benchmark results:
|     Method |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|----------- |---------:|---------:|---------:|------:|-------:|----------:|
| NonGeneric | 51.95 ns | 0.980 ns | 1.664 ns |  1.00 | 0.0024 |      40 B |
|    Generic | 24.06 ns | 0.150 ns | 0.133 ns |  0.46 | 0.0024 |      40 B |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class EnumGetValuesIntArrayBenchmark
{
    [Benchmark(Baseline = true)]
    public int[] NonGeneric()
    {
        return (int[])Enum.GetValues(typeof(Collation));
    }

    [Benchmark]
    public int[] Generic()
    {
        return (int[])(Array)Enum.GetValues<Collation>();
    }
}
  ```
  
</details>

## Customer Impact
Improve performance and reduced allocations.

## Regression
No.

## Testing
Local testing.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9210)