### PR TITLE
Fix keyboard focus is not navigating to next and previous tab items in tab control

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollViewer.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollViewer.xaml
@@ -32,7 +32,7 @@
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
                             Margin="{TemplateBinding Padding}">
-                            <ScrollContentPresenter CanContentScroll="{TemplateBinding CanContentScroll}" />
+                            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" CanContentScroll="{TemplateBinding CanContentScroll}" />
                         </Grid>
 
                         <ScrollBar


### PR DESCRIPTION
## Description

Fix for "keyboard focus is not navigating to next and previous tab items in tab control page."

## Customer Impact

Motor impaired users will not be able to navigate to the next/previous tab items.

## Regression

None

## Testing

Local build passed, tested sample app.

## Risk

NA

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9239)