### PR TITLE
Reduce allocations while enumerating Speller suggestions and improve performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -177,16 +177,15 @@ namespace System.Windows.Documents
         // for an error range.
         // This method actually runs the speller on the specified text,
         // re-evaluating the error from scratch.
-        internal IList GetSuggestionsForError(SpellingError error)
+        internal List<string> GetSuggestionsForError(SpellingError error)
         {
             ITextPointer contextStart;
             ITextPointer contextEnd;
             ITextPointer contentStart;
             ITextPointer contentEnd;
             TextMap textMap;
-            ArrayList suggestions;
 
-            suggestions = new ArrayList(1);
+            List<string> suggestions = new();
 
             //
             // IMPORTANT!!
@@ -915,7 +914,7 @@ namespace System.Windows.Documents
             {
                 if (textSegment.SubSegments.Count == 0)
                 {
-                    ArrayList suggestions = (ArrayList)data.Data;
+                    List<string> suggestions = (List<string>)data.Data;
                     if(textSegment.Suggestions.Count > 0)
                     {
                         foreach(string suggestion in textSegment.Suggestions)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -179,14 +179,6 @@ namespace System.Windows.Documents
         // re-evaluating the error from scratch.
         internal List<string> GetSuggestionsForError(SpellingError error)
         {
-            ITextPointer contextStart;
-            ITextPointer contextEnd;
-            ITextPointer contentStart;
-            ITextPointer contentEnd;
-            TextMap textMap;
-
-            List<string> suggestions = new();
-
             //
             // IMPORTANT!!
             //
@@ -194,18 +186,15 @@ namespace System.Windows.Documents
             // calculate the exact same error.  Keep the two methods in sync!
             //
 
-            XmlLanguage language;
-            CultureInfo culture = GetCurrentCultureAndLanguage(error.Start, out language);
-            if (culture == null || !_spellerInterop.CanSpellCheck(culture))
-            {
-                // Return an empty list.
-            }
-            else
-            {
-                ExpandToWordBreakAndContext(error.Start, LogicalDirection.Backward, language, out contentStart, out contextStart);
-                ExpandToWordBreakAndContext(error.End, LogicalDirection.Forward, language, out contentEnd, out contextEnd);
+            List<string> suggestions = new();
+            CultureInfo culture = GetCurrentCultureAndLanguage(error.Start, out XmlLanguage language);
 
-                textMap = new TextMap(contextStart, contextEnd, contentStart, contentEnd);
+            if (culture is not null || _spellerInterop.CanSpellCheck(culture))
+            {
+                ExpandToWordBreakAndContext(error.Start, LogicalDirection.Backward, language, out ITextPointer contentStart, out ITextPointer contextStart);
+                ExpandToWordBreakAndContext(error.End, LogicalDirection.Forward, language, out ITextPointer contentEnd, out ITextPointer contextEnd);
+
+                TextMap textMap = new(contextStart, contextEnd, contentStart, contentEnd);
 
                 SetCulture(culture);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -186,7 +186,7 @@ namespace System.Windows.Documents
             // calculate the exact same error.  Keep the two methods in sync!
             //
 
-            List<string> suggestions = new();
+            List<string> suggestions = new(4);
             CultureInfo culture = GetCurrentCultureAndLanguage(error.Start, out XmlLanguage language);
 
             if (culture is not null || _spellerInterop.CanSpellCheck(culture))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -189,7 +189,7 @@ namespace System.Windows.Documents
             List<string> suggestions = new(4);
             CultureInfo culture = GetCurrentCultureAndLanguage(error.Start, out XmlLanguage language);
 
-            if (culture is not null || _spellerInterop.CanSpellCheck(culture))
+            if (culture is not null && _spellerInterop.CanSpellCheck(culture))
             {
                 ExpandToWordBreakAndContext(error.Start, LogicalDirection.Backward, language, out ITextPointer contentStart, out ITextPointer contextStart);
                 ExpandToWordBreakAndContext(error.End, LogicalDirection.Forward, language, out ITextPointer contentEnd, out ITextPointer contextEnd);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerError.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SpellerError.cs
@@ -94,15 +94,7 @@ namespace System.Windows.Controls
         /// </remarks>
         public IEnumerable<string> Suggestions
         {
-            get
-            {
-                IList suggestions = _speller.GetSuggestionsForError(this);
-
-                for (int i=0; i<suggestions.Count; i++)
-                {
-                    yield return (string)suggestions[i];
-                }
-            }
+            get => _speller.GetSuggestionsForError(this);
         }
 
         #endregion Public Properties


### PR DESCRIPTION
## Description

Decreases allocations while enumerating suggestions in `Speller`. Further improves performance, anywhere from `1.5` to `2.5`.
- Replace `ArrayList` with `List<string>`.
- Replace custom iteration with the base implementation.
- Raises base allocation of items from 1 to 4 as in most cases the number of suggestions more than 1.
- The return type could be an `IList<string>` or `IEnumerable<string>` but since it is internal I didn't bother.

### 1 suggestion (worst case, uncommon)

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  21.56 ns |   0.345 ns |    0.288 ns | 0.0072 |       1,415 B |         120 B |
| PR__EDIT |  14.20 ns |   0.292 ns |    0.300 ns | 0.0076 |       1,531 B |         128 B |

### 2 suggestions

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  38.18 ns |   0.292 ns |    0.273 ns | 0.0095 |       1,910 B |         160 B |
| PR__EDIT |  18.31 ns |   0.269 ns |    0.251 ns | 0.0076 |       1,594 B |         128 B |

### 3 suggestions

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  52.59 ns |   0.659 ns |    0.584 ns | 0.0129 |       2,078 B |         216 B |
| PR__EDIT |  21.20 ns |   0.213 ns |    0.178 ns | 0.0076 |       1,661 B |         128 B |

### 6 suggestions

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  82.26 ns |   1.224 ns |    1.085 ns | 0.0181 |       2,874 B |         304 B |
| PR__EDIT |  55.22 ns |   0.851 ns |    0.754 ns | 0.0129 |       1,076 B |         216 B |

### 8 suggestions

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  99.92 ns |   0.714 ns |    0.557 ns | 0.0181 |       3,032 B |         304 B |
| PR__EDIT |  58.23 ns |   0.838 ns |    0.743 ns | 0.0129 |       1,160 B |         216 B |

### 9 suggestions

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 125.89 ns |   1.450 ns |    1.356 ns | 0.0272 |       3,056 B |         456 B |
| PR__EDIT |  78.59 ns |   1.368 ns |    1.279 ns | 0.0219 |       1,209 B |         368 B |

<details><summary>Benchmark code</summary>

```c#
[Benchmark]
public void Original()
{
    foreach (string suggestion in Suggestions)
        EmptyMethod(suggestion);
}

[Benchmark]
public void PR__EDIT()
{
    foreach (string suggestion in SuggestionsV2)
        EmptyMethod(suggestion);
}

[MethodImpl(MethodImplOptions.NoInlining)]
private int EmptyMethod(string suggestions) => suggestions[0];

public IEnumerable<string> Suggestions
{
    get
    {
        IList suggestions = _speller.GetSuggestionsForError();

        for (int i = 0; i < suggestions.Count; i++)
        {
            yield return (string)suggestions[i];
        }
    }
}

public IEnumerable<string> SuggestionsV2
{
    get => _speller.GetSuggestionsForErrorV2();
}

private readonly Speller _speller = new();

public class Speller
{
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public IList GetSuggestionsForError()
    {
        ArrayList suggestions = new ArrayList(1);

        suggestions.Add("hannah");
        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("hannah");
        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("hannah");

        return suggestions;
    }

    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public List<string> GetSuggestionsForErrorV2()
    {
        List<string> suggestions = new(4);

        suggestions.Add("hannah");
        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("hannah");
        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("lannal");
        suggestions.Add("hannah");

        suggestions.Add("hannah");

        return suggestions;
    }
}
```

</details>

## Customer Impact

Improved performance, decrease allocations.

## Regression

No.

## Testing

Local build, verifying Speller/Suggestions functionality.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9439)