### PR TITLE
Replace ArrayList in InputLanguageSource with fixed-size array, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputLanguageManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputLanguageManager.cs
@@ -287,7 +287,7 @@ namespace System.Windows.Input
                     return null;
                 }
 
-                return (IEnumerable)_source.InputLanguageList;
+                return _source.InputLanguageList;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputLanguageSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputLanguageSource.cs
@@ -130,11 +130,8 @@ namespace System.Windows.Input
                 EnsureInputProcessorProfile();
 
                 if (_ipp == null)
-                {
-                    ArrayList al = new ArrayList();
-                    al.Add(CurrentInputLanguage);
-                    return al;
-                }
+                    return new CultureInfo[1] { CurrentInputLanguage };
+
                 return _ipp.InputLanguageList;
              }
         }


### PR DESCRIPTION
## Description

Replaces `ArrayList` with a `CultureInfo[]` of 1 item downcasted to `IEnumerable` to improve performance of retrieval and decrease allocations caused by allocating an `ArrayList` and adding an item into it.

| Method       |  Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated |
|------------- |----------:|-----------:|------------:|--------------:|-------:|----------:|
| ArrayList | 13.167 ns |  0.2586 ns |   0.3362 ns |         488 B | 0.0053 |          88 B |
| GenericList|   8.222 ns |  0.1907 ns |   0.1690 ns |       1,261 B | 0.0038 |          64 B |
| PR__EDIT|  4.229 ns |  0.1225 ns |   0.2864 ns |          54 B | 0.0019 |          32 B |

## Customer Impact

Improved performance, less allocations.

## Regression

No.

## Testing

Local build, CI.

## Risk

As outlined in the discussion with @miloush, this is a change to a public type under the hood. If someone was relying on an implementation detail, that this was an `ArrayList`, it would break. Do note that is nowhere documented this is an `ArrayList`.

Documentation clearly states for [InputLanguageList](https://learn.microsoft.com/en-us/dotnet/api/system.windows.input.iinputlanguagesource.inputlanguagelist?view=windowsdesktop-8.0) property (nobody should assume otherwise):
_When implemented by a class, this property should return an object that implements the [IEnumerable](https://learn.microsoft.com/en-us/dotnet/api/system.collections.ienumerable?view=windowsdesktop-8.0) interface, and that supports enumerating a collection of [CultureInfo](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo?view=windowsdesktop-8.0) objects, each representing a supported input language._

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9221)