### PR TITLE
Remove CriticalHandle properties

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WindowsRuntime/Windows/UI/ViewManagement/InputPane.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/WindowsRuntime/Windows/UI/ViewManagement/InputPane.cs
@@ -137,7 +137,7 @@ namespace MS.Internal.WindowsRuntime
             /// <exception cref="PlatformNotSupportedException"></exception>
             internal static InputPane GetForWindow(HwndSource source)
             {
-                return new InputPane(source?.CriticalHandle ?? null);
+                return new InputPane(source?.Handle ?? null);
             }
 
             /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/InputElement.cs
@@ -276,8 +276,8 @@ namespace System.Windows.Input
                             HwndSource sourceTo = PresentationSource.CriticalFromVisual(rootTo) as HwndSource;
 
 
-                            if(sourceFrom != null && sourceFrom.CriticalHandle != IntPtr.Zero && sourceFrom.CompositionTarget != null &&
-                               sourceTo != null && sourceTo.CriticalHandle != IntPtr.Zero && sourceTo.CompositionTarget != null)
+                            if(sourceFrom != null && sourceFrom.Handle != IntPtr.Zero && sourceFrom.CompositionTarget != null &&
+                               sourceTo != null && sourceTo.Handle != IntPtr.Zero && sourceTo.CompositionTarget != null)
                             {
                                 // Translate the point into client coordinates.
                                 ptTranslated = PointUtil.RootToClient(ptTranslated, sourceFrom);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Input
         internal PenContexts(WispLogic stylusLogic, PresentationSource inputSource)
         {
             HwndSource hwndSource = inputSource as HwndSource;
-            if(hwndSource == null || IntPtr.Zero == (hwndSource).CriticalHandle)
+            if(hwndSource == null || IntPtr.Zero == (hwndSource).Handle)
             {
                 throw new InvalidOperationException(SR.Stylus_PenContextFailure);
             }
@@ -52,7 +52,7 @@ namespace System.Windows.Input
             if (_contexts == null)
             {
                 // create contexts
-                _contexts = _stylusLogic.WispTabletDevices.CreateContexts(_inputSource.CriticalHandle, this);
+                _contexts = _stylusLogic.WispTabletDevices.CreateContexts(_inputSource.Handle, this);
 
                 foreach(PenContext context in _contexts)
                 {
@@ -224,14 +224,14 @@ namespace System.Windows.Input
         {
             // We only tear down the old context when PenContexts are enabled without being
             // dispose and we have a valid index. Otherwise, no-op here.
-            if (_contexts is not null && index <= _contexts.Length && _inputSource.CriticalHandle != 0)
+            if (_contexts is not null && index <= _contexts.Length && _inputSource.Handle != 0)
             {
                 PenContext[] ctxs = new PenContext[_contexts.Length + 1];
                 uint preCopyCount = index;
                 uint postCopyCount = (uint)_contexts.Length - index;
 
                 Array.Copy(_contexts, 0, ctxs, 0, preCopyCount);
-                PenContext newContext = _stylusLogic.TabletDevices[(int)index].As<WispTabletDevice>().CreateContext(_inputSource.CriticalHandle, this);
+                PenContext newContext = _stylusLogic.TabletDevices[(int)index].As<WispTabletDevice>().CreateContext(_inputSource.Handle, this);
                 ctxs[index] = newContext;
                 Array.Copy(_contexts, index, ctxs, index+1, postCopyCount);
                 _contexts = ctxs;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -645,7 +645,7 @@ namespace System.Windows.Input.StylusWisp
                                             // We can only Activate the window without flashing the tray icon for it when
                                             // we are processing an Input message.  So we defer it till we see the mouse down.
                                             HwndSource hwndSource = mouseInputReport.InputSource as HwndSource;
-                                            IntPtr hwnd = hwndSource != null ? hwndSource.CriticalHandle : IntPtr.Zero;
+                                            IntPtr hwnd = hwndSource != null ? hwndSource.Handle : IntPtr.Zero;
 
                                             // If we see a stylusdown and we are not the foreground window
                                             // and there's no capture then make sure we get activated.
@@ -3163,7 +3163,7 @@ namespace System.Windows.Input.StylusWisp
                 }
 
                 // Detect if this window is disabled. If so then let the pencontexts know.
-                int style = UnsafeNativeMethods.GetWindowLong(new HandleRef(this, hwndSource.CriticalHandle), NativeMethods.GWL_STYLE);
+                int style = UnsafeNativeMethods.GetWindowLong(new HandleRef(this, hwndSource.Handle), NativeMethods.GWL_STYLE);
                 if ((style & NativeMethods.WS_DISABLED) != 0)
                 {
                     penContexts.IsWindowDisabled = true;
@@ -3201,7 +3201,7 @@ namespace System.Windows.Input.StylusWisp
                     penContexts.Disable(shutdownWorkThread);
 
                     // Make sure we remember the last location of this window for mapping stylus input later.
-                    if (UnsafeNativeMethods.IsWindow(new HandleRef(hwndSource, hwndSource.CriticalHandle)))
+                    if (UnsafeNativeMethods.IsWindow(new HandleRef(hwndSource, hwndSource.Handle)))
                     {
                         penContexts.DestroyedLocation = PointUtil.ClientToScreen(new Point(0, 0), hwndSource);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndKeyboardInputProvider.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Interop
                     _restoreFocus = null;
                 }
 
-                HandleRef thisWindow = new HandleRef(this, _source.CriticalHandle);
+                HandleRef thisWindow = new HandleRef(this, _source.Handle);
                 IntPtr focus = UnsafeNativeMethods.GetFocus();
 
                 int windowStyle = UnsafeNativeMethods.GetWindowLong(thisWindow, NativeMethods.GWL_EXSTYLE);
@@ -129,7 +129,7 @@ namespace System.Windows.Interop
                         // deactivated.  Now we detect that we already have
                         // Win32 focus but are not activated and treat it the
                         // same as getting focus.
-                        if (!_active && focus == _source.CriticalHandle)
+                        if (!_active && focus == _source.Handle)
                         {
                             OnSetFocus(focus);
                         }
@@ -143,7 +143,7 @@ namespace System.Windows.Interop
                         }
                     }
 
-                    result = (focus == _source.CriticalHandle);
+                    result = (focus == _source.Handle);
                 }
             }
             catch(System.ComponentModel.Win32Exception)
@@ -331,7 +331,7 @@ namespace System.Windows.Interop
                 // This is our clue that the keyboard is inactive.
                 case WindowMessage.WM_KILLFOCUS:
                 {
-                    if(_active && wParam != _source.CriticalHandle )
+                    if(_active && wParam != _source.Handle )
                     {
                         // Console.WriteLine("WM_KILLFOCUS");
 
@@ -340,7 +340,7 @@ namespace System.Windows.Interop
                             // when the window that's acquiring focus (wParam) is
                             // a descendant of our window, remember the immediate
                             // child so that we can restore focus to it.
-                            _restoreFocusWindow = GetImmediateChildFor((IntPtr)wParam, _source.CriticalHandle);
+                            _restoreFocusWindow = GetImmediateChildFor((IntPtr)wParam, _source.Handle);
 
                             _restoreFocus = null;
 
@@ -497,7 +497,7 @@ namespace System.Windows.Interop
                         // this window, we do not allow the focused element to be in
                         // a different window.
                         IntPtr focus = UnsafeNativeMethods.GetFocus();
-                        if (focus == thisSource.CriticalHandle)
+                        if (focus == thisSource.Handle)
                         {
                             restoreFocusDO = (DependencyObject)Keyboard.FocusedElement;
                             if (restoreFocusDO != null)
@@ -721,7 +721,7 @@ namespace System.Windows.Interop
             // Only deactivate the keyboard input stream if needed.
             if(deactivate)
             {
-                ReportInput(_source.CriticalHandle,
+                ReportInput(_source.Handle,
                             InputMode.Foreground,
                             _msgTime,
                             RawKeyboardActions.Deactivate,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndMouseInputProvider.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Interop
                 //Console.WriteLine("Disposing");
 
                 // Cleanup the mouse tracking.
-                StopTracking(_source.CriticalHandle);
+                StopTracking(_source.Handle);
 
                 // If we have capture, release it.
                 try
@@ -80,7 +80,7 @@ namespace System.Windows.Interop
         {
             if(_active)
             {
-                StopTracking(_source.CriticalHandle);
+                StopTracking(_source.Handle);
 
                 _active = false;
             }
@@ -125,9 +125,9 @@ namespace System.Windows.Interop
 
             try
             {
-                SafeNativeMethods.SetCapture(new HandleRef(this, _source.CriticalHandle));
+                SafeNativeMethods.SetCapture(new HandleRef(this, _source.Handle));
                 IntPtr capture = SafeNativeMethods.GetCapture();
-                if (capture != _source.CriticalHandle)
+                if (capture != _source.Handle)
                 {
                     success = false;
                 }
@@ -155,7 +155,7 @@ namespace System.Windows.Interop
                 {
                     try
                     {
-                        SafeNativeMethods.ScreenToClient(new HandleRef(this, _source.CriticalHandle), ref ptCursor);
+                        SafeNativeMethods.ScreenToClient(new HandleRef(this, _source.Handle), ref ptCursor);
                     }
                     catch(System.ComponentModel.Win32Exception)
                     {
@@ -166,7 +166,7 @@ namespace System.Windows.Interop
 
                     if(success)
                     {
-                        ReportInput(_source.CriticalHandle,
+                        ReportInput(_source.Handle,
                                     InputMode.Foreground,
                                     _msgTime,
                                     RawMouseActions.AbsoluteMove,
@@ -674,7 +674,7 @@ namespace System.Windows.Interop
                     try
                     {
                         IntPtr hwndCapture = SafeNativeMethods.GetCapture();
-                        IntPtr hwndCurrent = _source.CriticalHandle;
+                        IntPtr hwndCurrent = _source.Handle;
                         if (hwndCapture != hwndCurrent)
                         {
                             PossiblyDeactivate(hwndCapture, false);
@@ -728,7 +728,7 @@ namespace System.Windows.Interop
                     // If someone else is taking capture, we may need
                     // to deactivate the mouse input stream too.
 
-                    if(lParam != _source.CriticalHandle) // Ignore odd messages that claim we are losing capture to ourselves.
+                    if(lParam != _source.Handle) // Ignore odd messages that claim we are losing capture to ourselves.
                     {
                         // MITIGATION_SETCURSOR
                         _haveCapture = false;
@@ -939,7 +939,7 @@ namespace System.Windows.Interop
                     System.Diagnostics.Debug.WriteLine("HwndMouseInputProvider: WindowFromPoint failed!");
                 }
 
-                if (!stillActiveIfOverSelf && hwndToCheck == _source.CriticalHandle)
+                if (!stillActiveIfOverSelf && hwndToCheck == _source.Handle)
                 {
                     hwndToCheck = IntPtr.Zero;
                 }
@@ -981,7 +981,7 @@ namespace System.Windows.Interop
             // Only deactivate the mouse input stream if needed.
             if(deactivate)
             {
-                ReportInput(_source.CriticalHandle,
+                ReportInput(_source.Handle,
                             InputMode.Foreground,
                             _msgTime,
                             RawMouseActions.Deactivate,
@@ -1389,8 +1389,8 @@ namespace System.Windows.Interop
                 {
                     try
                     {
-                        //This has a SUC on it and accesses CriticalHandle
-                        int windowStyle = SafeNativeMethods.GetWindowStyle(new HandleRef(this, _source.CriticalHandle), true);
+                        //This has a SUC on it and accesses Handle
+                        int windowStyle = SafeNativeMethods.GetWindowStyle(new HandleRef(this, _source.Handle), true);
 
                         if((windowStyle & NativeMethods.WS_EX_LAYOUTRTL) == NativeMethods.WS_EX_LAYOUTRTL)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndPanningFeedback.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndPanningFeedback.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Interop
             {
                 if (_hwndSource != null)
                 {
-                    IntPtr handle = _hwndSource.CriticalHandle;
+                    IntPtr handle = _hwndSource.Handle;
                     if (handle != IntPtr.Zero)
                     {
                         return new HandleRef(_hwndSource, handle);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndPointerInputProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndPointerInputProvider.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Interop
             _pointerLogic.PlugInManagers[_source] = new PointerStylusPlugInManager(_source);
 
             // Store if this window is enabled or disabled
-            int style = MS.Win32.UnsafeNativeMethods.GetWindowLong(new HandleRef(this, source.CriticalHandle), MS.Win32.NativeMethods.GWL_STYLE);
+            int style = MS.Win32.UnsafeNativeMethods.GetWindowLong(new HandleRef(this, source.Handle), MS.Win32.NativeMethods.GWL_STYLE);
             IsWindowEnabled = (style & MS.Win32.NativeMethods.WS_DISABLED) == 0;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -683,7 +683,7 @@ namespace System.Windows.Interop
             foreach (PresentationSource source in PresentationSource.CriticalCurrentSources)
             {
                 HwndSource test = source as HwndSource;
-                if (test != null && test.CriticalHandle == hwnd)
+                if (test != null && test.Handle == hwnd)
                 {
                     // Don't hand out a disposed source.
                     if (!test.IsDisposed)
@@ -860,7 +860,7 @@ namespace System.Windows.Interop
         {
             // Find the topmost window.  This will handle the case where the HwndSource
             // is a child window.
-            IntPtr hwndRoot = UnsafeNativeMethods.GetAncestor(new HandleRef(this, CriticalHandle), NativeMethods.GA_ROOT);
+            IntPtr hwndRoot = UnsafeNativeMethods.GetAncestor(new HandleRef(this, Handle), NativeMethods.GA_ROOT);
 
             // Open the system menu.
             UnsafeNativeMethods.PostMessage(new HandleRef(this, hwndRoot), MS.Internal.Interop.WindowMessage.WM_SYSCOMMAND, new IntPtr(NativeMethods.SC_KEYMENU), new IntPtr(NativeMethods.VK_SPACE));
@@ -921,18 +921,7 @@ namespace System.Windows.Interop
         /// <summary>
         /// Returns the hwnd handle to the window.
         /// </summary>
-        ///<remarks>
-        ///     Callers must have UIPermission(UIPermissionWindow.AllWindows) to call this API.
-        ///</remarks>
         public IntPtr Handle
-        {
-            get
-            {
-                return CriticalHandle;
-            }
-        }
-
-        internal IntPtr CriticalHandle
         {
             get
             {
@@ -954,7 +943,7 @@ namespace System.Windows.Interop
             {
                 IntPtr capture = SafeNativeMethods.GetCapture();
 
-                return ( capture == CriticalHandle );
+                return ( capture == Handle );
             }
         }
 
@@ -1544,11 +1533,11 @@ namespace System.Windows.Interop
 
             if(_treatAncestorsAsNonClientArea)
             {
-                hwndRoot = UnsafeNativeMethods.GetAncestor(new HandleRef(this, CriticalHandle), NativeMethods.GA_ROOT);
+                hwndRoot = UnsafeNativeMethods.GetAncestor(new HandleRef(this, Handle), NativeMethods.GA_ROOT);
             }
             else
             {
-                hwndRoot = CriticalHandle;
+                hwndRoot = Handle;
             }
 
             SafeNativeMethods.GetWindowRect(new HandleRef(this, hwndRoot), ref rc);
@@ -2662,7 +2651,7 @@ namespace System.Windows.Interop
         {
             get
             {
-                return UnsafeNativeMethods.GetFocus() == CriticalHandle;
+                return UnsafeNativeMethods.GetFocus() == Handle;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/SecurityMgrSite.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/SecurityMgrSite.cs
@@ -32,7 +32,7 @@ namespace MS.Internal
                 Window curWindow = Application.Current.MainWindow;
                 if (curWindow != null)
                 {
-                    phwnd = curWindow.CriticalHandle;
+                    phwnd = curWindow.Handle;
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/Win32PrintDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Printing/Win32PrintDialog.cs
@@ -64,7 +64,7 @@ namespace MS.Internal.Printing
             {
                 System.Windows.Interop.WindowInteropHelper helper =
                     new System.Windows.Interop.WindowInteropHelper(System.Windows.Application.Current.MainWindow);
-                owner = helper.CriticalHandle;
+                owner = helper.Handle;
             }
 
             try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentViewerHelper.cs
@@ -283,7 +283,7 @@ namespace MS.Internal.Documents
             messageString = String.Format(System.Globalization.CultureInfo.CurrentCulture, messageString, findToolBar.SearchText);
 
             HwndSource hwndSource = PresentationSource.CriticalFromVisual(findToolBar) as HwndSource;
-            IntPtr hwnd = (hwndSource != null) ? hwndSource.CriticalHandle : IntPtr.Zero;
+            IntPtr hwnd = (hwndSource != null) ? hwndSource.Handle : IntPtr.Zero;
 
             PresentationFramework.SecurityHelper.ShowMessageBoxHelper(
                 hwnd,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Microsoft/Win32/CommonDialog.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Win32
             }
 
             // Get the handle of the owner window using WindowInteropHelper.
-            IntPtr hwndOwner = (new WindowInteropHelper(owner)).CriticalHandle;
+            IntPtr hwndOwner = (new WindowInteropHelper(owner)).Handle;
 
             // Just in case, check if the window's handle is zero.
             if (hwndOwner == IntPtr.Zero)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/HwndHostAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/HwndHostAutomationPeer.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Automation.Peers
                 HostedWindowWrapper wrapper = null;
                 
                 HwndHost host = (HwndHost)Owner;
-                IntPtr hwnd = host.CriticalHandle;
+                IntPtr hwnd = host.Handle;
                 
                 if(hwnd != IntPtr.Zero)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Automation.Peers
                     try
                     {
                         StringBuilder sb = new StringBuilder(512);
-                        UnsafeNativeMethods.GetWindowText(new HandleRef(null, window.CriticalHandle), sb, sb.Capacity);
+                        UnsafeNativeMethods.GetWindowText(new HandleRef(null, window.Handle), sb, sb.Capacity);
                         name = sb.ToString();
                     }
                     catch (Win32Exception)
@@ -79,7 +79,7 @@ namespace System.Windows.Automation.Peers
             if(!window.IsSourceWindowNull)
             {
                 NativeMethods.RECT rc = new NativeMethods.RECT(0,0,0,0);
-                IntPtr windowHandle = window.CriticalHandle;
+                IntPtr windowHandle = window.Handle;
                 if(windowHandle != IntPtr.Zero) //it is Zero on a window that was just closed
                 {
                     try { SafeNativeMethods.GetWindowRect(new HandleRef(null, windowHandle), ref rc); }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -3400,7 +3400,7 @@ namespace System.Windows.Controls.Primitives
             private static IntPtr GetHandle(HwndSource hwnd)
             {
                 // add hook to the popup's window
-                return (hwnd!=null ? hwnd.CriticalHandle : IntPtr.Zero);
+                return (hwnd!=null ? hwnd.Handle : IntPtr.Zero);
             }
 
             private static IntPtr GetParentHandle(HwndSource hwnd)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -939,7 +939,7 @@ namespace System.Windows.Interop
                 HwndSource hwndSource = source as HwndSource ;
                 if(hwndSource != null)
                 {
-                    hwndParent = hwndSource.CriticalHandle;
+                    hwndParent = hwndSource.Handle;
                 }
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
@@ -60,7 +60,7 @@ namespace System.Windows.Interop
             get
             {
                 Invariant.Assert(_window != null, "Cannot be null since we verify in the constructor");
-                return _window.CriticalHandle;
+                return _window.Handle;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/WindowInteropHelper.cs
@@ -55,18 +55,7 @@ namespace System.Windows.Interop
         /// <summary>
         /// Get the Handle of the window
         /// </summary>
-        /// <remarks>
-        ///     Callers must have UIPermission(UIPermissionWindow.AllWindows) to call this API.
-        /// </remarks>
         public IntPtr Handle
-        {
-            get
-            {
-                return CriticalHandle;
-            }
-        }
-
-        internal IntPtr CriticalHandle
         {
             get
             {
@@ -111,12 +100,12 @@ namespace System.Windows.Interop
         public IntPtr EnsureHandle()
         {
 
-            if (CriticalHandle == IntPtr.Zero)
+            if (Handle == IntPtr.Zero)
             {
                 _window.CreateSourceWindow(false /*create hwnd during show*/);
             }
 
-            return CriticalHandle;
+            return Handle;
         }
 
         #endregion Public Methods

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs
@@ -251,7 +251,7 @@ namespace System.Windows
             MessageBoxImage icon, MessageBoxResult defaultResult, 
             MessageBoxOptions options) 
         {
-            return ShowCore((new WindowInteropHelper(owner)).CriticalHandle, messageBoxText, caption, button, icon, defaultResult, options);
+            return ShowCore((new WindowInteropHelper(owner)).Handle, messageBoxText, caption, button, icon, defaultResult, options);
         }
 
         /// <devdoc>
@@ -267,7 +267,7 @@ namespace System.Windows
             MessageBoxImage icon, 
             MessageBoxResult defaultResult) 
         {
-            return ShowCore((new WindowInteropHelper (owner)).CriticalHandle, messageBoxText, caption, button, icon, defaultResult, 0);
+            return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, icon, defaultResult, 0);
         }
 
         /// <devdoc>
@@ -282,7 +282,7 @@ namespace System.Windows
             MessageBoxButton button, 
             MessageBoxImage icon) 
         {
-            return ShowCore((new WindowInteropHelper (owner)).CriticalHandle, messageBoxText, caption, button, icon, 0, 0);
+            return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, icon, 0, 0);
         }
 
         /// <devdoc>
@@ -296,7 +296,7 @@ namespace System.Windows
             string caption, 
             MessageBoxButton button) 
         {
-            return ShowCore((new WindowInteropHelper (owner)).CriticalHandle, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
+            return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, button, MessageBoxImage.None, 0, 0);
         }
 
         /// <devdoc>
@@ -306,7 +306,7 @@ namespace System.Windows
         /// </devdoc>
         public static MessageBoxResult Show(Window owner, string messageBoxText, string caption) 
         {
-            return ShowCore((new WindowInteropHelper (owner)).CriticalHandle, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
+            return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, caption, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
 
         /// <devdoc>
@@ -316,7 +316,7 @@ namespace System.Windows
         /// </devdoc>
         public static MessageBoxResult Show(Window owner, string messageBoxText) 
         {
-            return ShowCore((new WindowInteropHelper (owner)).CriticalHandle, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
+            return ShowCore((new WindowInteropHelper (owner)).Handle, messageBoxText, String.Empty, MessageBoxButton.OK, MessageBoxImage.None, 0, 0);
         }
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -268,8 +268,8 @@ namespace System.Windows
                     // and WM_LBUTTONUP return value just signify whether the WndProc handled the
                     // message or not, so they are not interesting
 #pragma warning disable 6523
-                    UnsafeNativeMethods.SendMessage( CriticalHandle, WindowMessage.WM_SYSCOMMAND, (IntPtr)NativeMethods.SC_MOUSEMOVE, IntPtr.Zero);
-                    UnsafeNativeMethods.SendMessage( CriticalHandle, WindowMessage.WM_LBUTTONUP, IntPtr.Zero, IntPtr.Zero);
+                    UnsafeNativeMethods.SendMessage( Handle, WindowMessage.WM_SYSCOMMAND, (IntPtr)NativeMethods.SC_MOUSEMOVE, IntPtr.Zero);
+                    UnsafeNativeMethods.SendMessage( Handle, WindowMessage.WM_LBUTTONUP, IntPtr.Zero, IntPtr.Zero);
 #pragma warning restore 6523
                 }
             }
@@ -516,7 +516,7 @@ namespace System.Windows
                 return false;
             }
 
-            return UnsafeNativeMethods.SetForegroundWindow(new HandleRef(null, CriticalHandle));
+            return UnsafeNativeMethods.SetForegroundWindow(new HandleRef(null, Handle));
         }
         #region LogicalTree
         /// <summary>
@@ -1097,7 +1097,7 @@ namespace System.Windows
                     return Rect.Empty;
                 }
 
-                return GetNormalRectLogicalUnits(CriticalHandle);
+                return GetNormalRectLogicalUnits(Handle);
             }
         }
 
@@ -1314,7 +1314,7 @@ namespace System.Windows
                     return;
                 }
 
-                SetOwnerHandle(_ownerWindow != null ? _ownerWindow.CriticalHandle: IntPtr.Zero);
+                SetOwnerHandle(_ownerWindow != null ? _ownerWindow.Handle: IntPtr.Zero);
 
                 // Update OwnerWindows of the new owner
                 if (_ownerWindow != null)
@@ -2276,7 +2276,7 @@ namespace System.Windows
                 // return value just signify whether the WndProc handled the
                 // message or not, so it is not interesting
 #pragma warning disable 6523
-                UnsafeNativeMethods.UnsafeSendMessage(CriticalHandle, WindowMessage.WM_CLOSE, new IntPtr(), new IntPtr());
+                UnsafeNativeMethods.UnsafeSendMessage(Handle, WindowMessage.WM_CLOSE, new IntPtr(), new IntPtr());
 #pragma warning enable 6523
             }
         }
@@ -2604,8 +2604,8 @@ namespace System.Windows
                 // SECURITY_MANDATORY_LOW_RID, so don't propagate failed error codes.
                 // It's not the end of the world if this fails: Shell integration simply won't work.
                 MSGFLTINFO info;
-                UnsafeNativeMethods.ChangeWindowMessageFilterEx(_swh.CriticalHandle, WM_TASKBARBUTTONCREATED, MSGFLT.ALLOW, out info);
-                UnsafeNativeMethods.ChangeWindowMessageFilterEx(_swh.CriticalHandle, WindowMessage.WM_COMMAND, MSGFLT.ALLOW, out info);
+                UnsafeNativeMethods.ChangeWindowMessageFilterEx(_swh.Handle, WM_TASKBARBUTTONCREATED, MSGFLT.ALLOW, out info);
+                UnsafeNativeMethods.ChangeWindowMessageFilterEx(_swh.Handle, WindowMessage.WM_COMMAND, MSGFLT.ALLOW, out info);
             }
 
             if (Standard.Utility.IsOSWindows10OrNewer)
@@ -2636,7 +2636,7 @@ namespace System.Windows
 
             if(_useDarkMode == useDarkMode) return;
 
-            IntPtr handle = CriticalHandle;
+            IntPtr handle = Handle;
             if (handle != IntPtr.Zero)
             {
                 bool succeeded = SNM.DwmSetWindowAttributeUseImmersiveDarkMode(handle, useDarkMode);
@@ -2863,7 +2863,7 @@ namespace System.Windows
             {
                 if (WindowState == WindowState.Normal)
                 {
-                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle),
+                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
                         new HandleRef(null, IntPtr.Zero),
                         DoubleUtil.DoubleToInt(xDeviceUnits),
                         DoubleUtil.DoubleToInt(yDeviceUnits),
@@ -2946,7 +2946,7 @@ namespace System.Windows
                     {
                         if (WindowState == WindowState.Normal)
                         {
-                            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle),
+                            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
                                 new HandleRef(null, IntPtr.Zero),
                                 DoubleUtil.DoubleToInt(xDeviceUnits),
                                 DoubleUtil.DoubleToInt(yDeviceUnits),
@@ -3034,7 +3034,7 @@ namespace System.Windows
             // Adding check for IsCompositionTargetInvalid
             if ( IsSourceWindowNull == false && IsCompositionTargetInvalid == false)
             {
-                UnsafeNativeMethods.SetWindowText(new HandleRef(this, CriticalHandle), title);
+                UnsafeNativeMethods.SetWindowText(new HandleRef(this, Handle), title);
             }
         }
 
@@ -3047,7 +3047,7 @@ namespace System.Windows
             Debug.Assert( IsSourceWindowNull == false , "IsSourceWindowNull cannot be true when calling this function");
 
             Point ptDeviceUnits = LogicalToDeviceUnits(new Point(widthLogicalUnits, heightLogicalUnits));
-            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle),
+            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
                         new HandleRef(null, IntPtr.Zero),
                         0,
                         0,
@@ -3212,14 +3212,14 @@ namespace System.Windows
         ///     Exposes the hwnd of the window. This property is used by the WindowInteropHandler
         ///     class
         /// </summary>
-        internal IntPtr CriticalHandle
+        internal IntPtr Handle
         {
             get
             {
                 VerifyContextAndObjectState();
                 if (_swh != null)
                 {
-                    return _swh.CriticalHandle;
+                    return _swh.Handle;
                 }
                 else
                 return IntPtr.Zero;
@@ -3851,7 +3851,7 @@ namespace System.Windows
                         // because it is possible that the hwnd is created (WIH.EnsureHandle) but it is not shown yet; layout has not
                         // happen; ActualWidth/Height is not calculated yet.
                         // If the owner hwnd is not yet created, we use Owner.Width/Height.
-                        if (Owner.CriticalHandle == IntPtr.Zero)
+                        if (Owner.Handle == IntPtr.Zero)
                         {
                             ownerSizeDeviceUnits = Owner.LogicalToDeviceUnits(new Point(Owner.Width, Owner.Height));
                         }
@@ -4135,7 +4135,7 @@ namespace System.Windows
             // We'll keep track of the true count separately.
             var iconWindows = new HandleRef[]
             {
-                new HandleRef(this, CriticalHandle),
+                new HandleRef(this, Handle),
                 default(HandleRef)
             };
             int iconWindowsCount = 1;
@@ -4209,7 +4209,7 @@ namespace System.Windows
 
             if (IsSourceWindowNull == false)
             {
-                UnsafeNativeMethods.SetWindowLong(new HandleRef(null, CriticalHandle),
+                UnsafeNativeMethods.SetWindowLong(new HandleRef(null, Handle),
                     NativeMethods.GWL_HWNDPARENT,
                     _ownerHandle);
 
@@ -4217,7 +4217,7 @@ namespace System.Windows
                 // We want to do this because once we are passed in the IntPtr for
                 // the parent window, the Owner window is not the parent anymore.
 
-                if ((_ownerWindow != null) && (_ownerWindow.CriticalHandle != _ownerHandle))
+                if ((_ownerWindow != null) && (_ownerWindow.Handle != _ownerHandle))
                 {
                     _ownerWindow.OwnedWindowsInternal.Remove(this);
                     _ownerWindow = null;
@@ -5168,7 +5168,7 @@ namespace System.Windows
                 // It is recommended to hide the window, chnage the style bits and then show it again.
                 if (_isVisible)
                 {
-                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
+                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
                                        NativeMethods.SWP_NOMOVE |
                                        NativeMethods.SWP_NOSIZE |
                                        NativeMethods.SWP_NOZORDER |
@@ -5185,7 +5185,7 @@ namespace System.Windows
                 // it won't break this code.
                 if (fHideWindow)
                 {
-                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
+                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
                                                     NativeMethods.SWP_NOMOVE |
                                                     NativeMethods.SWP_NOSIZE |
                                                     NativeMethods.SWP_NOZORDER |
@@ -5226,7 +5226,7 @@ namespace System.Windows
             {
                 if (_isVisible == true)
                 {
-                    HandleRef hr = new HandleRef(this,  CriticalHandle);
+                    HandleRef hr = new HandleRef(this,  Handle);
 
                     int style = _Style;
 
@@ -5367,7 +5367,7 @@ namespace System.Windows
             if (IsSourceWindowNull == false  && IsCompositionTargetInvalid == false)
             {
                 HandleRef hWnd = topmost ? NativeMethods.HWND_TOPMOST : NativeMethods.HWND_NOTOPMOST;
-                UnsafeNativeMethods.SetWindowPos(new HandleRef(null, CriticalHandle),
+                UnsafeNativeMethods.SetWindowPos(new HandleRef(null, Handle),
                        hWnd,
                        0, 0, 0, 0,
                        NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
@@ -5586,14 +5586,14 @@ namespace System.Windows
                     (nCmd == NativeMethods.SW_SHOW || nCmd == NativeMethods.SW_SHOWNA))
                 {
                     int flags = (nCmd == NativeMethods.SW_SHOWNA) ? NativeMethods.SWP_NOACTIVATE : 0;
-                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle),
+                    UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
                         NativeMethods.HWND_TOPMOST,
                         0, 0, 0, 0,
                         flags | NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOOWNERZORDER | NativeMethods.SWP_SHOWWINDOW);
                 }
                 else
                 {
-                    UnsafeNativeMethods.ShowWindow(new HandleRef(this, CriticalHandle), nCmd);
+                    UnsafeNativeMethods.ShowWindow(new HandleRef(this, Handle), nCmd);
                 }
 
                 // We already did a ShowWindow upabove and then because of the using, we will flush which
@@ -5946,7 +5946,7 @@ namespace System.Windows
 
             NativeMethods.WINDOWPLACEMENT wp = new NativeMethods.WINDOWPLACEMENT();
             wp.length = Marshal.SizeOf(typeof(NativeMethods.WINDOWPLACEMENT));
-            UnsafeNativeMethods.GetWindowPlacement(new HandleRef(this, CriticalHandle), ref wp);
+            UnsafeNativeMethods.GetWindowPlacement(new HandleRef(this, Handle), ref wp);
 
             double convertedValue = (LogicalToDeviceUnits(new Point(newValue, 0))).X;
             switch (specifiedRestoreBounds)
@@ -6012,7 +6012,7 @@ namespace System.Windows
             }
 
 
-            UnsafeNativeMethods.SetWindowPlacement(new HandleRef(this, CriticalHandle), ref wp);
+            UnsafeNativeMethods.SetWindowPlacement(new HandleRef(this, Handle), ref wp);
         }
 
         // deltaX = workAreaOriginValue - screenOriginValue (both in virtual co-ods)
@@ -6025,7 +6025,7 @@ namespace System.Windows
 
             // First we get the monitor on which the window is on.  [Get/Set]WindowPlacement
             // co-ods are dependent on the monitor on which the window is on.
-            IntPtr hMonitor = SafeNativeMethods.MonitorFromWindow(new HandleRef(this, CriticalHandle), NativeMethods.MONITOR_DEFAULTTONULL);
+            IntPtr hMonitor = SafeNativeMethods.MonitorFromWindow(new HandleRef(this, Handle), NativeMethods.MONITOR_DEFAULTTONULL);
 
             if (hMonitor != IntPtr.Zero)
             {
@@ -6267,7 +6267,7 @@ namespace System.Windows
 
             Point ptDeviceUnits = LogicalToDeviceUnits(new Point(leftLogicalUnits, topLogicalUnits));
 
-            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle),
+            UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle),
                         new HandleRef(null, IntPtr.Zero),
                         DoubleUtil.DoubleToInt(ptDeviceUnits.X),
                         DoubleUtil.DoubleToInt(ptDeviceUnits.Y),
@@ -6441,7 +6441,7 @@ namespace System.Windows
 
         private void OnTaskbarRetryTimerTick(object sender, EventArgs e)
         {
-            UnsafeNativeMethods.PostMessage(new HandleRef(this, CriticalHandle), WM_APPLYTASKBARITEMINFO, IntPtr.Zero, IntPtr.Zero);
+            UnsafeNativeMethods.PostMessage(new HandleRef(this, Handle), WM_APPLYTASKBARITEMINFO, IntPtr.Zero, IntPtr.Zero);
         }
 
         private void ApplyTaskbarItemInfo()
@@ -6580,7 +6580,7 @@ namespace System.Windows
                 }
             }
 
-            HRESULT hr = _taskbarList.SetProgressState(CriticalHandle, tbpf);
+            HRESULT hr = _taskbarList.SetProgressState(Handle, tbpf);
             if (hr.Succeeded)
             {
                 // Explicitly update this in case this property being set
@@ -6610,7 +6610,7 @@ namespace System.Windows
             Debug.Assert(0 <= taskbarInfo.ProgressValue && taskbarInfo.ProgressValue <= 1);
 
             var intValue = (ulong)(taskbarInfo.ProgressValue * precisionValue);
-            return _taskbarList.SetProgressValue(CriticalHandle, intValue, precisionValue);
+            return _taskbarList.SetProgressValue(Handle, intValue, precisionValue);
         }
 
         private HRESULT UpdateTaskbarOverlay()
@@ -6630,7 +6630,7 @@ namespace System.Windows
                     hicon = IconHelper.CreateIconHandleFromImageSource(taskbarInfo.Overlay, _overlaySize);
                 }
 
-                return _taskbarList.SetOverlayIcon(CriticalHandle, hicon, null);
+                return _taskbarList.SetOverlayIcon(Handle, hicon, null);
             }
             finally
             {
@@ -6650,7 +6650,7 @@ namespace System.Windows
                 tooltip = taskbarInfo.Description ?? "";
             }
 
-            return _taskbarList.SetThumbnailTooltip(CriticalHandle, tooltip);
+            return _taskbarList.SetThumbnailTooltip(Handle, tooltip);
         }
 
 
@@ -6670,7 +6670,7 @@ namespace System.Windows
 
             // Don't count on Window properties being in sync at the time of this call.
             // Just use native methods to check
-            if (UnsafeNativeMethods.IsIconic(CriticalHandle))
+            if (UnsafeNativeMethods.IsIconic(Handle))
             {
                 // If the window is minimized then don't try to update the clip.
                 return HRESULT.S_FALSE;
@@ -6685,7 +6685,7 @@ namespace System.Windows
                 Thickness margin = taskbarInfo.ThumbnailClipMargin;
                 // Use the native GetClientRect.  Window.ActualWidth and .ActualHeight include the non-client areas.
                 NativeMethods.RECT physicalClientRc = default(NativeMethods.RECT);
-                SafeNativeMethods.GetClientRect(new HandleRef(this, CriticalHandle), ref physicalClientRc);
+                SafeNativeMethods.GetClientRect(new HandleRef(this, Handle), ref physicalClientRc);
                 var logicalClientRc = new Rect(
                     DeviceToLogicalUnits(new Point(physicalClientRc.left, physicalClientRc.top)),
                     DeviceToLogicalUnits(new Point(physicalClientRc.right, physicalClientRc.bottom)));
@@ -6706,7 +6706,7 @@ namespace System.Windows
                 }
             }
 
-            return _taskbarList.SetThumbnailClip(CriticalHandle, interopRc);
+            return _taskbarList.SetThumbnailClip(Handle, interopRc);
         }
 
         private HRESULT RegisterTaskbarThumbButtons()
@@ -6729,7 +6729,7 @@ namespace System.Windows
 
             // If this gets called (successfully) more than once it usually returns E_INVALIDARG.  It's not really
             // a failure and we potentially want to retry this operation.
-            HRESULT hr = _taskbarList.ThumbBarAddButtons(CriticalHandle, (uint)nativeButtons.Length, nativeButtons);
+            HRESULT hr = _taskbarList.ThumbBarAddButtons(Handle, (uint)nativeButtons.Length, nativeButtons);
             if (hr == HRESULT.E_INVALIDARG)
             {
                 hr = HRESULT.S_FALSE;
@@ -6840,7 +6840,7 @@ namespace System.Windows
                 }
 
                 // Finally, apply the update.
-                return _taskbarList.ThumbBarUpdateButtons(CriticalHandle, (uint)nativeButtons.Length, nativeButtons);
+                return _taskbarList.ThumbBarUpdateButtons(Handle, (uint)nativeButtons.Length, nativeButtons);
             }
             finally
             {
@@ -6893,12 +6893,12 @@ namespace System.Windows
             //    this instance of the Manager.
             //
             HwndStyleManager manager = Manager;
-            if (manager.Dirty && CriticalHandle != IntPtr.Zero)
+            if (manager.Dirty && Handle != IntPtr.Zero)
             {
-                UnsafeNativeMethods.CriticalSetWindowLong(new HandleRef(this,CriticalHandle), NativeMethods.GWL_STYLE, (IntPtr)_styleDoNotUse);
-                UnsafeNativeMethods.CriticalSetWindowLong(new HandleRef(this,CriticalHandle), NativeMethods.GWL_EXSTYLE, (IntPtr)_styleExDoNotUse);
+                UnsafeNativeMethods.CriticalSetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_STYLE, (IntPtr)_styleDoNotUse);
+                UnsafeNativeMethods.CriticalSetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_EXSTYLE, (IntPtr)_styleExDoNotUse);
 
-                UnsafeNativeMethods.SetWindowPos(new HandleRef(this, CriticalHandle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
+                UnsafeNativeMethods.SetWindowPos(new HandleRef(this, Handle), NativeMethods.NullHandleRef, 0, 0, 0, 0,
                                                NativeMethods.SWP_NOMOVE |
                                                NativeMethods.SWP_NOSIZE |
                                                NativeMethods.SWP_NOZORDER |
@@ -7423,7 +7423,7 @@ namespace System.Windows
                     }
                 }
 
-                internal IntPtr CriticalHandle
+                internal IntPtr Handle
                 {
                     get
                     {
@@ -7449,7 +7449,7 @@ namespace System.Windows
                         NativeMethods.MONITORINFOEX monitorInfo = new NativeMethods.MONITORINFOEX();
                         monitorInfo.cbSize = Marshal.SizeOf(typeof(NativeMethods.MONITORINFOEX));
 
-                        monitor = SafeNativeMethods.MonitorFromWindow( new HandleRef( this, CriticalHandle), NativeMethods.MONITOR_DEFAULTTONEAREST  );
+                        monitor = SafeNativeMethods.MonitorFromWindow( new HandleRef( this, Handle), NativeMethods.MONITOR_DEFAULTTONEAREST  );
                         if ( monitor != IntPtr.Zero )
                         {
                             SafeNativeMethods.GetMonitorInfo( new HandleRef ( this, monitor ) , monitorInfo);
@@ -7464,7 +7464,7 @@ namespace System.Windows
                     get
                     {
                         NativeMethods.RECT rc = new NativeMethods.RECT(0,0,0,0);
-                        SafeNativeMethods.GetClientRect(new HandleRef(this, CriticalHandle), ref rc);
+                        SafeNativeMethods.GetClientRect(new HandleRef(this, Handle), ref rc);
 
                         return rc;
                     }
@@ -7475,7 +7475,7 @@ namespace System.Windows
                     get
                     {
                         NativeMethods.RECT rc = new NativeMethods.RECT(0,0,0,0);
-                        SafeNativeMethods.GetWindowRect(new HandleRef(this, CriticalHandle), ref rc);
+                        SafeNativeMethods.GetWindowRect(new HandleRef(this, Handle), ref rc);
 
                         return rc;
                     }
@@ -7491,7 +7491,7 @@ namespace System.Windows
                         NativeMethods.RECT rc = new NativeMethods.RECT(0, 0, 0, 0);
 
                         // with RTL window, GetClientRect returns reversed coordinates
-                        SafeNativeMethods.GetClientRect(new HandleRef(this, CriticalHandle), ref rc);
+                        SafeNativeMethods.GetClientRect(new HandleRef(this, Handle), ref rc);
 
                         // note that we use rc.right here for the RTL case and client to screen that point
                         pt = new NativeMethods.POINT(rc.right, rc.top);
@@ -7576,7 +7576,7 @@ namespace System.Windows
                     {
                         // Should never be called when Handle is non-null
                         Debug.Assert( IsSourceWindowNull == false , "Should only be invoked when we know Handle is non-null" );
-                        return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,CriticalHandle), NativeMethods.GWL_EXSTYLE);
+                        return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_EXSTYLE);
                     }
                 }
 
@@ -7586,7 +7586,7 @@ namespace System.Windows
                     {
                         // Should never be called when Handle is non-null
                         Debug.Assert( IsSourceWindowNull == false , "Should only be invoked when we know Handle is non-null" );
-                        return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,CriticalHandle), NativeMethods.GWL_STYLE);
+                        return UnsafeNativeMethods.GetWindowLong(new HandleRef(this,Handle), NativeMethods.GWL_STYLE);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -7429,7 +7429,7 @@ namespace System.Windows
                     {
                         if (_sourceWindow != null)
                         {
-                            return _sourceWindow.CriticalHandle;
+                            return _sourceWindow.Handle;
                         }
                         else
                         {
@@ -7496,7 +7496,7 @@ namespace System.Windows
                         // note that we use rc.right here for the RTL case and client to screen that point
                         pt = new NativeMethods.POINT(rc.right, rc.top);
                     }
-                    UnsafeNativeMethods.ClientToScreen(new HandleRef(this, _sourceWindow.CriticalHandle), ref pt);
+                    UnsafeNativeMethods.ClientToScreen(new HandleRef(this, _sourceWindow.Handle), ref pt);
 
                     return pt;
                 }
@@ -7526,7 +7526,7 @@ namespace System.Windows
                 {
                     get
                     {
-                        return (_sourceWindow.CriticalHandle == UnsafeNativeMethods.GetActiveWindow());
+                        return (_sourceWindow.Handle == UnsafeNativeMethods.GetActiveWindow());
                     }
                 }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PointUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/PointUtil.cs
@@ -172,7 +172,7 @@ namespace MS.Internal
             {
                 return pointClient;
             }
-            HandleRef handleRef = new HandleRef(inputSource, inputSource.CriticalHandle);
+            HandleRef handleRef = new HandleRef(inputSource, inputSource.Handle);
 
             NativeMethods.POINT ptClient            = FromPoint(pointClient);
             NativeMethods.POINT ptClientRTLAdjusted = AdjustForRightToLeft(ptClient, handleRef);
@@ -195,7 +195,7 @@ namespace MS.Internal
                 return pointScreen;
             }
 
-            HandleRef handleRef = new HandleRef(inputSource, inputSource.CriticalHandle);
+            HandleRef handleRef = new HandleRef(inputSource, inputSource.Handle);
 
             NativeMethods.POINT ptClient = FromPoint(pointScreen);
 


### PR DESCRIPTION
## Description
Removes CriticalHandle properties, these properties are overloads that are not useful since the deprecation of CAS. It complicates the code with no benefit.

## Customer Impact
Tiny performance improvement (Probably not measurable) and slightly smaller assemblies.

## Regression
No.

## Testing
Local testing.

## Risk
Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9292)