### PR TITLE
Use Environment.ProcessId instead of calling a Win32 function

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+ProcessDpiAwarenessHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/DpiUtil/DpiUtil+ProcessDpiAwarenessHelper.cs
@@ -99,7 +99,7 @@ namespace MS.Internal
                 {
                     // If a valid window is not specified, then query the current process instead of the process
                     // associated with the window
-                    windowThreadProcessId = SafeNativeMethods.GetCurrentProcessId();
+                    windowThreadProcessId = Environment.ProcessId;
                 }
 
                 Debug.Assert(windowThreadProcessId != 0, "GetWindowThreadProcessId failed");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/AutomationPeer.cs
@@ -1466,7 +1466,7 @@ namespace System.Windows.Automation.Peers
         ///
         internal int[] GetRuntimeId()
         {
-            return new int [] { 7, SafeNativeMethods.GetCurrentProcessId(), this.GetHashCode() };
+            return new int [] { 7, Environment.ProcessId, this.GetHashCode() };
         }
 
         ///
@@ -2500,7 +2500,7 @@ namespace System.Windows.Automation.Peers
         private static object IsKeyboardFocusable(AutomationPeer peer)      {   return peer.IsKeyboardFocusable();  }
         private static object IsEnabled(AutomationPeer peer)                {   return peer.IsEnabled();        }
         private static object GetBoundingRectangle(AutomationPeer peer)     {   return peer.GetBoundingRectangle(); }
-        private static object GetCurrentProcessId(AutomationPeer peer)      {   return SafeNativeMethods.GetCurrentProcessId(); }
+        private static object GetCurrentProcessId(AutomationPeer peer)      {   return Environment.ProcessId; }
         private static object GetRuntimeId(AutomationPeer peer)             {   return peer.GetRuntimeId();     }
         private static object GetClassName(AutomationPeer peer)             {   return peer.GetClassName();     }
         private static object GetHelpText(AutomationPeer peer)              {   return peer.GetHelpText();  }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -542,7 +542,7 @@ namespace System.Windows.Interop
                     "hwnd"
                     );
             }
-            else if (processId != SafeNativeMethods.GetCurrentProcessId())
+            else if (processId != Environment.ProcessId)
             {
                 throw new ArgumentException(
                     SR.HwndTarget_InvalidWindowProcess,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -1053,7 +1053,7 @@ namespace System.Windows.Interop
                 (idWindowProcess == UnsafeNativeMethods.GetProcessIdOfThread(hCurrentThread)))
 #else
             if ((idWindowThread == SafeNativeMethods.GetCurrentThreadId()) &&
-                (idWindowProcess == SafeNativeMethods.GetCurrentProcessId()))
+                (idWindowProcess == Environment.ProcessId))
 #endif
             {
                 _hwndSubclass = new HwndSubclass(_hwndSubclassHook);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
@@ -267,12 +267,6 @@ namespace MS.Win32
             }
         }
 
-        public static int GetCurrentProcessId()
-        {
-            return SafeNativeMethodsPrivate.GetCurrentProcessId();
-        }
-
-
         public static int GetCurrentThreadId()
         {
             return SafeNativeMethodsPrivate.GetCurrentThreadId();
@@ -290,7 +284,7 @@ namespace MS.Win32
 
             int sessionId;
             if (SafeNativeMethodsPrivate.ProcessIdToSessionId(
-                GetCurrentProcessId(), out sessionId))
+                Environment.ProcessId, out sessionId))
             {
                 result = sessionId;
             }
@@ -618,9 +612,6 @@ namespace MS.Win32
 
         private partial class SafeNativeMethodsPrivate
         {
-            [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-            public static extern int GetCurrentProcessId();
-
             [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = CharSet.Auto)]
             [return:MarshalAs(UnmanagedType.Bool)]
             public static extern bool ProcessIdToSessionId([In]int dwProcessId, [Out]out int pSessionId);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Accessible.cs
@@ -164,7 +164,7 @@ namespace MS.Internal.AutomationProxies
             // DuplicateHandle back to this process.)
             IntPtr wParam = IntPtr.Zero;
             if(Environment.OSVersion.Version.Major >= 6)
-                wParam = new IntPtr(UnsafeNativeMethods.GetCurrentProcessId());
+                wParam = new IntPtr(Environment.ProcessId);
 
             // send the window a WM_GETOBJECT message requesting the specific object id.
             IntPtr lResult = Misc.ProxySendMessage(hwnd, NativeMethods.WM_GETOBJECT, wParam, new IntPtr(idObject));

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/SafeProcessHandle.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/SafeProcessHandle.cs
@@ -25,7 +25,7 @@ namespace MS.Internal.AutomationProxies
 
             if (hwnd == IntPtr.Zero)
             {
-                processId = UnsafeNativeMethods.GetCurrentProcessId();
+                processId = (uint)Environment.ProcessId;
             }
             else
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/UnsafeNativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Win32/UnsafeNativeMethods.cs
@@ -34,8 +34,6 @@ namespace MS.Win32
         internal static extern IntPtr OpenProcess(int flags, bool inherit, uint dwProcessId);
 
         [DllImport(ExternDll.Kernel32)]
-        public static extern uint GetCurrentProcessId();
-        [DllImport(ExternDll.Kernel32)]
         internal static extern void GetSystemInfo(out NativeMethods.SYSTEM_INFO SystemInfo);
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         internal static extern bool IsWow64Process(MS.Internal.AutomationProxies.SafeProcessHandle hProcess, out bool Wow64Process);


### PR DESCRIPTION
## Description
Use Environment.ProcessId instead of calling a Win32 function. Environment.ProcessId uses the same [Win32 function](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocessid) that we were currently using but the difference is that Environment.ProcessId caches the process id instead of doing a PInvoke every time it is accessed (The Win32 function is documented as not changing during the lifetime of the process, see [here](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocessid#remarks)). 

Here's the current implementation of Environment.ProcessId on Windows: https://github.com/dotnet/runtime/blob/60edbf9371ff00349e9224fb0920c8bca51f1a4f/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L124.

The goal of this PR is to improve performance by using Environment.ProcessId which caches the value and reduce the complexity of the WPF codebase by using a property from the BCL instead of a Win32 function.

## Customer Impact
Better performance.

## Regression
No.

## Testing
Local testing.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9211)