### PR TITLE
Remove Marshalling code during Color Translation, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -431,7 +431,7 @@ namespace System.Windows.Media
                 c2.context = new ColorContext(PixelFormats.Bgra32);
 
                 ColorTransform colorTransform = new ColorTransform(c1.context, c2.context);
-                float[] sRGBValue = new float[3];
+                Span<float> sRGBValue = stackalloc float[3];
 
                 colorTransform.Translate(c1.nativeColorValue, sRGBValue);
 
@@ -550,7 +550,7 @@ namespace System.Windows.Media
                 c2.context = new ColorContext(PixelFormats.Bgra32);
 
                 ColorTransform colorTransform = new ColorTransform(c1.context, c2.context);
-                float[] sRGBValue = new float[3];
+                Span<float> sRGBValue = stackalloc float[3];
 
                 colorTransform.Translate(c1.nativeColorValue, sRGBValue);
 
@@ -1097,7 +1097,7 @@ namespace System.Windows.Media
                 c2.context = new ColorContext(PixelFormats.Bgra32);
 
                 ColorTransform colorTransform = new ColorTransform(this.context, c2.context);
-                float[] scRGBValue = new float[3];
+                Span<float> scRGBValue = stackalloc float[3];
 
                 colorTransform.Translate(this.nativeColorValue, scRGBValue);
 
@@ -1110,9 +1110,9 @@ namespace System.Windows.Media
         private void ComputeNativeValues(int numChannels)
         {
             this.nativeColorValue = new float[numChannels];
-            if (this.nativeColorValue.GetLength(0) > 0)
+            if (this.nativeColorValue.Length > 0)
             {
-                float[] sRGBValue = new float[3];
+                Span<float> sRGBValue = stackalloc float[3];
 
                 sRGBValue[0] = this.sRgbColor.r / 255.0f;
                 sRGBValue[1] = this.sRgbColor.g / 255.0f;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -1112,14 +1112,9 @@ namespace System.Windows.Media
             this.nativeColorValue = new float[numChannels];
             if (this.nativeColorValue.Length > 0)
             {
-                Span<float> sRGBValue = stackalloc float[3];
-
-                sRGBValue[0] = this.sRgbColor.r / 255.0f;
-                sRGBValue[1] = this.sRgbColor.g / 255.0f;
-                sRGBValue[2] = this.sRgbColor.b / 255.0f;
+                Span<float> sRGBValue = [this.sRgbColor.r / 255.0f, this.sRgbColor.g / 255.0f, this.sRgbColor.b / 255.0f];
 
                 ColorTransform colorTransform = new ColorTransform(this.context, new ColorContext(PixelFormats.Bgra32));
-
                 colorTransform.Translate(sRGBValue, this.nativeColorValue);
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
@@ -106,7 +106,7 @@ namespace System.Windows.Media
 
         #region Internal Methods
 
-        internal unsafe void Translate(float[] srcValue, float[] dstValue)
+        internal unsafe void Translate(Span<float> srcValue, Span<float> dstValue)
         {
             // Transform colors using TranslateColors
             const UInt32 NumColors = 1;
@@ -148,7 +148,7 @@ namespace System.Windows.Media
             _colorTransformHelper = new ColorTransformHelper();
         }
 
-        private long ICM2Color(float[] srcValue)
+        private long ICM2Color(Span<float> srcValue)
         {
             long colorValue;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/ColorTransform.cs
@@ -161,7 +161,6 @@ namespace System.Windows.Media
             {
                 Span<UInt16> channel = stackalloc UInt16[4];
 
-                channel[0] = channel[1] = channel[2] = channel[3] = 0;
                 for (int i = 0; i < srcValue.Length; i++)
                 {
                     if (srcValue[i] >= 1.0)// this fails for values above 1.0 and below 0.0
@@ -184,8 +183,6 @@ namespace System.Windows.Media
             {
                 Span<byte> channel = stackalloc byte[8];
 
-                channel[0] = channel[1] = channel[2] = channel[3] =
-                        channel[4] = channel[5] = channel[6] = channel[7] = 0;
                 for (int i = 0; i < srcValue.Length; i++)
                 {
                     if (srcValue[i] >= 1.0)// this fails for values above 1.0 and below 0.0


### PR DESCRIPTION
## Description

Improves slightly performance and subsequent allocations when subtracting/multiplying or just generally working with `Color` using a custom profile / `ColorContext` by removing `Marshal` code/allocs and simply using `stackalloc` for the buffer, replacing some dead code (It is obvious `Translate` method has been rewritten previously) and removing the `try`/`finally` block used for unmanaged memory deallocation.

Redundant array inits to `0` have been removed in `ICM2Color` and also some heap-allocated arrays have been replaced with stack-allocated spans in the call chain.

Last two commits are not included in benchmarks but are pretty straightforward improvements.

### Color Subtraction with custom profile

| Method     | Mean     | Error     | StdDev    | Gen0   | Allocated |
|----------- |---------:|----------:|----------:|-------:|----------:|
| Marshalled | 2.919 ms | 0.0460 ms | 0.0408 ms | 3.9063 |  79.03 KB |
| StackAlloc | 2.887 ms | 0.0555 ms | 0.0519 ms | 3.9063 |  78.82 KB |

<details><summary>Benchmark code</summary>

```c#
public Uri sRGB = new("C:\\Windows\\System32\\spool\\drivers\\color\\sRGB Color Space Profile.icm", UriKind.Absolute);

[Benchmark]
public Color Benchmark()
{
    Color x = Color.FromAValues(1.0f, [0.0f, 1.0f, 1.0f], sRGB);
    Color y = Color.FromAValues(0.5f, [0.0f, 0.5f, 1.0f], sRGB);

    return x - y;
}
```

</details>

### Multiplication by factor with custom profile
 
| Method     | Mean     | Error     | StdDev    | Allocated |
|----------- |---------:|----------:|----------:|----------:|
| Marshalled | 1.918 ms | 0.0116 ms | 0.0097 ms |  47.67 KB |
| StackAlloc | 1.915 ms | 0.0153 ms | 0.0144 ms |  47.53 KB |

<details><summary>Benchmark code</summary>

```c#
public Uri sRGB = new("C:\\Windows\\System32\\spool\\drivers\\color\\sRGB Color Space Profile.icm", UriKind.Absolute);

[Benchmark]
public Color Benchmark()
{
    Color x = Color.FromAValues(1.0f, [0.0f, 1.0f, 1.0f], sRGB);

    return x * 0.1f;
}
```

</details>

### Raw Translate method call chain

| Method     | Mean      | Error    | StdDev   | Gen0   | Allocated |
|----------- |----------:|---------:|---------:|-------:|----------:|
| Marshalled | 118.36 ns | 1.284 ns | 1.201 ns | 0.0086 |     144 B |
| StackAlloc |  22.80 ns | 0.430 ns | 0.402 ns | 0.0043 |      72 B |

## Customer Impact

Improved performance, decreased allocations.

## Regression

None.

## Testing

Build, benchmark, using the code and comparing outputs (addition, subtraction, multiplication).

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9330)