### PR TITLE
Fall back to Window.Title if GetWindowText fails. Fixes #7344 (#7345)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Automation/Peers/WindowAutomationPeer.cs
@@ -44,12 +44,18 @@ namespace System.Windows.Automation.Peers
 
                 if(!window.IsSourceWindowNull)
                 {
-                    StringBuilder sb = new StringBuilder(512);
-                    UnsafeNativeMethods.GetWindowText(new HandleRef(null, window.CriticalHandle), sb, sb.Capacity);
-                    name = sb.ToString();
+                    try
+                    {
+                        StringBuilder sb = new StringBuilder(512);
+                        UnsafeNativeMethods.GetWindowText(new HandleRef(null, window.CriticalHandle), sb, sb.Capacity);
+                        name = sb.ToString();
+                    }
+                    catch (Win32Exception)
+                    {
+                        name = window.Title;
+                    }
 
-                    if (name == null)
-                        name = string.Empty;
+                    name ??= "";
                 }
             }
 


### PR DESCRIPTION
This is an attempt to recover from badly-behaving windows message hooks that may change the last error during message processing.

(cherry picked from commit 09608ab5ef47e8a142e16285ec55500e3c01287e)

Fixes #https://github.com/dotnet/wpf/issues/7344
Fixes #https://github.com/dotnet/wpf/issues/4181


Main PR [<!-- Link to PR if any that fixed this in the main branch. -->]()
https://github.com/dotnet/wpf/pull/7345

## Description

UnsafeNativeMethods.GetWindowText may throw if badly-behaving Windows message hooks are installed on the system, or potentially for other reasons. This can crash a WPF application.

Instead of crashing, we now ignore the exception and try to fall back to using Window.Title, which should contain the same text.

## Customer Impact

WPF applications can crash unpredictably. It may be possible for customers to work around it with more P/Invoke code: https://github.com/dotnet/wpf/issues/6026#issuecomment-1051096657

Having a fix in WPF itself would be simpler for most customers.

## Regression

No.

## Testing

This is the cherry pick. Testing was done on the main branch by the original contributor.

## Risk

Legitimate failures of GetWindowText (too short a buffer? something else?) might incorrectly be ignored. However, if Window.Title is used as a fallback, the risk seems minimal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9378)