### PR TITLE
Simplify CriticalCopyPixels in BitmapSource by removing duplicate type checks

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows.Media.Composition;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.IO;
 using MS.Internal;
-using System.Runtime.InteropServices;
-using System.Windows.Media.Composition;
 using MS.Win32;
 
 using UnsafeNativeMethods = MS.Win32.PresentationCore.UnsafeNativeMethods;
@@ -663,43 +664,13 @@ namespace System.Windows.Media.Imaging
 
             int destBufferSize = checked(elementSize * (pixels.Length - offset));
 
+            // Check whether offset is out of bounds manually
+            if (offset >= pixels.Length)
+                throw new IndexOutOfRangeException();
 
-            if (pixels is byte[])
-            {
-                fixed (void* pixelArray = &((byte[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is short[])
-            {
-                fixed (void* pixelArray = &((short[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is ushort[])
-            {
-                fixed (void* pixelArray = &((ushort[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is int[])
-            {
-                fixed (void* pixelArray = &((int[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is uint[])
-            {
-                fixed (void* pixelArray = &((uint[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is float[])
-            {
-                fixed (void* pixelArray = &((float[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-            else if (pixels is double[])
-            {
-                fixed (void* pixelArray = &((double[])pixels)[offset])
-                    CriticalCopyPixels(sourceRect, (IntPtr)pixelArray, destBufferSize, stride);
-            }
-}
+            fixed (byte* pixelArray = &Unsafe.AddByteOffset(ref MemoryMarshal.GetArrayDataReference(pixels), (nint)offset * elementSize))
+                CriticalCopyPixels(sourceRect, (nint)pixelArray, destBufferSize, stride);
+        }
 
         /// <summary>
         /// CriticalCopyPixels


### PR DESCRIPTION
## Description

Removes redundant type checks second-time around when copying pixels in `CriticalCopyPixels`. There's a small performance improvement, however, the main goal here is decreasing code size, and also code simplification that has been made possible with the introduction of `GetArrayDataReference` few releases ago.

Since `Unsafe.AddByteOffset` won't do an index-out-of-bounds check for us, we do it ourselves to keep the same behaviour as previously, throwing `IndexOutOfRangeException` on when `offset` exceeds the array length.

## Customer Impact

Smaller code-size of PresentationCore.

## Regression

No.

## Testing

Local build.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9395)