### PR TITLE
Replace GCHandle allocs for short-term pinning with fixed statements

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/PropVariant.cs
@@ -143,7 +143,7 @@ namespace System.Windows.Media.Imaging
 
         internal void Init(Array array, Type type, VarEnum vt)
         {
-            varType = (ushort) vt;
+            varType = (ushort)vt;
             ca.cElems = 0;
             ca.pElems = IntPtr.Zero;
 
@@ -152,17 +152,16 @@ namespace System.Windows.Media.Imaging
             if (length > 0)
             {
                 long size = Marshal.SizeOf(type) * length;
-
-                IntPtr destPtr =IntPtr.Zero;
-                GCHandle handle = new GCHandle();
+                IntPtr destPtr = IntPtr.Zero;
 
                 try
                 {
-                    destPtr = Marshal.AllocCoTaskMem((int) size);
-                    handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+                    destPtr = Marshal.AllocCoTaskMem((int)size);
+
                     unsafe
                     {
-                        CopyBytes((byte *) destPtr, (int)size, (byte *)handle.AddrOfPinnedObject(), (int)size);
+                        fixed (byte* sourcePtr = &MemoryMarshal.GetArrayDataReference(array))
+                            CopyBytes((byte*)destPtr, (int)size, sourcePtr, (int)size);
                     }
 
                     ca.cElems = (uint)length;
@@ -172,11 +171,6 @@ namespace System.Windows.Media.Imaging
                 }
                 finally
                 {
-                    if (handle.IsAllocated)
-                    {
-                        handle.Free();
-                    }
-
                     if (destPtr != IntPtr.Zero)
                     {
                         Marshal.FreeCoTaskMem(destPtr);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/WindowsRuntime/Generated/WinRT/Marshalers.cs
@@ -322,15 +322,12 @@ namespace WinRT
         public static unsafe void CopyManagedArray(Array array, IntPtr data)
         {
             if (array is null)
-            {
                 return;
-            }
-            var length = array.Length;
-            var byte_length = length * Marshal.SizeOf<T>();
-            var array_handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-            var array_data = array_handle.AddrOfPinnedObject();
-            Buffer.MemoryCopy(array_data.ToPointer(), data.ToPointer(), byte_length, byte_length);
-            array_handle.Free();
+
+            int byte_length = array.Length * Marshal.SizeOf<T>();
+
+            fixed (void* array_data = &MemoryMarshal.GetArrayDataReference(array))
+                Buffer.MemoryCopy(array_data, data.ToPointer(), byte_length, byte_length);
         }
 
         public static void DisposeMarshalerArray(object box)


### PR DESCRIPTION
## Description

Removes `GCHandle` allocations for short-term pinning operations with `fixed` statements to improve performance of the actual pinning up to 3 times per pinning operation. Any non-pinning and long-term instance pins were not modified.

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|
| Fixed    |  8.821 ns |  0.1969 ns |   0.4066 ns | 0.0167 |         280 B |
| Handle | 25.544 ns |  0.5316 ns |   0.5221 ns | 0.0167 |         280 B |

### Benchmark code
```c#
[Benchmark]
public void Fixed() => UnsafePin(new byte[256]);
[Benchmark]
public void Handle() => GCHandleAlloc(new byte[256]);

[MethodImpl(MethodImplOptions.NoInlining)]
private unsafe void GCHandleAlloc(Array sourceBuffer)
{
    GCHandle arrayHandle = GCHandle.Alloc(sourceBuffer, GCHandleType.Pinned);
    try
    {
        IntPtr buffer = arrayHandle.AddrOfPinnedObject();
        WritePixelsImpl(2, (byte*)buffer, false);
    }
    finally
    {
        arrayHandle.Free();
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
private unsafe void UnsafePin(Array sourceBuffer)
{
    fixed (byte* buffer = &MemoryMarshal.GetArrayDataReference(sourceBuffer))
        WritePixelsImpl(2, buffer, false);
}

[MethodImpl(MethodImplOptions.NoInlining)]
[SkipLocalsInit]
private unsafe void WritePixelsImpl(int uselessParam, byte* buffer, bool doWork)
{
    Span<byte> bytes = stackalloc byte[256];

    if(doWork == true)
        for (int i = 0; i < 256; i++)
            bytes[i] = buffer[i];
}

```
## Customer Impact

Improved performance.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9365)