### PR TITLE
Replace boxing ArrayLists in UIAutomationClientSideProviders (hWnd proxies)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -15,12 +15,13 @@
 //                  AdviseEventAdded
 //                  AdviseEventRemoved
 
-using System;
-using System.Windows;
-using System.Windows.Automation;
 using System.Windows.Automation.Provider;
+using System.Runtime.InteropServices;
 using System.Collections.Generic;
+using System.Windows.Automation;
+using System.Windows;
 using MS.Win32;
+using System;
 
 namespace MS.Internal.AutomationProxies
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -68,24 +68,23 @@ namespace MS.Internal.AutomationProxies
                 return;
             }
 
-            int cEvents = 0;
             ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents;
 
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)
             {
-                aEvents = PropertyToWinEvent (aidProps, out cEvents);
+                aEvents = PropertyToWinEvent(aidProps, out _);
             }
             else
             {
-                aEvents = EventToWinEvent (eventId, out cEvents);
+                aEvents = EventToWinEvent(eventId, out _);
             }
 
             // If we have WinEvents to trap, add those to the list of WinEvent
             // notification list
-            if (cEvents > 0)
+            if (aEvents.Length > 0)
             {
-                WinEventTracker.AddToNotificationList (_hwnd, _createOnEvent, aEvents, cEvents);
+                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents);
             }
         }
 
@@ -98,24 +97,23 @@ namespace MS.Internal.AutomationProxies
                 return;
             }
 
-            int cEvents;
             ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents;
 
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)
             {
-                aEvents = PropertyToWinEvent (aidProps, out cEvents);
+                aEvents = PropertyToWinEvent(aidProps, out _);
             }
             else
             {
-                aEvents = EventToWinEvent (eventId, out cEvents);
+                aEvents = EventToWinEvent(eventId, out _);
             }
 
             // If we have WinEvents to remove, remive those to the list of WinEvent
             // notification list
-            if (cEvents > 0)
+            if (aEvents.Length > 0)
             {
-                WinEventTracker.RemoveToNotificationList (_hwnd, aEvents, null, cEvents);
+                WinEventTracker.RemoveToNotificationList(_hwnd, aEvents, null);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -69,7 +69,7 @@ namespace MS.Internal.AutomationProxies
             }
 
             int cEvents = 0;
-            WinEventTracker.EvtIdProperty [] aEvents;
+            ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents;
 
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)
@@ -99,7 +99,7 @@ namespace MS.Internal.AutomationProxies
             }
 
             int cEvents;
-            WinEventTracker.EvtIdProperty [] aEvents;
+            ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents;
 
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.AutomationProxies
 
         // Advises proxy that an event has been added.
         // Maps the Automation Events into WinEvents and add those to the list of WinEvents notification hooks
-        internal virtual void AdviseEventAdded (AutomationEvent eventId, AutomationProperty [] aidProps)
+        internal virtual void AdviseEventAdded(AutomationEvent eventId, AutomationProperty[] aidProps)
         {
             // No RawElementBase creation callback, exit from here
             if (_createOnEvent == null)
@@ -73,11 +73,11 @@ namespace MS.Internal.AutomationProxies
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)
             {
-                aEvents = PropertyToWinEvent(aidProps, out _);
+                aEvents = PropertyToWinEvent(aidProps);
             }
             else
             {
-                aEvents = EventToWinEvent(eventId, out _);
+                aEvents = EventToWinEvent(eventId);
             }
 
             // If we have WinEvents to trap, add those to the list of WinEvent
@@ -102,11 +102,11 @@ namespace MS.Internal.AutomationProxies
             // Gets an Array of WinEvents to trap on a per window handle basis
             if (eventId == AutomationElement.AutomationPropertyChangedEvent)
             {
-                aEvents = PropertyToWinEvent(aidProps, out _);
+                aEvents = PropertyToWinEvent(aidProps);
             }
             else
             {
-                aEvents = EventToWinEvent(eventId, out _);
+                aEvents = EventToWinEvent(eventId);
             }
 
             // If we have WinEvents to remove, remive those to the list of WinEvent
@@ -394,29 +394,27 @@ namespace MS.Internal.AutomationProxies
         }
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        protected virtual WinEventTracker.EvtIdProperty [] EventToWinEvent (AutomationEvent idEvent, out int cEvent)
+        protected virtual ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             // Fill this variable with a WinEvent id if found
-            int idWinEvent = 0;
+            int idWinEvent;
 
             if (idEvent == SelectionItemPattern.ElementSelectedEvent)
             {
-                cEvent = 2;
                 return new WinEventTracker.EvtIdProperty[2]
                 {
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectSelection, idEvent), 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectStateChange, idEvent)
+                    new(NativeMethods.EventObjectSelection, idEvent), 
+                    new(NativeMethods.EventObjectStateChange, idEvent)
                 };
             }
             else if (idEvent == SelectionItemPattern.ElementAddedToSelectionEvent)
             {
                 // For some control, the Event Selection is sent instead of SelectionAdd
                 // Trap both.
-                cEvent = 2;
                 return new WinEventTracker.EvtIdProperty [2]
                 {
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectSelectionAdd, idEvent), 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectSelection, idEvent)
+                    new(NativeMethods.EventObjectSelectionAdd, idEvent), 
+                    new(NativeMethods.EventObjectSelection, idEvent)
                 };
             }
             else if (idEvent == SelectionItemPattern.ElementRemovedFromSelectionEvent)
@@ -429,40 +427,35 @@ namespace MS.Internal.AutomationProxies
             }
             else if (idEvent == InvokePattern.InvokedEvent)
             {
-                cEvent = 4;
                 return new WinEventTracker.EvtIdProperty[4] { 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventSystemCaptureEnd, idEvent), // For SysHeaders
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectStateChange, idEvent),
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectValueChange, idEvent), // For WindowsScrollBarBits
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectInvoke, idEvent)
+                    new(NativeMethods.EventSystemCaptureEnd, idEvent), // For SysHeaders
+                    new(NativeMethods.EventObjectStateChange, idEvent),
+                    new(NativeMethods.EventObjectValueChange, idEvent), // For WindowsScrollBarBits
+                    new(NativeMethods.EventObjectInvoke, idEvent)
                 };
             }
             else if (idEvent == AutomationElement.StructureChangedEvent)
             {
-                cEvent = 3;
                 return new WinEventTracker.EvtIdProperty[3] { 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectCreate, idEvent), 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectDestroy, idEvent), 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectReorder, idEvent) 
+                    new(NativeMethods.EventObjectCreate, idEvent), 
+                    new(NativeMethods.EventObjectDestroy, idEvent), 
+                    new(NativeMethods.EventObjectReorder, idEvent) 
                 };
             }
             else if (idEvent == TextPattern.TextSelectionChangedEvent)
             {
-                cEvent = 2;
                 return new WinEventTracker.EvtIdProperty[2] {
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectLocationChange, idEvent),
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectTextSelectionChanged, idEvent)
+                    new(NativeMethods.EventObjectLocationChange, idEvent),
+                    new(NativeMethods.EventObjectTextSelectionChanged, idEvent)
                 };
             }
             else
             {
-                cEvent = 0;
-                return null;
+                return ReadOnlySpan<WinEventTracker.EvtIdProperty>.Empty;
             }
 
             // found one and only one
-            cEvent = 1;
-            return new WinEventTracker.EvtIdProperty [1] { new WinEventTracker.EvtIdProperty (idWinEvent, idEvent) };
+            return new WinEventTracker.EvtIdProperty [1] { new(idWinEvent, idEvent) };
         }
         
         // Check if a point is within the client Rect of a window
@@ -510,7 +503,7 @@ namespace MS.Internal.AutomationProxies
 
         // Builds a list of Win32 WinEvents to process changes in properties changes values.
         // Returns an array of Events to Set. The number of valid entries in this array is pass back in cEvents
-        private ReadOnlySpan<WinEventTracker.EvtIdProperty> PropertyToWinEvent(AutomationProperty[] aProps, out int cEvent)
+        private ReadOnlySpan<WinEventTracker.EvtIdProperty> PropertyToWinEvent(AutomationProperty[] aProps)
         {
             List<WinEventTracker.EvtIdProperty> automationEvents = new(16);
 
@@ -524,9 +517,6 @@ namespace MS.Internal.AutomationProxies
                 }
 
             }
-
-            //Assign OUT parameter
-            cEvent = automationEvents.Count;
 
             return CollectionsMarshal.AsSpan(automationEvents);
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -393,7 +393,9 @@ namespace MS.Internal.AutomationProxies
             return null;
         }
 
-        // Builds a list of Win32 WinEvents to process a UIAutomation Event.
+        /// <summary> Builds a list of Win32 WinEvents to process a UIAutomation Event. </summary>
+        /// <param name="idEvent"> An UIAutomation event. </param>
+        /// <returns> Returns an array of Events to Set. </returns>
         protected virtual ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             // Fill this variable with a WinEvent id if found

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -19,7 +19,7 @@ using System;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
-using System.Collections;
+using System.Collections.Generic;
 using MS.Win32;
 
 namespace MS.Internal.AutomationProxies

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxyHwnd.cs
@@ -512,29 +512,25 @@ namespace MS.Internal.AutomationProxies
 
         // Builds a list of Win32 WinEvents to process changes in properties changes values.
         // Returns an array of Events to Set. The number of valid entries in this array is pass back in cEvents
-        private WinEventTracker.EvtIdProperty [] PropertyToWinEvent (AutomationProperty [] aProps, out int cEvent)
+        private ReadOnlySpan<WinEventTracker.EvtIdProperty> PropertyToWinEvent(AutomationProperty[] aProps, out int cEvent)
         {
-            ArrayList alEvents = new ArrayList (16);
+            List<WinEventTracker.EvtIdProperty> automationEvents = new(16);
 
             foreach (AutomationProperty idProp in aProps)
             {
-                int [] evtId = PropertyToWinEvent (idProp);
+                int[] evtId = PropertyToWinEvent(idProp);
 
                 for (int i = 0; evtId != null && i < evtId.Length; i++)
                 {
-                    alEvents.Add (new WinEventTracker.EvtIdProperty (evtId [i], idProp));
+                    automationEvents.Add(new WinEventTracker.EvtIdProperty(evtId[i], idProp));
                 }
 
             }
 
-            WinEventTracker.EvtIdProperty [] aEvtIdProperties = new WinEventTracker.EvtIdProperty [alEvents.Count];
+            //Assign OUT parameter
+            cEvent = automationEvents.Count;
 
-            cEvent = alEvents.Count;
-            for (int i = 0; i < cEvent; i++)
-            {
-                aEvtIdProperties [i] = (WinEventTracker.EvtIdProperty) alEvents [i];
-            }
-            return aEvtIdProperties;
+            return CollectionsMarshal.AsSpan(automationEvents);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
@@ -44,7 +44,7 @@ namespace MS.Internal.AutomationProxies
         // Param name="raiseEvents" - function to call to create a raw element
         // Param name="aEvtIdProp"
         // Param name="cProps" - Number of valid props in the array
-        static internal void AddToNotificationList (IntPtr hwnd, ProxyRaiseEvents raiseEvents, EvtIdProperty[] aEvtIdProp, int cProps)
+        static internal void AddToNotificationList(IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp, int cProps)
         {
             GetCallbackQueue();
 
@@ -74,7 +74,7 @@ namespace MS.Internal.AutomationProxies
         // Param name="raiseEvents" - Callback, should be null for non system-wide events
         // Param name="aEvtIdProp"
         // Param name="cProps" - Number of valid props in the array
-        static internal void RemoveToNotificationList (IntPtr hwnd, EvtIdProperty[] aEvtIdProp, ProxyRaiseEvents raiseEvents, int cProps)
+        static internal void RemoveToNotificationList(IntPtr hwnd, ReadOnlySpan<EvtIdProperty> aEvtIdProp, ProxyRaiseEvents raiseEvents, int cProps)
         {
             // Remove the list of Event to Window List
             // NOTE: raiseEvents must be null in the case when event is not a system-wide event
@@ -337,7 +337,7 @@ namespace MS.Internal.AutomationProxies
         //      raiseEvents - function to call to create a raw element
         //      aEvtIdProp - Array of Tupples WinEvent and Automation properties
         //      cProps  - Number of valid props in the array
-        private static void BuildEventsList (EventFlag eFlag, IntPtr hwnd, ProxyRaiseEvents raiseEvents, EvtIdProperty[] aEvtIdProp, int cProps)
+        private static void BuildEventsList(EventFlag eFlag, IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp, int cProps)
         {
             // All operations in the list of events and windows handle must be atomic
             lock (_ahp)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WinEventTracker.cs
@@ -43,13 +43,12 @@ namespace MS.Internal.AutomationProxies
         // Param name="hwnd"
         // Param name="raiseEvents" - function to call to create a raw element
         // Param name="aEvtIdProp"
-        // Param name="cProps" - Number of valid props in the array
-        static internal void AddToNotificationList(IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp, int cProps)
+        static internal void AddToNotificationList(IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp)
         {
             GetCallbackQueue();
 
             // Build the list of Event to Window List
-            BuildEventsList (EventFlag.Add, hwnd, raiseEvents, aEvtIdProp, cProps);
+            BuildEventsList(EventFlag.Add, hwnd, raiseEvents, aEvtIdProp);
         }
 
 
@@ -73,12 +72,11 @@ namespace MS.Internal.AutomationProxies
         // Param name="hwnd"
         // Param name="raiseEvents" - Callback, should be null for non system-wide events
         // Param name="aEvtIdProp"
-        // Param name="cProps" - Number of valid props in the array
-        static internal void RemoveToNotificationList(IntPtr hwnd, ReadOnlySpan<EvtIdProperty> aEvtIdProp, ProxyRaiseEvents raiseEvents, int cProps)
+        static internal void RemoveToNotificationList(IntPtr hwnd, ReadOnlySpan<EvtIdProperty> aEvtIdProp, ProxyRaiseEvents raiseEvents)
         {
             // Remove the list of Event to Window List
             // NOTE: raiseEvents must be null in the case when event is not a system-wide event
-            BuildEventsList (EventFlag.Remove, hwnd, raiseEvents, aEvtIdProp, cProps);
+            BuildEventsList(EventFlag.Remove, hwnd, raiseEvents, aEvtIdProp);
         }
 
         #endregion
@@ -336,16 +334,13 @@ namespace MS.Internal.AutomationProxies
         //      hwnd
         //      raiseEvents - function to call to create a raw element
         //      aEvtIdProp - Array of Tupples WinEvent and Automation properties
-        //      cProps  - Number of valid props in the array
-        private static void BuildEventsList(EventFlag eFlag, IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp, int cProps)
+        private static void BuildEventsList(EventFlag eFlag, IntPtr hwnd, ProxyRaiseEvents raiseEvents, ReadOnlySpan<EvtIdProperty> aEvtIdProp)
         {
             // All operations in the list of events and windows handle must be atomic
             lock (_ahp)
             {
-                for (int i = 0; i < cProps; i++)
+                foreach(EvtIdProperty evtIdProp in aEvtIdProp)
                 {
-                    EvtIdProperty evtIdProp = aEvtIdProp[i];
-
                     // Map a property into a WinEventHookProperty
                     int evt = EventIdToIndex.BinarySearch(evtIdProp._evtId);
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsButton.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsButton.cs
@@ -282,19 +282,16 @@ namespace MS.Internal.AutomationProxies
         #region ProxyHwnd Overrides
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        protected override WinEventTracker.EvtIdProperty[] EventToWinEvent(AutomationEvent idEvent, out int cEvent)
+        protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             // For Vista, we only need register for EventObjectInvoke to handle InvokePattern.InvokedEvent.
             // For XP, we rely on state changes, handled in ProxyHwnd.EventToWinEvent().
             if (idEvent == InvokePattern.InvokedEvent && Environment.OSVersion.Version.Major >= 6)
             {
-                cEvent = 1;
-                return new WinEventTracker.EvtIdProperty[] { 
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectInvoke, idEvent)
-                };
+                return new WinEventTracker.EvtIdProperty[1] { new(NativeMethods.EventObjectInvoke, idEvent) };
             }
 
-            return base.EventToWinEvent(idEvent, out cEvent);
+            return base.EventToWinEvent(idEvent);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
@@ -303,13 +303,11 @@ namespace MS.Internal.AutomationProxies
                         // subscribe to edit-specific notifications, that would be presented as combo le event
                         // ValueAsString, ValueAsObject, IsReadOnly
                         // create array containing events that user is interested in
-                        WinEventTracker.EvtIdProperty [] editPortionEvents;
-                        int counter;
+                        ReadOnlySpan<WinEventTracker.EvtIdProperty> editPortionEvents = CreateEditPortionEvents(aidProps);
 
-                        CreateEditPortionEvents (out editPortionEvents, out counter, aidProps);
-                        if ( counter > 0 )
+                        if (editPortionEvents.Length > 0)
                         {
-                            WinEventTracker.AddToNotificationList( cbInfo.hwndItem, new WinEventTracker.ProxyRaiseEvents( EditPortionEvents ), editPortionEvents, counter );
+                            WinEventTracker.AddToNotificationList(cbInfo.hwndItem, new WinEventTracker.ProxyRaiseEvents(EditPortionEvents), editPortionEvents, editPortionEvents.Length);
                         }
                     }
                 }
@@ -341,13 +339,11 @@ namespace MS.Internal.AutomationProxies
                         // un-subscribe from edit-specific notifications
                         // ValueAsString, ValueAsObject, IsReadOnly
                         // create array containing events from which user wants to unsubscribe
-                        WinEventTracker.EvtIdProperty [] editPortionEvents;
-                        int counter;
+                        ReadOnlySpan<WinEventTracker.EvtIdProperty> editPortionEvents = CreateEditPortionEvents(aidProps);
 
-                        CreateEditPortionEvents (out editPortionEvents, out counter, aidProps);
-                        if ( counter > 0 )
+                        if (editPortionEvents.Length > 0)
                         {
-                            WinEventTracker.RemoveToNotificationList( cbInfo.hwndItem, editPortionEvents, null, counter );
+                            WinEventTracker.RemoveToNotificationList(cbInfo.hwndItem, editPortionEvents, null, editPortionEvents.Length);
                         }
                     }
                 }
@@ -799,40 +795,36 @@ namespace MS.Internal.AutomationProxies
 
         // Return an array that contains combo's edit portion specific events
         // These events will be remapped as combo box events
-        private static void CreateEditPortionEvents (out WinEventTracker.EvtIdProperty [] editPortionEvents, out int counter, AutomationProperty [] aidProps)
+        private static ReadOnlySpan<WinEventTracker.EvtIdProperty> CreateEditPortionEvents(AutomationProperty[] aidProps)
         {
             // count how many events to pass back for the edit part of combo
             int c = 0;
-            foreach ( AutomationProperty p in aidProps )
+            foreach (AutomationProperty p in aidProps)
             {
-                if ( p == ValuePattern.ValueProperty || p == ValuePattern.IsReadOnlyProperty )
+                if (p == ValuePattern.ValueProperty || p == ValuePattern.IsReadOnlyProperty)
                 {
                     c++;
                 }
             }
 
+            // no events to pass
             if (c == 0)
-            {
-                editPortionEvents = null;
-                counter = 0;
-                return;
-            }
+                return ReadOnlySpan<WinEventTracker.EvtIdProperty>.Empty;
 
-            // allocate array with the number of events from above
-            editPortionEvents = new WinEventTracker.EvtIdProperty[c];
+            // allocate an array with the number of events from above
+            WinEventTracker.EvtIdProperty[] editPortionEvents = new WinEventTracker.EvtIdProperty[c];
 
             c = 0;
-            foreach ( AutomationProperty p in aidProps )
+            foreach (AutomationProperty p in aidProps)
             {
-                if ( p == ValuePattern.ValueProperty || p == ValuePattern.IsReadOnlyProperty )
+                if (p == ValuePattern.ValueProperty || p == ValuePattern.IsReadOnlyProperty)
                 {
-                    editPortionEvents[c]._idProp = p;
                     editPortionEvents[c]._evtId = (p == ValuePattern.ValueProperty) ? NativeMethods.EventObjectValueChange : NativeMethods.EventObjectStateChange;
-                    c++;
+                    editPortionEvents[c]._idProp = p;
                 }
             }
 
-            counter = c;
+            return editPortionEvents;
         }
 
         // When _hwndEx is not IntPtr.Zero the control is a ComboBoxEx32 control.

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
@@ -821,6 +821,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     editPortionEvents[c]._evtId = (p == ValuePattern.ValueProperty) ? NativeMethods.EventObjectValueChange : NativeMethods.EventObjectStateChange;
                     editPortionEvents[c]._idProp = p;
+                    c++;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
@@ -307,7 +307,7 @@ namespace MS.Internal.AutomationProxies
 
                         if (editPortionEvents.Length > 0)
                         {
-                            WinEventTracker.AddToNotificationList(cbInfo.hwndItem, new WinEventTracker.ProxyRaiseEvents(EditPortionEvents), editPortionEvents, editPortionEvents.Length);
+                            WinEventTracker.AddToNotificationList(cbInfo.hwndItem, new WinEventTracker.ProxyRaiseEvents(EditPortionEvents), editPortionEvents);
                         }
                     }
                 }
@@ -343,7 +343,7 @@ namespace MS.Internal.AutomationProxies
 
                         if (editPortionEvents.Length > 0)
                         {
-                            WinEventTracker.RemoveToNotificationList(cbInfo.hwndItem, editPortionEvents, null, editPortionEvents.Length);
+                            WinEventTracker.RemoveToNotificationList(cbInfo.hwndItem, editPortionEvents, null);
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsEditBox.cs
@@ -250,9 +250,9 @@ namespace MS.Internal.AutomationProxies
         #region ProxyHwnd Overrides
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        protected override WinEventTracker.EvtIdProperty[] EventToWinEvent(AutomationEvent idEvent, out int cEvent)
+        protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
-            return base.EventToWinEvent(idEvent, out cEvent);
+            return base.EventToWinEvent(idEvent);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
@@ -66,9 +66,6 @@ namespace MS.Internal.AutomationProxies
         #region ProxyHwnd Interface
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        // Param name="idEvent", UIAuotmation event
-        // Param name="cEvent"out, number of winevent set in the array
-        // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent
         protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == InvokePattern.InvokedEvent)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsFormsLinkLabel.cs
@@ -69,15 +69,14 @@ namespace MS.Internal.AutomationProxies
         // Param name="idEvent", UIAuotmation event
         // Param name="cEvent"out, number of winevent set in the array
         // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent
-        protected override WinEventTracker.EvtIdProperty[] EventToWinEvent(AutomationEvent idEvent, out int cEvent)
+        protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == InvokePattern.InvokedEvent)
             {
-                cEvent = 1;
-                return new WinEventTracker.EvtIdProperty[1] { new WinEventTracker.EvtIdProperty(NativeMethods.EventSystemCaptureEnd, idEvent) };
+                return new WinEventTracker.EvtIdProperty[1] { new(NativeMethods.EventSystemCaptureEnd, idEvent) };
             }
 
-            return base.EventToWinEvent(idEvent, out cEvent);
+            return base.EventToWinEvent(idEvent);
         }
 
         #endregion ProxyHwnd Interface

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
@@ -125,15 +125,14 @@ namespace MS.Internal.AutomationProxies
         // Param name="idEvent", UIAuotmation event
         // Param name="cEvent"out, number of winevent set in the array
         // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent
-        protected override WinEventTracker.EvtIdProperty[] EventToWinEvent(AutomationEvent idEvent, out int cEvent)
+        protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == InvokePattern.InvokedEvent)
             {
-                cEvent = 1;
-                return new WinEventTracker.EvtIdProperty[1] { new WinEventTracker.EvtIdProperty(NativeMethods.EventSystemCaptureEnd, idEvent) };
+                return new WinEventTracker.EvtIdProperty[1] { new(NativeMethods.EventSystemCaptureEnd, idEvent) };
             }
 
-            return base.EventToWinEvent(idEvent, out cEvent);
+            return base.EventToWinEvent(idEvent);
         }
 
         #endregion ProxyHwnd Interface

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsHyperlink.cs
@@ -122,9 +122,6 @@ namespace MS.Internal.AutomationProxies
         #region ProxyHwnd Interface
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        // Param name="idEvent", UIAuotmation event
-        // Param name="cEvent"out, number of winevent set in the array
-        // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent
         protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == InvokePattern.InvokedEvent)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListBox.cs
@@ -453,7 +453,7 @@ namespace MS.Internal.AutomationProxies
                 // This array must be kept in sync with the array in PropertyToWinEvent
                 ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvtIdProperties = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, SelectionPattern.IsSelectionRequiredProperty)];
 
-                WinEventTracker.RemoveToNotificationList(hwnd, aEvtIdProperties, null, aEvtIdProperties.Length);
+                WinEventTracker.RemoveToNotificationList(hwnd, aEvtIdProperties, null);
                 el = wlb;
             }
             else if (eventId == NativeMethods.EventObjectSelection || eventId == NativeMethods.EventObjectSelectionRemove || eventId == NativeMethods.EventObjectSelectionAdd)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListBox.cs
@@ -451,7 +451,7 @@ namespace MS.Internal.AutomationProxies
             if ((eventId == NativeMethods.EventObjectSelection || eventId == NativeMethods.EventObjectSelectionAdd) && (idProp as AutomationProperty) == SelectionPattern.IsSelectionRequiredProperty)
             {
                 // This array must be kept in sync with the array in PropertyToWinEvent
-                WinEventTracker.EvtIdProperty[] aEvtIdProperties = new WinEventTracker.EvtIdProperty[] { new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, SelectionPattern.IsSelectionRequiredProperty) };
+                ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvtIdProperties = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, SelectionPattern.IsSelectionRequiredProperty)];
 
                 WinEventTracker.RemoveToNotificationList(hwnd, aEvtIdProperties, null, aEvtIdProperties.Length);
                 el = wlb;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
@@ -84,7 +84,7 @@ namespace MS.Internal.AutomationProxies
             _createOnEvent = new WinEventTracker.ProxyRaiseEvents (RaiseEvents);
 
             // internally track some of the lv events
-            WinEventTracker.AddToNotificationList (_hwnd, new WinEventTracker.ProxyRaiseEvents (WindowsListView.GroupSpecificEvents), _groupEvents, 3);
+            WinEventTracker.AddToNotificationList (_hwnd, new WinEventTracker.ProxyRaiseEvents (WindowsListView.GroupSpecificEvents), _groupEvents, _groupEvents.Length);
         }
 
         #endregion Constructors
@@ -496,8 +496,8 @@ namespace MS.Internal.AutomationProxies
                         if (hwndHeader != IntPtr.Zero && SafeNativeMethods.IsWindowVisible (hwndHeader))
                         {
                             WindowsSysHeader header = (WindowsSysHeader) WindowsSysHeader.Create (hwndHeader, 0);
-                            WinEventTracker.EvtIdProperty[] aEvents = new WinEventTracker.EvtIdProperty[] { new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty) };
-                            WinEventTracker.AddToNotificationList(hwndHeader, header._createOnEvent, aEvents, 1);
+                            ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty)];
+                            WinEventTracker.AddToNotificationList(hwndHeader, header._createOnEvent, aEvents, aEvents.Length);
                         }
                     }
                 }
@@ -505,8 +505,8 @@ namespace MS.Internal.AutomationProxies
 
             if (eventId == InvokePattern.InvokedEvent)
             {
-                WinEventTracker.EvtIdProperty[] aEvents = new WinEventTracker.EvtIdProperty[] { new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId) };
-                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, 1); 
+                ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId)];
+                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, aEvents.Length); 
             }
 
             base.AdviseEventAdded (eventId, aidProps);
@@ -525,8 +525,8 @@ namespace MS.Internal.AutomationProxies
                         if (hwndHeader != IntPtr.Zero && SafeNativeMethods.IsWindowVisible (hwndHeader))
                         {
                             WindowsSysHeader header = (WindowsSysHeader) WindowsSysHeader.Create (hwndHeader, 0);
-                            WinEventTracker.EvtIdProperty[] aEvents = new WinEventTracker.EvtIdProperty[] { new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty) };
-                            WinEventTracker.RemoveToNotificationList (hwndHeader, aEvents, header._createOnEvent, 1);
+                            ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty)];
+                            WinEventTracker.RemoveToNotificationList(hwndHeader, aEvents, header._createOnEvent, aEvents.Length);
                         }
                     }
                 }
@@ -534,8 +534,8 @@ namespace MS.Internal.AutomationProxies
 
             if (eventId == InvokePattern.InvokedEvent)
             {
-                WinEventTracker.EvtIdProperty[] aEvents = new WinEventTracker.EvtIdProperty[] { new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId) };
-                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, 1);
+                ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId)];
+                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, aEvents.Length);
             }
 
             base.AdviseEventRemoved(eventId, aidProps);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
@@ -84,7 +84,7 @@ namespace MS.Internal.AutomationProxies
             _createOnEvent = new WinEventTracker.ProxyRaiseEvents (RaiseEvents);
 
             // internally track some of the lv events
-            WinEventTracker.AddToNotificationList (_hwnd, new WinEventTracker.ProxyRaiseEvents (WindowsListView.GroupSpecificEvents), _groupEvents, _groupEvents.Length);
+            WinEventTracker.AddToNotificationList(_hwnd, new WinEventTracker.ProxyRaiseEvents (WindowsListView.GroupSpecificEvents), _groupEvents);
         }
 
         #endregion Constructors
@@ -497,7 +497,7 @@ namespace MS.Internal.AutomationProxies
                         {
                             WindowsSysHeader header = (WindowsSysHeader) WindowsSysHeader.Create (hwndHeader, 0);
                             ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty)];
-                            WinEventTracker.AddToNotificationList(hwndHeader, header._createOnEvent, aEvents, aEvents.Length);
+                            WinEventTracker.AddToNotificationList(hwndHeader, header._createOnEvent, aEvents);
                         }
                     }
                 }
@@ -506,7 +506,7 @@ namespace MS.Internal.AutomationProxies
             if (eventId == InvokePattern.InvokedEvent)
             {
                 ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId)];
-                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, aEvents.Length); 
+                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents); 
             }
 
             base.AdviseEventAdded (eventId, aidProps);
@@ -526,7 +526,7 @@ namespace MS.Internal.AutomationProxies
                         {
                             WindowsSysHeader header = (WindowsSysHeader) WindowsSysHeader.Create (hwndHeader, 0);
                             ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectCreate, TablePattern.ColumnHeadersProperty)];
-                            WinEventTracker.RemoveToNotificationList(hwndHeader, aEvents, header._createOnEvent, aEvents.Length);
+                            WinEventTracker.RemoveToNotificationList(hwndHeader, aEvents, header._createOnEvent);
                         }
                     }
                 }
@@ -535,7 +535,7 @@ namespace MS.Internal.AutomationProxies
             if (eventId == InvokePattern.InvokedEvent)
             {
                 ReadOnlySpan<WinEventTracker.EvtIdProperty> aEvents = [new WinEventTracker.EvtIdProperty(NativeMethods.EventObjectSelection, eventId)];
-                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents, aEvents.Length);
+                WinEventTracker.AddToNotificationList(_hwnd, _createOnEvent, aEvents);
             }
 
             base.AdviseEventRemoved(eventId, aidProps);
@@ -1149,7 +1149,7 @@ namespace MS.Internal.AutomationProxies
                         if (_groupsCollection.Contains (hwnd))
                         {
                             _groupsCollection.Remove (hwnd);
-                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null, _groupEvents.Length);
+                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null);
                         }
                     }
                     break;
@@ -1165,7 +1165,7 @@ namespace MS.Internal.AutomationProxies
                         if (_groupsCollection.Contains (hwnd) && !SafeNativeMethods.IsWindowVisible (hwnd) && !SafeNativeMethods.IsWindowEnabled (hwnd))
                         {
                             _groupsCollection.Remove (hwnd);
-                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null, _groupEvents.Length);
+                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null);
                         }
                     }
                     break;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
@@ -1149,7 +1149,7 @@ namespace MS.Internal.AutomationProxies
                         if (_groupsCollection.Contains (hwnd))
                         {
                             _groupsCollection.Remove (hwnd);
-                            WinEventTracker.RemoveToNotificationList (hwnd, _groupEvents, null, 3);
+                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null, _groupEvents.Length);
                         }
                     }
                     break;
@@ -1165,7 +1165,7 @@ namespace MS.Internal.AutomationProxies
                         if (_groupsCollection.Contains (hwnd) && !SafeNativeMethods.IsWindowVisible (hwnd) && !SafeNativeMethods.IsWindowEnabled (hwnd))
                         {
                             _groupsCollection.Remove (hwnd);
-                            WinEventTracker.RemoveToNotificationList (hwnd, _groupEvents, null, 3);
+                            WinEventTracker.RemoveToNotificationList(hwnd, _groupEvents, null, _groupEvents.Length);
                         }
                     }
                     break;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -457,7 +457,7 @@ namespace MS.Internal.AutomationProxies
             if (MenuRelatedEvent(eventId, aidProps))
             {
                 // Sytem wide event register with hwnd == IntPtr.Zero
-                WinEventTracker.AddToNotificationList(IntPtr.Zero, new WinEventTracker.ProxyRaiseEvents(MenuEvents), _menuEvents, _menuEvents.Length);
+                WinEventTracker.AddToNotificationList(IntPtr.Zero, new WinEventTracker.ProxyRaiseEvents(MenuEvents), _menuEvents);
 
                 // Keep counter of how many requests came so we will know when to remove ourselves from the notification list
                 // We need a counter since system wide events are not based on the hwnd.
@@ -478,7 +478,7 @@ namespace MS.Internal.AutomationProxies
                 --_eventListeners;
                 if (_eventListeners == 0 && MenuRelatedEvent (eventId, aidProps))
                 {
-                    WinEventTracker.RemoveToNotificationList (IntPtr.Zero, _menuEvents, new WinEventTracker.ProxyRaiseEvents (MenuEvents), _menuEvents.Length);
+                    WinEventTracker.RemoveToNotificationList(IntPtr.Zero, _menuEvents, new WinEventTracker.ProxyRaiseEvents(MenuEvents));
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
@@ -316,10 +316,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     // Register for UpDown ValueChange WinEvents, which will be
                     // translated to scrolling events for the tab control.
-                    WinEventTracker.AddToNotificationList(
-                        upDownHwnd,
-                        new WinEventTracker.ProxyRaiseEvents(UpDownControlRaiseEvents),
-                        _upDownEvents, _upDownEvents.Length);
+                    WinEventTracker.AddToNotificationList(upDownHwnd, new WinEventTracker.ProxyRaiseEvents(UpDownControlRaiseEvents), _upDownEvents);
                 }
             }
 
@@ -336,8 +333,7 @@ namespace MS.Internal.AutomationProxies
                 IntPtr upDownHwnd = GetUpDownHwnd();
                 if (upDownHwnd != IntPtr.Zero)
                 {
-                    WinEventTracker.RemoveToNotificationList(
-                        upDownHwnd, _upDownEvents, null, 1);
+                    WinEventTracker.RemoveToNotificationList(upDownHwnd, _upDownEvents, null);
                 }
             }
             base.AdviseEventRemoved(eventId, aidProps);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTab.cs
@@ -319,7 +319,7 @@ namespace MS.Internal.AutomationProxies
                     WinEventTracker.AddToNotificationList(
                         upDownHwnd,
                         new WinEventTracker.ProxyRaiseEvents(UpDownControlRaiseEvents),
-                        _upDownEvents, 1);
+                        _upDownEvents, _upDownEvents.Length);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
@@ -87,7 +87,7 @@ namespace MS.Internal.AutomationProxies
             else if( eventId == AutomationElement.ToolTipClosedEvent )
             {
                 // subscribe to ToolTip specific events, keeping track of how many times the event has been added
-                WinEventTracker.AddToNotificationList( IntPtr.Zero, new WinEventTracker.ProxyRaiseEvents( OnToolTipEvents ), _toolTipEventIds, _toolTipEventIds.Length );
+                WinEventTracker.AddToNotificationList(IntPtr.Zero, new WinEventTracker.ProxyRaiseEvents(OnToolTipEvents), _toolTipEventIds);
                 _listenerCount++;
             }
         }
@@ -104,7 +104,7 @@ namespace MS.Internal.AutomationProxies
             {
                 // decrement the event counter
                 --_listenerCount;
-                WinEventTracker.RemoveToNotificationList( IntPtr.Zero, _toolTipEventIds, new WinEventTracker.ProxyRaiseEvents( OnToolTipEvents ), _toolTipEventIds.Length );
+                WinEventTracker.RemoveToNotificationList(IntPtr.Zero, _toolTipEventIds, new WinEventTracker.ProxyRaiseEvents(OnToolTipEvents));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTreeView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTreeView.cs
@@ -344,19 +344,19 @@ namespace MS.Internal.AutomationProxies
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
         // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent.
-        protected override WinEventTracker.EvtIdProperty [] EventToWinEvent (AutomationEvent idEvent, out int cEvent)
+        protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == AutomationElement.StructureChangedEvent)
             {
-                cEvent = 3;
-                return new WinEventTracker.EvtIdProperty [3] {
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectStateChange, idEvent),
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectCreate, idEvent),
-                    new WinEventTracker.EvtIdProperty (NativeMethods.EventObjectDestroy, idEvent)
+                return new WinEventTracker.EvtIdProperty [3]
+                {
+                    new(NativeMethods.EventObjectStateChange, idEvent),
+                    new(NativeMethods.EventObjectCreate, idEvent),
+                    new(NativeMethods.EventObjectDestroy, idEvent)
                 };
             }
 
-            return base.EventToWinEvent (idEvent, out cEvent);
+            return base.EventToWinEvent(idEvent);
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTreeView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTreeView.cs
@@ -343,12 +343,11 @@ namespace MS.Internal.AutomationProxies
         }
 
         // Builds a list of Win32 WinEvents to process a UIAutomation Event.
-        // Returns an array of Events to Set. The number of valid entries in this array pass back in cEvent.
         protected override ReadOnlySpan<WinEventTracker.EvtIdProperty> EventToWinEvent(AutomationEvent idEvent)
         {
             if (idEvent == AutomationElement.StructureChangedEvent)
             {
-                return new WinEventTracker.EvtIdProperty [3]
+                return new WinEventTracker.EvtIdProperty[3]
                 {
                     new(NativeMethods.EventObjectStateChange, idEvent),
                     new(NativeMethods.EventObjectCreate, idEvent),


### PR DESCRIPTION
## Description

This should be one of the last boxing `ArrayList` that are still left.

- Adds `System.Collections` reference to `UIAutomationClientSideProviders` to allow for generic collections in the first place.
- Removes two boxing `ArrayList` instances, for `EvtIdProperty` (main method in `ProxyHwnd.PropertyToWinEvent`) structs and `EventCreateParams` (struct was made internal) — main method in `(WinEventTracker.WinEventProc`).
- Afterwards removes out params for the functions that contain Length of the array as it is not needed (`Length` is contained within `ReadOnlySpan<T>`).
- Modifiers the call chains to work with `ReadOnlySpan<T>` to take advantage of `CollectionsMarshal`.
- Also removes few unnecessary heap array allocations and uses InlineArrays instead.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9388)