### PR TITLE
Replace ArrayList in CursorConverter with preallocated array and reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/CursorConverter.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
-using System.Collections;
 using System.Globalization;
 using System.Reflection;
 using System.Windows.Media; // TypeConverterHelper, UriHolder
@@ -54,34 +53,28 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        ///     Gets the public/static properties of the Cursors class
-        /// </summary>
-        /// <returns>PropertyInfo array of the objects properties</returns>
-        private PropertyInfo[] GetProperties()
-        {
-            return typeof(Cursors).GetProperties(BindingFlags.Public | BindingFlags.Static);
-        }
-
-        /// <summary>
         ///     StandardValuesCollection method override
         /// </summary>
         /// <param name="context">ITypeDescriptorContext</param>
         /// <returns>TypeConverter.StandardValuesCollection</returns>
         public override TypeConverter.StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            if(this._standardValues == null)
+            if(_standardValues is null)
             {
-                ArrayList list1 = new ArrayList();
-                PropertyInfo[] infoArray1 = this.GetProperties();
-                for(int num1 = 0; num1 < infoArray1.Length; num1++)
+                PropertyInfo[] properties = typeof(Cursors).GetProperties(BindingFlags.Public | BindingFlags.Static);
+                object[] values = new object[properties.Length]; //Could use Cursor but its wrapped in ICollection anyways
+
+                for (int i = 0; i < properties.Length; i++)
                 {
-                    PropertyInfo info1 = infoArray1[num1];
-                    object[] objArray1 = null;
-                    list1.Add(info1.GetValue(null, objArray1));
+                    PropertyInfo info = properties[i];
+
+                    values[i] = info.GetValue(null, null);
                 }
-                this._standardValues = new TypeConverter.StandardValuesCollection(list1.ToArray());
+
+                _standardValues = new TypeConverter.StandardValuesCollection(values);
             }
-            return this._standardValues;
+
+            return _standardValues;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Optimizes `GetStandardValues` function from TypeConverter by replacing `ArrayList` with preallocated array as we know the size beforehand, removes unnecessary allocations caused by copying the list and re-allocating the internal array.

Removes the private helper function `GetProperties` that's only used in 1 place, inlining it instead.

| Method                    | Mean     | Error    | StdDev   | Median   | Gen0   | Allocated |
|-------------------------- |---------:|---------:|---------:|---------:|-------:|----------:|
| GetStandardValues         | 560.4 ns | 11.12 ns | 15.21 ns | 555.2 ns | 0.0677 |    1136 B |
| GetStandardValues_PR      | 455.9 ns |  9.11 ns | 16.88 ns | 447.2 ns | 0.0315 |     528 B |

## Customer Impact

Improved performance, reduced allocations.

## Regression

No.

## Testing

Method functionality test, build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9222)