### PR TITLE
Reduce ThicknessConverter allocs to minimum and improve conversion performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LengthConverter.cs
@@ -221,11 +221,6 @@ namespace System.Windows
             }
         }
 
-        static internal string ToString(double l, CultureInfo cultureInfo)
-        {
-            if(double.IsNaN(l)) return "Auto";
-            return Convert.ToString(l, cultureInfo);
-        }
 
         #endregion
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/LengthConverter.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.ComponentModel;
-
 using System.ComponentModel.Design.Serialization;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -162,7 +162,7 @@ namespace System.Windows
             }
             throw GetConvertToException(value, destinationType);
         }
-        #endregion 
+        #endregion
 
         //-------------------------------------------------------------------
         //
@@ -172,6 +172,18 @@ namespace System.Windows
 
         #region Internal Methods
 
+        /// <summary> Format <see cref="double"/> into <see cref="string"/> using specified <see cref="CultureInfo"/>
+        /// in <paramref name="handler"/>. <br /> <br />
+        /// Special representation applies for <see cref="double.NaN"/> values, emitted as "Auto" string instead. </summary>
+        /// <param name="value">The value to format as string.</param>
+        /// <param name="handler">The handler specifying culture used for conversion.</param>
+        static internal void FormatLengthAsString(double value, ref DefaultInterpolatedStringHandler handler)
+        {
+            if (double.IsNaN(value))
+                handler.AppendLiteral("Auto");
+            else
+                handler.AppendFormatted(value);
+        }
 
         // Parse a Length from a string given the CultureInfo.
         // Formats: 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
@@ -5,7 +5,7 @@
 //
 // 
 //
-// Description: Contains the ThicknessConverter: TypeConverter for the Thicknessclass.
+// Description: Contains the ThicknessConverter: TypeConverter for the Thickness struct.
 //
 //
 
@@ -74,15 +74,7 @@ namespace System.Windows
         public override bool CanConvertTo(ITypeDescriptorContext typeDescriptorContext, Type destinationType)
         {
             // We can convert to an InstanceDescriptor or to a string.
-            if (    destinationType == typeof(InstanceDescriptor) 
-                ||  destinationType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return destinationType == typeof(InstanceDescriptor) || destinationType == typeof(string);
         }
 
         /// <summary>
@@ -103,12 +95,16 @@ namespace System.Windows
         /// <param name="source"> The object to convert to a Thickness. </param>
         public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, CultureInfo cultureInfo, object source)
         {
-            if (source != null)
+            if (source is not null)
             {
-                if (source is string)      { return FromString((string)source, cultureInfo); }
-                else if (source is double) { return new Thickness((double)source); }
-                else                       { return new Thickness(Convert.ToDouble(source, cultureInfo)); }
+                if (source is string sourceString)
+                    return FromString(sourceString, cultureInfo);
+                else if (source is double sourceValue)
+                    return new Thickness(sourceValue);
+                else
+                    return new Thickness(Convert.ToDouble(source, cultureInfo));
             }
+
             throw GetConvertFromException(source);
         }
 
@@ -134,22 +130,18 @@ namespace System.Windows
             ArgumentNullException.ThrowIfNull(value);
             ArgumentNullException.ThrowIfNull(destinationType);
 
-            if (!(value is Thickness))
-            {
-                #pragma warning suppress 6506 // value is obviously not null
-                throw new ArgumentException(SR.Format(SR.UnexpectedParameterType, value.GetType(), typeof(Thickness)), "value");
-            }
+            if (value is not Thickness thickness)
+                throw new ArgumentException(SR.Format(SR.UnexpectedParameterType, value.GetType(), typeof(Thickness)), nameof(value));
 
-            Thickness th = (Thickness)value;
-            if (destinationType == typeof(string)) { return ToString(th, cultureInfo); }
-            if (destinationType == typeof(InstanceDescriptor))
+            if (destinationType == typeof(string))
+                return ToString(thickness, cultureInfo);
+            else if (destinationType == typeof(InstanceDescriptor))
             {
                 ConstructorInfo ci = typeof(Thickness).GetConstructor(new Type[] { typeof(double), typeof(double), typeof(double), typeof(double) });
-                return new InstanceDescriptor(ci, new object[] { th.Left, th.Top, th.Right, th.Bottom });
+                return new InstanceDescriptor(ci, new object[] { thickness.Left, thickness.Top, thickness.Right, thickness.Bottom });
             }
 
             throw new ArgumentException(SR.Format(SR.CannotConvertType, typeof(Thickness), destinationType.FullName));
-
         }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThicknessConverter.cs
@@ -204,19 +204,20 @@ namespace System.Windows
                 handler.AppendFormatted(value);
         }
 
-        static internal Thickness FromString(string s, CultureInfo cultureInfo)
+        static internal unsafe Thickness FromString(string s, CultureInfo cultureInfo)
         {
             TokenizerHelper th = new(s, cultureInfo);
-            Span<double> lengths = stackalloc double[4];
+            double* lengths = stackalloc double[4];
             int i = 0;
 
             // Peel off each double in the delimited list.
             while (th.NextToken())
             {
-                if (i == 4) // In case we've got more than 4 doubles, we throw
+                if (i >= 4) // In case we've got more than 4 doubles, we throw
                     throw new FormatException(SR.Format(SR.InvalidStringThickness, s));
 
-                lengths[i++] = LengthConverter.FromString(th.GetCurrentToken(), cultureInfo);
+                lengths[i] = LengthConverter.FromString(th.GetCurrentToken(), cultureInfo);
+                i++;
             }
 
             // We have a reasonable interpretation for one value (all four edges),


### PR DESCRIPTION
## Description

Simplifies code in `CanConvertTo`/`ConvertFrom`/`ConvertTo`, removes additional type casts by using `is` checks/pattern match. Commits should be easy to review.

Uses `DefaultInterpolatedStringHandler` instead of `StringBuilder` to handle conversion in `ToString` with a pre-allocated on-stack buffer (not using interpolated strings directly due to the `NaN`->`Auto` conversion which would box as Roslyn won't handle that one.

Also stackallocs 4 doubles instead of allocating an array in `FromString`, this uses unsafe quotation due to how the current code-gen with Span<double> looks like; additional perf improvement. I didn't include benchmark/tests in this one, they're together in the other PR for `LengthConverter` #9364.

### Multiple decimals point (edge case but within original range)

```c#
ToString(new Thickness(3.33371, 2.25888, 6.6666, 8.444), CultureInfo.InvariantCulture);
```

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR_EDIT |  348.2 ns |    2.56 ns |     2.27 ns | 0.0048 |          80 B |
| Original |  393.2 ns |    3.05 ns |     2.70 ns | 0.0257 |         432 B |

### Single decimal point, standard use-case

```c#
ToString(new Thickness(1, 2, 2.5, 4), CultureInfo.InvariantCulture);
```

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR_EDIT |  277.4 ns |    2.22 ns |     2.08 ns | 0.0024 |          40 B |
| Original |  328.1 ns |    4.37 ns |     4.09 ns | 0.0205 |         344 B |

### Conversion from `double.NaN` to `Auto`

```c#
ToString(new Thickness(double.NaN), CultureInfo.InvariantCulture);
```

| Method     | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|----------- |----------:|-----------:|------------:|-------:|--------------:|
| PR_EDIT |  24.23 ns |   0.187 ns |    0.146 ns | 0.0038 |          64 B |
| Original |  32.90 ns |   0.441 ns |    0.391 ns | 0.0157 |         264 B |

## Customer Impact

Improved performance, greatly decreased allocations.

## Regression

No.

## Testing

Local build, basic set of assert testing.

```c#
CultureInfo CachedNorwegian = new CultureInfo("nn-NO");

Assert.AreEqual(ToString(new Thickness(1.5, 2, 1.25, 3), CultureInfo.InvariantCulture), ToString2(new Thickness(1.5, 2, 1.25, 3), CultureInfo.InvariantCulture));
Assert.AreEqual(ToString(new Thickness(3, 2, 6, 8), CultureInfo.InvariantCulture), ToString2(new Thickness(3, 2, 6, 8), CultureInfo.InvariantCulture));
Assert.AreEqual(ToString(new Thickness(3.33371, 2.25888, 6.6666, 8.444), CultureInfo.InvariantCulture), ToString2(new Thickness(3.33371, 2.25888, 6.6666, 8.444), CultureInfo.InvariantCulture));

//Culture with decimal comma separator
Assert.AreEqual(ToString(new Thickness(1.5, 2, 1.25, 3), CachedNorwegian), ToString2(new Thickness(1.5, 2, 1.25, 3), CachedNorwegian));
Assert.AreEqual(ToString(new Thickness(3, 2, 6, 8), CachedNorwegian), ToString2(new Thickness(3, 2, 6, 8), CachedNorwegian));
Assert.AreEqual(ToString(new Thickness(3.33371, 2.25888, 6.6666, 8.444), CachedNorwegian), ToString2(new Thickness(3.33371, 2.25888, 6.6666, 8.444), CachedNorwegian));

Assert.AreEqual(ToString(new Thickness(), CachedNorwegian), ToString2(new Thickness(), CachedNorwegian));

Assert.AreEqual(ToString(new Thickness(double.NaN), CachedNorwegian), ToString2(new Thickness(double.NaN), CachedNorwegian));
```

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9363)