### PR TITLE
Replace Array.CreateInstance(...) calls in DataObject with the new[] operator

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/dataobject.cs
@@ -3617,13 +3617,13 @@ namespace System.Windows
 
                 if (datalist == null)
                 {
-                    datalist = (DataStoreEntry[])Array.CreateInstance(typeof(DataStoreEntry), 1);
+                    datalist = new DataStoreEntry[1];
                 }
                 else
                 {
                     DataStoreEntry[] newlist;
 
-                    newlist = (DataStoreEntry[])Array.CreateInstance(typeof(DataStoreEntry), datalist.Length + 1);
+                    newlist = new DataStoreEntry[datalist.Length + 1];
                     datalist.CopyTo(newlist, 1);
                     datalist = newlist;
                 }


### PR DESCRIPTION
## Description

Replaces two `Array.CreateInstance` calls with the `new[]` keyword. There is no reason to use the former call in this case.

## Customer Impact

Improved array allocation performance.

## Regression

None.

## Testing

Verifying basic method functionality.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9218)