### PR TITLE
Remove redundant Guid-init from array/alloc in NotificationWindowHelper

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2581,7 +2581,7 @@ namespace System.Windows.Interop
                                                 IntPtr.Zero,
                                                 wrapperHooks);
 
-                    Guid monitorGuid = new Guid(NativeMethods.GUID_MONITOR_POWER_ON.ToByteArray());
+                    Guid monitorGuid = NativeMethods.GUID_MONITOR_POWER_ON;
                     unsafe
                     {
                         _hPowerNotify = UnsafeNativeMethods.RegisterPowerSettingNotification(_notificationHwnd.Handle, &monitorGuid, 0);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2530,18 +2530,8 @@ namespace System.Windows.Interop
         {
             #region Data
 
-            /// <SecurityNode>
-            ///     Critical: We dont want _notificationHwnd to be exposed and used
-            ///         by anyone besides this class.
-            /// </SecurityNode>
             private HwndWrapper _notificationHwnd; // The hwnd used to listen system wide messages
-
-            /// <SecurityNode>
-            ///     Critical: _notificationHook is the hook to listen to window
-            ///         messages. We want this to be critical that no one can get it
-            ///         listen to window messages.
-            /// </SecurityNode>
-            private HwndWrapperHook _notificationHook;
+            private HwndWrapperHook _notificationHook; // The hwnd hook to listen to window messages
 
             private int _hwndTargetCount;
             public event EventHandler<MonitorPowerEventArgs> MonitorPowerEvent;
@@ -2551,10 +2541,6 @@ namespace System.Windows.Interop
 
             #endregion
 
-            /// <SecurityNode>
-            ///     Critical: Calls critical code.
-            ///     TreatAsSafe: Doesn't expose the critical resource.
-            /// </SecurityNode>
             public NotificationWindowHelper()
             {
                 // Check for Vista or newer is needed for RegisterPowerSettingNotification.
@@ -2589,10 +2575,6 @@ namespace System.Windows.Interop
                 }
             }
 
-            /// <SecurityNode>
-            ///     Critical: Calls critical code.
-            ///     TreatAsSafe: Doesn't expose the critical resource.
-            /// </SecurityNode>
             public void Dispose()
             {
                 if (_hPowerNotify != IntPtr.Zero)
@@ -2612,10 +2594,6 @@ namespace System.Windows.Interop
                 }
             }
 
-            /// <SecurityNode>
-            ///     Critical: Calls critical code.
-            ///     TreatAsSafe: Doesn't expose the critical resource.
-            /// </SecurityNode>
             public void AttachHwndTarget(HwndTarget hwndTarget)
             {
                 Debug.Assert(hwndTarget != null);
@@ -2633,10 +2611,6 @@ namespace System.Windows.Interop
                 _hwndTargetCount++;
             }
 
-            /// <SecurityNode>
-            ///     Critical: Calls critical code.
-            ///     TreatAsSafe: Doesn't expose the critical resource.
-            /// </SecurityNode>
             public bool DetachHwndTarget(HwndTarget hwndTarget)
             {
                 Debug.Assert(hwndTarget != null);


### PR DESCRIPTION
## Description

Removes redundant `byte[]` allocation caused by static `Guid` conversion to `byte[]` and initializing from such.
This way it is simply `vmovups` copy -> `lea` to push stack address as expected.

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|
| Original | 0.8887 ns |  0.0198 ns |   0.0175 ns |      - |             - |
| PR__Edit | 4.6857 ns |  0.1146 ns |   0.0957 ns | 0.0024 |          40 B |

Also removes some obsolete code security notes from the classes that were leftover from previous PRs (second commit).

## Customer Impact

Improved performance, decreased allocation.

## Regression

No.

## Testing

Local build; functionality verified.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9394)