### PR TITLE
Release font resources to fix memory leak

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMFontResource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMFontResource.cs
@@ -35,5 +35,9 @@ namespace System.Windows.Xps.Serialization.RCW
         [MethodImpl(MethodImplOptions.InternalCall)]
         [return: ComAliasName("System.Windows.Xps.Serialization.RCW.XPS_FONT_EMBEDDING")]
         XPS_FONT_EMBEDDING GetEmbeddingOption();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [return: MarshalAs(UnmanagedType.Interface)]
+        IOpcPartUri GetPartUri();
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMFontResource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMFontResource.cs
@@ -35,9 +35,5 @@ namespace System.Windows.Xps.Serialization.RCW
         [MethodImpl(MethodImplOptions.InternalCall)]
         [return: ComAliasName("System.Windows.Xps.Serialization.RCW.XPS_FONT_EMBEDDING")]
         XPS_FONT_EMBEDDING GetEmbeddingOption();
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [return: MarshalAs(UnmanagedType.Interface)]
-        IOpcPartUri GetPartUri();
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMPartUriCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/RCW/IXpsOMPartUriCollection.cs
@@ -23,16 +23,16 @@ namespace System.Windows.Xps.Serialization.RCW
     [ComImport]
     internal interface IXpsOMPartUriCollection
     {
-        void Append([In] IOpcPartUri partUri);
+        uint GetCount();
 
         IOpcPartUri GetAt([In] uint index);
-
-        uint GetCount();
 
         void InsertAt([In] uint index, [In] IOpcPartUri partUri);
 
         void RemoveAt([In] uint index);
 
         void SetAt([In] uint index, [In] IOpcPartUri partUri);
+        
+        void Append([In] IOpcPartUri partUri);
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMPackagingPolicy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMPackagingPolicy.cs
@@ -68,7 +68,6 @@ namespace System.Windows.Xps.Packaging
                     IOpcPartUri partUri = GenerateIOpcPartUri(XpsS0Markup.DocumentSequenceContentType);
                     IOpcPartUri discardControlPartUri = GenerateIOpcPartUri(XpsS0Markup.DiscardContentType);
                     _currentFixedDocumentSequenceWriter = _packageTarget.GetXpsOMPackageWriter(partUri, discardControlPartUri);
-                    //_currentFixedDocumentSequenceWriter = _packageTarget.GetXpsOMPackageWriter(partUri, null);
                     if (_printQueue != null)
                     {
                         ((PrintQueue)_printQueue).XpsOMPackageWriter = _currentFixedDocumentSequenceWriter;
@@ -541,17 +540,18 @@ namespace System.Windows.Xps.Packaging
             IXpsOMFontResourceCollection fontCollection = _xpsPartResources.GetFontResources();
             IOpcPartUri partUri = GenerateIOpcPartUri(uri);
             IXpsOMFontResource fontResourceToRemove = fontCollection.GetByPartName(partUri);
-            _discardableResourceParts.Append(partUri);
-            if (fontResourceToRemove != null)
-            {
-                for (uint i = 0, n = fontCollection.GetCount(); i < n; ++i)
+                _discardableResourceParts.Append(partUri);
+                if (fontResourceToRemove != null)
                 {
-                    IXpsOMFontResource fontResource = fontCollection.GetAt(i);
-                    if (fontResource == fontResourceToRemove)
+                    for (uint i = 0, n = fontCollection.GetCount(); i < n; ++i)
                     {
-                        fontCollection.RemoveAt(i);
-                        break;
-                    }
+                        IXpsOMFontResource fontResource = fontCollection.GetAt(i);
+                        if (fontResource == fontResourceToRemove)
+                        {
+                            _currentFixedDocumentSequenceWriter.AddResource(fontResource);
+                            fontCollection.RemoveAt(i);
+                            break;
+                        }
                 }
             }
         }
@@ -889,7 +889,6 @@ namespace System.Windows.Xps.Packaging
                 SetHyperlinkTargetsForCurrentPage();
 
                 XPS_SIZE xpsSize = new XPS_SIZE() { width = (float)_currentPageSize.Width, height = (float)_currentPageSize.Height };
-                //_currentFixedDocumentSequenceWriter.AddPage(_currentFixedPageWriter, xpsSize, null, null, printTicketResource, null);
                 _currentFixedDocumentSequenceWriter.AddPage(_currentFixedPageWriter, xpsSize, _discardableResourceParts, null, printTicketResource, null);
 
                 while (_discardableResourceParts.GetCount() > 0)

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMPackagingPolicy.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMPackagingPolicy.cs
@@ -540,18 +540,18 @@ namespace System.Windows.Xps.Packaging
             IXpsOMFontResourceCollection fontCollection = _xpsPartResources.GetFontResources();
             IOpcPartUri partUri = GenerateIOpcPartUri(uri);
             IXpsOMFontResource fontResourceToRemove = fontCollection.GetByPartName(partUri);
-                _discardableResourceParts.Append(partUri);
-                if (fontResourceToRemove != null)
+            _discardableResourceParts.Append(partUri);
+            if (fontResourceToRemove != null)
+            {
+                for (uint i = 0, n = fontCollection.GetCount(); i < n; ++i)
                 {
-                    for (uint i = 0, n = fontCollection.GetCount(); i < n; ++i)
+                    IXpsOMFontResource fontResource = fontCollection.GetAt(i);
+                    if (fontResource == fontResourceToRemove)
                     {
-                        IXpsOMFontResource fontResource = fontCollection.GetAt(i);
-                        if (fontResource == fontResourceToRemove)
-                        {
-                            _currentFixedDocumentSequenceWriter.AddResource(fontResource);
-                            fontCollection.RemoveAt(i);
-                            break;
-                        }
+                        _currentFixedDocumentSequenceWriter.AddResource(fontResource);
+                        fontCollection.RemoveAt(i);
+                        break;
+                    }
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/XpsOMSerializationManager.cs
@@ -377,8 +377,6 @@ namespace System.Windows.Xps.Serialization
         {
             Toolbox.EmitEvent(EventTrace.Event.WClientDRXReleaseWriterStart);
 
-            signalReleaseToFontService(writerType);
-
             //
             // Allow the packaging policy to release the stream
             //
@@ -394,6 +392,7 @@ namespace System.Windows.Xps.Serialization
                 }
             }
 
+            signalReleaseToFontService(writerType);
             Toolbox.EmitEvent(EventTrace.Event.WClientDRXReleaseWriterEnd);
         }
 


### PR DESCRIPTION
Fixes #6296

## Description
Printing a large size of document ends up consuming a lot of memory. The change in the PR targets to address this issue.
This change releases the font resources after every four pages. We see huge memory consumption difference as the number of pages grow.
Also, with the change we make sure that all resources gests released once printing is completed.


<img width="369" alt="image" src="https://github.com/user-attachments/assets/1b7dd209-79ce-4ca9-8766-26059e537512">

## Regression
Don't know.

## Testing
Made sure existing functionality remains same. Validated this by comparing the file sizes and the content of it.

## Risk
Low. 
