### PR TITLE
Enabling Fluent theme in Windows 10

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -132,7 +132,7 @@ internal static class ThemeManager
     /// <returns></returns>
     private static bool SetImmersiveDarkMode(Window window, bool useDarkMode)
     {
-        if (window == null)
+        if (window == null || !Utility.IsOSWindows11OrNewer)
         {
             return false;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -2515,7 +2515,7 @@ namespace System.Windows
                 UnsafeNativeMethods.ChangeWindowMessageFilterEx(_swh.CriticalHandle, WindowMessage.WM_COMMAND, MSGFLT.ALLOW, out info);
             }
 
-            if (Standard.Utility.IsOSWindows11OrNewer && ThemeManager.IsFluentThemeEnabled)
+            if (Standard.Utility.IsOSWindows10OrNewer && ThemeManager.IsFluentThemeEnabled)
             {
                 ThemeManager.InitializeFluentTheme();
                 ThemeManager.ApplySystemTheme(this, true);


### PR DESCRIPTION
## Description
The current implementation of `Fluent` themes does not work in Windows 10. The following changes makes the control styles and theme effects affective for windows 10 as well. 
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Customers will be able to use Fluent themes in Windows 10 by including the Fluent resource dictionary as they could have in windows 11.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing
<!-- What kind of testing has been done with the fix. -->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9407)