### PR TITLE
Replace boxing ArrayList in LassoSelectionBehavior, remove unnecessary array alloc

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
@@ -167,9 +167,8 @@ namespace MS.Internal.Ink
 
         #region ArePointsInLasso
         /// <summary>Copy-pasted Platform's Lasso.Contains(...)</summary>
-        public bool ArePointsInLasso(Point[] points, int percentIntersect)
+        public bool ArePointsInLasso(Span<Point> points, int percentIntersect)
         {
-            System.Diagnostics.Debug.Assert(null != points);
             System.Diagnostics.Debug.Assert((0 <= percentIntersect) && (100 >= percentIntersect));
 
             // Find out how many of the points need to be inside the lasso to satisfy the percentIntersect.
@@ -185,9 +184,9 @@ namespace MS.Internal.Ink
             // If the no of such segments is odd then the point is within the lasso otherwise not.
             int countPointsInLasso = 0;
 
-            foreach (Point point in points)
+            foreach (ref Point point in points)
             {
-                if (true == Contains(point))
+                if (true == Contains(in point))
                 {
                     countPointsInLasso++;
                     if (countPointsInLasso == marginCount)
@@ -198,8 +197,8 @@ namespace MS.Internal.Ink
             return (countPointsInLasso == marginCount);
         }
 
-        /// <summary>TBS</summary>
-        private bool Contains(Point point)
+        /// <summary>Checks whether supplied point is inside.</summary>
+        private bool Contains(ref readonly Point point)
         {
             if (false == _boundingBox.Contains(point))
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoHelper.cs
@@ -167,7 +167,7 @@ namespace MS.Internal.Ink
 
         #region ArePointsInLasso
         /// <summary>Copy-pasted Platform's Lasso.Contains(...)</summary>
-        public bool ArePointsInLasso(Span<Point> points, int percentIntersect)
+        public bool ArePointsInLasso(ReadOnlySpan<Point> points, int percentIntersect)
         {
             System.Diagnostics.Debug.Assert((0 <= percentIntersect) && (100 >= percentIntersect));
 
@@ -184,9 +184,9 @@ namespace MS.Internal.Ink
             // If the no of such segments is odd then the point is within the lasso otherwise not.
             int countPointsInLasso = 0;
 
-            foreach (ref Point point in points)
+            foreach (Point point in points)
             {
-                if (true == Contains(in point))
+                if (true == Contains(point))
                 {
                     countPointsInLasso++;
                     if (countPointsInLasso == marginCount)
@@ -198,7 +198,7 @@ namespace MS.Internal.Ink
         }
 
         /// <summary>Checks whether supplied point is inside.</summary>
-        private bool Contains(ref readonly Point point)
+        private bool Contains(Point point)
         {
             if (false == _boundingBox.Contains(point))
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
@@ -593,10 +593,10 @@ namespace MS.Internal.Ink
             Debug.Assert(!_disableLasso && _lassoHelper == null, "StartLasso is called unexpectedly.");
 
             if ( InkCanvas.ClearSelectionRaiseSelectionChanging() // If user cancels clearing the selection, we shouldn't initiate Lasso.
-                                                                 // 
-                                                                 // If the active editng mode is no longer as Select, we shouldn't activate LassoSelectionBehavior.
-                                                                 // Note the order really matters here. This checking has to be done 
-                                                                 // after ClearSelectionRaiseSelectionChanging is invoked.
+                // 
+                // If the active editng mode is no longer as Select, we shouldn't activate LassoSelectionBehavior.
+                // Note the order really matters here. This checking has to be done 
+                // after ClearSelectionRaiseSelectionChanging is invoked.
                 && EditingCoordinator.ActiveEditingMode == InkCanvasEditingMode.Select )
             {
                 //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
@@ -25,6 +25,7 @@ using System.Windows.Ink;
 using System.Windows.Interop;
 using System.Windows.Navigation;
 using System.Windows.Media;
+using System.Runtime.InteropServices;
 
 namespace MS.Internal.Ink
 {
@@ -365,10 +366,10 @@ namespace MS.Internal.Ink
         /// </summary>
         private void HitTestElement(InkCanvasInnerCanvas parent, UIElement uiElement, List<UIElement> elementsToSelect)
         {
-            ElementCornerPoints elementPoints = LassoSelectionBehavior.GetTransformedElementCornerPoints(parent, uiElement);
+            ElementCornerPoints elementPoints = GetTransformedElementCornerPoints(parent, uiElement);
             if (elementPoints.Set != false)
             {
-                Point[] points = GeneratePointGrid(elementPoints);
+                Span<Point> points = GeneratePointGrid(elementPoints);
 
                 //
                 // perform hit testing against our lasso
@@ -409,8 +410,8 @@ namespace MS.Internal.Ink
             //
             // get the transform from us to our parent InkCavas
             //
-            GeneralTransform parentTransform = childElement.TransformToAncestor(canvas);            
-            
+            GeneralTransform parentTransform = childElement.TransformToAncestor(canvas);
+
             // REVIEW: any of the methods below may not actually perform the transformation
             // Do we need to do anything special in that scenario?
             parentTransform.TryTransform(new Point(0, 0), out elementPoints.UpperLeft);
@@ -426,16 +427,14 @@ namespace MS.Internal.Ink
         /// Private helper that will generate a grid of points 5 px apart given the elements bounding points
         /// this works with any affline transformed points
         /// </summary>
-        private Point[] GeneratePointGrid(ElementCornerPoints elementPoints)
+        private Span<Point> GeneratePointGrid(ElementCornerPoints elementPoints)
         {
             if (!elementPoints.Set)
-            {
-                return new Point[]{};
-            }
-            ArrayList pointArray = new ArrayList();
+                return Span<Point>.Empty;
 
             UpdatePointDistances(elementPoints);
 
+            List<Point> pointArray = new(4);
             //
             // add our original points
             //
@@ -447,36 +446,34 @@ namespace MS.Internal.Ink
             pointArray.Add(elementPoints.LowerRight);
             FillInPoints(pointArray, elementPoints.LowerLeft, elementPoints.LowerRight);
 
-            FillInGrid( pointArray,
-                        elementPoints.UpperLeft,
-                        elementPoints.UpperRight,
-                        elementPoints.LowerRight,
-                        elementPoints.LowerLeft);
+            FillInGrid(pointArray,
+                       elementPoints.UpperLeft,
+                       elementPoints.UpperRight,
+                       elementPoints.LowerRight,
+                       elementPoints.LowerLeft);
 
-            Point[] retPointArray = new Point[pointArray.Count];
-            pointArray.CopyTo(retPointArray);
-            return retPointArray;
+            return CollectionsMarshal.AsSpan(pointArray);
         }
 
         /// <summary>
         /// Private helper that fills in the points between two points by calling itself
         /// recursively in a divide and conquer fashion
         /// </summary>
-        private void FillInPoints(ArrayList pointArray, Point point1, Point point2)
+        private void FillInPoints(List<Point> pointArray, Point point1, Point point2)
         {
             // this algorithm improves perf by 20%
-            if(!PointsAreCloseEnough(point1, point2))
+            if (!PointsAreCloseEnough(point1, point2))
             {
                 Point midPoint = LassoSelectionBehavior.GeneratePointBetweenPoints(point1, point2);
                 pointArray.Add(midPoint);
 
-                if(!PointsAreCloseEnough(point1, midPoint))
+                if (!PointsAreCloseEnough(point1, midPoint))
                 {
                     FillInPoints(pointArray, point1, midPoint);
                 }
 
                 //sort the right
-                if(!PointsAreCloseEnough(midPoint, point2))
+                if (!PointsAreCloseEnough(midPoint, point2))
                 {
                     FillInPoints(pointArray, midPoint, point2);
                 }
@@ -487,14 +484,14 @@ namespace MS.Internal.Ink
         /// Private helper that fills in the points between four points by calling itself
         /// recursively in a divide and conquer fashion
         /// </summary>
-        private void FillInGrid(ArrayList pointArray,
+        private void FillInGrid(List<Point> pointArray,
                                 Point upperLeft,
                                 Point upperRight,
                                 Point lowerRight,
                                 Point lowerLeft)
         {
             // this algorithm improves perf by 20%
-            if(!PointsAreCloseEnough(upperLeft, lowerLeft))
+            if (!PointsAreCloseEnough(upperLeft, lowerLeft))
             {
                 Point midPointLeft = LassoSelectionBehavior.GeneratePointBetweenPoints(upperLeft, lowerLeft);
                 Point midPointRight = LassoSelectionBehavior.GeneratePointBetweenPoints(upperRight, lowerRight);
@@ -502,13 +499,13 @@ namespace MS.Internal.Ink
                 pointArray.Add(midPointRight);
                 FillInPoints(pointArray, midPointLeft, midPointRight);
 
-                if(!PointsAreCloseEnough(upperLeft, midPointLeft))
+                if (!PointsAreCloseEnough(upperLeft, midPointLeft))
                 {
                     FillInGrid(pointArray, upperLeft, upperRight, midPointRight, midPointLeft);
                 }
 
                 //sort the right
-                if(!PointsAreCloseEnough(midPointLeft, lowerLeft))
+                if (!PointsAreCloseEnough(midPointLeft, lowerLeft))
                 {
                     FillInGrid(pointArray, midPointLeft, midPointRight, lowerRight, lowerLeft);
                 }
@@ -596,10 +593,10 @@ namespace MS.Internal.Ink
             Debug.Assert(!_disableLasso && _lassoHelper == null, "StartLasso is called unexpectedly.");
 
             if ( InkCanvas.ClearSelectionRaiseSelectionChanging() // If user cancels clearing the selection, we shouldn't initiate Lasso.
-                // 
-                // If the active editng mode is no longer as Select, we shouldn't activate LassoSelectionBehavior.
-                // Note the order really matters here. This checking has to be done 
-                // after ClearSelectionRaiseSelectionChanging is invoked.
+                                                                 // 
+                                                                 // If the active editng mode is no longer as Select, we shouldn't activate LassoSelectionBehavior.
+                                                                 // Note the order really matters here. This checking has to be done 
+                                                                 // after ClearSelectionRaiseSelectionChanging is invoked.
                 && EditingCoordinator.ActiveEditingMode == InkCanvasEditingMode.Select )
             {
                 //
@@ -656,7 +653,7 @@ namespace MS.Internal.Ink
                 // Try to find out whether we have a pre-select object.
                 tappedElement = InkCanvas.InnerCanvas.HitTestOnElements(pointOnInnerCanvas);
             }
-}
+        }
 
         #endregion Private Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Ink/LassoSelectionBehavior.cs
@@ -369,7 +369,7 @@ namespace MS.Internal.Ink
             ElementCornerPoints elementPoints = GetTransformedElementCornerPoints(parent, uiElement);
             if (elementPoints.Set != false)
             {
-                Span<Point> points = GeneratePointGrid(elementPoints);
+                ReadOnlySpan<Point> points = GeneratePointGrid(elementPoints);
 
                 //
                 // perform hit testing against our lasso
@@ -427,7 +427,7 @@ namespace MS.Internal.Ink
         /// Private helper that will generate a grid of points 5 px apart given the elements bounding points
         /// this works with any affline transformed points
         /// </summary>
-        private Span<Point> GeneratePointGrid(ElementCornerPoints elementPoints)
+        private ReadOnlySpan<Point> GeneratePointGrid(ElementCornerPoints elementPoints)
         {
             if (!elementPoints.Set)
                 return Span<Point>.Empty;


### PR DESCRIPTION
## Description

Replaces boxing `ArrayList` with generic `List<Point>` with preallocated size of 4 as that's always gonna be filled in the least, and removes array allocation through usage of `Span<Point>` as a new return type. 

In `LassoHelper` the function to match points finally runs an efficient `foreach` (as it was iterating over an array before).

Note that we could return `ROS<Point>` instead and iterate via value but this solution offers an additional performance without really introducing any real risks.

In total, this will run about 3x faster along with less than 50% of originally introduced allocations.

## Customer Impact

Improved performance, decreased allocations.

## Regression

None.

## Testing

Build and benchmark only but there are no functional changes.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9223)