### PR TITLE
Replace boxing ArrayLists in UIAutomationClientSideProviders (ClickablePoint)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -17,6 +17,7 @@ namespace MS.Internal.AutomationProxies
         /// </summary>
         static ClickablePoint()
         {
+            _hwndDesktop = UnsafeNativeMethods.GetDesktopWindow();
             _hwndProgman = Misc.FindWindowEx(IntPtr.Zero, IntPtr.Zero, "Progman", null);
             if (_hwndProgman == IntPtr.Zero)
             {
@@ -457,16 +458,16 @@ namespace MS.Internal.AutomationProxies
         }
 
         #endregion
-        
+
         #region Private fields
-        
+
         // Top level Desktop window
-        private static IntPtr _hwndDesktop = UnsafeNativeMethods.GetDesktopWindow();
+        private static readonly IntPtr _hwndDesktop;
 
         /// The WindowsRect for "Program" is the union for the real
         /// estate for all the monitors. Instead of doing clipping against the root of the hwnd
         /// tree that is the desktop. The last clipping should be done against the Progman hwnd.
-        private static IntPtr _hwndProgman;
+        private static readonly IntPtr _hwndProgman;
         
         #endregion Private fields
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
+using System.Collections.Generic;
 using MS.Win32;
+using System;
 
 namespace MS.Internal.AutomationProxies
 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -207,13 +207,13 @@ namespace MS.Internal.AutomationProxies
             }
 
             // return true if the 2 rectangle intersects
-            internal bool Intersect(ref CPRect ri)
+            internal readonly bool Intersect(ref CPRect ri)
             {
                 return !(_top >= ri._bottom || ri._top >= _bottom || _left >= ri._right || ri._left >= _right);
             }
 
             // return true if ri completely covers this
-            internal bool Overlap(ref CPRect ri)
+            internal readonly bool Overlap(ref CPRect ri)
             {
                 return (ri._left <= _left && ri._right >= _right && ri._top <= _top && ri._bottom >= _bottom);
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -155,9 +155,9 @@ namespace MS.Internal.AutomationProxies
                 SplitRect(listIn, ref rcp, listOut, true);
 
                 // recurse on the children
-                if (simple is ProxyFragment)
+                if (simple is ProxyFragment proxyFrag)
                 {
-                    ExcludeChildren((ProxyFragment)simple, listIn, listOut);
+                    ExcludeChildren(proxyFrag, listIn, listOut);
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -50,7 +50,7 @@ namespace MS.Internal.AutomationProxies
         /// <param name="alOut">Output list of Rectangles after the exclusion test</param>
         /// <param name="pt">Clickable Point</param>
         /// <returns>True if there is a clickable in ro</returns>
-        static internal bool GetPoint(IntPtr hwnd, ArrayList alIn, ArrayList alOut, ref NativeMethods.Win32Point pt)
+        static internal bool GetPoint(IntPtr hwnd, List<CPRect> alIn, List<CPRect> alOut, ref NativeMethods.Win32Point pt)
         {
             IntPtr hwndStart = hwnd;
             IntPtr hwndCurrent = hwnd;
@@ -133,7 +133,7 @@ namespace MS.Internal.AutomationProxies
         /// <param name="fragment"></param>
         /// <param name="alIn"></param>
         /// <param name="alOut"></param>
-        internal static void ExcludeChildren(ProxyFragment fragment, ArrayList alIn, ArrayList alOut)
+        internal static void ExcludeChildren(ProxyFragment fragment, List<CPRect> alIn, List<CPRect> alOut)
         {
             // First go through all the children to exclude whatever is on top
             for (ProxySimple simple = fragment.GetFirstChild(); simple != null; simple = fragment.GetNextSibling(simple))
@@ -151,7 +151,7 @@ namespace MS.Internal.AutomationProxies
                 NativeMethods.Win32Rect rc = new NativeMethods.Win32Rect(simple.BoundingRectangle);
                 CPRect rcp = new CPRect(ref rc, false);
 
-                ClickablePoint.SplitRect(alIn, ref rcp, alOut, true);
+                SplitRect(alIn, ref rcp, alOut, true);
 
                 // recurse on the children
                 if (simple is ProxyFragment)
@@ -228,7 +228,7 @@ namespace MS.Internal.AutomationProxies
 
         #region Private Methods
 
-        private static bool ClickableInRect(IntPtr hwnd, ref NativeMethods.Win32Point pt, bool fRiAsInsideRect, ArrayList alIn, ArrayList alOut)
+        private static bool ClickableInRect(IntPtr hwnd, ref NativeMethods.Win32Point pt, bool fRiAsInsideRect, List<CPRect> alIn, List<CPRect> alOut)
         {
             if (!SafeNativeMethods.IsWindowVisible(hwnd))
             {
@@ -275,7 +275,7 @@ namespace MS.Internal.AutomationProxies
 
             CPRect rcp = new CPRect(ref rc, false);
 
-            ClickablePoint.SplitRect(alIn, ref rcp, alOut, fRiAsInsideRect);
+            SplitRect(alIn, ref rcp, alOut, fRiAsInsideRect);
             if (!GetClickablePoint(alOut, out pt.x, out pt.y))
             {
                 return false;
@@ -296,7 +296,7 @@ namespace MS.Internal.AutomationProxies
         /// <param name="right">Right Margin for the resulting rectangles</param>
         /// <param name="alRect">Array of resulting rectangles</param>
         /// <param name="fRiAsInsideRect">Covered flag</param>
-        static private void SplitVertical(ref CPRect ro, ref CPRect ri, int left, int right, ArrayList alRect, bool fRiAsInsideRect)
+        static private void SplitVertical(ref CPRect ro, ref CPRect ri, int left, int right, List<CPRect> alRect, bool fRiAsInsideRect)
         {
             // bottom clip
             if (ri._bottom > ro._bottom)
@@ -350,7 +350,7 @@ namespace MS.Internal.AutomationProxies
         /// <param name="ri">Inside Rectangle</param>
         /// <param name="alRect">Collection of resulting rectangles</param>
         /// <param name="fRiAsInsideRect"></param>
-        static private void SplitRect(ref CPRect ro, CPRect ri, ArrayList alRect, bool fRiAsInsideRect)
+        static private void SplitRect(ref CPRect ro, CPRect ri, List<CPRect> alRect, bool fRiAsInsideRect)
         {
             // If ri is fully outside easy way out.
             if (!ro._fNotCovered || !ro.Intersect(ref ri))
@@ -413,12 +413,12 @@ namespace MS.Internal.AutomationProxies
         /// <param name="alOut">New sets of reactangle</param>
         /// <param name="fRiAsInsideRect">Input Rectangle is rectangle covering alIn Rects or everything
         ///                               outside of ri must be marked as covered</param>
-        static private void SplitRect(ArrayList alIn, ref CPRect ri, ArrayList alOut, bool fRiAsInsideRect)
+        static private void SplitRect(List<CPRect> alIn, ref CPRect ri, List<CPRect> alOut, bool fRiAsInsideRect)
         {
             alOut.Clear();
-            for (int i = 0, c = alIn.Count; i < c; i++)
+            for (int i = 0; i < alIn.Count; i++)
             {
-                CPRect ro = (CPRect)alIn[i];
+                CPRect ro = alIn[i];
 
                 SplitRect(ref ro, ri, alOut, fRiAsInsideRect);
             }
@@ -433,11 +433,11 @@ namespace MS.Internal.AutomationProxies
         /// <param name="x">X coordinate for a clickable point</param>
         /// <param name="y">Y coordinate for a clickable point</param>
         /// <returns>Clickable point found</returns>
-        static private bool GetClickablePoint(ArrayList al, out int x, out int y)
+        static private bool GetClickablePoint(List<CPRect> al, out int x, out int y)
         {
             for (int i = 0, c = al.Count; i < c; i++)
             {
-                CPRect r = (CPRect)al[i];
+                CPRect r = al[i];
 
                 if (r._fNotCovered == true && (r._right - r._left) * (r._bottom - r._top) > 0)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ClickablePoint.cs
@@ -11,8 +11,8 @@ namespace MS.Internal.AutomationProxies
     static internal class ClickablePoint
     {
         /// <summary>
-        /// Static Constructor. Retrieve and keeps the hwnd for "Program"
-        /// The Windows Rectangle for "Program"  is the union for the real
+        /// Static Constructor. Retrieve and keeps the hwnd for "Progman"
+        /// The Windows Rectangle for "Progman" is the union for the real
         /// Estate for all the monitors.
         /// </summary>
         static ClickablePoint()
@@ -464,7 +464,7 @@ namespace MS.Internal.AutomationProxies
         // Top level Desktop window
         private static readonly IntPtr _hwndDesktop;
 
-        /// The WindowsRect for "Program" is the union for the real
+        /// The WindowsRect for "Progman" is the union for the real
         /// estate for all the monitors. Instead of doing clipping against the root of the hwnd
         /// tree that is the desktop. The last clipping should be done against the Progman hwnd.
         private static readonly IntPtr _hwndProgman;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
+using System.Collections.Generic;
 using Accessibility;
 using System.Windows;
 using MS.Win32;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
@@ -593,8 +593,7 @@ namespace MS.Internal.AutomationProxies
             listOut.Add(new ClickablePoint.CPRect(ref rcItem, true));
 
             // First go through all the children to exclude whatever is on top
-            ProxyFragment proxyFrag = this as ProxyFragment;
-            if (proxyFrag != null)
+            if (this is ProxyFragment proxyFrag)
             {
                 ClickablePoint.ExcludeChildren(proxyFrag, listIn, listOut);
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
@@ -29,7 +29,6 @@
 using System;
 using System.Windows.Automation;
 using System.Windows.Automation.Provider;
-using System.Collections;
 using Accessibility;
 using System.Windows;
 using MS.Win32;
@@ -585,8 +584,8 @@ namespace MS.Internal.AutomationProxies
                 }
             }
 
-            ArrayList alIn = new ArrayList(100);
-            ArrayList alOut = new ArrayList(100);
+            List<ClickablePoint.CPRect> alIn = new(100);
+            List<ClickablePoint.CPRect> alOut = new(100);
 
             // Get the mid point to start with
             pt.x = (rcItem.right - 1 + rcItem.left) / 2;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/ProxySimple.cs
@@ -584,22 +584,22 @@ namespace MS.Internal.AutomationProxies
                 }
             }
 
-            List<ClickablePoint.CPRect> alIn = new(100);
-            List<ClickablePoint.CPRect> alOut = new(100);
+            List<ClickablePoint.CPRect> listIn = new(100);
+            List<ClickablePoint.CPRect> listOut = new(100);
 
             // Get the mid point to start with
             pt.x = (rcItem.right - 1 + rcItem.left) / 2;
             pt.y = (rcItem.bottom - 1 + rcItem.top) / 2;
-            alOut.Add(new ClickablePoint.CPRect(ref rcItem, true));
+            listOut.Add(new ClickablePoint.CPRect(ref rcItem, true));
 
             // First go through all the children to exclude whatever is on top
             ProxyFragment proxyFrag = this as ProxyFragment;
             if (proxyFrag != null)
             {
-                ClickablePoint.ExcludeChildren(proxyFrag, alIn, alOut);
+                ClickablePoint.ExcludeChildren(proxyFrag, listIn, listOut);
             }
 
-            return ClickablePoint.GetPoint(_hwnd, alIn, alOut, ref pt);
+            return ClickablePoint.GetPoint(_hwnd, listIn, listOut, ref pt);
         }
 
         internal string GetAccessibleName(int item)


### PR DESCRIPTION
## Description

This should be the last boxing `ArrayList` that's still left in `UIAutomationClientSideProviders` when #9388 would be merged.

- Adds `System.Collections` reference to `UIAutomationClientSideProviders` to allow for generic collections in the first place.
- Removes two boxing `ArrayList` instances, both times for `CPRect` structure in `ClickablePoint` and `ProxySimple` class.
- Makes the static fields `readonly` and moves the other static field init into the `static constructor` for readability.
- Adjusts the `CPRect` bool methods as `readonly` since they do not modify struct state.
- Renames the "al*" params as "list*" to reflect reality this ain't an `ArrayList`.
- Adjusts internal comments from "Program" to "Progman".

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9430)