### PR TITLE
Ensure WPF builds against framework SRSF version

### DIFF
--- a/eng/WpfArcadeSdk/tools/TestProjects.targets
+++ b/eng/WpfArcadeSdk/tools/TestProjects.targets
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryPackageVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" CopyLocal="true"  />
     <PackageReference Include="System.Diagnostics.EventLog" Version="$(SystemDiagnosticsEventLogPackageVersion)" CopyLocal="true" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" CopyLocal="true" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" CopyLocal="true" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" CopyLocal="true" />
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.5.24307.3",
+    "dotnet": "9.0.100-preview.6.24328.19",
     "runtimes": {
       "dotnet": [
         "2.1.7",
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24375.3"
   },
   "sdk": {
-    "version": "9.0.100-preview.5.24307.3"
+    "version": "9.0.100-preview.6.24328.19"
   },
   "native-tools": {
     "strawberry-perl": "5.38.0.1",

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -1452,6 +1452,7 @@
     <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
     <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
@@ -1467,8 +1468,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
     <PackageReference Include="System.Formats.Nrbf" Version="$(SystemFormatsNrbfVersion)" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore-ref.csproj
@@ -50,6 +50,7 @@
     <NetCoreReference Include="System.Runtime.CompilerServices.VisualC" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
     <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
@@ -62,8 +63,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj
@@ -1406,6 +1406,7 @@
     <NetCoreReference Include="System.Resources.ResourceManager" />
     <NetCoreReference Include="System.Runtime.CompilerServices.DynamicAttribute" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Tasks" />
@@ -1450,8 +1451,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework-ref.csproj
@@ -58,6 +58,7 @@
     <NetCoreReference Include="System.Resources.ResourceManager" />
     <NetCoreReference Include="System.Runtime.CompilerServices.DynamicAttribute" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.RegularExpressions" />
     <NetCoreReference Include="System.Threading" />
     <NetCoreReference Include="System.Threading.Tasks" />
@@ -89,8 +90,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
     <PackageReference Include="$(SystemIOPackagingPackage)" Version="$(SystemIOPackagingVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -111,6 +111,7 @@
     <NetCoreReference Include="System.Reflection" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.Encoding" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
     <NetCoreReference Include="System.Threading" />
@@ -121,8 +122,6 @@
     <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup>
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/ref/System.Xaml-ref.csproj
@@ -38,6 +38,7 @@
     <NetCoreReference Include="System.Reflection" />
     <NetCoreReference Include="System.Runtime.Extensions" />
     <NetCoreReference Include="System.Runtime.InteropServices" />
+    <NetCoreReference Include="System.Runtime.Serialization.Formatters" />
     <NetCoreReference Include="System.Text.Encoding" />
     <NetCoreReference Include="System.Text.Encoding.Extensions" />
     <NetCoreReference Include="System.Threading" />
@@ -48,8 +49,6 @@
     <NetCoreReference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup>
-    <!-- PrivateAssets metadata is required as Packaging.props in WpfArcadeSdk unconditionally sets it to all which is wrong: https://github.com/dotnet/wpf/issues/9261. -->
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" PrivateAssets="contentfiles;analyzers;build" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Formats.Nrbf" Version="$(SystemFormatsNrbfVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes # https://github.com/dotnet/wpf/issues/9309

## Description

WPF was depending on the package version of System.Runtime.Serialization.Formatters but never shipping it. Instead WPF should depend on the built-in assembly version.  To do that we need to update the SDK version since WPF's vcxprojs don't
enable the nuget package targeting pack https://github.com/dotnet/wpf/issues/9490

## Customer Impact

Customers see a `FileNotFoundException` instead of the expected `PlatformNotSupportedException` when using API that depends on `BinaryFormatter`.

## Regression

Yes, regressed in Preview6.

## Testing

I've run the unit tests with the fix.  I made sure the test assemblies reference the compatibility package.  WPF should add more tests to validate that without the package they'll throw PNSE - https://github.com/dotnet/wpf/issues/9491

## Risk

Low.  If it builds it should be doing what we want.  It could have more fallout in other tests which aren't represented in `test.cmd`.  Those may need to add a reference to the compat packages.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9492)