### PR TITLE
Use Delegate.EnumerateInvocationList instead of Delegate.GetInvocationList

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/ValueChangedEventManager.cs
@@ -89,7 +89,7 @@ namespace MS.Internal.Data
         public static void AddHandler(object source, EventHandler<ValueChangedEventArgs> handler, PropertyDescriptor pd)
         {
             ArgumentNullException.ThrowIfNull(handler);
-            if (handler.GetInvocationList().Length != 1)
+            if (!handler.HasSingleTarget)
                 throw new NotSupportedException(SR.NoMulticastHandlers);
 
             CurrentManager.PrivateAddHandler(source, handler, pd);
@@ -101,7 +101,7 @@ namespace MS.Internal.Data
         public static void RemoveHandler(object source, EventHandler<ValueChangedEventArgs> handler, PropertyDescriptor pd)
         {
             ArgumentNullException.ThrowIfNull(handler);
-            if (handler.GetInvocationList().Length != 1)
+            if (!handler.HasSingleTarget)
                 throw new NotSupportedException(SR.NoMulticastHandlers);
 
             CurrentManager.PrivateRemoveHandler(source, handler, pd);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcherThread.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Interop/ComponentDispatcherThread.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Interop
         }
 
         /// <summary>
-        ///     Removes the first occurance of the specified handler from the
+        ///     Removes the first occurrence of the specified handler from the
         ///     invocation list of the PreprocessMessage event.
         /// <summary>
         public void RemoveThreadPreprocessMessageHandlerFirst(ThreadMessageEventHandler handler)
@@ -170,12 +170,12 @@ namespace System.Windows.Interop
             {
                 ThreadMessageEventHandler newHandler = null;
 
-                foreach (ThreadMessageEventHandler testHandler in _threadPreprocessMessage.GetInvocationList())
+                foreach (ThreadMessageEventHandler testHandler in Delegate.EnumerateInvocationList(_threadPreprocessMessage))
                 {
                     if (testHandler == handler)
                     {
                         // This is the handler to remove.  We should not check
-                        // for any more occurances.
+                        // for any more occurrences.
                         handler = null;
                     }
                     else

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/PropertyMetadata.cs
@@ -591,14 +591,21 @@ namespace System.Windows
 
                 // Build the handler list such that handlers added
                 // via OverrideMetadata are called last (base invocation first)
-                Delegate[] handlers = baseMetadata.PropertyChangedCallback.GetInvocationList();
-                if (handlers.Length > 0)
+                PropertyChangedCallback headHandler = null;
+                foreach (PropertyChangedCallback handler in Delegate.EnumerateInvocationList(baseMetadata.PropertyChangedCallback))
                 {
-                    PropertyChangedCallback headHandler = (PropertyChangedCallback)handlers[0];
-                    for (int i = 1; i < handlers.Length; i++)
+                    if (headHandler is null)
                     {
-                        headHandler += (PropertyChangedCallback)handlers[i];
+                        headHandler = handler;
                     }
+                    else
+                    {
+                        headHandler += handler;
+                    }
+                }
+
+                if (headHandler is not null)
+                {
                     headHandler += _propertyChangedCallback;
                     _propertyChangedCallback = headHandler;
                 }


### PR DESCRIPTION
## Description
Use `Delegate.EnumerateInvocationList` instead of `Delegate.GetInvocationList`. `Delegate.GetInvocationList` allocates an array on every call while `Delegate.EnumerateInvocationList` doesn't allocate which makes the code faster and use less memory.

I also used `Delegate.HasSingleTarget` for places where we only wanted to check if there was only one entry in `Delegate.GetInvocationList`, which makes it even faster.

`Delegate.EnumerateInvocationList` and `Delegate.HasSingleTarget` were added in .Net 9.0 Preview 4 with dotnet/runtime#97683.

Benchmark results for `Delegate.EnumerateInvocationList`:
| Method                  | count | eventHandler         | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------ |------ |--------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| GetInvocationList       | 1     | Syste(...)Args] [39] |  6.159 ns | 0.1593 ns | 0.2872 ns |  1.00 |    0.00 | 0.0019 |      32 B |        1.00 |
| EnumerateInvocationList | 1     | Syste(...)Args] [39] |  3.389 ns | 0.0120 ns | 0.0100 ns |  0.55 |    0.02 |      - |         - |        0.00 |
|                         |       |                      |           |           |           |       |         |        |           |             |
| GetInvocationList       | 5     | Syste(...)Args] [39] | 24.718 ns | 0.2882 ns | 0.2555 ns |  1.00 |    0.00 | 0.0038 |      64 B |        1.00 |
| EnumerateInvocationList | 5     | Syste(...)Args] [39] |  8.205 ns | 0.0431 ns | 0.0382 ns |  0.33 |    0.00 |      - |         - |        0.00 |
|                         |       |                      |           |           |           |       |         |        |           |             |
| GetInvocationList       | 10    | Syste(...)Args] [39] | 46.508 ns | 0.9130 ns | 1.1547 ns |  1.00 |    0.00 | 0.0062 |     104 B |        1.00 |
| EnumerateInvocationList | 10    | Syste(...)Args] [39] | 14.742 ns | 0.0720 ns | 0.0602 ns |  0.32 |    0.01 |      - |         - |        0.00 |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class GetInvocationListVsEnumerateInvocationListBenchmark
{
    public IEnumerable<object[]> GetArguments()
    {
        EventHandler<EventArgs> handler = (s, e) => { };

        yield return [1, handler];

        EventHandler<EventArgs> handler2 = (s, e) => { };

        for (int x = 0; x < 4; x++)
            handler2 += (s, e) => { };

        yield return [5, handler2];

        EventHandler<EventArgs> handler3 = (s, e) => { };

        for (int x = 0; x < 9; x++)
            handler3 += (s, e) => { };

        yield return [10, handler3];
    }

    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(GetArguments))]
    public Delegate GetInvocationList(int count, EventHandler<EventArgs> eventHandler)
    {
        Delegate result = null;
        foreach (Delegate value in eventHandler.GetInvocationList())
        {
            result = value;
        }
        return result;
    }

    [Benchmark]
    [ArgumentsSource(nameof(GetArguments))]
    public Delegate EnumerateInvocationList(int count, EventHandler<EventArgs> eventHandler)
    {
        EventHandler<EventArgs> result = null;
        foreach (EventHandler<EventArgs> value in Delegate.EnumerateInvocationList(eventHandler))
        {
            result = value;
        }
        return result;
    }
}
  ```
  
</details>

Benchmark results for `Delegate.HasSingleTarget`:
| Method            | count | eventHandler         | Mean       | Error     | StdDev    | Ratio | Gen0   | Allocated | Alloc Ratio |
|------------------ |------ |--------------------- |-----------:|----------:|----------:|------:|-------:|----------:|------------:|
| GetInvocationList | 1     | Syste(...)Args] [39] |  6.4361 ns | 0.1005 ns | 0.0940 ns |  1.00 | 0.0019 |      32 B |        1.00 |
| HasSingleTarget   | 1     | Syste(...)Args] [39] |  0.9718 ns | 0.0009 ns | 0.0008 ns |  0.15 |      - |         - |        0.00 |
|                   |       |                      |            |           |           |       |        |           |             |
| GetInvocationList | 5     | Syste(...)Args] [39] | 19.6740 ns | 0.3254 ns | 0.2717 ns |  1.00 | 0.0038 |      64 B |        1.00 |
| HasSingleTarget   | 5     | Syste(...)Args] [39] |  0.9788 ns | 0.0032 ns | 0.0030 ns |  0.05 |      - |         - |        0.00 |
|                   |       |                      |            |           |           |       |        |           |             |
| GetInvocationList | 10    | Syste(...)Args] [39] | 38.0967 ns | 0.7512 ns | 0.7714 ns |  1.00 | 0.0062 |     104 B |        1.00 |
| HasSingleTarget   | 10    | Syste(...)Args] [39] |  0.9816 ns | 0.0017 ns | 0.0014 ns |  0.03 |      - |         - |        0.00 |

I used this benchmark:
<details>
  <summary>Code</summary>

  ```csharp
[MemoryDiagnoser]
public class GetInvocationListVsHasSingleTargetBenchmark
{
    public IEnumerable<object[]> GetArguments()
    {
        EventHandler<EventArgs> handler = (s, e) => { };

        yield return [1, handler];

        EventHandler<EventArgs> handler2 = (s, e) => { };

        for (int x = 0; x < 4; x++)
            handler2 += (s, e) => { };

        yield return [5, handler2];

        EventHandler<EventArgs> handler3 = (s, e) => { };

        for (int x = 0; x < 9; x++)
            handler3 += (s, e) => { };

        yield return [10, handler3];
    }

    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(GetArguments))]
    public bool GetInvocationList(int count, EventHandler<EventArgs> eventHandler)
    {
        return eventHandler.GetInvocationList().Length != 1;
    }

    [Benchmark]
    [ArgumentsSource(nameof(GetArguments))]
    public bool HasSingleTarget(int count, EventHandler<EventArgs> eventHandler)
    {
        return !eventHandler.HasSingleTarget;
    }
}
  ```
  
</details>

## Customer Impact
Improved performance and reduced allocations.

## Regression
No.

## Testing
Local testing

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9246)