### PR TITLE
Replace X509Certificate2 ctor with X509CertificateLoader.LoadCertificate

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/IO/Packaging/Certificate.cs
@@ -113,7 +113,7 @@ namespace MS.Internal.IO.Packaging
                         // X509Certificate constructor desires a byte array
                         Byte[] byteArray = new Byte[s.Length];
                         PackagingUtilities.ReliableRead(s, byteArray, 0, (int)s.Length);
-                        _certificate = new X509Certificate2(byteArray);
+                        _certificate = X509CertificateLoader.LoadCertificate(byteArray);
                     }
                 }
             }


### PR DESCRIPTION
Fix Build failure: https://github.com/dotnet/wpf/pull/9366

### Description
Use ```X509Certificate2``` constructor to create certificate is marked as obsolete. 
Update it with new ```X509CertificateLoader.LoadCertificate``` added in runtime.

Reference:
https://github.com/dotnet/runtime/pull/104165
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9368)