### PR TITLE
Modify AvTrace call chain to use params ReadOnlySpan<object> instead of an array

### DIFF
--- a/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
+++ b/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
@@ -70,51 +70,27 @@ namespace MS.Internal
 <#		} #>
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
+++ b/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
@@ -70,13 +70,13 @@ namespace MS.Internal
 <#		} #>
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }

--- a/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
+++ b/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
@@ -81,7 +81,7 @@ namespace MS.Internal
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        static public bool IsEnabled
+        public static bool IsEnabled
         {
             get { return _avTrace != null && _avTrace.IsEnabled; }
         }

--- a/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
+++ b/eng/WpfArcadeSdk/tools/CodeGen/AvTrace/AvTraceMessages.tt
@@ -75,25 +75,13 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
-        public static bool IsEnabled
+        static public bool IsEnabled
         {
             get { return _avTrace != null && _avTrace.IsEnabled; }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
@@ -74,22 +74,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        static public void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -233,22 +221,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
@@ -228,51 +228,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters )
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
@@ -69,13 +69,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -216,13 +216,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Generated/AvTraceMessages.cs
@@ -69,51 +69,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        static public void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -171,28 +171,23 @@ namespace System.Windows
                     
                     // Invoke listeners
 
-                    var traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
-                    if ( traceRoutedEventIsEnabled )
+                    bool traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
+                    if (traceRoutedEventIsEnabled)
                     {
-                        _traceArguments ??= new object[3];
-                        _traceArguments[0] = _routeItemList[i].Target;
-                        _traceArguments[1] = args;
-                        _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                         TraceRoutedEvent.Trace(
                             TraceEventType.Start,
                             TraceRoutedEvent.InvokeHandlers,
-                            _traceArguments);
+                            _routeItemList[i].Target, args, BooleanBoxes.Box(args.Handled));
                     }
                     
                     _routeItemList[i].InvokeHandler(args);
 
-                    if( traceRoutedEventIsEnabled )
+                    if(traceRoutedEventIsEnabled)
                     {
-                        _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                         TraceRoutedEvent.Trace(
                             TraceEventType.Stop,
                             TraceRoutedEvent.InvokeHandlers,
-                            _traceArguments);
+                            _routeItemList[i].Target, args, BooleanBoxes.Box(args.Handled));
                     }
 
 
@@ -243,17 +238,13 @@ namespace System.Windows
                         }
                         
                         
-                        var traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
-                        if ( traceRoutedEventIsEnabled )
+                        bool traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
+                        if (traceRoutedEventIsEnabled)
                         {
-                            _traceArguments ??= new object[3];
-                            _traceArguments[0] = _routeItemList[i].Target;
-                            _traceArguments[1] = args;
-                            _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Start,
                                 TraceRoutedEvent.InvokeHandlers,
-                                _traceArguments);
+                                _routeItemList[i].Target, args, BooleanBoxes.Box(args.Handled));
                         }
 
                         // Invoke listeners
@@ -261,11 +252,10 @@ namespace System.Windows
 
                         if (traceRoutedEventIsEnabled)
                         {
-                            _traceArguments[2] = BooleanBoxes.Box(args.Handled);
                             TraceRoutedEvent.Trace(
                                 TraceEventType.Stop,
                                 TraceRoutedEvent.InvokeHandlers,
-                                _traceArguments);
+                                _routeItemList[i].Target, args, BooleanBoxes.Box(args.Handled));
                         }
 
                     }
@@ -531,9 +521,6 @@ namespace System.Windows
 
         // Stores Source Items for separated trees
         private FrugalStructList<SourceItem> _sourceItemList;
-
-        // Stores arguments that are passed to TraceRoutedEvent.Trace (to reduce allocations)
-        private object[] _traceArguments;
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventRoute.cs
@@ -168,7 +168,7 @@ namespace System.Windows
                                 args.Source=newSource;
                         }
                     }
-                    
+
                     // Invoke listeners
 
                     bool traceRoutedEventIsEnabled = TraceRoutedEvent.IsEnabled;
@@ -179,10 +179,10 @@ namespace System.Windows
                             TraceRoutedEvent.InvokeHandlers,
                             _routeItemList[i].Target, args, BooleanBoxes.Box(args.Handled));
                     }
-                    
+
                     _routeItemList[i].InvokeHandler(args);
 
-                    if(traceRoutedEventIsEnabled)
+                    if (traceRoutedEventIsEnabled)
                     {
                         TraceRoutedEvent.Trace(
                             TraceEventType.Stop,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
@@ -1333,51 +1333,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1460,51 +1436,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem( AvTraceDetails traceDetails, params Span<object> parameters )
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1699,51 +1651,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters )
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1994,51 +1922,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -2079,51 +1983,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters )
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
@@ -1338,22 +1338,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         public static bool IsEnabled
@@ -1441,22 +1429,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Span<object> parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1651,27 +1627,15 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1924,25 +1888,13 @@ namespace MS.Internal
         /// <summary> Send a single trace output </summary>
         public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -1988,22 +1940,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters )
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -2125,22 +2065,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
@@ -1333,13 +1333,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -1424,13 +1424,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -1627,13 +1627,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -1886,13 +1886,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -1935,13 +1935,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -2060,13 +2060,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Generated/AvTraceMessages.cs
@@ -2240,51 +2240,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
@@ -87,7 +87,7 @@ namespace MS.Internal
         }
 
         // report/describe any additional parameters passed to TraceData.Trace()
-        public static void OnTrace( AvTraceBuilder traceBuilder, object[] parameters, int start )
+        public static void OnTrace(AvTraceBuilder traceBuilder, Span<object> parameters, int start)
         {
             for( int i = start; i < parameters.Length; i++ )
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
@@ -87,7 +87,7 @@ namespace MS.Internal
         }
 
         // report/describe any additional parameters passed to TraceData.Trace()
-        public static void OnTrace(AvTraceBuilder traceBuilder, Span<object> parameters, int start)
+        public static void OnTrace(AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters, int start)
         {
             for( int i = start; i < parameters.Length; i++ )
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
@@ -87,14 +87,13 @@ namespace MS.Internal
         }
 
         // report/describe any additional parameters passed to TraceData.Trace()
-        public static void OnTrace(AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters, int start)
+        public static void OnTrace(AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters)
         {
-            for( int i = start; i < parameters.Length; i++ )
+            for (int i = 0; i < parameters.Length; i++)
             {
                 object o = parameters[i];
-                string s = o as string;
                 traceBuilder.Append(" ");
-                if (s != null)
+                if (o is string s)
                 {
                     traceBuilder.Append(s);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/TraceData.cs
@@ -91,17 +91,18 @@ namespace MS.Internal
         {
             for (int i = 0; i < parameters.Length; i++)
             {
-                object o = parameters[i];
+                object objectParam = parameters[i];
                 traceBuilder.Append(" ");
-                if (o is string s)
+
+                if (objectParam is string stringValue)
                 {
-                    traceBuilder.Append(s);
+                    traceBuilder.Append(stringValue);
                 }
-                else if (o != null)
+                else if (objectParam is not null)
                 {
-                    traceBuilder.Append(o.GetType().Name);
+                    traceBuilder.Append(objectParam.GetType().Name);
                     traceBuilder.Append(":");
-                    Describe(traceBuilder, o);
+                    Describe(traceBuilder, objectParam);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -267,12 +267,12 @@ namespace MS.Internal
             if (parameters != Span<object>.Empty && labels != null && labels.Length > 0)
             {
                 int i = 1, j = 0;
-                for(; i < labels.Length && j < parameters.Length; i++, j++)
+                for (; i < labels.Length && j < parameters.Length; i++, j++)
                 {
                     // Append to the format string a "; {0} = '{1}'", where the index increments (e.g. the second iteration will
                     // produce {2} & {3}).
 
-                    traceBuilder.Append("; {" + (formatIndex++).ToString() + "}='{" + (formatIndex++).ToString() + "}'" );
+                    traceBuilder.Append($"; {{{++formatIndex}}}='{{{++formatIndex}}}'");
 
                     // If this parameter is null, convert to "<null>"; otherwise, when a string.format is ultimately called
                     // it produces bad results.
@@ -291,11 +291,8 @@ namespace MS.Internal
                              && !(parameters[j] is Type)
                              && !(parameters[j] is DependencyProperty) )
                     {
-                        traceBuilder.Append("; " + labels[i].ToString() + ".HashCode='"
-                                                    + GetHashCodeHelper(parameters[j]).ToString() + "'" );
-
-                        traceBuilder.Append("; " + labels[i].ToString() + ".Type='"
-                                                    + GetTypeHelper(parameters[j]).ToString() + "'" );
+                        traceBuilder.Append($"; {labels[i]}.HashCode='{GetHashCodeHelper(parameters[j])}'");
+                        traceBuilder.Append($"; {labels[i]}.Type='{GetTypeHelper(parameters[j])}'");
                     }
 
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -250,12 +250,8 @@ namespace MS.Internal
         {
             // Don't bother building the string if this trace is going to be ignored.
 
-            if( _traceSource == null
-                || !_traceSource.Switch.ShouldTrace( type ))
-            {
+            if(_traceSource == null|| !_traceSource.Switch.ShouldTrace(type))
                 return null;
-            }
-
 
             // Compose the trace string.
 
@@ -285,11 +281,11 @@ namespace MS.Internal
                     // Otherwise, if this is an interesting object, add the hash code and type to
                     // the format string explicitely.
 
-                    else if( !SuppressGeneratedParameters
-                             && parameters[j].GetType() != typeof(string)
-                             && !(parameters[j] is ValueType)
-                             && !(parameters[j] is Type)
-                             && !(parameters[j] is DependencyProperty) )
+                    else if(SuppressGeneratedParameters == false
+                            && parameters[j].GetType() != typeof(string)
+                            && parameters[j] is not ValueType
+                            && parameters[j] is not Type
+                            && parameters[j] is not DependencyProperty)
                     {
                         traceBuilder.Append($"; {labels[i]}.HashCode='{GetHashCodeHelper(parameters[j])}'");
                         traceBuilder.Append($"; {labels[i]}.Type='{GetTypeHelper(parameters[j])}'");

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -245,7 +245,7 @@ namespace MS.Internal
         //  note: labels start at index 1, parameters start at index 0
         //
 
-        public string Trace( TraceEventType type, int eventId, string message, string[] labels, object[] parameters )
+        public string Trace(TraceEventType type, int eventId, string message, string[] labels, params Span<object> parameters)
         {
             // Don't bother building the string if this trace is going to be ignored.
 
@@ -263,10 +263,10 @@ namespace MS.Internal
 
             int formatIndex = 0;
 
-            if (parameters != null && labels != null && labels.Length > 0)
+            if (parameters != Span<object>.Empty && labels != null && labels.Length > 0)
             {
                 int i = 1, j = 0;
-                for( ; i < labels.Length && j < parameters.Length; i++, j++ )
+                for(; i < labels.Length && j < parameters.Length; i++, j++)
                 {
                     // Append to the format string a "; {0} = '{1}'", where the index increments (e.g. the second iteration will
                     // produce {2} & {3}).
@@ -276,7 +276,7 @@ namespace MS.Internal
                     // If this parameter is null, convert to "<null>"; otherwise, when a string.format is ultimately called
                     // it produces bad results.
 
-                    if( parameters[j] == null )
+                    if(parameters[j] == null)
                     {
                         parameters[j] = "<null>";
                     }
@@ -311,7 +311,7 @@ namespace MS.Internal
 
                 if( TraceExtraMessages != null && j < parameters.Length)
                 {
-                    TraceExtraMessages( traceBuilder, parameters, j );
+                    TraceExtraMessages(traceBuilder, parameters, j);
                 }
             }
 
@@ -342,10 +342,10 @@ namespace MS.Internal
         //  (information is contained in the Start event)
         //
 
-        public void TraceStartStop( int eventID, string message, string[] labels, Object[] parameters )
+        public void TraceStartStop(int eventID, string message, string[] labels, params Span<object> parameters)
         {
-            Trace( TraceEventType.Start, eventID, message, labels, parameters );
-            _traceSource.TraceEvent( TraceEventType.Stop, eventID);
+            Trace(TraceEventType.Start, eventID, message, labels, parameters);
+            _traceSource.TraceEvent(TraceEventType.Stop, eventID);
         }
 
 
@@ -506,7 +506,7 @@ namespace MS.Internal
 
     }
 
-    internal delegate void AvTraceEventHandler(AvTraceBuilder traceBuilder, object[] parameters, int start);
+    internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, Span<object> parameters, int start );
 
     internal class AvTraceBuilder
     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -500,7 +500,7 @@ namespace MS.Internal
 
     }
 
-    internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, Span<object> parameters, int start );
+    internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters, int start );
 
     internal class AvTraceBuilder
     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -17,6 +17,7 @@ using System.Windows;
 using Microsoft.Win32;
 using MS.Win32;
 using MS.Internal.WindowsBase;
+using System.Collections.Generic;
 
 namespace MS.Internal
 {
@@ -259,7 +260,7 @@ namespace MS.Internal
             // Compose the trace string.
 
             AvTraceBuilder traceBuilder = new AvTraceBuilder(AntiFormat(message)); // Holds the format string
-            ArrayList arrayList = new ArrayList(); // Holds the combined labels & parameters arrays.
+            List<object> combinedList = new(parameters.Length * 2); // Holds the combined labels & parameters arrays.
 
             int formatIndex = 0;
 
@@ -302,14 +303,14 @@ namespace MS.Internal
                     // (As an optimization, the generated classes could pre-allocate a thread-safe static array, to avoid
                     // this allocation and the ToArray allocation below.)
 
-                    arrayList.Add( labels[i] );
-                    arrayList.Add( parameters[j] );
+                    combinedList.Add(labels[i]);
+                    combinedList.Add(parameters[j]);
                 }
 
                 // It's OK if we terminate because we have more lables than parameters;
                 // this is used by traces to have out-values in the Stop message.
 
-                if( TraceExtraMessages != null && j < parameters.Length)
+                if(TraceExtraMessages != null && j < parameters.Length)
                 {
                     TraceExtraMessages(traceBuilder, parameters, j);
                 }
@@ -323,7 +324,7 @@ namespace MS.Internal
                 type,
                 eventId,
                 traceMessage,
-                arrayList.ToArray() );
+                combinedList.ToArray()); //Cannot avoid the alloc here, no ROS<object> overload
 
             // When in the debugger, always flush the output, to guarantee that the
             // traces and other info (e.g. exceptions) get interleaved correctly.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -250,7 +250,7 @@ namespace MS.Internal
         {
             // Don't bother building the string if this trace is going to be ignored.
 
-            if(_traceSource == null|| !_traceSource.Switch.ShouldTrace(type))
+            if (_traceSource == null|| !_traceSource.Switch.ShouldTrace(type))
                 return null;
 
             // Compose the trace string.
@@ -273,19 +273,17 @@ namespace MS.Internal
                     // If this parameter is null, convert to "<null>"; otherwise, when a string.format is ultimately called
                     // it produces bad results.
 
-                    if(parameters[j] == null)
-                    {
+                    if (parameters[j] == null)
                         parameters[j] = "<null>";
-                    }
 
                     // Otherwise, if this is an interesting object, add the hash code and type to
                     // the format string explicitely.
 
-                    else if(SuppressGeneratedParameters == false
-                            && parameters[j].GetType() != typeof(string)
-                            && parameters[j] is not ValueType
-                            && parameters[j] is not Type
-                            && parameters[j] is not DependencyProperty)
+                    else if (SuppressGeneratedParameters == false
+                             && parameters[j].GetType() != typeof(string)
+                             && parameters[j] is not ValueType
+                             && parameters[j] is not Type
+                             && parameters[j] is not DependencyProperty)
                     {
                         traceBuilder.Append($"; {labels[i]}.HashCode='{GetHashCodeHelper(parameters[j])}'");
                         traceBuilder.Append($"; {labels[i]}.Type='{GetTypeHelper(parameters[j])}'");
@@ -303,7 +301,7 @@ namespace MS.Internal
                 // It's OK if we terminate because we have more lables than parameters;
                 // this is used by traces to have out-values in the Stop message.
 
-                if(TraceExtraMessages != null && j < parameters.Length)
+                if (TraceExtraMessages != null && j < parameters.Length)
                 {
                     TraceExtraMessages(traceBuilder, parameters, j);
                 }
@@ -322,10 +320,8 @@ namespace MS.Internal
             // When in the debugger, always flush the output, to guarantee that the
             // traces and other info (e.g. exceptions) get interleaved correctly.
 
-            if( IsDebuggerAttached() )
-            {
+            if (IsDebuggerAttached())
                 _traceSource.Flush();
-            }
 
             return traceMessage;
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -260,7 +260,7 @@ namespace MS.Internal
 
             int formatIndex = 0;
 
-            if (parameters != Span<object>.Empty && labels != null && labels.Length > 0)
+            if (!parameters.IsEmpty && labels?.Length > 0)
             {
                 int i = 1, j = 0;
                 for (; i < labels.Length && j < parameters.Length; i++, j++)
@@ -500,7 +500,7 @@ namespace MS.Internal
 
     }
 
-    internal delegate void AvTraceEventHandler( AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters, int start );
+    internal delegate void AvTraceEventHandler(AvTraceBuilder traceBuilder, ReadOnlySpan<object> parameters, int start);
 
     internal class AvTraceBuilder
     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -249,12 +249,10 @@ namespace MS.Internal
         public string Trace(TraceEventType type, int eventId, string message, string[] labels, params ReadOnlySpan<object> parameters)
         {
             // Don't bother building the string if this trace is going to be ignored.
-
-            if (_traceSource == null || !_traceSource.Switch.ShouldTrace(type))
+            if (_traceSource is null || !_traceSource.Switch.ShouldTrace(type))
                 return null;
 
             // Compose the trace string.
-
             AvTraceBuilder traceBuilder = new AvTraceBuilder(AntiFormat(message)); // Holds the format string
             object[] combinedArgs = null; // Holds the combined labels & parameters arrays.
             int formatIndex = 0;
@@ -264,7 +262,7 @@ namespace MS.Internal
                 // Create array of pre-computed size
                 int combinedArgsLength = Math.Min(labels.Length - 1, parameters.Length) * 2;
                 if (combinedArgsLength > 0)
-                    combinedArgs = new object[combinedArgsLength];             
+                    combinedArgs = new object[combinedArgsLength];
 
                 int i = 1, j = 0;
                 for (; i < labels.Length && j < parameters.Length; i++, j++)
@@ -278,14 +276,13 @@ namespace MS.Internal
 
                     // If the parameter is null, convert to "<null>"; otherwise,
                     // when a string.format is ultimately called it produces bad results.
-                    if (parameters[j] == null)
+                    if (parameters[j] is null)
                     {
                         combinedArgs[j * 2 + 1] = "<null>";
                     }
 
                     // Otherwise, if this is an interesting object, add the hash code and type to
                     // the format string explicitly.
-
                     else if (!SuppressGeneratedParameters
                              && parameters[j].GetType() != typeof(string)
                              && parameters[j] is not ValueType
@@ -296,10 +293,10 @@ namespace MS.Internal
                         traceBuilder.Append($"; {labels[i]}.Type='{GetTypeHelper(parameters[j])}'");
 
                         // Add the parameter to the combined list.
-
                         combinedArgs[j * 2 + 1] = parameters[j];
                     }
-                    else // Add the parameter to the combined list.
+                    // Add the parameter to the combined list.
+                    else
                     {
                         combinedArgs[j * 2 + 1] = parameters[j];
                     }
@@ -307,8 +304,7 @@ namespace MS.Internal
 
                 // It's OK if we terminate because we have more labels than parameters;
                 // this is used by traces to have out-values in the Stop message.
-
-                if (TraceExtraMessages != null && j < parameters.Length)
+                if (TraceExtraMessages is not null && j < parameters.Length)
                 {
                     TraceExtraMessages(traceBuilder, parameters.Slice(j));
                 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/AvTrace.cs
@@ -268,7 +268,7 @@ namespace MS.Internal
                     // Append to the format string a "; {0} = '{1}'", where the index increments (e.g. the second iteration will
                     // produce {2} & {3}).
 
-                    traceBuilder.Append($"; {{{++formatIndex}}}='{{{++formatIndex}}}'");
+                    traceBuilder.Append($"; {{{formatIndex++}}}='{{{formatIndex++}}}'");
 
                     // If this parameter is null, convert to "<null>"; otherwise, when a string.format is ultimately called
                     // it produces bad results.

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
@@ -70,13 +70,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -161,13 +161,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
@@ -225,13 +225,13 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params ReadOnlySpan<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
@@ -75,22 +75,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Span<object> parameters)
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -178,22 +166,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -254,22 +230,10 @@ namespace MS.Internal
             _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
-        /// <summary> These help delay allocation of object array </summary>
-        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
-        {
-            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
-        }
-
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
         public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
             _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
-        }
-
-        /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem(AvTraceDetails traceDetails)
-        {
-            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/Generated/AvTraceMessages.cs
@@ -70,51 +70,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem( AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
         public static void TraceActivityItem( AvTraceDetails traceDetails )
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -197,51 +173,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled
@@ -297,51 +249,27 @@ namespace MS.Internal
         }
 
         /// <summary> Send a single trace output </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, params object[] parameters )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails )
+        public static void Trace(TraceEventType type, AvTraceDetails traceDetails)
         {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void Trace( TraceEventType type, AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.Trace( type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.Trace(type, traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         /// <summary> Send a singleton "activity" trace (really, this sends the same trace as both a Start and a Stop) </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails, params Object[] parameters )
+        public static void TraceActivityItem(AvTraceDetails traceDetails, params Span<object> parameters)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, parameters);
         }
 
         /// <summary> These help delay allocation of object array </summary>
-        public static void TraceActivityItem( AvTraceDetails traceDetails )
+        public static void TraceActivityItem(AvTraceDetails traceDetails)
         {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>() );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2 } );
-        }
-        public static void TraceActivityItem( AvTraceDetails traceDetails, object p1, object p2, object p3 )
-        {
-            _avTrace.TraceStartStop( traceDetails.Id, traceDetails.Message, traceDetails.Labels, new object[] { p1, p2, p3 } );
+            _avTrace.TraceStartStop(traceDetails.Id, traceDetails.Message, traceDetails.Labels, Array.Empty<object>());
         }
 
         public static bool IsEnabled


### PR DESCRIPTION
Fixes #9467 Reference #9463 

## Description

More of a complex fix, modifies the call chain to make use of the latest .NET features.
- ~~I've used `Span<object>` instead of `ReadOnlySpan<object>` as the `parameters` array has always been mutated by the trace class, hence I didn't want to currently change the behaviour.~~
- Builds on the original intention of #6700 
- The fixes should be compatible with my other PR too, #9361 and #9352.
- `ArrayList` replaced with pre-allocated array and used interpolation for building the trace data.
- Modifies the `AvTraceMessages.tt` for completion.
- The overall cost of `AvTrace` / `AvTraceMessages` will be greatly reduced.

## Customer Impact

Improved performance when tracing is active, decreased array allocations per each executed trace, smaller assemblies due to the function removal.

## Regression

Fixes the ref held by `_traceArguments` from #6700 

## Testing 

Local build, app run with tracing, comparing outputs of release/PR.

## Risk

Low, the actual change is small and was reviewed/tested.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9468)