### PR TITLE
Adding Subitem value to hitTest

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
@@ -1426,6 +1426,7 @@ namespace MS.Internal.AutomationProxies
                         result = XSendMessage.XSendGetIndex(hwnd, NativeMethods.LVM_SUBITEMHITTEST, IntPtr.Zero, new IntPtr(&hitTestNative), Marshal.SizeOf(hitTestNative.GetType()));
                         hitTest.flags = hitTestNative.flags;
                         hitTest.iItem = hitTestNative.iItem;
+                        hitTest.iSubItem = hitTestNative.iSubItem;
                         hitTest.iGroup = hitTestNative.iGroup;
                     }
                     else
@@ -1434,6 +1435,7 @@ namespace MS.Internal.AutomationProxies
                         result = XSendMessage.XSendGetIndex(hwnd, NativeMethods.LVM_SUBITEMHITTEST, IntPtr.Zero, new IntPtr(&hitTestNative), Marshal.SizeOf(hitTestNative.GetType()));
                         hitTest.flags = hitTestNative.flags;
                         hitTest.iItem = hitTestNative.iItem;
+                        hitTest.iSubItem = hitTestNative.iSubItem;
                     }
                 }
             }


### PR DESCRIPTION
Fixes  https://github.com/dotnet/wpf/issues/9216

## Description
The issue is that the function is returning the header item value in case of subitem too.
This is because we are not storing the iSubItem value in our local HitTest (which stores information about the hit item)

Fix is to store SubItem details in  HitTest (NativeMethods.LVHITTESTINFO_INTERNAL).
On function "ElementProviderFromPoint" call, if there is a SubItem then condition passes, and we return new ListViewSubItem.

```cs
if( hitTest.iSubItem >=0 )
{
	return new ListViewSubItem( hwd, paarent, hitTest.iSubItem, item);

}
```

## Customer Impact
Customer who are using wrong value for subitem in UI Automation will need to update.
This fix is **not affecting** the UI Automation tree of the ListView.

## Regression
N/A

## Testing
Sample application is working as expected.
Further testing needs to be done.

## Risk
Low

