### PR TITLE
Replace occurrences of params T[] with params ReadOnlySpan<T> where possible

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PresentationSource.cs
@@ -584,24 +584,20 @@ namespace System.Windows
         ///     Helper method which returns true when all the given visuals 
         ///     are in the same presentation source.
         /// </summary>
-        internal static bool UnderSamePresentationSource(params DependencyObject[] visuals)
+        internal static bool IsUnderSamePresentationSource(params ReadOnlySpan<DependencyObject> visuals)
         {
-            if (visuals == null || visuals.Length == 0)
-            {
+            if (visuals.IsEmpty)
                 return true;
-            }
 
             PresentationSource baseSource = CriticalFromVisual(visuals[0]);
-
-            int count = visuals.Length;
-            for (int i = 1; i < count; i++)
+            for (int i = 1; i < visuals.Length; i++)
             {
-                PresentationSource currentSource = CriticalFromVisual(visuals[i]);
-                if (currentSource != baseSource)
+                if (baseSource != CriticalFromVisual(visuals[i]))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Commands/CommandHelpers.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Commands/CommandHelpers.cs
@@ -15,7 +15,7 @@ namespace MS.Internal.Commands
 
         internal static void RegisterCommandHandler(Type controlType, RoutedCommand command, ExecutedRoutedEventHandler executedRoutedEventHandler)
         {
-            PrivateRegisterCommandHandler(controlType, command, executedRoutedEventHandler, null, null);
+            PrivateRegisterCommandHandler(controlType, command, executedRoutedEventHandler, null);
         }
 
         internal static void RegisterCommandHandler(Type controlType, RoutedCommand command, ExecutedRoutedEventHandler executedRoutedEventHandler,
@@ -39,7 +39,7 @@ namespace MS.Internal.Commands
         internal static void RegisterCommandHandler(Type controlType, RoutedCommand command, ExecutedRoutedEventHandler executedRoutedEventHandler,
                                                     CanExecuteRoutedEventHandler canExecuteRoutedEventHandler)
         {
-            PrivateRegisterCommandHandler(controlType, command, executedRoutedEventHandler, canExecuteRoutedEventHandler, null);
+            PrivateRegisterCommandHandler(controlType, command, executedRoutedEventHandler, canExecuteRoutedEventHandler);
         }
 
         internal static void RegisterCommandHandler(Type controlType, RoutedCommand command, ExecutedRoutedEventHandler executedRoutedEventHandler,
@@ -90,7 +90,7 @@ namespace MS.Internal.Commands
 
         // 'params' based method is private.  Call sites that use this bloat unwittingly due to implicit construction of the params array that goes into IL.
         private static void PrivateRegisterCommandHandler(Type controlType, RoutedCommand command, ExecutedRoutedEventHandler executedRoutedEventHandler,
-                                                          CanExecuteRoutedEventHandler canExecuteRoutedEventHandler, params InputGesture[] inputGestures)
+                                                          CanExecuteRoutedEventHandler canExecuteRoutedEventHandler, params ReadOnlySpan<InputGesture> inputGestures)
         {
             // Validate parameters
             Debug.Assert(controlType != null);
@@ -102,12 +102,9 @@ namespace MS.Internal.Commands
             CommandManager.RegisterClassCommandBinding(controlType, new CommandBinding(command, executedRoutedEventHandler, canExecuteRoutedEventHandler));
 
             // Create additional input binding for this command
-            if (inputGestures != null)
+            for (int i = 0; i < inputGestures.Length; i++)
             {
-                for (int i = 0; i < inputGestures.Length; i++)
-                {
-                    CommandManager.RegisterClassInputBinding(controlType, new InputBinding(command, inputGestures[i]));
-                }
+                CommandManager.RegisterClassInputBinding(controlType, new InputBinding(command, inputGestures[i]));
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridDetailsPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridDetailsPresenter.cs
@@ -105,7 +105,7 @@ namespace System.Windows.Controls.Primitives
         private void OnAnyMouseLeftButtonDown(System.Windows.Input.MouseButtonEventArgs e)
         {
             // Ignore actions if the button down arises from a different presentation source
-            if (!PresentationSource.UnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
+            if (!PresentationSource.IsUnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ScrollViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ScrollViewer.cs
@@ -1648,7 +1648,7 @@ namespace System.Windows.Controls
         {
             // If the original source is not from the same PresentationSource as of ScrollViewer,
             // then do not start the manipulation.
-            if (!PresentationSource.UnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
+            if (!PresentationSource.IsUnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
             {
                 return false;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -12117,7 +12117,7 @@ namespace System.Windows.Controls
             }
 
             // for use from VS Immediate window
-            static void Mark(params object[] args)
+            static void Mark(params ReadOnlySpan<object> args)
             {
                 ScrollTraceRecord record = new ScrollTraceRecord(ScrollTraceOp.Mark, null, -1, 0, 0, BuildDetail(args));
                 lock (s_TargetToTraceListMap)
@@ -12229,7 +12229,7 @@ namespace System.Windows.Controls
                 return (sti != null && sti.ScrollTracer != null);
             }
 
-            internal static void Trace(VirtualizingStackPanel vsp, ScrollTraceOp op, params object[] args)
+            internal static void Trace(VirtualizingStackPanel vsp, ScrollTraceOp op, params ReadOnlySpan<object> args)
             {
                 ScrollTracingInfo sti = ScrollTracingInfoField.GetValue(vsp);
                 ScrollTracer tracer = sti.ScrollTracer;
@@ -12272,16 +12272,12 @@ namespace System.Windows.Controls
                 return sb.ToString();
             }
 
-            private static string BuildDetail(object[] args)
+            private static string BuildDetail(ReadOnlySpan<object> args)
             {
-                int length = (args != null) ? args.Length : 0;
-                if (length == 0)
-                    return String.Empty;
-                else
-                    return String.Format(CultureInfo.InvariantCulture, s_format[length], args);
+                return args.IsEmpty ? string.Empty : string.Format(CultureInfo.InvariantCulture, s_format[args.Length], args);
             }
 
-            private static string[] s_format = new string[] {
+            private static readonly string[] s_format = new string[] {
                 "",
                 "{0}",
                 "{0} {1}",
@@ -12392,7 +12388,7 @@ namespace System.Windows.Controls
                 }
             }
 
-            private void AddTrace(VirtualizingStackPanel vsp, ScrollTraceOp op, ScrollTracingInfo sti, params object[] args)
+            private void AddTrace(VirtualizingStackPanel vsp, ScrollTraceOp op, ScrollTracingInfo sti, params ReadOnlySpan<object> args)
             {
                 // the trace list contains references back into the VSP that can lead
                 // to memory leaks if the app removes the VSP.  To avoid this, treat
@@ -12403,10 +12399,8 @@ namespace System.Windows.Controls
                 {
                     if (++_luCount > _luThreshold)
                     {
-                        AddTrace(null, ScrollTraceOp.ID, _nullInfo,
-                            "Inactive at", DateTime.Now);
-                        ItemsControl ic;
-                        if (_wrIC.TryGetTarget(out ic))
+                        AddTrace(null, ScrollTraceOp.ID, _nullInfo, "Inactive at", DateTime.Now);
+                        if (_wrIC.TryGetTarget(out ItemsControl ic))
                         {
                             ic.LayoutUpdated -= OnLayoutUpdated;
                         }
@@ -12421,10 +12415,8 @@ namespace System.Windows.Controls
 
                     if (luCount < 0)
                     {
-                        AddTrace(null, ScrollTraceOp.ID, _nullInfo,
-                            "Reactivate at", DateTime.Now);
-                        ItemsControl ic;
-                        if (_wrIC.TryGetTarget(out ic))
+                        AddTrace(null, ScrollTraceOp.ID, _nullInfo, "Reactivate at", DateTime.Now);
+                        if (_wrIC.TryGetTarget(out ItemsControl ic))
                         {
                             ic.LayoutUpdated += OnLayoutUpdated;
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VisualStates.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VisualStates.cs
@@ -4,10 +4,7 @@
 
 namespace System.Windows.Controls
 {
-    /// <summary>
-    /// Names and helpers for visual states in the controls.
-    /// <remarks>THIS IS A SHARED FILE.  PresentationFramework.Design.dll must be rebuilt if changed.</remarks>
-    /// </summary>
+    /// <summary> Names and helpers for visual states in the controls. </summary>
     internal static class VisualStates
     {
         #region CalendarDayButton
@@ -414,9 +411,9 @@ namespace System.Windows.Controls
         /// Ordered list of state names and fallback states to transition into.
         /// Only the first state to be found will be used.
         /// </param>
-        public static void GoToState(Control control, bool useTransitions, params string[] stateNames)
+        public static void GoToState(Control control, bool useTransitions, params ReadOnlySpan<string> stateNames)
         {
-            if (stateNames == null)
+            if (stateNames.IsEmpty)
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -4755,7 +4755,7 @@ namespace System.Windows.Documents
             }
 
             // for use from VS Immediate window
-            internal static void Mark(params object[] args)
+            internal static void Mark(params ReadOnlySpan<object> args)
             {
                 IMECompositionTraceRecord record = new IMECompositionTraceRecord(IMECompositionTraceOp.Mark, BuildDetail(args));
                 lock (s_TargetToTraceListMap)
@@ -4807,7 +4807,7 @@ namespace System.Windows.Documents
                 return (cti != null && cti.IMECompositionTracer != null);
             }
 
-            internal static void Trace(TextStore textStore, IMECompositionTraceOp op, params object[] args)
+            internal static void Trace(TextStore textStore, IMECompositionTraceOp op, params ReadOnlySpan<object> args)
             {
                 IMECompositionTracingInfo cti = IMECompositionTracingInfoField.GetValue(textStore.UiScope);
                 IMECompositionTracer tracer = cti.IMECompositionTracer;
@@ -4850,16 +4850,12 @@ namespace System.Windows.Documents
                 return sb.ToString();
             }
 
-            private static string BuildDetail(object[] args)
+            private static string BuildDetail(ReadOnlySpan<object> args)
             {
-                int length = (args != null) ? args.Length : 0;
-                if (length == 0)
-                    return String.Empty;
-                else
-                    return String.Format(CultureInfo.InvariantCulture, s_format[length], args);
+                return args.IsEmpty ? string.Empty : string.Format(CultureInfo.InvariantCulture, s_format[args.Length], args);
             }
 
-            private static string[] s_format = new string[] {
+            private static readonly string[] s_format = new string[] {
                 "",
                 "{0}",
                 "{0} {1}",
@@ -4924,7 +4920,7 @@ namespace System.Windows.Documents
                 AddTrace(textStore, IMECompositionTraceOp.ID, _nullInfo, DisplayType(uiScope));
             }
 
-            private void AddTrace(TextStore textStore, IMECompositionTraceOp op, IMECompositionTracingInfo cti, params object[] args)
+            private void AddTrace(TextStore textStore, IMECompositionTraceOp op, IMECompositionTracingInfo cti, params ReadOnlySpan<object> args)
             {
                 // pop a E* op from the stack
                 if (IMECompositionTraceOp.FirstEndOp <= op && _opStack.Count > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -66,16 +66,16 @@ namespace System.Windows
     /// </summary>
     public static class SystemParameters
     {
-        public static event System.ComponentModel.PropertyChangedEventHandler StaticPropertyChanged;
+        public static event PropertyChangedEventHandler StaticPropertyChanged;
 
-        private static void OnPropertiesChanged(params string[] propertyNames)
+        private static void OnPropertiesChanged(params ReadOnlySpan<string> propertyNames)
         {
-            System.ComponentModel.PropertyChangedEventHandler handler = StaticPropertyChanged;
-            if (handler != null)
+            PropertyChangedEventHandler handler = StaticPropertyChanged;
+            if (handler is not null)
             {
-                for (int i=0; i<propertyNames.Length; ++i)
+                foreach (string propertyName in propertyNames)
                 {
-                    handler(null, new System.ComponentModel.PropertyChangedEventArgs(propertyNames[i]));
+                    handler.Invoke(null, new PropertyChangedEventArgs(propertyName));
                 }
             }
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateGroup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/VisualStateGroup.cs
@@ -94,40 +94,38 @@ namespace System.Windows
             }
         }
 
-        internal void StartNewThenStopOld(FrameworkElement element, params Storyboard[] newStoryboards)
+        internal void StartNewThenStopOld(FrameworkElement element, params ReadOnlySpan<Storyboard> newStoryboards)
         {
             // Remove the old Storyboards. Remove is delayed until the next TimeManager tick, so the
             // handoff to the new storyboard is unaffected.
-            for (int index = 0; index < CurrentStoryboards.Count; ++index)
+            for (int i = 0; i < CurrentStoryboards.Count; i++)
             {
-                if (CurrentStoryboards[index] == null)
-                {
+                Storyboard currentStoryboard = CurrentStoryboards[i];
+                if (currentStoryboard is null)
                     continue;
-                }
 
-                CurrentStoryboards[index].Remove(element);
+                currentStoryboard.Remove(element);
             }
+
             CurrentStoryboards.Clear();
 
             // Start the new Storyboards
-            for (int index = 0; index < newStoryboards.Length; ++index)
-            {
-                if (newStoryboards[index] == null)
-                {
+            foreach (Storyboard newStoryboard in newStoryboards)
+            { 
+                if (newStoryboard is null)
                     continue;
-                }
 
-                newStoryboards[index].Begin(element, HandoffBehavior.SnapshotAndReplace, true);
+                newStoryboard.Begin(element, HandoffBehavior.SnapshotAndReplace, true);
                 
                 // Hold on to the running Storyboards
-                CurrentStoryboards.Add(newStoryboards[index]);
+                CurrentStoryboards.Add(newStoryboard);
 
                 // Silverlight had an issue where initially, a checked CheckBox would not show the check mark
                 // until the second frame. They chose to do a Seek(0) at this point, which this line
                 // is supposed to mimic. It does not seem to be equivalent, though, and WPF ends up
                 // with some odd animation behavior. I haven't seen the CheckBox issue on WPF, so
                 // commenting this out for now.
-                // newStoryboards[index].SeekAlignedToLastTick(element, TimeSpan.Zero, TimeSeekOrigin.BeginTime);
+                // newStoryboard.SeekAlignedToLastTick(element, TimeSpan.Zero, TimeSeekOrigin.BeginTime);
             }
 
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -7038,7 +7038,7 @@ namespace System.Windows
 
             // If the original source is not from the same PresentationSource as of the Window,
             // then do not act on the PanningFeedback.
-            if (!PresentationSource.UnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
+            if (!PresentationSource.IsUnderSamePresentationSource(e.OriginalSource as DependencyObject, this))
             {
                 return;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
@@ -19,12 +19,8 @@ namespace MS.Internal.Documents.Application
     // Internal Methods
     //--------------------------------------------------------------------------
 
-    /// <summary>
-    /// Will permit only internet zone permissions for TraceListeners and is
-    /// safe to use inside of asserts for partial trust code.
-    /// </summary>
     internal static void SafeWrite(
-        BooleanSwitch boolSwitch, string format, params object[] args)
+        BooleanSwitch boolSwitch, string format, params ReadOnlySpan<object> args)
     {
         if (AvTrace.IsWpfTracingEnabledInRegistry())
         {
@@ -38,15 +34,11 @@ namespace MS.Internal.Documents.Application
         }
     }
 
-    /// <summary>
-    /// Will permit only internet zone permissions for TraceListeners and is
-    /// safe to use inside of asserts for partial trust code.
-    /// </summary>
     internal static void SafeWriteIf(
         bool condition,
         BooleanSwitch boolSwitch,
         string format,
-        params object[] args)
+        params ReadOnlySpan<object> args)
     {
         if (AvTrace.IsWpfTracingEnabledInRegistry())
         {
@@ -67,16 +59,11 @@ namespace MS.Internal.Documents.Application
     // Internal Fields
     //--------------------------------------------------------------------------
 
-    internal static BooleanSwitch File = new BooleanSwitch(
-        FileSwitchName, FileSwitchName, "1");
-    internal static BooleanSwitch Packaging = new BooleanSwitch(
-        PackagingSwitchName, PackagingSwitchName, "1");
-    internal static BooleanSwitch Presentation = new BooleanSwitch(
-        PresentationSwitchName, PresentationSwitchName, "1");
-    internal static BooleanSwitch Rights = new BooleanSwitch(
-        RightsSwitchName, RightsSwitchName, "1");
-    internal static BooleanSwitch Signatures = new BooleanSwitch(
-        SignaturesSwitchName, SignaturesSwitchName, "1");
+    internal static readonly BooleanSwitch File = new(FileSwitchName, FileSwitchName, "1");
+    internal static readonly BooleanSwitch Packaging = new(PackagingSwitchName, PackagingSwitchName, "1");
+    internal static readonly BooleanSwitch Presentation = new(PresentationSwitchName, PresentationSwitchName, "1");
+    internal static readonly BooleanSwitch Rights = new(RightsSwitchName, RightsSwitchName, "1");
+    internal static readonly BooleanSwitch Signatures = new(SignaturesSwitchName, SignaturesSwitchName, "1");
     #endregion Internal Fields
 
     #region Private Fields

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-// Description: Utility class for Trace switches and methods for XpsViewer.
-
+using System;
 using System.Diagnostics;
 using System.Globalization;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/Trace.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,69 +13,68 @@ namespace MS.Internal.Documents.Application
     /// Utility class for Trace switches and methods for XpsViewer.
     /// <summary>
     internal static class Trace
-{
-    #region Internal Methods
-    //--------------------------------------------------------------------------
-    // Internal Methods
-    //--------------------------------------------------------------------------
-
-    internal static void SafeWrite(
-        BooleanSwitch boolSwitch, string format, params ReadOnlySpan<object> args)
     {
-        if (AvTrace.IsWpfTracingEnabledInRegistry())
+        #region Internal Methods
+        //--------------------------------------------------------------------------
+        // Internal Methods
+        //--------------------------------------------------------------------------
+
+        internal static void SafeWrite(BooleanSwitch boolSwitch, string format, params ReadOnlySpan<object> args)
         {
-            System.Diagnostics.Trace.WriteLineIf(
-                boolSwitch.Enabled,
-                string.Format(
-                CultureInfo.CurrentCulture,
-                format,
-                args),
-                boolSwitch.DisplayName);
+            if (AvTrace.IsWpfTracingEnabledInRegistry())
+            {
+                System.Diagnostics.Trace.WriteLineIf(
+                    boolSwitch.Enabled,
+                    string.Format(
+                    CultureInfo.CurrentCulture,
+                    format,
+                    args),
+                    boolSwitch.DisplayName);
+            }
         }
-    }
 
-    internal static void SafeWriteIf(
-        bool condition,
-        BooleanSwitch boolSwitch,
-        string format,
-        params ReadOnlySpan<object> args)
-    {
-        if (AvTrace.IsWpfTracingEnabledInRegistry())
+        internal static void SafeWriteIf(
+            bool condition,
+            BooleanSwitch boolSwitch,
+            string format,
+            params ReadOnlySpan<object> args)
         {
-            System.Diagnostics.Trace.WriteLineIf(
-                boolSwitch.Enabled && condition,
-                string.Format(
-                CultureInfo.CurrentCulture,
-                format,
-                args),
-                boolSwitch.DisplayName);
+            if (AvTrace.IsWpfTracingEnabledInRegistry())
+            {
+                System.Diagnostics.Trace.WriteLineIf(
+                    boolSwitch.Enabled && condition,
+                    string.Format(
+                    CultureInfo.CurrentCulture,
+                    format,
+                    args),
+                    boolSwitch.DisplayName);
+            }
         }
+
+        #endregion Internal Methods
+
+        #region Internal Fields
+        //--------------------------------------------------------------------------
+        // Internal Fields
+        //--------------------------------------------------------------------------
+
+        internal static readonly BooleanSwitch File = new(FileSwitchName, FileSwitchName, "1");
+        internal static readonly BooleanSwitch Packaging = new(PackagingSwitchName, PackagingSwitchName, "1");
+        internal static readonly BooleanSwitch Presentation = new(PresentationSwitchName, PresentationSwitchName, "1");
+        internal static readonly BooleanSwitch Rights = new(RightsSwitchName, RightsSwitchName, "1");
+        internal static readonly BooleanSwitch Signatures = new(SignaturesSwitchName, SignaturesSwitchName, "1");
+        #endregion Internal Fields
+
+        #region Private Fields
+        //--------------------------------------------------------------------------
+        // Private Fields
+        //--------------------------------------------------------------------------
+
+        private const string FileSwitchName = "XpsViewerFile";
+        private const string PackagingSwitchName = "XpsViewerPackaging";
+        private const string PresentationSwitchName = "XpsViewerUI";
+        private const string RightsSwitchName = "XpsViewerRights";
+        private const string SignaturesSwitchName = "XpsViewerSignatures";
+        #endregion Private Fields
     }
-
-    #endregion Internal Methods
-
-    #region Internal Fields
-    //--------------------------------------------------------------------------
-    // Internal Fields
-    //--------------------------------------------------------------------------
-
-    internal static readonly BooleanSwitch File = new(FileSwitchName, FileSwitchName, "1");
-    internal static readonly BooleanSwitch Packaging = new(PackagingSwitchName, PackagingSwitchName, "1");
-    internal static readonly BooleanSwitch Presentation = new(PresentationSwitchName, PresentationSwitchName, "1");
-    internal static readonly BooleanSwitch Rights = new(RightsSwitchName, RightsSwitchName, "1");
-    internal static readonly BooleanSwitch Signatures = new(SignaturesSwitchName, SignaturesSwitchName, "1");
-    #endregion Internal Fields
-
-    #region Private Fields
-    //--------------------------------------------------------------------------
-    // Private Fields
-    //--------------------------------------------------------------------------
-
-    private const string FileSwitchName = "XpsViewerFile";
-    private const string PackagingSwitchName = "XpsViewerPackaging";
-    private const string PresentationSwitchName = "XpsViewerUI";
-    private const string RightsSwitchName = "XpsViewerRights";
-    private const string SignaturesSwitchName = "XpsViewerSignatures";
-    #endregion Private Fields
-}
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/Exceptions.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Input.Manipulations/System/Windows/Input/Manipulations/Exceptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Globalization;
 
 namespace System.Windows.Input.Manipulations
 {
@@ -233,13 +234,10 @@ namespace System.Windows.Input.Manipulations
         /// <param name="format"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        private static string Format(string format, params object[] args)
+        private static string Format(string format, params ReadOnlySpan<object> args)
         {
             Debug.Assert(format != null);
-            return string.Format(
-                System.Globalization.CultureInfo.CurrentCulture,
-                format,
-                args);
+            return string.Format(CultureInfo.CurrentCulture, format, args);
         }
     }
 }


### PR DESCRIPTION
## Description

Continues the journey that started in #9468 and converts some internal call-chains from `params T[]` to `params ReadOnlySpan<T>` where I felt it is without any side-effects, largely decreasing allocations in other scenarios besides just tracing and improving both performance and allocations since we do not need to create a new heap array of `T[]` everytime.

### Simple benchmark with 0, 1, and 3 params

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  7.547 ns |  0.1129 ns |   0.1056 ns | 0.0029 |         143 B |          48 B |
| PR__EDIT |  1.532 ns |  0.0096 ns |   0.0085 ns |      - |         120 B |             - |

<details><summary>Benchmark code</summary>

```c#
private static object target1;
private static object target2;
private static object target3;

[GlobalSetup]
public void Setup()
{
    target1 = new object();
    target2 = new object();
    target3 = new object();
}

[Benchmark]
public int Original()
{
    int test1_1 = Test1(1);
    int test1_2 = Test1(1, null);
    int test1_3 = Test1(1, target1, target2, target3);

    return  test1_1 + test1_2 + test1_3;
}


[Benchmark]
public int PR__EDIT()
{
    int test2_1 = Test2(1);
    int test2_2 = Test2(1, null);
    int test2_3 = Test2(1, target1, target2, target3);

    return test2_1 + test2_2 + test2_3;
}

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private int Test1(int stuff, params object[] args)
{
    if (args is null || args.Length == 0)
        return stuff;

    return args[0].GetHashCode();
}

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private int Test2(int stuff, params ReadOnlySpan<object> args)
{
    if (args.IsEmpty)
        return stuff;

    return args[0].GetHashCode();
}

```
</details>


## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, test app run.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9481)