### PR TITLE
Replace Interlocked.{Compare}Exchange Int32 overloads with generic <bool> variants

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaSystem.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/MediaSystem.cs
@@ -9,6 +9,7 @@
 using System.Collections;
 using System.Windows.Media.Composition;
 using System.Windows.Threading;
+using System.Threading;
 using MS.Internal;
 
 using SafeNativeMethods = MS.Win32.PresentationCore.SafeNativeMethods;
@@ -144,12 +145,12 @@ namespace System.Windows.Media
         /// </summary>
         internal static void PropagateDirtyRectangleSettings()
         {
-            int oldValue = s_DisableDirtyRectangles;
-            int disableDirtyRectangles = CoreAppContextSwitches.DisableDirtyRectangles ? 1 : 0;
+            bool oldValue = s_disableDirtyRectangles;
+            bool disableDirtyRectangles = CoreAppContextSwitches.DisableDirtyRectangles;
 
             if (disableDirtyRectangles != oldValue)
             {
-                if (System.Threading.Interlocked.CompareExchange(ref s_DisableDirtyRectangles, disableDirtyRectangles, oldValue) == oldValue)
+                if (Interlocked.CompareExchange(ref s_disableDirtyRectangles, disableDirtyRectangles, oldValue) == oldValue)
                 {
                     NotifyRedirectionEnvironmentChanged();
                 }
@@ -158,7 +159,7 @@ namespace System.Windows.Media
 
         internal static bool DisableDirtyRectangles
         {
-            get { return (s_DisableDirtyRectangles != 0); }
+            get => s_disableDirtyRectangles;
         }
 
         /// <summary>
@@ -355,9 +356,10 @@ namespace System.Windows.Media
         /// </summary>
         private static bool s_forceSoftareForGraphicsStreamMagnifier;
 
-        // 1 if app is requesting to disable D3D dirty rectangle work, 0 otherwise.
-        // We use Interlocked.CompareExchange to change this, which supports int but not bool.
-        private static int s_DisableDirtyRectangles = 0;
+        /// <summary>
+        /// <see langword="true"/> if the app is requesting to disable D3D dirty rectangle work, <see langword="false"/> otherwise.
+        /// </summary>
+        private static bool s_disableDirtyRectangles = false;
      }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
@@ -677,7 +677,7 @@ namespace MS.Internal.PtsHost
         //-------------------------------------------------------------------
         // Is this page already disposed?
         //-------------------------------------------------------------------
-        internal bool IsDisposed { get { return (_disposed != 0) || _structuralCache.PtsContext.Disposed; } }
+        internal bool IsDisposed { get { return _disposed || _structuralCache.PtsContext.Disposed; } }
 
         //-------------------------------------------------------------------
         // Size of content on page.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/FlowDocumentPage.cs
@@ -798,7 +798,7 @@ namespace MS.Internal.PtsHost
         private void Dispose(bool disposing)
         {
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 if (disposing)
                 {
@@ -1098,7 +1098,7 @@ namespace MS.Internal.PtsHost
         //-------------------------------------------------------------------
         // Is it already disposed?
         //-------------------------------------------------------------------
-        private int _disposed;
+        private bool _disposed;
 
         //-------------------------------------------------------------------
         // Max of dcpDepend for page

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PageBreakRecord.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PageBreakRecord.cs
@@ -131,7 +131,7 @@ namespace MS.Internal.PtsHost
             PtsContext ptsContext = null;
 
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 // Dispose PTS break record.
                 // According to following article the entire reachable graph from 
@@ -183,7 +183,7 @@ namespace MS.Internal.PtsHost
         /// <summary>
         /// Whether object is already disposed.
         /// </summary>
-        private int _disposed;
+        private bool _disposed;
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
@@ -163,7 +163,7 @@ namespace MS.Internal.PtsHost
         ~PtsCache()
         {
             // After shutdown is initiated, do not allow Finalizer thread to the cleanup.
-            if (0 == Interlocked.CompareExchange(ref _disposed, 1, 0))
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 // Destroy all PTS contexts
                 DestroyPTSContexts();
@@ -292,7 +292,7 @@ namespace MS.Internal.PtsHost
 
             // After shutdown is initiated, do not allow Finalizer thread to add any
             // items to _releaseQueue.
-            if (0 == Interlocked.CompareExchange(ref _disposed, 1, 0))
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 // Dispose any pending PtsContexts stored in _releaseQueue
                 OnPtsContextReleased(false);
@@ -763,7 +763,7 @@ namespace MS.Internal.PtsHost
         /// <summary>
         /// Whether object is already disposed.
         /// </summary>
-        private int _disposed;
+        private bool _disposed;
 
         #endregion Private Fields
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsCache.cs
@@ -118,7 +118,7 @@ namespace MS.Internal.PtsHost
                 PtsCache ptsCache = Dispatcher.CurrentDispatcher.PtsCache as PtsCache;
                 if (ptsCache != null)
                 {
-                    disposed = (ptsCache._disposed == 1);
+                    disposed = ptsCache._disposed;
                 }
             }
             return disposed;
@@ -225,7 +225,7 @@ namespace MS.Internal.PtsHost
             {
                 // After shutdown is initiated, do not allow Finalizer thread to add any
                 // items to _releaseQueue.
-                if (_disposed == 0)
+                if (_disposed == false)
                 {
                     // Add PtsContext to collection of released PtsContexts.
                     // If the queue is empty, schedule Dispatcher time to dispose

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
@@ -370,7 +370,7 @@ namespace MS.Internal.PtsHost
         /// </summary>
         internal bool Disposed
         {
-            get { return (_disposed != 0); }
+            get { return _disposed; }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsContext.cs
@@ -72,7 +72,7 @@ namespace MS.Internal.PtsHost
             int index;
 
             // Do actual dispose only once.
-            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 // Destroy all page break records. The collection is allocated during creation
                 // of the context, and can be only destroyed during dispose process.
@@ -609,7 +609,7 @@ namespace MS.Internal.PtsHost
         /// <summary>
         /// Whether object is already disposed.
         /// </summary>
-        private int _disposed;
+        private bool _disposed;
 
         /// <summary>
         /// Whether Dispose has been completed. It may be set to 'false' even when

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/PtsPage.cs
@@ -705,7 +705,7 @@ namespace MS.Internal.PtsHost
         /// </remarks>
         private void Dispose(bool disposing)
         {
-            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+            if (Interlocked.CompareExchange(ref _disposed, true, false) == false)
             {
                 // Destroy PTS page.
                 // According to following article the entire reachable graph from 
@@ -1522,7 +1522,7 @@ namespace MS.Internal.PtsHost
         // ------------------------------------------------------------------
         // Is object already disposed.
         // ------------------------------------------------------------------
-        private int _disposed;
+        private bool _disposed;
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ShutDownListener.cs
@@ -116,9 +116,8 @@ namespace MS.Internal
         private void HandleShutDown(object sender, EventArgs e)
         {
             // The dispatcher and AppDomain events might arrive on separate threads
-            // at the same time.  The interlock assures that we only do the work
-            // once.
-            if (Interlocked.Exchange(ref _inShutDown, 1) == 0)
+            // at the same time. The interlock assures that we only do the work once.
+            if (Interlocked.Exchange(ref _inShutDown, true) == false)
             {
                 // ShutDown is a one-time event.  Stop listening (thus releasing
                 // references to the ShutDownListener).
@@ -146,6 +145,6 @@ namespace MS.Internal
 
         PrivateFlags _flags;
         WeakReference _dispatcherWR;
-        int _inShutDown;
+        bool _inShutDown;
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -38,7 +38,7 @@ namespace System.Windows
         /// <summary>
         /// Guards against multiple verifications of the switch values.
         /// </summary>
-        static int s_SwitchesVerified = 0;
+        private static bool s_switchesVerified = false;
 
         #endregion
 
@@ -183,7 +183,7 @@ namespace System.Windows
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void VerifySwitches(Dispatcher dispatcher)
         {
-            if (Interlocked.CompareExchange(ref s_SwitchesVerified, 1, 0) == 0)
+            if (Interlocked.CompareExchange(ref s_switchesVerified, true, false) == false)
             {
                 bool netFx47 = UseNetFx47CompatibleAccessibilityFeatures;
                 bool netFx471 = UseNetFx471CompatibleAccessibilityFeatures;


### PR DESCRIPTION
## Description

As [dotnet/runtime - #65184](https://github.com/dotnet/runtime/issues/65184#issue-1132211395) was approved last week and changes were made in the runtime repo to unconstrain the generic overload from class-only behaviour for `Interlocked.Exchange` and `Interlocked.CompareExchange`, we can adjust the code in the WPF repo for improved code quality as well.

Given how few places we rely on `Interlocked` functionality, this should be easy to review.

## Customer Impact

None, just internal code quality changes that do not measurably affect performance in any direction.

## Regression

No.

## Testing

Local build/CI.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9480)