### PR TITLE
Fix InvalidOperationException in AvTrace and improve general thread-safety

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -59,13 +59,13 @@ namespace MS.Internal
         /// </summary>
         static AvTrace() => LoadWpfTracingSettings();
 
-        //
-        //  Refresh this trace source -- see if it needs to be enabled
-        //  because registry setting has changed or debugger is attached.
-        //
-        //  To re-read the config file, call System.Diagnostics.Trace.Refresh() .
-        //
 
+        /// <summary>
+        /// Refreshes this trace source. Checks again if it has been enabled
+        /// either because registry setting has changed or debugger has been attached.
+        /// <br/><br/>
+        ///  To re-read the config file, call <see cref="System.Diagnostics.Trace.Refresh"/>
+        /// </summary>
         public void Refresh()
         {
             // Re-read current WPF Trace settings from Registry in case it has changed.
@@ -165,7 +165,7 @@ namespace MS.Internal
         //
         // Internal initialization
         //
-       private void Initialize(bool isEnabledInRegistry)
+        private void Initialize(bool isEnabledInRegistry)
         {
             // Decide if we should actually create a TraceSource instance (doing so isn't free,
             // so we don't want to do it if we can avoid it).
@@ -198,17 +198,9 @@ namespace MS.Internal
         //  the TraceSource.)
         //
 
-        static private bool ShouldCreateTraceSources(bool isEnabledInRegistry)
+        private static bool ShouldCreateTraceSources(bool isEnabledInRegistry)
         {
-            if( isEnabledInRegistry
-                || IsDebuggerAttached()
-                || _hasBeenRefreshed
-              )
-            {
-                return true;
-            }
-
-            return false;
+            return isEnabledInRegistry || IsDebuggerAttached() || _hasBeenRefreshed;
         }
 
         /// <summary> Initializes <see cref="s_enabledInRegistry"/> variable from Registry and returns the value. </summary>
@@ -231,10 +223,10 @@ namespace MS.Internal
             return enabled;
         }
 
-        /// <summary> Retrieves cached value to see whether WPF Tracing is enabled. </summary>
+        /// <summary> Retrieves cached value from <see cref=" s_enabledInRegistry"/> to see whether WPF Tracing is enabled. </summary>
         /// <returns> A boolean value specifying whether WPF Tracing is enabled. </returns>
         [FriendAccessAllowed]
-        static internal bool IsWpfTracingEnabledInRegistry() => s_enabledInRegistry;
+        internal static bool IsWpfTracingEnabledInRegistry() => s_enabledInRegistry;
 
         //
         // Check for an attached debugger.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -51,9 +51,13 @@ namespace MS.Internal
             PresentationTraceSources.TraceRefresh += new TraceRefreshEventHandler(Refresh);
 
             // Fetch and cache the TraceSource from PresentationTraceSources
-            Initialize();
+            Initialize(IsWpfTracingEnabledInRegistry());
         }
 
+        /// <summary>
+        /// Performs thread-safe initialization of <see cref="s_enabledInRegistry"/> value.
+        /// </summary>
+        static AvTrace() => LoadWpfTracingSettings();
 
         //
         //  Refresh this trace source -- see if it needs to be enabled
@@ -64,11 +68,11 @@ namespace MS.Internal
 
         public void Refresh()
         {
-            // Cause the registry to be re-read in case it's changed.
-            _enabledInRegistry = null;
+            // Re-read current WPF Trace settings from Registry in case it has changed.
+            bool isEnabledInRegistry = LoadWpfTracingSettings();
 
             // Re-initialize everything
-            Initialize();
+            Initialize(isEnabledInRegistry);
         }
 
         //
@@ -161,12 +165,12 @@ namespace MS.Internal
         //
         // Internal initialization
         //
-        void Initialize( )
+       private void Initialize(bool isEnabledInRegistry)
         {
             // Decide if we should actually create a TraceSource instance (doing so isn't free,
             // so we don't want to do it if we can avoid it).
 
-            if( ShouldCreateTraceSources() )
+            if(ShouldCreateTraceSources(isEnabledInRegistry))
             {
                 // Get TraceSource from the PresentationTraceSources
                 // (this call will indirectly create the TraceSource if one doesn't already exist)
@@ -175,7 +179,7 @@ namespace MS.Internal
                 // We go enabled if tracing is enabled in the registry, if
                 // PresentationTraceSources.Refresh has been called, or if we're in the debugger
                 // and the debugger is supposed to enable tracing.
-                _isEnabled = IsWpfTracingEnabledInRegistry() || _hasBeenRefreshed || _enabledByDebugger ;
+                _isEnabled = isEnabledInRegistry || _hasBeenRefreshed || _enabledByDebugger ;
             }
             else
             {
@@ -194,9 +198,9 @@ namespace MS.Internal
         //  the TraceSource.)
         //
 
-        static private bool ShouldCreateTraceSources()
+        static private bool ShouldCreateTraceSources(bool isEnabledInRegistry)
         {
-            if( IsWpfTracingEnabledInRegistry()
+            if( isEnabledInRegistry
                 || IsDebuggerAttached()
                 || _hasBeenRefreshed
               )
@@ -207,40 +211,30 @@ namespace MS.Internal
             return false;
         }
 
-
-
-        ///
-        ///  Read the registry to see if WPF tracing is allowed
-        ///
-
-        [FriendAccessAllowed]
-        static internal bool IsWpfTracingEnabledInRegistry()
+        /// <summary> Initializes <see cref="s_enabledInRegistry"/> variable from Registry and returns the value. </summary>
+        /// <returns> A boolean value specifying whether WPF Tracing is enabled. </returns>
+        internal static bool LoadWpfTracingSettings()
         {
-            // First time this is called, initialize from the registry
+            // Initialize from the registry
+            bool enabled = false;
 
-            if( _enabledInRegistry == null )
-            {
-                bool enabled = false;
+            object keyValue = SecurityHelper.ReadRegistryValue(Registry.CurrentUser,
+                                                               @"Software\Microsoft\Tracing\WPF",
+                                                               "ManagedTracing");
 
-                object keyValue = SecurityHelper.ReadRegistryValue(
-                                                            Registry.CurrentUser,
-                                                            @"Software\Microsoft\Tracing\WPF",
-                                                            "ManagedTracing");
+            if (keyValue is int value && value == 1) //REG_DWORD
+                enabled = true;
 
-                if( keyValue is int && ((int) keyValue) == 1 )
-                {
-                    enabled = true;
-                }
+            // Update the static value
+            s_enabledInRegistry = enabled;
 
-                // Update the static.  Doing this last protects us from threading problems; worse case, multiple
-                // threads will set the same value into it.
-                _enabledInRegistry = enabled;
-            }
-
-            return (bool) _enabledInRegistry;
+            return enabled;
         }
 
-
+        /// <summary> Retrieves cached value to see whether WPF Tracing is enabled. </summary>
+        /// <returns> A boolean value specifying whether WPF Tracing is enabled. </returns>
+        [FriendAccessAllowed]
+        static internal bool IsWpfTracingEnabledInRegistry() => s_enabledInRegistry;
 
         //
         // Check for an attached debugger.
@@ -513,8 +507,8 @@ namespace MS.Internal
         // Cache of TraceSource instance; real value resides in PresentationTraceSources.
         TraceSource _traceSource;
 
-        // Cache used by IsWpfTracingEnabledInRegistry
-        static Nullable<bool> _enabledInRegistry = null;
+        // Cache used by IsWpfTracingEnabledInRegistry, written by LoadWpfTracingSettings
+        private static volatile bool s_enabledInRegistry = false;
 
         static char[] FormatChars = new char[]{ '{', '}' };
     }


### PR DESCRIPTION
Fixes #9347

## Description

As I believe `AvTrace` should be close to thread-safe class and it seems the original intention was for it to be from the comments, especially since even running during debug will have another thread initializing a source, based on the report in issue #9347, I've decided to create a little improvement.

- We introduce a static constructor that loads the setting from registry with true/false output (false by default) in a thread-safe manner (so that internal methods that call might call into `IsWpfTracingEnabledInRegistry` get what they came for)
- Each new instance initializes based on the latest fetched/saved in static `s_enabledInRegistry` result
- Upon calling Refresh, we reload the setting from registry and update the value in `s_enabledInRegistry` accordingly
- We then use this fetched variable down the callstack to ensure the current operation has the latest value
- `IsWpfTracingEnabledInRegistry` now merely retrieves the latest value for static `s_enabledInRegistry`
- `s_enabledInRegistry` doesn't necessarily need to be volatile but I felt like the memory fence here is worth it for consistency.
- This should improve overall performance (very minor) and stability of the `AvTrace` instances/refreshes in general.
- Also fixes a possible but unlikely race-condition in `Initialize` function between `ShouldCreateTraceSources` where a different value could have been obtained from `IsWpfTracingEnabledInRegistry` afterwards if changed by a different thread meanwhile; if the setting in registry was changed.

It is not perfect, but it prevents the exception problem and improves the behaviour overall.

## Customer Impact

Ocassionally, `InvalidOperationException` might be thrown when setting up WPF trace sources, note that the class is used by multiple threads by default without forcing it; e.g. when debugging.

## Regression

No.

## Testing

Build, local testing, verifying setting retrieval and stability.

## Risk

Low.
