### PR TITLE
Simplify constructor in CachedBitmap by removing duplicate type checks

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-using MS.Internal;
+using System.Runtime.InteropServices;
 using MS.Win32.PresentationCore;
+using MS.Internal;
 
 namespace System.Windows.Media.Imaging
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/CachedBitmap.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Media.Imaging
             ArgumentNullException.ThrowIfNull(pixels);
 
             if (pixels.Rank != 1)
-                throw new ArgumentException(SR.Collection_BadRank, "pixels");
+                throw new ArgumentException(SR.Collection_BadRank, nameof(pixels));
 
             int elementSize = -1;
 
@@ -131,55 +131,8 @@ namespace System.Windows.Media.Imaging
 
             int destBufferSize = elementSize * pixels.Length;
 
-            if (pixels is byte[])
-            {
-                fixed(void * pixelArray = (byte[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is short[])
-            {
-                fixed(void * pixelArray = (short[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is ushort[])
-            {
-                fixed(void * pixelArray = (ushort[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is int[])
-            {
-                fixed(void * pixelArray = (int[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is uint[])
-            {
-                fixed(void * pixelArray = (uint[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is float[])
-            {
-                fixed(void * pixelArray = (float[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is double[])
-            {
-                fixed(void * pixelArray = (double[])pixels)
-                    InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY,
-                                      pixelFormat, palette,
-                                      (IntPtr)pixelArray, destBufferSize, stride);
-            }
+            fixed (byte* pixelArray = &MemoryMarshal.GetArrayDataReference(pixels))
+                InitFromMemoryPtr(pixelWidth, pixelHeight, dpiX, dpiY, pixelFormat, palette, (nint)pixelArray, destBufferSize, stride);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Removes redundant type checks second-time around when constructing `CachedBitmap` (this constructor is used by `BitmapSource.Create()`. There's minimal performance benefit, the main goal here is code simplification, that has been made possible with the introduction of `GetArrayDataReference` few releases ago.

Method has been tested with all array types for correct functionality when constructing in-memory Bitmap.

## Customer Impact

Smaller code-size of PresentationCore.

## Regression

None.

## Testing

Build, constructing Bitmap from memory source.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9333)