### PR TITLE
Replace boxing ArrayList in Window with List<IntPtr> (ThreadWindowHandles)

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -353,12 +353,12 @@ namespace System.Windows
             Debug.Assert(_threadWindowHandles == null, "_threadWindowHandles must be null before enumerating the thread windows");
 
             // NOTE:
-            // _threadWindowHandles is created here.  This reference is nulled out in EnableThreadWindows
-            // when it is called with a true parameter.  Please do not null it out anywhere else.
-            // EnableThreadWindow(true) is called when dialog is going away.  Once dialog is closed and
-            // thread windows have been enabled, then there no need to keep the array list around.
+            // _threadWindowHandles is created here. This reference is nulled out in EnableThreadWindows
+            // when it is called with a true parameter. Please do not null it out anywhere else.
+            // EnableThreadWindow(true) is called when dialog is going away. Once dialog is closed and
+            // thread windows have been enabled, then there no need to keep the list around.
             // Please see BUG 929740 before making any changes to how _threadWindowHandles works.
-            _threadWindowHandles = new ArrayList();
+            _threadWindowHandles = new();
             //Get visible and enabled windows in the thread
             // If the callback function returns true for all windows in the thread, the return value is true.
             // If the callback function returns false on any enumerated window, or if there are no windows
@@ -3524,7 +3524,7 @@ namespace System.Windows
 
             for (int i = 0; i < _threadWindowHandles.Count; i++)
             {
-                IntPtr hWnd = (IntPtr)_threadWindowHandles[i];
+                IntPtr hWnd = _threadWindowHandles[i];
 
                 if (UnsafeNativeMethods.IsWindow(new HandleRef(null, hWnd)))
                 {
@@ -7152,7 +7152,7 @@ namespace System.Windows
         // which is different than the owner Window object
         private IntPtr              _ownerHandle = IntPtr.Zero;   // no need to dispose this
         private WindowCollection    _ownedWindows;
-        private ArrayList           _threadWindowHandles;
+        private List<IntPtr>        _threadWindowHandles;
 
         private bool                _updateHwndSize     = true;
         private bool                _updateHwndLocation = true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -358,7 +358,7 @@ namespace System.Windows
             // EnableThreadWindow(true) is called when dialog is going away. Once dialog is closed and
             // thread windows have been enabled, then there no need to keep the list around.
             // Please see BUG 929740 before making any changes to how _threadWindowHandles works.
-            _threadWindowHandles = new();
+            _threadWindowHandles = new List<IntPtr>();
             //Get visible and enabled windows in the thread
             // If the callback function returns true for all windows in the thread, the return value is true.
             // If the callback function returns false on any enumerated window, or if there are no windows


### PR DESCRIPTION
## Description

Replaces boxing `ArrayList` with `List<IntPtr>` to hold window handles for the current thread (`_threadWindowHandles`).

Sample benchmark showing difference between `ArrayList` and `List<IntPtr>` (box/unbox cost).

### 10 additions, 10 unboxes

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 108.51 ns |   2.088 ns |    1.953 ns | 0.0339 |       1,179 B |         568 B |
| PR__EDIT |  58.36 ns |   0.880 ns |    0.780 ns | 0.0196 |         305 B |         328 B |

<details><summary>Benchmark code</summary>

```c#
[Benchmark]
public void Original()
{
    ArrayList? _threadWindowHandles = null;

    for (int i = 0; i < 10; i++)
        BenchV1(ref _threadWindowHandles);

    for (int i = 0; i < _threadWindowHandles!.Count; i++)
        EmptyMethod((IntPtr)_threadWindowHandles![i]!);
}

[Benchmark]
public void PR__EDIT()
{
    List<IntPtr>? _threadWindowHandles = null;

    for (int i = 0; i < 10; i++)
        BenchV2(ref _threadWindowHandles);

    for (int i = 0; i < _threadWindowHandles!.Count; i++)
        EmptyMethod(_threadWindowHandles![i]);
}

[MethodImpl(MethodImplOptions.NoInlining)]
private int EmptyMethod(IntPtr hwnd) => hwnd.ToInt32();

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private void BenchV1(ref ArrayList? _threadWindowHandles)
{
    IntPtr emptyGroupItem = 5;

    if (_threadWindowHandles == null)
        _threadWindowHandles = new ArrayList();

    _threadWindowHandles.Add(emptyGroupItem);
}

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private void BenchV2(ref List<IntPtr>? _threadWindowHandles)
{
    IntPtr emptyGroupItem = 5;

    if (_threadWindowHandles == null)
        _threadWindowHandles = new();

    _threadWindowHandles.Add(emptyGroupItem);
}
```

</details>

## Customer Impact

Improved performance, reduced allocations.

## Regression

No.

## Testing

Local build.

## Risk

None, changes are minimal.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9431)