### PR TITLE
Replace Array.GetLength on single-dimensional arrays with Length property

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Color.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Media
             if (c1.context != null)
             {
                 c1.nativeColorValue = new float[c1.context.NumChannels];
-                for (int i = 0; i < c1.nativeColorValue.GetLength(0); i++)
+                for (int i = 0; i < c1.nativeColorValue.Length; i++)
                 {
                     c1.nativeColorValue[i] = 0.0f;
                 }
@@ -80,12 +80,12 @@ namespace System.Windows.Media
                 throw new ArgumentException(SR.Format(SR.Color_DimensionMismatch, null));
             }
 
-            if (values.GetLength(0) != c1.nativeColorValue.GetLength(0))
+            if (values.Length != c1.nativeColorValue.Length)
             {
                 throw new ArgumentException(SR.Format(SR.Color_DimensionMismatch, null));
             }
 
-            for (int numChannels = 0; numChannels < values.GetLength(0); numChannels++)
+            for (int numChannels = 0; numChannels < values.Length; numChannels++)
             {
                 c1.nativeColorValue[numChannels] = values[numChannels];
             }
@@ -305,10 +305,10 @@ namespace System.Windows.Media
                 var sb = new StringBuilder();
                 sb.AppendFormat(provider, "{0}{1} ", Parsers.s_ContextColor, uriString);
                 sb.AppendFormat(provider,"{1:" + format + "}{0}",separator,scRgbColor.a);
-                for (int i= 0; i< nativeColorValue.GetLength(0); ++i )
+                for (int i = 0; i < nativeColorValue.Length; ++i )
                 {
                     sb.AppendFormat(provider,"{0:" + format + "}",nativeColorValue[i]);
-                    if (i< nativeColorValue.GetLength(0)-1 )
+                    if (i < nativeColorValue.Length - 1)
                     {
                         sb.AppendFormat(provider,"{0}",separator);
                     }
@@ -350,7 +350,7 @@ namespace System.Windows.Media
             }
             else
             {
-                for (int i = 0; i < color.nativeColorValue.GetLength(0); i++)
+                for (int i = 0; i < color.nativeColorValue.Length; i++)
                     result = result && FloatUtil.AreClose(nativeColorValue[i], color.nativeColorValue[i]);
             }
 
@@ -421,9 +421,9 @@ namespace System.Windows.Media
                 
                 #pragma warning suppress 6506 // c1.context is obviously not null - both color1.context AND color2.context are not null
                 c1.nativeColorValue = new float[c1.context.NumChannels];
-                for (int i = 0; i < c1.nativeColorValue.GetLength(0); i++)
+                for (int i = 0; i < c1.nativeColorValue.Length; i++)
                 {
-                    c1.nativeColorValue[i] = color1.nativeColorValue[i] + color2.nativeColorValue[i] ;
+                    c1.nativeColorValue[i] = color1.nativeColorValue[i] + color2.nativeColorValue[i];
                 }
 
                 Color c2 = Color.FromRgb(0, 0, 0);
@@ -540,7 +540,7 @@ namespace System.Windows.Media
 
                 #pragma warning suppress 6506 // c1.context is obviously not null - both color1.context AND color2.context are not null
                 c1.nativeColorValue = new float[c1.context.NumChannels];
-                for (int i = 0; i < c1.nativeColorValue.GetLength(0); i++)
+                for (int i = 0; i < c1.nativeColorValue.Length; i++)
                 {
                     c1.nativeColorValue[i] = color1.nativeColorValue[i] - color2.nativeColorValue[i];
                 }
@@ -750,12 +750,12 @@ namespace System.Windows.Media
                     return false;
                 }
 
-                if (color1.nativeColorValue.GetLength(0) != color2.nativeColorValue.GetLength(0))
+                if (color1.nativeColorValue.Length != color2.nativeColorValue.Length)
                 {
                     return false;
                 }
 
-                for (int i = 0; i < color1.nativeColorValue.GetLength(0); i++)
+                for (int i = 0; i < color1.nativeColorValue.Length; i++)
                 {
                     if (color1.nativeColorValue[i] != color2.nativeColorValue[i])
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -1085,7 +1085,7 @@ namespace System.Windows.Media.Imaging
 
             if (sourceBuffer.Rank == 1)
             {
-                if (sourceBuffer.GetLength(0) <= 0)
+                if (sourceBuffer.Length == 0)
                 {
                     if (backwardsCompat)
                     {
@@ -1104,7 +1104,7 @@ namespace System.Windows.Media.Imaging
                     {
                         object exemplar = sourceBuffer.GetValue(0);
                         elementSize = Marshal.SizeOf(exemplar);
-                        sourceBufferSize = sourceBuffer.GetLength(0) * elementSize;
+                        sourceBufferSize = sourceBuffer.Length * elementSize;
                         elementType = exemplar.GetType();
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -1085,7 +1085,8 @@ namespace System.Windows.Media.Imaging
 
             if (sourceBuffer.Rank == 1)
             {
-                if (sourceBuffer.Length == 0)
+                int firstDimLength = sourceBuffer.GetLength(0);
+                if (firstDimLength == 0)
                 {
                     if (backwardsCompat)
                     {
@@ -1095,7 +1096,7 @@ namespace System.Windows.Media.Imaging
                     }
                     else
                     {
-                        throw new ArgumentException(SR.Image_InsufficientBuffer, "sourceBuffer");
+                        throw new ArgumentException(SR.Image_InsufficientBuffer, nameof(sourceBuffer));
                     }
                 }
                 else
@@ -1104,14 +1105,16 @@ namespace System.Windows.Media.Imaging
                     {
                         object exemplar = sourceBuffer.GetValue(0);
                         elementSize = Marshal.SizeOf(exemplar);
-                        sourceBufferSize = sourceBuffer.Length * elementSize;
+                        sourceBufferSize = firstDimLength * elementSize;
                         elementType = exemplar.GetType();
                     }
                 }
 }
             else if (sourceBuffer.Rank == 2)
             {
-                if (sourceBuffer.GetLength(0) <= 0 || sourceBuffer.GetLength(1) <= 0)
+                int firstDimLength = sourceBuffer.GetLength(0);
+                int secondDimLength = sourceBuffer.GetLength(1);
+                if (firstDimLength == 0 || secondDimLength == 0)
                 {
                     if (backwardsCompat)
                     {
@@ -1121,16 +1124,16 @@ namespace System.Windows.Media.Imaging
                     }
                     else
                     {
-                        throw new ArgumentException(SR.Image_InsufficientBuffer, "sourceBuffer");
+                        throw new ArgumentException(SR.Image_InsufficientBuffer, nameof(sourceBuffer));
                     }
                 }
                 else
                 {
                     checked
                     {
-                        object exemplar = sourceBuffer.GetValue(0,0);
+                        object exemplar = sourceBuffer.GetValue(0, 0);
                         elementSize = Marshal.SizeOf(exemplar);
-                        sourceBufferSize = sourceBuffer.GetLength(0) * sourceBuffer.GetLength(1) * elementSize;
+                        sourceBufferSize = (firstDimLength * secondDimLength) * elementSize;
                         elementType = exemplar.GetType();
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Parsers.cs
@@ -105,7 +105,7 @@ namespace MS.Internal
             string tokens = trimmedColor.Substring(s_ContextColor.Length);
             tokens = tokens.Trim();
             string[] preSplit = tokens.Split(' ');
-            if (preSplit.GetLength(0)< 2)
+            if (preSplit.Length < 2)
             {
                 throw new FormatException(SR.Parsers_IllegalToken);
             }
@@ -114,7 +114,7 @@ namespace MS.Internal
 
             TokenizerHelper th = new TokenizerHelper(tokens, formatProvider);
             string[] split = tokens.Split(new Char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            int numTokens = split.GetLength(0);
+            int numTokens = split.Length;
 
             float alpha = Convert.ToSingle(th.NextTokenRequired(), formatProvider);
 

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/ColorTypeConverter.cs
@@ -185,10 +185,10 @@ namespace System.Windows.Xps.Serialization
 
                 sb.AppendFormat(provider, "ContextColor {0} ", uriString);
                 sb.AppendFormat(provider, "{1:R}{0}", separator, color.ScA);
-                for (int i = 0; i < color.GetNativeColorValues().GetLength(0); ++i)
+                for (int i = 0; i < color.GetNativeColorValues().Length; ++i)
                 {
                     sb.AppendFormat(provider, "{0:R}", color.GetNativeColorValues()[i]);
-                    if (i < color.GetNativeColorValues().GetLength(0) - 1)
+                    if (i < color.GetNativeColorValues().Length - 1)
                     {
                         sb.AppendFormat(provider, "{0}", separator);
                     }
@@ -329,12 +329,12 @@ namespace System.Windows.Xps.Serialization
                         
                     XpsResourceStream resourceStream = manager.AcquireResourceStream(typeof(ColorContext), colorContextMimeType.ToString());
 
-                    byte [] buffer = new byte[512];
+                    byte[] buffer = new byte[512];
 
                     Stream profileStream = colorContext.OpenProfileStream();
                     int count;
                     
-                    while ( (count = profileStream.Read( buffer, 0, buffer.GetLength(0)) ) > 0 )
+                    while ( (count = profileStream.Read( buffer, 0, buffer.Length) ) > 0 )
                     {
                         resourceStream.Stream.Write(buffer,0,count);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationCacheItems.cs
+++ b/src/Microsoft.DotNet.Wpf/src/ReachFramework/Serialization/manager/ReachSerializationCacheItems.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Xps.Serialization
             //    and that are not hidden
             //
             if (propertyInfo.CanRead && 
-                propertyInfo.GetIndexParameters().GetLength(0) == 0)
+                propertyInfo.GetIndexParameters().Length == 0)
             {
                 MemberInfo memberInfo          = (MemberInfo) propertyInfo;
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/XmlSignatureProperties.cs
@@ -382,7 +382,7 @@ namespace MS.Internal.IO.Packaging
         /// <returns>-1 if not found</returns>
         private static int GetIndex(String format)
         {
-            for (int i = 0; i < _dateTimePatternMap.GetLength(0); i++)
+            for (int i = 0; i < _dateTimePatternMap.Length; i++)
             {
                 if (string.Equals(_dateTimePatternMap[i].Format, format, StringComparison.Ordinal))
                 {


### PR DESCRIPTION
## Description

Replaces `Array.GetLength(0)` on single-dimensional arrays with the `Length` property for performance benefit, clarity and general code quality. I didn't replace a few in `Color` and `ColorTransform` as that's part of my other PR and I don't want to create conflicts.

## Customer Impact

Improved performance.

## Regression

No.

## Testing

Build, the changes are minimal hence no further testing.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9334)