### PR TITLE
Remove Redundant Semicolons

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeRenderer.cs
@@ -317,7 +317,7 @@ namespace MS.Internal.Ink
                                     //  | |----|     |
                                     //  |------------|
                                     //
-                                    prevPrevStrokeNode = iterator[index - 1, prevPrevStrokeNode.Index - 1]; ;
+                                    prevPrevStrokeNode = iterator[index - 1, prevPrevStrokeNode.Index - 1];
                                     prevPrevStrokeNodeBounds = Rect.Union(prevStrokeNodeBounds, prevPrevStrokeNodeBounds);
 
                                     // at this point prevPrevStrokeNodeBounds already contains this node

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Command/MouseGestureConverter.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Input
                 string modifiersToken;
 
                 if (fullName.Length == 0)
-                    return new MouseGesture(MouseAction.None, ModifierKeys.None); ;
+                    return new MouseGesture(MouseAction.None, ModifierKeys.None);
 
                 // break apart LocalName and Prefix
                 int Offset = fullName.LastIndexOf(MODIFIERS_DELIMITER);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Input.StylusWisp
         {
             Statistics.FeaturesUsed |= StylusTraceLogger.FeatureFlags.WispStackEnabled;
 
-            _inputManager = new SecurityCriticalData<InputManager>(inputManager); ;
+            _inputManager = new SecurityCriticalData<InputManager>(inputManager);
             _inputManager.Value.PreProcessInput += new PreProcessInputEventHandler(PreProcessInput);
             _inputManager.Value.PreNotifyInput += new NotifyInputEventHandler(PreNotifyInput);
             _inputManager.Value.PostProcessInput += new ProcessInputEventHandler(PostProcessInput);
@@ -885,7 +885,7 @@ namespace System.Windows.Input.StylusWisp
                         else if (input.Report.Type == InputType.Stylus)
                         {
                             RawStylusInputReport stylusInputReport = (RawStylusInputReport)input.Report;
-                            WispStylusDevice stylusDevice = stylusInputReport?.StylusDevice?.As<WispStylusDevice>(); ; // RTI sets this if it finds StylusDevice based on Id.
+                            WispStylusDevice stylusDevice = stylusInputReport?.StylusDevice?.As<WispStylusDevice>(); // RTI sets this if it finds StylusDevice based on Id.
                             bool cancelInput = true; // Only process if we see we have valid input data.
 
                             if (stylusInputReport.InputSource != null && stylusInputReport.PenContext != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2037,7 +2037,7 @@ namespace System.Windows.Interop
         {
             get
             {
-                return OSVersionHelper.IsOsWindows10RS1OrGreater; ;
+                return OSVersionHelper.IsOsWindows10RS1OrGreater;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/FontFamilyConverter.cs
@@ -126,7 +126,7 @@ namespace System.Windows.Media
 
                 return new FontFamily(baseUri, s);
             }
-            return base.ConvertFrom(context, cultureInfo, o); ;
+            return base.ConvertFrom(context, cultureInfo, o);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -220,7 +220,7 @@ namespace System.Windows
                     }
                     if (info == null || info.Count == 0)
                     {
-                        uie.VisualAncestorChanged -= new Visual.AncestorChangedEventHandler(uie.OnVisualAncestorChanged); ;
+                        uie.VisualAncestorChanged -= new Visual.AncestorChangedEventHandler(uie.OnVisualAncestorChanged);
                         RemoveElementFromWatchList(uie);
                     }
                 }
@@ -234,7 +234,7 @@ namespace System.Windows
                     }
                     if (info == null || info.Count == 0)
                     {
-                        uie3D.VisualAncestorChanged -= new Visual.AncestorChangedEventHandler(uie3D.OnVisualAncestorChanged); ;
+                        uie3D.VisualAncestorChanged -= new Visual.AncestorChangedEventHandler(uie3D.OnVisualAncestorChanged);
                         RemoveElementFromWatchList(uie3D);
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/Journaling.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/Journaling.cs
@@ -272,7 +272,7 @@ namespace MS.Internal.AppModel
             : base(info, context)
         {
             _pageFunctionId = (Guid)info.GetValue("_pageFunctionId", typeof(Guid));
-            _parentPageFunctionId = (Guid)info.GetValue("_parentPageFunctionId", typeof(Guid)); ;
+            _parentPageFunctionId = (Guid)info.GetValue("_parentPageFunctionId", typeof(Guid));
         }
 
         //

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextAdaptor.cs
@@ -103,7 +103,7 @@ namespace MS.Internal.Automation
             {
                 if (!textView.Contains(start) && start.CompareTo(textSegments[0].Start) < 0)
                 {
-                    start = textSegments[0].Start.CreatePointer(); ;
+                    start = textSegments[0].Start.CreatePointer();
                 }
                 if (!textView.Contains(end) && end.CompareTo(textSegments[textSegments.Count-1].End) > 0)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -8641,7 +8641,7 @@ namespace System.Windows.Documents
                     {
                         // Read the windows metafile from the rtf content and then convert it
                         // to bitmap data then save it as PNG on the container image part
-                        MemoryStream metafileStream = new MemoryStream(); ;
+                        MemoryStream metafileStream = new MemoryStream();
 
                         using (metafileStream)
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextSelection.cs
@@ -841,12 +841,12 @@ namespace System.Windows.Documents
                 if (anchorWordRange.Start.CompareTo(cursorWordRange.Start) <= 0)
                 {
                     startPosition = anchorWordRange.Start.GetFrozenPointer(LogicalDirection.Forward);
-                    movingPosition = cursorWordRange.End.GetFrozenPointer(LogicalDirection.Backward); ;
+                    movingPosition = cursorWordRange.End.GetFrozenPointer(LogicalDirection.Backward);
                 }
                 else
                 {
                     startPosition = anchorWordRange.End.GetFrozenPointer(LogicalDirection.Backward);
-                    movingPosition = cursorWordRange.Start.GetFrozenPointer(LogicalDirection.Forward); ;
+                    movingPosition = cursorWordRange.Start.GetFrozenPointer(LogicalDirection.Forward);
                 }
 
                 // Note that we use includeCellAtMovingPosition=true because we want that hit-tested table cell

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfKnownMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfKnownMemberInvoker.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Baml2006
                 Type declaringType = _member.UnderlyingMember.DeclaringType;
                 string methodName = $"ShouldSerialize{_member.Name}";
                 BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
-                Type[] args = new Type[] { typeof(DependencyObject) }; ;
+                Type[] args = new Type[] { typeof(DependencyObject) };
                 if (_member.IsAttachable)
                 {
                     _shouldSerializeMethod = declaringType.GetMethod(methodName, flags, null, args, null);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfMemberInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/WpfMemberInvoker.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Baml2006
                 Type declaringType = _member.UnderlyingMember.DeclaringType;
                 string methodName = $"ShouldSerialize{_member.Name}";
                 BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
-                Type[] args = new Type[] { typeof(DependencyObject) }; ;
+                Type[] args = new Type[] { typeof(DependencyObject) };
                 if (_member.IsAttachable)
                 {
                     _shouldSerializeMethod = declaringType.GetMethod(methodName, flags, null, args, null);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
@@ -409,7 +409,7 @@ namespace System.Windows.Navigation
         /// </summary>
         internal Guid NavigationServiceId
         {
-            get { return _jeGroupState.NavigationServiceId; ; }
+            get { return _jeGroupState.NavigationServiceId; }
         }
 
         /// <summary>


### PR DESCRIPTION
Hi 🙂

This pull request removes unnecessary semicolons from the `PresentationCore` and `PresentationFramework` projects in the .NET WPF repository.

There is no risk to functionality from these changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9426)