### PR TITLE
Combining backdrop disabled and default window styles

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3583,14 +3583,7 @@ namespace System.Windows
             // TODO : Remove when Fluent theme is enabled by default
             if (ThemeManager.IsFluentThemeEnabled)
             {
-                if(WindowBackdropManager.IsBackdropEnabled)
-                {
-                    SetResourceReference(StyleProperty, typeof(Window));
-                }
-                else
-                {
-                    SetResourceReference(StyleProperty, "BackdropDisabledWindowStyle");
-                }
+                SetResourceReference(StyleProperty, typeof(Window));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Window.xaml
@@ -8,6 +8,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:framework="clr-namespace:MS.Internal;assembly=PresentationFramework"
     xmlns:controls="clr-namespace:Fluent.Controls">
 
     <ControlTemplate x:Key="WindowTemplateKey"
@@ -71,11 +72,13 @@
                 <Setter Property="Template"
                         Value="{StaticResource WindowTemplateKey}"/>
             </Trigger>
+            <DataTrigger Binding="{Binding Path=(SystemParameters.HighContrast)}" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=(framework:FrameworkAppContextSwitches.DisableFluentThemeWindowBackdrop)}" Value="True">
+                <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
+            </DataTrigger>  
         </Style.Triggers>
-    </Style>
-
-    <Style x:Key="BackdropDisabledWindowStyle" BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" >
-        <Setter Property="Background" Value="{DynamicResource WindowBackground}" />
     </Style>
 
     <Style BasedOn="{StaticResource DefaultWindowStyle}" TargetType="{x:Type Window}" />


### PR DESCRIPTION
## Description
Until now, we had two different styles for Window, one for Highcontrast and when backdrop is disabled and other one that is used in the normal scenario. 

## Customer Impact
We don't need to handle two different styles for Window in Fluent theme.

## Regression
N/A

## Testing
Local testing with WPF Gallery application.

## Risk
N/A
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9425)