### PR TITLE
Enable PresentationCore tests

### DIFF
--- a/Microsoft.Dotnet.Wpf.sln
+++ b/Microsoft.Dotnet.Wpf.sln
@@ -247,11 +247,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{34B64A4A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{A48B585E-6AB0-4F8D-8484-77F37CB44437}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFB}") = "System.Xaml.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\System.Xaml.Tests\System.Xaml.Tests.csproj", "{B2F2A89C-55C9-41B1-A645-0948609BD8BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Xaml.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\System.Xaml.Tests\System.Xaml.Tests.csproj", "{B2F2A89C-55C9-41B1-A645-0948609BD8BE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationFramework.Fluent", "src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\PresentationFramework.Fluent.csproj", "{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationFramework.Fluent-ref", "src\Microsoft.DotNet.Wpf\src\Themes\PresentationFramework.Fluent\ref\PresentationFramework.Fluent-ref.csproj", "{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PresentationCore.Tests", "src\Microsoft.DotNet.Wpf\tests\UnitTests\PresentationCore.Tests\PresentationCore.Tests.csproj", "{A4377D3F-6BA1-4994-945C-88667993E4F3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1924,28 +1926,22 @@ Global
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.ActiveCfg = Release|Win32
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.Build.0 = Release|Win32
 		{AF9084C3-BF37-4A56-A851-89F3BAE731B3}.Release|x86.Deploy.0 = Release|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.Build.0 = Debug|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.Deploy.0 = Debug|Win32
+		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|ARM64.ActiveCfg = Debug|ARM64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|ARM64.Build.0 = Debug|ARM64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x64.ActiveCfg = Debug|x64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x64.Build.0 = Debug|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x64.Deploy.0 = Debug|x64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x86.ActiveCfg = Debug|x86
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x86.Build.0 = Debug|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Debug|x86.Deploy.0 = Debug|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.ActiveCfg = Release|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.Build.0 = Release|Win32
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.Deploy.0 = Release|Win32
+		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|ARM64.ActiveCfg = Release|ARM64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|ARM64.Build.0 = Release|ARM64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x64.ActiveCfg = Release|x64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x64.Build.0 = Release|x64
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x64.Deploy.0 = Release|x64
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x86.ActiveCfg = Release|x86
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x86.Build.0 = Release|x86
-		{B2F2A89C-55C9-41B1-A645-0948609BD8BE}.Release|x86.Deploy.0 = Release|x86
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9}.Debug|ARM64.ActiveCfg = Debug|arm64
@@ -1978,6 +1974,22 @@ Global
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x64.Build.0 = Release|x64
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD}.Release|x86.Build.0 = Release|Any CPU
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|ARM64.Build.0 = Debug|ARM64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x64.ActiveCfg = Debug|x64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x64.Build.0 = Debug|x64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x86.ActiveCfg = Debug|x86
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Debug|x86.Build.0 = Debug|x86
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|ARM64.ActiveCfg = Release|ARM64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|ARM64.Build.0 = Release|ARM64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x64.ActiveCfg = Release|x64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x64.Build.0 = Release|x64
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x86.ActiveCfg = Release|x86
+		{A4377D3F-6BA1-4994-945C-88667993E4F3}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2100,6 +2112,7 @@ Global
 		{B2F2A89C-55C9-41B1-A645-0948609BD8BE} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
 		{3F2C0E0E-BB13-46D9-8D9A-08256A49ECA9} = {5ACFB055-649D-4A01-98C2-B0BFE7E543D6}
 		{3C43C553-2C1F-4EB9-8BF8-371D4A42E0FD} = {60F4058B-D35B-42D2-B276-D44B3AC579BD}
+		{A4377D3F-6BA1-4994-945C-88667993E4F3} = {A48B585E-6AB0-4F8D-8484-77F37CB44437}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B4340004-DAC0-497D-B69D-CFA7CD93F567}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -86,10 +86,10 @@
   </PropertyGroup>
   <!-- XUnit-related (not extensions) -->
   <PropertyGroup>
-    <XUnitVersion>2.4.0</XUnitVersion>
+    <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitAssertVersion>$(XUnitVersion)</XUnitAssertVersion>
     <XUnitRunnerConsoleVersion>$(XUnitVersion)</XUnitRunnerConsoleVersion>
-    <XUnitRunnerVisualStudioVersion>2.4.0</XUnitRunnerVisualStudioVersion>
+    <XUnitRunnerVisualStudioVersion>2.8.1</XUnitRunnerVisualStudioVersion>
     <XUnitExtensibilityExecutionVersion>$(XUnitVersion)</XUnitExtensibilityExecutionVersion>
     <XUnitStaFactPackageVersion>1.2.46-alpha</XUnitStaFactPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/OtherAssemblyAttrs.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/OtherAssemblyAttrs.cs
@@ -18,7 +18,7 @@ using System.Runtime.CompilerServices;
 [assembly:InternalsVisibleTo(BuildInfo.PresentationFrameworkSystemDrawing)]
 [assembly:InternalsVisibleTo(BuildInfo.SystemWindowsControlsRibbon)]
 [assembly:InternalsVisibleTo(BuildInfo.WindowsFormsIntegration)]
-[assembly:InternalsVisibleTo("PresentationCore.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly:InternalsVisibleTo($"PresentationCore.Tests, PublicKey={BuildInfo.WCP_PUBLIC_KEY_STRING}")]
 [assembly: TypeForwardedTo(typeof(System.Windows.Markup.IUriContext))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Media.TextFormattingMode))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Input.ICommand))]

--- a/src/Microsoft.DotNet.Wpf/tests/Directory.Build.props
+++ b/src/Microsoft.DotNet.Wpf/tests/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
     <IsShipping>false</IsShipping>
     <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
@@ -2,25 +2,16 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-  <ItemGroup>
-    <PackageReference Include="runtime.$(WpfRuntimeIdentifier).$(DncEngTransportPackageName)"
-                      Condition="'$(RepositoryName)'=='wpf'"
-                      Version="$(MicrosoftDotNetWpfDncEngVersion)">
-      <CopyLocal>true</CopyLocal>
-      <GeneratePathProperty>true</GeneratePathProperty>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup>
-    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' != 'Debug'">$(Pkgruntime_win-x64_Microsoft_DotNet_Wpf_DncEng)</_DncEngPackagePath>
-    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' == 'Debug'">$(Pkgruntime_win-x64_Microsoft_DotNet_Wpf_DncEng_Debug)</_DncEngPackagePath>
-    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' != 'Debug'">$(Pkgruntime_win-x86_Microsoft_DotNet_Wpf_DncEng)</_DncEngPackagePath>
-    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' == 'Debug'">$(Pkgruntime_win-x86_Microsoft_DotNet_Wpf_DncEng_Debug)</_DncEngPackagePath>
+    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' != 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\x64\Microsoft.DotNet.Wpf.GitHub</_PackagingNativePath>
+    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' == 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\x64\Microsoft.DotNet.Wpf.GitHub.Debug</_PackagingNativePath>
+    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' != 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\Microsoft.DotNet.Wpf.GitHub</_PackagingNativePath>
+    <_PackagingNativePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' == 'Debug'">$(ArtifactsDir)packaging\$(Configuration)\Microsoft.DotNet.Wpf.GitHub.Debug</_PackagingNativePath>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- These exist to ensure that dependencies (esp. native ones) are binplaced with tests correctly -->
-    <None Include="$(_DncEngPackagePath)\runtimes\$(WpfRuntimeIdentifier)\native\*.dll"
+    <None Include="$(_PackagingNativePath)\runtimes\$(WpfRuntimeIdentifier)\native\*.dll"
           CopyToOutputDirectory="PreserveNewest"
           Visible="False" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/Directory.Build.targets
@@ -1,0 +1,36 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <PackageReference Include="runtime.$(WpfRuntimeIdentifier).$(DncEngTransportPackageName)"
+                      Condition="'$(RepositoryName)'=='wpf'"
+                      Version="$(MicrosoftDotNetWpfDncEngVersion)">
+      <CopyLocal>true</CopyLocal>
+      <GeneratePathProperty>true</GeneratePathProperty>
+    </PackageReference>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' != 'Debug'">$(Pkgruntime_win-x64_Microsoft_DotNet_Wpf_DncEng)</_DncEngPackagePath>
+    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x64' And '$(Configuration)' == 'Debug'">$(Pkgruntime_win-x64_Microsoft_DotNet_Wpf_DncEng_Debug)</_DncEngPackagePath>
+    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' != 'Debug'">$(Pkgruntime_win-x86_Microsoft_DotNet_Wpf_DncEng)</_DncEngPackagePath>
+    <_DncEngPackagePath Condition="'$(WpfRuntimeIdentifier)'=='win-x86' And '$(Configuration)' == 'Debug'">$(Pkgruntime_win-x86_Microsoft_DotNet_Wpf_DncEng_Debug)</_DncEngPackagePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- These exist to ensure that dependencies (esp. native ones) are binplaced with tests correctly -->
+    <None Include="$(_DncEngPackagePath)\runtimes\$(WpfRuntimeIdentifier)\native\*.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="False" />
+  </ItemGroup>
+
+  <Target Name="RemoveWindowsBaseNetCoreAppReference"
+          AfterTargets="ResolveTargetingPackAssets"
+          Returns="@(Reference)">
+    <ItemGroup>
+      <Reference Remove="@(Reference)" Condition="'%(Reference.AssemblyName)' == 'WindowsBase' And '%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App'" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
@@ -5,26 +5,24 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <Nullable>enable</Nullable>
-    <TargetFramework>net9.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <Platforms>AnyCPU;x64;x86</Platforms>
-    <SignAssembly>True</SignAssembly>
+    <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\PresentationCore\PresentationCore.csproj" />
-    <ProjectReference Include="..\..\..\src\WindowsBase\WindowsBase.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)DirectWriteForwarder\DirectWriteForwarder.vcxproj">
+      <UndefineProperties>TargetFramework;TargetFrameworks</UndefineProperties>
+    </ProjectReference>
+    <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildPackageVersion)" />
-    <PackageReference Include="Xunit" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0-preview.7.24359.11 " />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System.Xaml.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/System.Xaml.Tests/System.Xaml.Tests.csproj
@@ -5,10 +5,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <Nullable>enable</Nullable>
+    <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\System.Xaml\System.Xaml.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Enables PresentationCore tests.

@adamsitnik noted here https://github.com/dotnet/wpf/pull/9465#discussion_r1691382762 that PresentationCore.Tests was not included so the tests were not running. By reading the commit messages in dotnet/wpf#8532 it seems like they were disabled temporarily but I don't know why. I took it upon myself on enabling them and fixing the build and runtime errors (I don't know if they were the cause on why they were disabled).

It also fixes the build errors and some runtime errors in dotnet/wpf#8215 but WindowsBase.Tests would need some changes to completely fix it and I plan on working on it once this PR is merged.

I hope I didn't step on anyone's toes if they were working on it.

## Customer Impact
WPF would be more tested.

## Regression
No.

## Testing
Local build + tests passing locally.

## Risk
None, shouldn't affect shipping binaries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9471)