### PR TITLE
Replace Marshal.SizeOf(...) calls for primitive types with sizeof(...)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/GestureRecognizer/NativeRecognizer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/GestureRecognizer/NativeRecognizer.cs
@@ -505,7 +505,7 @@ namespace MS.Internal.Ink.GestureRecognition
             Debug.Assert(propertyGuids.Length == StylusPointDescription.RequiredCountOfProperties);
 
             // Get the packet description
-            packetDescription.cbPacketSize = (uint)(propertyGuids.Length * Marshal.SizeOf(typeof(Int32)));
+            packetDescription.cbPacketSize = (uint)(propertyGuids.Length * sizeof(Int32));
             packetDescription.cPacketProperties = (uint)propertyGuids.Length;
 
             //
@@ -554,7 +554,7 @@ namespace MS.Internal.Ink.GestureRecognition
             int packetCount = rawPackets.Length;
             if (packetCount != 0)
             {
-                countOfBytes = packetCount * Marshal.SizeOf(typeof(Int32));
+                countOfBytes = packetCount * sizeof(Int32);
                 packets = Marshal.AllocCoTaskMem(countOfBytes);
                 Marshal.Copy(rawPackets, 0, packets, packetCount);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputProcessorProfiles.cs
@@ -155,12 +155,10 @@ namespace System.Windows.Input
 
                  ArrayList arrayLang = new ArrayList();
 
-                 int sizeOfShort = Marshal.SizeOf(typeof(short));
-
                  for (int i = 0; i < nCount; i++)
                  {
                      // Unmarshal each langid from short array.
-                     short langid = Marshal.PtrToStructure<short>((IntPtr)((Int64)langids + sizeOfShort * i));
+                     short langid = Marshal.PtrToStructure<short>((IntPtr)((Int64)langids + sizeof(short) * i));
                      arrayLang.Add(new CultureInfo(langid));
                  }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PixelFormat.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/PixelFormat.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 
 using SR=MS.Internal.PresentationCore.SR;
 using UnsafeNativeMethods=MS.Win32.PresentationCore.UnsafeNativeMethods;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Media
 {
@@ -169,7 +170,7 @@ namespace System.Windows.Media
                 // Compare only the first 15 bytes of the GUID.  If the first
                 // 15 bytes match the WIC pixel formats, then the 16th byte
                 // will be the format enum value.
-                Debug.Assert(Marshal.SizeOf(typeof(Guid)) == 16);
+                Debug.Assert(Unsafe.SizeOf<Guid>() == 16);
                 int compareCount = 15;
                 
                 bool fBuiltIn = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
@@ -350,7 +350,7 @@ namespace MS.Internal.AppModel
                 _secMgr.ProcessUrlAction(targetString,
                                             NativeMethods.URLACTION_FEATURE_ZONE_ELEVATION,
                                             (byte*)&policy,
-                                            Marshal.SizeOf(typeof(int)),
+                                            sizeof(int),
                                             null,
                                             0,
                                             NativeMethods.PUAF_NOUI,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/PrintDlgExMarshaler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/PrintDlgExMarshaler.cs
@@ -693,8 +693,7 @@ namespace MS.Internal.Printing
             bool
             Is64Bit()
             {
-                IntPtr temp = IntPtr.Zero;
-                return Marshal.SizeOf(temp) == 8;
+                return IntPtr.Size == sizeof(long);
             }
 
             /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
@@ -148,7 +148,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                m._array = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                m._array = Marshal.AllocCoTaskMem(length * IntPtr.Size);
                 m._marshalers = new MarshalString[length];
                 var elements = (IntPtr*)m._array.ToPointer();
                 for (int i = 0; i < length; i++)
@@ -215,7 +215,7 @@ namespace WinRT
             try
             {
                 var length = array.Length;
-                data = Marshal.AllocCoTaskMem(length * Marshal.SizeOf<IntPtr>());
+                data = Marshal.AllocCoTaskMem(length * IntPtr.Size);
                 var elements = (IntPtr*)data;
                 for (i = 0; i < length; i++)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/ImmComposition.cs
@@ -430,7 +430,7 @@ namespace System.Windows.Documents
                 size = UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_RESULTSTR, IntPtr.Zero, 0);
                 if (size > 0)
                 {
-                    result = new char[size / Marshal.SizeOf(typeof(short))];
+                    result = new char[size / sizeof(short)];
 
                     // 3rd param is out and contains actual result of this call.
                     // suppress Presharp 6031.
@@ -447,7 +447,7 @@ namespace System.Windows.Documents
                 size = UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_COMPSTR, IntPtr.Zero, 0);
                 if (size > 0)
                 {
-                    composition = new char[size / Marshal.SizeOf(typeof(short))];
+                    composition = new char[size / sizeof(short)];
                     // 3rd param is out and contains actual result of this call.
                     // suppress Presharp 6031.
 #pragma warning suppress 6031
@@ -477,7 +477,7 @@ namespace System.Windows.Documents
                         size = UnsafeNativeMethods.ImmGetCompositionString(new HandleRef(this, himc), NativeMethods.GCS_COMPATTR, IntPtr.Zero, 0);
                         if (size > 0)
                         {
-                            attributes = new byte[size / Marshal.SizeOf(typeof(byte))];
+                            attributes = new byte[size / sizeof(byte)];
                             // 3rd param is out and contains actual result of this call.
                             // suppress Presharp 6031.
 #pragma warning suppress 6031
@@ -1349,7 +1349,7 @@ namespace System.Windows.Documents
 
             string target = range.Text;
 
-            int requestSize = Marshal.SizeOf(typeof(NativeMethods.RECONVERTSTRING)) + (target.Length * Marshal.SizeOf(typeof(short))) + ((_maxSrounding + 1) * Marshal.SizeOf(typeof(short)) * 2);
+            int requestSize = Marshal.SizeOf(typeof(NativeMethods.RECONVERTSTRING)) + (target.Length * sizeof(short)) + ((_maxSrounding + 1) * sizeof(short) * 2);
             IntPtr lret = new IntPtr(requestSize);
 
             if (lParam != IntPtr.Zero)
@@ -1365,9 +1365,9 @@ namespace System.Windows.Documents
                 reconv.dwStrLen = surrounding.Length;                                         // in char count
                 reconv.dwStrOffset = Marshal.SizeOf(typeof(NativeMethods.RECONVERTSTRING));   // in byte count
                 reconv.dwCompStrLen = target.Length;                                          // in char count
-                reconv.dwCompStrOffset = offsetStart * Marshal.SizeOf(typeof(short));         // in byte count
+                reconv.dwCompStrOffset = offsetStart * sizeof(short);                         // in byte count
                 reconv.dwTargetStrLen = target.Length;                                        // in char count
-                reconv.dwTargetStrOffset = offsetStart * Marshal.SizeOf(typeof(short));       // in byte count
+                reconv.dwTargetStrOffset = offsetStart * sizeof(short);                       // in byte count
 
                 if (!fDocFeed)
                 {
@@ -1543,7 +1543,7 @@ namespace System.Windows.Documents
                 ITextPointer start = range.Start.CreatePointer(LogicalDirection.Backward);
 
                 // Move the start point to new  dwCompStrOffset.
-                start = MoveToNextCharPos(start, (reconv.dwCompStrOffset - _reconv.dwCompStrOffset) / Marshal.SizeOf(typeof(short)));
+                start = MoveToNextCharPos(start, (reconv.dwCompStrOffset - _reconv.dwCompStrOffset) / sizeof(short));
                 // Create the end position and move this as dwCompStrLen.
                 ITextPointer end = start.CreatePointer(LogicalDirection.Forward);
                 end = MoveToNextCharPos(end, reconv.dwCompStrLen);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InputScopeAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/InputScopeAttribute.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Documents
                 count = _inputScope.Names.Count;
                 try 
                 {
-                    ppinputscopes = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(Int32)) * count);
+                    ppinputscopes = Marshal.AllocCoTaskMem(sizeof(Int32) * count);
                 }
                 catch (OutOfMemoryException)
                 {
@@ -72,12 +72,12 @@ namespace System.Windows.Documents
                 for (int i = 0; i < count; i++)
                 {
                     Marshal.WriteInt32(ppinputscopes, offset, (Int32)((InputScopeName)_inputScope.Names[i]).NameValue);
-                    offset += Marshal.SizeOf(typeof(Int32));
+                    offset += sizeof(Int32);
                 }
             }
             else
             {
-                ppinputscopes = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(Int32)) * 1);
+                ppinputscopes = Marshal.AllocCoTaskMem(sizeof(Int32) * 1);
                 Marshal.WriteInt32(ppinputscopes, (Int32)InputScopeNameValue.Default);
                 count = 1;
             }
@@ -90,7 +90,7 @@ namespace System.Windows.Documents
             count = _inputScope == null ? 0 : _inputScope.PhraseList.Count;
             try
             {
-                ppbstrPhrases = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(IntPtr))*count);
+                ppbstrPhrases = Marshal.AllocCoTaskMem(IntPtr.Size * count);
             }
             catch (OutOfMemoryException)
             {
@@ -111,13 +111,13 @@ namespace System.Windows.Documents
                     for (int j=0; j < i; j++)
                     {
                         Marshal.FreeBSTR(Marshal.ReadIntPtr(ppbstrPhrases,  offset));
-                        offset += Marshal.SizeOf(typeof(IntPtr));
+                        offset += IntPtr.Size;
                     }
                     throw new COMException(SR.InputScopeAttribute_E_OUTOFMEMORY, NativeMethods.E_OUTOFMEMORY);
                 }
 
                 Marshal.WriteIntPtr(ppbstrPhrases , offset, pbstr);
-                offset += Marshal.SizeOf(typeof(IntPtr));
+                offset += IntPtr.Size;
             }
              
             return  count > 0 ? NativeMethods.S_OK : NativeMethods.S_FALSE;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Standard/NativeMethods.cs
@@ -2403,7 +2403,7 @@ namespace Standard
 
                 for (int i = 0; i < numArgs; i++)
                 {
-                    IntPtr currArg = Marshal.ReadIntPtr(argv, i * Marshal.SizeOf(typeof(IntPtr)));
+                    IntPtr currArg = Marshal.ReadIntPtr(argv, i * IntPtr.Size);
                     result[i] = Marshal.PtrToStringUni(currArg);
                 }
 
@@ -2628,7 +2628,7 @@ namespace Standard
         {
             Assert.IsTrue(Utility.IsWindows11_22H2OrNewer);
             var dwmWindowAttribute = (int)dwBackdropType;
-            return _DwmSetWindowAttribute(hwnd, DWMWA.SYSTEMBACKDROP_TYPE, ref dwmWindowAttribute, Marshal.SizeOf(typeof(int)));
+            return _DwmSetWindowAttribute(hwnd, DWMWA.SYSTEMBACKDROP_TYPE, ref dwmWindowAttribute, sizeof(int));
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
@@ -2636,7 +2636,7 @@ namespace Standard
         {
             Assert.IsTrue(Utility.IsWindows11_22H2OrNewer);
             var pvAttribute = useImmersiveDarkMode ? 0x1 : 0x0;
-            var dwmResult = _DwmSetWindowAttribute(hwnd, DWMWA.USE_IMMERSIVE_DARK_MODE, ref pvAttribute, Marshal.SizeOf(typeof(int)));
+            var dwmResult = _DwmSetWindowAttribute(hwnd, DWMWA.USE_IMMERSIVE_DARK_MODE, ref pvAttribute, sizeof(int));
             return dwmResult == HRESULT.S_OK;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/PeoplePickerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/PeoplePickerWrapper.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Windows.TrustUI;
@@ -513,7 +514,7 @@ namespace MS.Internal.Documents
             /// DsObjects array.
             /// </summary>
             private static readonly int _dsObjectArrayFieldOffset = 
-                Marshal.SizeOf(typeof(Guid)) + Marshal.SizeOf(typeof(UInt32));
+                Unsafe.SizeOf<Guid>() + sizeof(UInt32);
 
             /// <summary>
             /// The size of a DsObject.

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/FallbackPTProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/PrintConfig/FallbackPTProvider.cs
@@ -756,28 +756,28 @@ namespace MS.Internal.Printing.Configuration
                     IntPtr ptr = pPrinterBuffer.Handle.DangerousGetHandle();
 
                     //   LPTSTR               pPrinterName;
-                    IntPtr pPrinterName = Marshal.ReadIntPtr(ptr, 1 * Marshal.SizeOf(typeof(IntPtr)));
+                    IntPtr pPrinterName = Marshal.ReadIntPtr(ptr, 1 * IntPtr.Size);
                     if (pPrinterName != IntPtr.Zero)
                     {
                         PRINTER_INFO_2.pPrinterName = Marshal.PtrToStringUni(pPrinterName);
                     }
 
                     //   LPTSTR               pPortName;
-                    IntPtr pPortName = Marshal.ReadIntPtr(ptr, 3 * Marshal.SizeOf(typeof(IntPtr)));
+                    IntPtr pPortName = Marshal.ReadIntPtr(ptr, 3 * IntPtr.Size);
                     if (pPortName != IntPtr.Zero)
                     {
                         PRINTER_INFO_2.pPortName = Marshal.PtrToStringUni(pPortName);
                     }
 
                     //   LPTSTR               pDriverName;
-                    IntPtr pDriverName = Marshal.ReadIntPtr(ptr, 4 * Marshal.SizeOf(typeof(IntPtr)));
+                    IntPtr pDriverName = Marshal.ReadIntPtr(ptr, 4 * IntPtr.Size);
                     if (pDriverName != IntPtr.Zero)
                     {
                         PRINTER_INFO_2.pDriverName = Marshal.PtrToStringUni(pDriverName);
                     }
 
                     //   LPDEVMODE            pDevMode;
-                    IntPtr pDevMode = Marshal.ReadIntPtr(ptr, 7 * Marshal.SizeOf(typeof(IntPtr)));
+                    IntPtr pDevMode = Marshal.ReadIntPtr(ptr, 7 * IntPtr.Size);
                     if (pDevMode != IntPtr.Zero)
                     {
                         PRINTER_INFO_2.pDevMode = DevMode.FromIntPtr(pDevMode);

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Ink/Native.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/Ink/Native.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Security;
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace MS.Internal.Ink
 {
@@ -18,14 +18,14 @@ namespace MS.Internal.Ink
             // NOTICE-2005/10/14-WAYNEZEN,
             // Make sure those lengths are indepentent from the 32bit or 64bit platform. Otherwise it could 
             // break the ISF format.
-            SizeOfInt = (uint)Marshal.SizeOf(typeof(int));
-            SizeOfUInt = (uint)Marshal.SizeOf(typeof(uint));
-            SizeOfUShort = (uint)Marshal.SizeOf(typeof(ushort));
-            SizeOfByte = (uint)Marshal.SizeOf(typeof(byte));
-            SizeOfFloat = (uint)Marshal.SizeOf(typeof(float));
-            SizeOfDouble = (uint)Marshal.SizeOf(typeof(double));
-            SizeOfGuid = (uint)Marshal.SizeOf(typeof(Guid));
-            SizeOfDecimal = (uint)Marshal.SizeOf(typeof(decimal));
+            SizeOfInt = sizeof(int);
+            SizeOfUInt = sizeof(uint);
+            SizeOfUShort = sizeof(ushort);
+            SizeOfByte = sizeof(byte);
+            SizeOfFloat = sizeof(float);
+            SizeOfDouble = sizeof(double);
+            SizeOfGuid = (uint)Unsafe.SizeOf<Guid>();
+            SizeOfDecimal = sizeof(decimal);
         }
 
         internal static readonly uint SizeOfInt;      // Size of an int

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/System/Windows/Automation/Condition.cs
@@ -57,17 +57,15 @@ namespace System.Windows.Automation
 
 
         // used by And/Or conditions to allocate an array of pointers to other conditions
-        internal static SafeConditionMemoryHandle AllocateConditionArrayHandle(Condition [] conditions)
+        internal static SafeConditionMemoryHandle AllocateConditionArrayHandle(Condition[] conditions)
         {
             // Allocate SafeHandle first to avoid failure later.
             SafeConditionMemoryHandle sh = new SafeConditionMemoryHandle();
 
-            int intPtrSize = Marshal.SizeOf(typeof(IntPtr));
-
             try { }
             finally
             {
-                IntPtr mem = Marshal.AllocCoTaskMem(conditions.Length * intPtrSize);
+                IntPtr mem = Marshal.AllocCoTaskMem(conditions.Length * IntPtr.Size);
                 sh.SetHandle(mem);
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/CommonXSendMessage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/CommonXSendMessage.cs
@@ -153,7 +153,7 @@ namespace MS.Internal.AutomationProxies
                 // Local process is running in native mode
 
                 // Check the machine bitness.
-                if (Marshal.SizeOf(hwnd) == sizeof(int))
+                if (IntPtr.Size == sizeof(int))
                 {
                     // The machine bitness is 32-bit.
 
@@ -1512,7 +1512,7 @@ namespace MS.Internal.AutomationProxies
                     // NtQueryInformationProcess is available for use in Windows 2000 and Windows XP.
                     // It may be altered or unavailable in subsequent versions. Applications should use the alternate functions
                     ulong infoWOW64 = 0;
-                    int status = UnsafeNativeMethods.NtQueryInformationProcess(hProcess, UnsafeNativeMethods.ProcessWow64Information, ref infoWOW64, Marshal.SizeOf(typeof(ulong)), null);
+                    int status = UnsafeNativeMethods.NtQueryInformationProcess(hProcess, UnsafeNativeMethods.ProcessWow64Information, ref infoWOW64, sizeof(ulong), null);
                     if (NT_ERROR(status))
                     {
                         // Query failed. Assume not running under WOW64.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/CompoundFile/ContainerUtilities.cs
@@ -34,13 +34,13 @@ namespace MS.Internal.IO.Packaging.CompoundFile
     /// </summary>
     static internal class ContainerUtilities
     {
-        static private readonly Int32 _int16Size = SizeOfInt16();
-        static private readonly Int32 _int32Size = SizeOfInt32();
+        static private readonly Int32 _int16Size = sizeof(Int16);
+        static private readonly Int32 _int32Size = sizeof(Int32);
         static private readonly byte[] _paddingBuf = new byte[4];        // for writing DWORD padding
 
 
 #if !PBTCOMPILER
-        static private readonly Int32 _int64Size = SizeOfInt64();
+        static private readonly Int32 _int64Size = sizeof(Int64);
 
         /// Used by ConvertBackSlashPathToStringArrayPath and 
         ///     ConvertStringArrayPathToBackSlashPath to separate path elements.
@@ -272,29 +272,6 @@ namespace MS.Internal.IO.Packaging.CompoundFile
                 throw new ArgumentNullException(testStringIdentifier);
         }
 
-#if !PBTCOMPILER
-
-#endif        
-        private static int SizeOfInt16()
-        {
-            return Marshal.SizeOf(typeof(Int16));
-        }
-        
-#if !PBTCOMPILER
-
-#endif        
-        private static int SizeOfInt32()
-        {
-            return Marshal.SizeOf(typeof(Int32));
-        }
-        
-#if !PBTCOMPILER
-        private static int SizeOfInt64()
-        {
-            return Marshal.SizeOf(typeof(Int64));
-        }
-#endif
-        
 #if !PBTCOMPILER
         /// <summary>
         ///     Interprets a single string by treating it as a set of names


### PR DESCRIPTION
## Description

Replaces `Marshal.SizeOf` calls for primitive types with `sizeof` operator, saving some unnecessary overhead as the codegen results in a constant number generated in compile time.

I've also replaced the calls for `Marshal.SizeOf(typeof(Guid))` with `Unsafe.SizeOf<Guid>()` as the source counts on 16 bytes in all instances I could find anyways.

Finally, I've replaced some instances of weird ways to retrieve IntPtr size, using its property instead, which also results in a constant in runtime.

| Method   | Mean [ns]   | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |------------:|-----------:|------------:|--------------:|--------------:|
| Original | 117.3583 ns |  0.3339 ns |   0.2960 ns |         689 B |             - |
| PR__EDIT |   0.2285 ns |  0.0056 ns |   0.0047 ns |          81 B |             - |

```csharp
[Benchmark]
public void Original()
{
    SizeOfInt = (uint)Marshal.SizeOf(typeof(int));
    SizeOfUInt = (uint)Marshal.SizeOf(typeof(uint));
    SizeOfUShort = (uint)Marshal.SizeOf(typeof(ushort));
    SizeOfByte = (uint)Marshal.SizeOf(typeof(byte));
    SizeOfFloat = (uint)Marshal.SizeOf(typeof(float));
    SizeOfDouble = (uint)Marshal.SizeOf(typeof(double));
    SizeOfGuid = (uint)Marshal.SizeOf(typeof(Guid));
    SizeOfDecimal = (uint)Marshal.SizeOf(typeof(decimal));
}

[Benchmark]
public void PR__EDIT()
{
    SizeOfInt = sizeof(int);
    SizeOfUInt = sizeof(uint);
    SizeOfUShort = sizeof(ushort);
    SizeOfByte = sizeof(byte);
    SizeOfFloat = sizeof(float);
    SizeOfDouble = sizeof(double);
    SizeOfGuid = (uint)Unsafe.SizeOf<Guid>();
    SizeOfDecimal = sizeof(decimal);
}
```

## Customer Impact

Improved performance, less overhead. `Native` class static constructor goes from 120ns to 0.02ns for example.

## Regression

No.

## Testing

Verifying basic library functionality. Changes are minimal.

## Risk

No.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9220)