### PR TITLE
Spanify AntiFormat function in AvTrace, decrease allocations, improve perf

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -375,37 +375,43 @@ namespace MS.Internal
 
 
         // replace { and } by {{ and }} - call if literal string will be passed to Format
-        static public string AntiFormat(string s)
+        public static string AntiFormat(string value)
         {
-            int formatIndex = s.IndexOfAny(FormatChars);
-            if (formatIndex < 0)
-                return s;
+            ReadOnlySpan<char> input = value.AsSpan();
 
-            StringBuilder sb = new StringBuilder();
-            int index = 0;
-            int lengthMinus1 = s.Length - 1;
+            // Check if there are any chars present
+            int formatIndex = input.IndexOfAny(FormatChars);
+            if (formatIndex == -1)
+                return value;
 
-            while (formatIndex >= 0)
+            StringBuilder sb = new(value.Length * 2);
+
+            while (input.Length > 0)
             {
-                if (formatIndex < lengthMinus1 && s[formatIndex] == s[formatIndex+1])
+                if (formatIndex == -1)
                 {
-                    // formatting character is already duplicated - leave them alone
-                    formatIndex = s.IndexOfAny(FormatChars, formatIndex+2);
+                    // No formatting character found, append rest of the string and exit
+                    sb.Append(input);
+                    break;
+                }
+                else if (input.Length > formatIndex + 1 && input[formatIndex] == input[formatIndex + 1])
+                {
+                    // Formatting character is already duplicated (append string only)
+                    sb.Append(input.Slice(0, formatIndex + 2));
+
+                    input = input.Slice(formatIndex + 2);
                 }
                 else
                 {
-                    // duplicate the formatting character
-                    sb.Append(s.AsSpan(index, formatIndex - index + 1));
-                    sb.Append(s[formatIndex]);
+                    // Duplicate the formatting character and append string
+                    sb.Append(input.Slice(0, formatIndex + 1));
+                    sb.Append(input[formatIndex]);
 
-                    index = formatIndex + 1;
-                    formatIndex = s.IndexOfAny(FormatChars, index);
+                    input = input.Slice(formatIndex + 1);
                 }
-            }
 
-            if (index <= lengthMinus1)
-            {
-                sb.Append(s.AsSpan(index));
+                // Find the next formatting character
+                formatIndex = input.IndexOfAny(FormatChars);
             }
 
             return sb.ToString();
@@ -491,14 +497,15 @@ namespace MS.Internal
         // Cache used by IsWpfTracingEnabledInRegistry
         private static Nullable<bool> _enabledInRegistry = null;
 
-        private static char[] FormatChars = new char[]{ '{', '}' };
+        private static ReadOnlySpan<char> FormatChars => ['{', '}'];
+
     }
 
     internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, object[] parameters, int start );
 
     internal class AvTraceBuilder
     {
-        private StringBuilder  _sb;
+        private readonly StringBuilder _sb;
 
         public AvTraceBuilder()
         {
@@ -527,25 +534,25 @@ namespace MS.Internal
 
         public void AppendFormat( string message, object arg1 )
         {
-            _sb.AppendFormat( CultureInfo.InvariantCulture, message, new object[] { AvTrace.ToStringHelper(arg1) } );
+            _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.ToStringHelper(arg1));
         }
 
         public void AppendFormat( string message, object arg1, object arg2 )
         {
-            _sb.AppendFormat( CultureInfo.InvariantCulture, message, new object[] { AvTrace.ToStringHelper(arg1), AvTrace.ToStringHelper(arg2) } );
+            _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.ToStringHelper(arg1), AvTrace.ToStringHelper(arg2));
         }
 
         public void AppendFormat( string message, string arg1 )
         {
-            _sb.AppendFormat( CultureInfo.InvariantCulture, message, new object[] { AvTrace.AntiFormat(arg1) } );
+            _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.AntiFormat(arg1));
         }
 
         public void AppendFormat( string message, string arg1, string arg2 )
         {
-            _sb.AppendFormat( CultureInfo.InvariantCulture, message, new object[] { AvTrace.AntiFormat(arg1), AvTrace.AntiFormat(arg2) } );
+            _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.AntiFormat(arg1), AvTrace.AntiFormat(arg2));
         }
 
-        public override string ToString( )
+        public override string ToString()
         {
             return _sb.ToString();
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -374,7 +374,13 @@ namespace MS.Internal
         }
 
 
-        // replace { and } by {{ and }} - call if literal string will be passed to Format
+        /// <summary> Replaces '{' and '}' occurrences with '{{' and '}}'.
+        /// <para>
+        /// Call if literal string will be passed to StringBuilder.AppendFormat() overloads.
+        /// </para>
+        /// </summary>
+        /// <param name="value">The string to replace formatting characters in.</param>
+        /// <returns>A formatted string, no-op in case there are no '{' or '}'. </returns>
         public static string AntiFormat(string value)
         {
             ReadOnlySpan<char> input = value.AsSpan();
@@ -501,7 +507,7 @@ namespace MS.Internal
 
     }
 
-    internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, object[] parameters, int start );
+    internal delegate void AvTraceEventHandler(AvTraceBuilder traceBuilder, object[] parameters, int start);
 
     internal class AvTraceBuilder
     {
@@ -512,42 +518,42 @@ namespace MS.Internal
             _sb = new StringBuilder();
         }
 
-        public AvTraceBuilder( string message )
+        public AvTraceBuilder(string message)
         {
-            _sb = new StringBuilder( message );
+            _sb = new StringBuilder(message);
         }
 
-        public void Append( string message )
+        public void Append(string message)
         {
-            _sb.Append( message );
+            _sb.Append(message);
         }
 
-        public void AppendFormat( string message, params object[] args )
+        public void AppendFormat(string message, params object[] args)
         {
             object[] argstrs = new object[args.Length];
             for (int i = 0; i < args.Length; ++i)
             {
-                argstrs[i] = (args[i] is string s) ? s : AvTrace.ToStringHelper(args[i]);
+                argstrs[i] = (args[i] is string value) ? value : AvTrace.ToStringHelper(args[i]);
             }
-            _sb.AppendFormat( CultureInfo.InvariantCulture, message, argstrs );
+            _sb.AppendFormat(CultureInfo.InvariantCulture, message, argstrs);
         }
 
-        public void AppendFormat( string message, object arg1 )
+        public void AppendFormat(string message, object arg1)
         {
             _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.ToStringHelper(arg1));
         }
 
-        public void AppendFormat( string message, object arg1, object arg2 )
+        public void AppendFormat(string message, object arg1, object arg2)
         {
             _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.ToStringHelper(arg1), AvTrace.ToStringHelper(arg2));
         }
 
-        public void AppendFormat( string message, string arg1 )
+        public void AppendFormat(string message, string arg1)
         {
             _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.AntiFormat(arg1));
         }
 
-        public void AppendFormat( string message, string arg1, string arg2 )
+        public void AppendFormat(string message, string arg1, string arg2)
         {
             _sb.AppendFormat(CultureInfo.InvariantCulture, message, AvTrace.AntiFormat(arg1), AvTrace.AntiFormat(arg2));
         }


### PR DESCRIPTION
## Description

Improves performance of the `AntiFormat` function in `AvTrace`, reducing allocations and improving the overall performance up to 2 times in some cases. Also changes `FormatChars` from `char[]` to `ReadOnlySpan<char>`, occurrence I've missed in #9230.

Second commit features added documentation for the function. I've included some basic asserts at the **Testing** section.

### Small strings within `StringBuilder` default capacity

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR__Edit |  236.1 ns |    4.75 ns |     5.84 ns | 0.0730 |        1224 B |
| Original |  400.7 ns |    8.04 ns |    15.29 ns | 0.1040 |        1744 B |

<details><summary>Benchmark code</summary>

```c#
AntiFormat2("{aaaa}");
AntiFormat2("{aaaa}}");
AntiFormat2("{{aaaa}}");
AntiFormat2("{aa{{aa}}");
AntiFormat2("{aa{{aa}}ab}c}d");
AntiFormat2("aaaa}");
AntiFormat2("aaaa");
AntiFormat2("a{{{aaa");
AntiFormat2("a{{{aaa}}}");

```

</details>

### Large strings, mostly without any replacements

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR__Edit|  127.5 ns |    1.29 ns |     1.08 ns | 0.0880 |        1472 B |
| Original |  242.9 ns |    4.87 ns |     5.00 ns | 0.1094 |        1832 B |

<details><summary>Benchmark code</summary>

```c#
AntiFormat("aaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
AntiFormat("aaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
AntiFormat("aaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa");
AntiFormat("aaaaxxxc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
AntiFormat("aaaaabcd}yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy");
AntiFormat("aaaa}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
AntiFormat("aaaa}6666666666666666666666666666666666666666666666666666666666666");
AntiFormat("aaaa7777777777777777777777777777777777777777777777777777777777777");
AntiFormat("aaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg");
```

</details>

### Large strings, with replacements (up to two times the perf)

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR__Edit|  394.7 ns |    7.73 ns |    10.05 ns | 0.3271 |        5472 B |
| Original|  798.9 ns |   11.30 ns |    10.57 ns | 0.4425 |        7408 B |

<details><summary>Benchmark code</summary>

```c#
AntiFormat("aaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}");
AntiFormat("aaaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx}");
AntiFormat("aaaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa}");
AntiFormat("aaaaxxxc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc}");
AntiFormat("aaaaabcd}yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy");
AntiFormat("aaaa}xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
AntiFormat("aaaa}6666666666666666666666666666666666666666666666666666666666666");
AntiFormat("aaaa7777777777777777777777777777777777777777777777777777777777777{");
AntiFormat("aaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg}");
AntiFormat("aaaa77777777777777777777777777{}777777777777777777777777777777777{");
AntiFormat("aaaaggggggggggggggggggggggggggggggggggggggggggggggggg{gggggggggggggg}");
```

</details>

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, base testing between the two functions.

```c#
Assert.AreEqual(AntiFormat("{aaaa}}"), AntiFormat2("{aaaa}}"));
Assert.AreEqual(AntiFormat("{aa{{aa}}"), AntiFormat2("{aa{{aa}}"));
Assert.AreEqual(AntiFormat("{aa{{aa}}ab}c}d"), AntiFormat2("{aa{{aa}}ab}c}d"));
Assert.AreEqual(AntiFormat("aaaa}"), AntiFormat2("aaaa}"));
Assert.AreEqual(AntiFormat("aaaa"), AntiFormat2("aaaa"));
Assert.AreEqual(AntiFormat("a{{{aaa"), AntiFormat2("a{{{aaa"));
Assert.AreEqual(AntiFormat("a{{{aaa}}}"), AntiFormat2("a{{{aaa}}}"));
Assert.AreEqual(AntiFormat("{aaaa}"), AntiFormat2("{aaaa}"));
Assert.AreEqual(AntiFormat("{{aaaa}}"), AntiFormat2("{{aaaa}}"));
Assert.AreEqual(AntiFormat("{{{}aaaa}}"), AntiFormat2("{{{}aaaa}}"));
Assert.AreEqual(AntiFormat(string.Empty), AntiFormat2(string.Empty));
Assert.AreEqual(AntiFormat("a{{{}aaaa}}"), AntiFormat2("a{{{}aaaa}}"));
Assert.AreEqual(AntiFormat("a}aaaa}"), AntiFormat2("a}aaaa}"));
Assert.AreEqual(AntiFormat("}aaaa}"), AntiFormat2("}aaaa}"));
```

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9361)