### PR TITLE
Try fix EventRoute weak memory leak

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -200,9 +200,9 @@ namespace System.Windows
                             TraceEventType.Stop,
                             TraceRoutedEvent.InvokeHandlers,
                             _traceArguments);
+
+                        Array.Clear(_traceArguments);
                     }
-
-
                 }
             }
             else
@@ -273,6 +273,8 @@ namespace System.Windows
                                 TraceEventType.Stop,
                                 TraceRoutedEvent.InvokeHandlers,
                                 _traceArguments);
+
+                            Array.Clear(_traceArguments);
                         }
 
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/wpf/issues/9467

Reference https://github.com/dotnet/wpf/pull/6700 and https://github.com/dotnet/wpf/pull/9460

## Description

See https://github.com/dotnet/wpf/issues/9467

After https://github.com/dotnet/wpf/pull/6700 , to reduce allocations when tracing routed events, we'll use `_traceArguments` field to store the trace arguments which cause https://github.com/dotnet/wpf/issues/9467 issues.

I try clear the reference from `_traceArguments` after call the `TraceRoutedEvent.Trace`.

And this pr is a patch, and I think https://github.com/dotnet/wpf/pull/9460 will be better. Thank you @kasperk81

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
See https://github.com/dotnet/wpf/issues/9467

The memory will still be freed, albeit at a slower pace. Even if this issue is not addressed, it won't have a significant impact. There are two reasons for this. Firstly, the memory will still be freed, it just can't be released immediately. Secondly, this issue only affects those who have enabled Trace, which normal users typically do not do.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
Reference https://github.com/dotnet/wpf/pull/6700

And Cc @bgrainger 

## Testing

<!-- What kind of testing has been done with the fix. -->
CI Only.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

Middling

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9463)