### PR TITLE
Fix for "Narrator is announcing incorrect information for expand button"

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -308,7 +308,8 @@
                                 BorderThickness="1"
                                 CornerRadius="{TemplateBinding Border.CornerRadius}">
                             <ToggleButton
-                                        x:Name="ExpanderToggleButton"
+                                        x:Name="HeaderSite"
+                                        AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                         Margin="0"
                                         Padding="{TemplateBinding Padding}"
                                         HorizontalAlignment="Stretch"
@@ -550,7 +551,7 @@
                                     TargetName="ToggleButtonBorder"/>
                             <Setter Property="Template"
                                     Value="{StaticResource DefaultExpanderToggleButtonRightStyle}"
-                                    TargetName="ExpanderToggleButton"/>
+                                    TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
                                     Value="{DynamicResource WidthAnimation}"
                                     TargetName="ContentPresenterBorder" />
@@ -566,7 +567,7 @@
                                     TargetName="ToggleButtonBorder"/>
                             <Setter Property="Template"
                                     Value="{StaticResource DefaultExpanderToggleButtonUpStyle}"
-                                    TargetName="ExpanderToggleButton"/>
+                                    TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
                                     Value="{DynamicResource HeightAnimation}"
                                     TargetName="ContentPresenterBorder" />
@@ -589,7 +590,7 @@
                                     TargetName="ToggleButtonBorder"/>
                             <Setter Property="Template"
                                     Value="{StaticResource DefaultExpanderToggleButtonLeftStyle}"
-                                    TargetName="ExpanderToggleButton"/>
+                                    TargetName="HeaderSite"/>
                             <Setter Property="RenderTransform"
                                     Value="{DynamicResource WidthAnimation}"
                                     TargetName="ContentPresenterBorder" />
@@ -598,12 +599,12 @@
                         <Trigger Property="IsEnabled"
                                  Value="False">
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />
-                            <Setter TargetName="ExpanderToggleButton" Property="Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />
-                            <Setter TargetName="ExpanderToggleButton" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderDisabledBorderBrush}" />
+                            <Setter TargetName="HeaderSite" Property="Foreground" Value="{DynamicResource ExpanderHeaderDisabledForeground}" />
+                            <Setter TargetName="HeaderSite" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderDisabledBorderBrush}" />
                         </Trigger>
 
-                        <Trigger SourceName="ExpanderToggleButton" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="ExpanderToggleButton" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPointerOverBrush}" />
+                        <Trigger SourceName="HeaderSite" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="HeaderSite" Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderPointerOverBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
## Description

Fix for "Narrator is announcing incorrect information for expand button"

## Customer Impact

Users who rely on the screen reader users will be confused if Narrator is announcing incorrect information for expand button in the Design Guidance.

## Regression

None 

## Testing

Local build passed, tested sample app.

## Risk

NA

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9255)