### PR TITLE
Fix WriteableBitmap's Write/CopyPixels (Clone) to support up to 4GB backbuffers

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/BitmapSource.cs
@@ -390,7 +390,7 @@ namespace System.Windows.Media.Imaging
             // Demand Site Of origin on the URI if it passes then this  information is ok to expose
             CheckIfSiteOfOrigin();
 
-            CriticalCopyPixels(sourceRect, buffer, bufferSize, stride);
+            CriticalCopyPixels(sourceRect, buffer, (uint)bufferSize, stride);
         }
 
         /// <summary>
@@ -662,7 +662,7 @@ namespace System.Windows.Media.Imaging
             if (elementSize == -1)
                 throw new ArgumentException(SR.Image_InvalidArrayForPixel);
 
-            int destBufferSize = checked(elementSize * (pixels.Length - offset));
+            uint destBufferSize = checked((uint)elementSize * (uint)(pixels.Length - offset));
 
             // Check whether offset is out of bounds manually
             if (offset >= pixels.Length)
@@ -679,7 +679,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="buffer"></param>
         /// <param name="bufferSize"></param>
         /// <param name="stride"></param>
-        internal void CriticalCopyPixels(Int32Rect sourceRect, IntPtr buffer, int bufferSize, int stride)
+        internal void CriticalCopyPixels(Int32Rect sourceRect, IntPtr buffer, uint bufferSize, int stride)
         {
             if (buffer == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(buffer));
@@ -698,7 +698,7 @@ namespace System.Windows.Media.Imaging
             int minStride = checked(((sourceRect.Width * Format.BitsPerPixel) + 7) / 8);
             ArgumentOutOfRangeException.ThrowIfLessThan(stride, minStride);
 
-            int minRequiredDestSize = checked((stride * (sourceRect.Height - 1)) + minStride);
+            uint minRequiredDestSize = checked(((uint)stride * (uint)(sourceRect.Height - 1)) + (uint)minStride);
             ArgumentOutOfRangeException.ThrowIfLessThan(bufferSize, minRequiredDestSize);
 
             lock (_syncObject)
@@ -707,7 +707,7 @@ namespace System.Windows.Media.Imaging
                     WicSourceHandle,
                     ref sourceRect,
                     (uint)stride,
-                    (uint)bufferSize,
+                    bufferSize,
                     buffer
                     ));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Imaging/WriteableBitmap.cs
@@ -752,7 +752,7 @@ namespace System.Windows.Media.Imaging
                 try
                 {
                     Int32Rect rcFull = new Int32Rect(0, 0, _pixelWidth, _pixelHeight);
-                    int bufferSize = checked(_backBufferStride * source.PixelHeight);
+                    uint bufferSize = checked((uint)_backBufferStride * (uint)source.PixelHeight);
                     source.CriticalCopyPixels(rcFull, _backBuffer, bufferSize, _backBufferStride);
                     AddDirtyRect(rcFull);
                 }
@@ -886,7 +886,7 @@ namespace System.Windows.Media.Imaging
                 //
                 unsafe
                 {
-                    uint destOffset = (uint)(destinationY * _backBufferStride) + destXbyteOffset;
+                    uint destOffset = ((uint)destinationY * (uint)_backBufferStride) + destXbyteOffset;
                     byte* pDest = (byte*)_backBuffer.ToPointer();
                     pDest += destOffset;
                     uint outputBufferSize = _backBufferSize - destOffset;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/WriteableBitmap.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/WriteableBitmap.Tests.cs
@@ -14,12 +14,12 @@ public sealed class WriteableBitmapTests
     [InlineData(256, 512, 96.0, 96.0)]
     [InlineData(256, 256, 120.0, 120.0)]
     [InlineData(512, 256, 120.0, 120.0)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(30_000, 30_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(30_000, 30_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public void Constructor_CreationSucceeds_HasCorrectParameters(int width, int height, double dpiX, double dpiY)
     {
@@ -36,16 +36,17 @@ public sealed class WriteableBitmapTests
     }
 
     // Under 2GB back-buffer (4 channels)
+    [InlineData(2_000, 2_000, 96.0, 96.0)]
     [InlineData(4_000, 4_000, 120, 120)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public void WritePixels_SmallRect_Safe_Succeeds(int width, int height, double dpiX, double dpiY)
     {
-        const int tileSize = 1000;
+        const int tileSize = 500;
         const int channels = 4;
 
         // Create 1000x1000 rectangle with 4 channels, fill the rectangle with teal color
@@ -76,16 +77,17 @@ public sealed class WriteableBitmapTests
     }
 
     // Under 2GB back-buffer (4 channels)
+    [InlineData(2_000, 2_000, 96.0, 96.0)]
     [InlineData(4_000, 4_000, 120, 120)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public unsafe void WritePixels_SmallRect_Unsafe_Succeeds(int width, int height, double dpiX, double dpiY)
     {
-        const int tileSize = 1000;
+        const int tileSize = 500;
         const int channels = 4;
 
         // Create 1000x1000 rectangle with 4 channels, fill the rectangle with teal color
@@ -116,12 +118,13 @@ public sealed class WriteableBitmapTests
     }
 
     // Under 2GB back-buffer (4 channels)
+    [InlineData(512, 512, 96.0, 96.0)]
     [InlineData(4_000, 4_000, 120, 120)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public void WritePixels_FullRect_Safe_Succeeds(int width, int height, double dpiX, double dpiY)
     {
@@ -139,12 +142,13 @@ public sealed class WriteableBitmapTests
     }
 
     // Under 2GB back-buffer (4 channels)
+    [InlineData(512, 512, 96.0, 96.0)]
     [InlineData(4_000, 4_000, 120, 120)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public unsafe void WritePixels_FullRect_Unsafe_Succeeds(int width, int height, double dpiX, double dpiY)
     {
@@ -167,11 +171,11 @@ public sealed class WriteableBitmapTests
     [InlineData(256, 512, 96.0, 96.0)]
     [InlineData(256, 256, 120.0, 120.0)]
     [InlineData(512, 256, 120.0, 120.0)]
-    [InlineData(10_000, 10_000, 96.0, 96.0)]
-    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(20_000, 20_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
-    [InlineData(25_000, 25_000, 96.0, 96.0)]
-    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [InlineData(25_000, 25_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
+    [InlineData(32_000, 32_000, 96.0, 96.0, Skip = "Disabled to reduce working set")]
     [Theory]
     public void Clone_CopyPixels_Succeeds(int width, int height, double dpiX, double dpiY)
     {

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/WriteableBitmap.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/Media/Imaging/WriteableBitmap.Tests.cs
@@ -1,0 +1,197 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Media.Imaging;
+
+[Collection("WriteableBitmapTests")]
+public sealed class WriteableBitmapTests
+{
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(128, 128, 96.0, 96.0)]
+    [InlineData(256, 512, 96.0, 96.0)]
+    [InlineData(256, 256, 120.0, 120.0)]
+    [InlineData(512, 256, 120.0, 120.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(30_000, 30_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public void Constructor_CreationSucceeds_HasCorrectParameters(int width, int height, double dpiX, double dpiY)
+    {
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Assert
+        Assert.Equal(width, writeableBitmap.PixelWidth);
+        Assert.Equal(height, writeableBitmap.PixelHeight);
+
+        Assert.Equal(dpiX, writeableBitmap.DpiX);
+        Assert.Equal(dpiY, writeableBitmap.DpiY);
+
+        Assert.Equal(PixelFormats.Pbgra32, writeableBitmap.Format);
+    }
+
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(4_000, 4_000, 120, 120)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public void WritePixels_SmallRect_Safe_Succeeds(int width, int height, double dpiX, double dpiY)
+    {
+        const int tileSize = 1000;
+        const int channels = 4;
+
+        // Create 1000x1000 rectangle with 4 channels, fill the rectangle with teal color
+        byte[] smallRect = GC.AllocateUninitializedArray<byte>(tileSize * tileSize * channels);
+        MemoryMarshal.Cast<byte, uint>(smallRect.AsSpan()).Fill(0xFF00E6FF);
+
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Top-Left
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
+                                    smallRect, tileSize * channels, 0, 0);
+
+        // Top-Right
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
+                                    smallRect, tileSize * channels, width - tileSize, 0);
+
+        // Middle Rect
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
+                                    smallRect, tileSize * channels, (width - tileSize) / 2, (height - tileSize) / 2);
+
+        // Bottom-Left
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
+                                    smallRect, tileSize * channels, 0, height - tileSize);
+
+        // Bottom-Right
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
+                                    smallRect, tileSize * channels, width - tileSize, height - tileSize);
+    }
+
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(4_000, 4_000, 120, 120)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public unsafe void WritePixels_SmallRect_Unsafe_Succeeds(int width, int height, double dpiX, double dpiY)
+    {
+        const int tileSize = 1000;
+        const int channels = 4;
+
+        // Create 1000x1000 rectangle with 4 channels, fill the rectangle with teal color
+        Span<byte> smallRect = GC.AllocateUninitializedArray<byte>(tileSize * tileSize * channels, pinned: true);
+        MemoryMarshal.Cast<byte, uint>(smallRect).Fill(0xFF00E6FF);
+
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Top-Left
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize), smallRect.AsNativePointer(),
+                                    smallRect.Length, tileSize * channels, 0, 0);
+
+        // Top-Right
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize), smallRect.AsNativePointer(),
+                                    smallRect.Length, tileSize * channels, width - tileSize, 0);
+
+        // Middle Rect
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize), smallRect.AsNativePointer(),
+                                    smallRect.Length, tileSize * channels, (width - tileSize) / 2, (height - tileSize) / 2);
+
+        // Bottom-Left
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize), smallRect.AsNativePointer(),
+                                    smallRect.Length, tileSize * channels, 0, height - tileSize);
+
+        // Bottom-Right
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize), smallRect.AsNativePointer(),
+                                    smallRect.Length, tileSize * channels, width - tileSize, height - tileSize);
+    }
+
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(4_000, 4_000, 120, 120)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public void WritePixels_FullRect_Safe_Succeeds(int width, int height, double dpiX, double dpiY)
+    {
+        const int channels = 4;
+
+        // Create same-sized rectangle with 4 channels, fill the rectangle with teal color
+        // NOTE: We use uint[] over byte[] to avoid Array.MaxLength limit for single-dims on 2GB+ bitmaps
+        uint[] bigRect = GC.AllocateUninitializedArray<uint>(width * height);
+        Array.Fill(bigRect, 0xFF00E6FF);
+
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Paint the full rect teal
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, width, height), bigRect, width * channels, 0, 0);
+    }
+
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(4_000, 4_000, 120, 120)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public unsafe void WritePixels_FullRect_Unsafe_Succeeds(int width, int height, double dpiX, double dpiY)
+    {
+        const int channels = 4;
+
+        // Create same-sized rectangle with 4 channels, fill the rectangle with teal color
+        // NOTE: We use uint[] over byte[] to avoid Array.MaxLength limit for single-dims on 2GB+ bitmaps
+        Span<uint> bigRect = GC.AllocateUninitializedArray<uint>(width * height, pinned: true);
+        bigRect.Fill(0xFF00E6FF);
+
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Paint the full rect teal
+        writeableBitmap.WritePixels(new Int32Rect(0, 0, width, height), bigRect.AsNativePointer(),
+                                    bigRect.Length * channels, width * channels, 0, 0);
+    }
+
+    // Under 2GB back-buffer (4 channels)
+    [InlineData(128, 128, 96.0, 96.0)]
+    [InlineData(256, 512, 96.0, 96.0)]
+    [InlineData(256, 256, 120.0, 120.0)]
+    [InlineData(512, 256, 120.0, 120.0)]
+    [InlineData(10_000, 10_000, 96.0, 96.0)]
+    [InlineData(20_000, 20_000, 96.0, 96.0)]
+    // Over 2GB back-buffer (4 channels) -- NOTE: These tests shall not be run on x86 without PAE
+    [InlineData(25_000, 25_000, 96.0, 96.0)]
+    [InlineData(32_000, 32_000, 96.0, 96.0)]
+    [Theory]
+    public void Clone_CopyPixels_Succeeds(int width, int height, double dpiX, double dpiY)
+    {
+        WriteableBitmap writeableBitmap = new(width, height, dpiX, dpiY, PixelFormats.Pbgra32, null);
+
+        // Invoke bitmap copy
+        BitmapSource bitmapSource = writeableBitmap.Clone();
+
+        // Must succeed
+        Assert.NotNull(bitmapSource);
+    }
+}
+
+public static unsafe class SpanExtensions
+{
+    /// <summary>Retrieves the data pointer of the underlying <see cref="Span{T}"/> data reference.</summary>
+    /// <param name="span">The <see cref="Span{T}"/> to retrieve a pointer to.</param>
+    /// <returns>A <see cref="nuint"/> pointer of the underlying data reference.</returns>
+    /// <remarks>The pointer reference is not pinned, use only on <see langword="fixed"/> buffers or <see langword="stackalloc"/> pointers.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static nint AsNativePointer<T>(this Span<T> span) => (nint)Unsafe.AsPointer(ref MemoryMarshal.GetReference(span));
+
+}


### PR DESCRIPTION
Fixes #9438 

## Description

Fixes working with `WriteableBitmap` to (`WritePixels`/`Clone`) operations on large buffers (over `Int32.MaxValue`) as those are supported by `WpfGfx`/`Milcore` as the underlying layer supports creation and working with such buffers.

Previously you were just able to create such WriteableBitmap but unable to `WritePixels` to the bottom-right corner or `Clone` it.

This departs from `BitmapSource` behaviour which uses `WIC` and there's an ongoing disparity between `IWICBitmapSource_CopyPixels_Proxy` and `IWICImagingFactory_CreateBitmapFromMemory_Proxy` where the former works with up to 4GB buffers but creating such bitmap fails with `0x80070057` even though both bufferSize params are documented as `uint`.

Base code that would fail with `OverflowException` before on `WritePixels` (creation would succeed).

```csharp
//Base vars
int width = 30000;
int height = 30000;
int tileSize = 1000;
int channels = 4;
int stride = tileSize * channels;
byte[] smallRect = new byte[tileSize * tileSize * channels];
WriteableBitmap bitmap = new WriteableBitmap(width, height, 96, 96, PixelFormats.Pbgra32, null);

//Set teal color
for (int row = 0; row < tileSize; row++)
{
    for (int col = 0; col < tileSize; col++)
    {
        // BGRA
        smallRect[row * stride + col * 4 + 0] = 255;
        smallRect[row * stride + col * 4 + 1] = 230;
        smallRect[row * stride + col * 4 + 2] = 0;
        smallRect[row * stride + col * 4 + 3] = 255;
    }
}

//Top-Left
bitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
                    smallRect, tileSize * channels, 0, 0);

//Top-Right
bitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
                    smallRect, tileSize * channels, width - tileSize, 0);
                    
//Middle Rect
bitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
                    smallRect, tileSize * channels, (width - tileSize) / 2, (height - tileSize) / 2);

//Bottom-Left
bitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
                    smallRect, tileSize * channels, 0, height - tileSize);

//Bottom-Right
bitmap.WritePixels(new Int32Rect(0, 0, tileSize, tileSize),
                    smallRect, tileSize * channels, width - tileSize, height - tileSize);

//Save (Test CriticalPixelsCopy)
BitmapSource bitmapCopy = bitmap.Clone();
```

## Customer Impact

Ability to write pixels on bitmaps over 23xxx x 23xxxx bitmaps with 4 channels, etc. (using backbuffers over 2GB).

## Regression

No.

## Testing

Local build, working with `WriteableBitmap`.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9470)