### PR TITLE
Optimize unescaping/parsing performance of BamlResourceContent/BamlStringToken

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlResourceContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlResourceContent.cs
@@ -93,7 +93,7 @@ namespace MS.Internal.Globalization
 
             for (int i = 0; i < contentSpan.Length; i++)
             {
-                if (contentSpan[i] == '\\') //An escape token
+                if (contentSpan[i] == BamlConst.EscapeChar) //An escape token ('\')
                 {
                     if (contentSpan.Length > i + 1) //Check whether we're at the end
                     {
@@ -103,16 +103,16 @@ namespace MS.Internal.Globalization
                     else //We are, break out of the loop
                         break;
                 }
-                else if (contentSpan[i] == '&') //A known escape token
+                else if (contentSpan[i] == '&') //A known escape sequence
                 {
-                    EvaulateEscape(stringBuilder, contentSpan, ref i);
+                    EvaulateEscapeSequence(stringBuilder, contentSpan, ref i);
                 }
                 else //Nothing interesting, append character
                     stringBuilder.Append(contentSpan[i]);
             }
 
-            //Evaluates whether any of the known tokens follows "&" (&quot; - &apos; - &amp; - &lt; - &gt;)
-            static void EvaulateEscape(StringBuilder stringBuilder, ReadOnlySpan<char> contentSpan, ref int i)
+            //Evaluates whether any of the known escape sequences follows '&' (&quot; - &apos; - &amp; - &lt; - &gt;)
+            static void EvaulateEscapeSequence(StringBuilder stringBuilder, ReadOnlySpan<char> contentSpan, ref int i)
             {
                 contentSpan = contentSpan.Slice(i);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlResourceContent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlResourceContent.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -23,7 +23,7 @@ namespace MS.Internal.Globalization
         /// </summary>
         internal static string EscapeString(string content)
         {
-            if (content == null)
+            if (content is null)
                 return null;
 
             StringBuilder builder = new(content.Length * 2);
@@ -95,36 +95,36 @@ namespace MS.Internal.Globalization
         /// </summary>
         internal static string UnescapeString(ReadOnlySpan<char> contentSpan, bool returnNewInstance = true)
         {
-            //Check whether there's anything to unescape
+            // Check whether there's anything to unescape
             int firstEscapeToken = contentSpan.IndexOfAny(s_escapeTokens);
             if (firstEscapeToken == -1)
                 return returnNewInstance ? new string(contentSpan) : null;
 
-            //Allocate buffer and append the chunk without tokens (unescaped)
+            // Allocate buffer and append the chunk without tokens (unescaped)
             StringBuilder stringBuilder = new(contentSpan.Length);
             stringBuilder.Append(contentSpan.Slice(0, firstEscapeToken));
 
             for (int i = firstEscapeToken; i < contentSpan.Length; i++)
             {
-                if (contentSpan[i] == BamlConst.EscapeChar) //An escape token ('\')
+                if (contentSpan[i] == BamlConst.EscapeChar) // An escape token ('\')
                 {
-                    if (contentSpan.Length > i + 1) //Check whether we're at the end
+                    if (contentSpan.Length > i + 1) // Check whether we're at the end
                     {
                         i++;
                         stringBuilder.Append(contentSpan[i]);
                     }
-                    else //We are, break out of the loop
+                    else // We are, break out of the loop
                         break;
                 }
-                else if (contentSpan[i] == '&') //A known escape sequence shall follow
+                else if (contentSpan[i] == '&') // A known escape sequence shall follow
                 {
                     EvaulateEscapeSequence(stringBuilder, contentSpan, ref i);
                 }
-                else //Nothing interesting, append character
+                else // Nothing interesting, append character
                     stringBuilder.Append(contentSpan[i]);
             }
 
-            //Evaluates whether any of the known escape sequences follows '&' (&quot; - &apos; - &amp; - &lt; - &gt;)
+            // Evaluates whether any of the known escape sequences follows '&' (&quot; - &apos; - &amp; - &lt; - &gt;)
             static void EvaulateEscapeSequence(StringBuilder stringBuilder, ReadOnlySpan<char> contentSpan, ref int i)
             {
                 contentSpan = contentSpan.Slice(i);
@@ -169,7 +169,7 @@ namespace MS.Internal.Globalization
                     }
                 }
 
-                //Default case, no escaped sequence found
+                // Default case, no escaped sequence found
                 stringBuilder.Append('&');
             }
 
@@ -183,7 +183,7 @@ namespace MS.Internal.Globalization
         /// </summary>
         internal static ReadOnlySpan<BamlStringToken> ParseChildPlaceholder(string input)
         {
-            if (input == null)
+            if (input is null)
                 return ReadOnlySpan<BamlStringToken>.Empty;
 
             List<BamlStringToken> tokens = new(8);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
@@ -613,9 +613,9 @@ namespace MS.Internal.Globalization
             IList<BamlTreeNode> newChildrenList          // list of new children
             )
         {
-            BamlStringToken[] tokens = BamlResourceContentUtil.ParseChildPlaceholder(content);
+            ReadOnlySpan<BamlStringToken> tokens = BamlResourceContentUtil.ParseChildPlaceholder(content);
 
-            if (tokens == null)
+            if (tokens.IsEmpty)
             {
                 bamlTreeMap.Resolver.RaiseErrorNotifyEvent(
                     new BamlLocalizerErrorNotifyEventArgs(

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/BamlTreeUpdater.cs
@@ -627,19 +627,19 @@ namespace MS.Internal.Globalization
             }
 
             bool succeed = true;
-            for (int i = 0; i < tokens.Length; i++)
+            foreach (BamlStringToken token in tokens)
             {
-                switch (tokens[i].Type)
+                switch (token.Type)
                 {
                     case BamlStringToken.TokenType.Text:
                         {
-                            BamlTreeNode node = new BamlTextNode(tokens[i].Value);
+                            BamlTreeNode node = new BamlTextNode(token.Value);
                             newChildrenList.Add(node);
                             break;
                         }
                     case BamlStringToken.TokenType.ChildPlaceHolder:
                         {
-                            BamlTreeNode node = bamlTreeMap.MapUidToBamlTreeElementNode(tokens[i].Value);
+                            BamlTreeNode node = bamlTreeMap.MapUidToBamlTreeElementNode(token.Value);
 
                             // The value will be null if there is no uid-matching node in the tree.                        
                             if (node != null)
@@ -651,7 +651,7 @@ namespace MS.Internal.Globalization
                                 bamlTreeMap.Resolver.RaiseErrorNotifyEvent(
                                     new BamlLocalizerErrorNotifyEventArgs(
                                         new BamlLocalizableResourceKey(
-                                            tokens[i].Value,
+                                            token.Value,
                                             string.Empty,
                                             string.Empty
                                             ),


### PR DESCRIPTION
## Description

Optimizes parsing BAML string resource content (e.g. localized resources) by replacing the slowest `Regex` use available (`MatchEvaluator` delegate) with a custom unescape function tailored for the specific use. Also further removes array allocs by using `ReadOnlySpan<BamlStringToken>` instead.
- Firstly a short-circuit check is done to find out whether any escape tokens are present (via `SearchValues<string>`)
If not, we return a new string instance / or if the string overload was used, we return the original one.
- In case any escape token was found, we allocate a `StringBuilder` instance and run through the supplied buffer.
- We could use slices like `Slice(1, 4)`; `Slice(1, 3)` etc. and do the compares without `&` and `;` but I've chosen readability.
- Yes, `SearchValues<string>` uses `Ordinal` compare and `Regex` was compiled with `InvariantCulture`, however then a binary comparison was made, so those are equal.

### 1 string, 0 escape tokens
| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original | 24.132 ns |  0.1507 ns |   0.1336 ns |         940 B |             - |
| PR__EDIT |  7.017 ns |  0.0551 ns |   0.0516 ns |         366 B |             - |
<details><summary>Benchmark source strings</summary>

```csharp
string escaped = "annah123456789hannah123456789hannah123456789hannah123456789hannah123456789hannah123456789";
```

</details>

### 1 string, 1 escape token (end)
| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 488.47 ns |   5.163 ns |    4.830 ns | 0.0372 |         942 B |         632 B |
| PR__EDIT |  38.31 ns |   0.790 ns |    1.666 ns | 0.0272 |         541 B |         456 B |
<details><summary>Benchmark source strings</summary>

```csharp
string escaped = "annah123456789hannah123456789hannah123456789hannah123456789hannah123456789hannah123456789\\";
```

</details>

### 1 string, 2 escape tokens
| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 270.53 ns |   2.783 ns |    2.467 ns | 0.0358 |         939 B |         600 B |
| PR__EDIT |  44.70 ns |   0.575 ns |    0.537 ns | 0.0086 |         995 B |         144 B |
<details><summary>Benchmark source strings</summary>

```csharp
private static readonly string escaped = "&lt;hello&gt;";
```

</details>

### 16 strings, mixed escape tokens
| Method   | Mean [ns]   | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |------------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 14,424.4 ns |  121.24 ns |   101.24 ns | 2.6703 |       1,766 B |       44720 B |
| PR__EDIT |  2,126.4 ns |   16.57 ns |    15.50 ns | 0.2785 |       1,303 B |        4680 B |
<details><summary>Benchmark source strings</summary>

```csharp
string escaped0 = "\\hannah123456789&lt;idkwhatshappeninghere&gt;buttrustme&amp;nothingisworse&quot;thanthis&quot;";
string escaped1 = "\\hannah123456789&lt;idkwhatshappeninghere&gt;buttr\\\\\\\\ustme&amp;nothingisworse&quot;thanthis&quot;\\\\\\&amp;";
string escaped2 = "\\hannah123456789&lt;idkwhatshappenin\\ghere&lt;&gt;buttr\\\\\\\\ustme&amp;no&apos;\\\\thingisworse&quot;thanthis&quot;\\\\\\&amp;";
string escaped3 = "\\hannah123456789&lt;idkwhatshappenin\\ghere&lt;&gt;buttr\\\\\\\\ustme&amp;no&apos;\\\\thingisworse&quot;thanthis&quot;\\\\\\&amp;&amp;&";
string escaped4 = "\\hannah123456789&lt;idkwhatshappenin\\ghere&lt;&gt;buttr\\\\\\\\ustme&amp;no&apos;\\\\thingisworse&quot;thanthis&quot;\\\\\\&amp;&amp;&xd;\\";
string escaped5 = "\\\\hannah123456789&lt;idkwhatshappenin\\ghere&lt;&gt;buttr\\\\\\\\ustme&amp;no&apos;\\\\thingisworse&quot;thanthis&quot;\\\\\\&amp;&amp;&xd;\\&\\";
string escaped6 = "\\&a;\\;\\\\&&&\\\\&amp;&amp;&xd;\\&\\";
string escaped7 = "\\&a;\\;\\\\&apos&&\\\\&quot;&amp;&xd;\\&\\;;;;\\&&\\123";
string escaped8 = "&a;\\;\\\\&apos&&\\\\&quot;&amp;&xd;\\&\\;;;;\\&&\\123\\\\\\\\\\\\\\\\&amp;\\\\\\\\\\\\\\\\&\\\\\\\\\\\\\\&\\'\\\\m\\\\\\\\\\\\";
string escaped9 = "\\..............................................1&;";
string escaped10 = "\\&;";
string escaped11 = "\\";
string escaped12 = "\\\\";
string escaped13 = "&&amp;";
string escaped14 = "&lt;hello&gt;";
string escaped15 = "annah123456789hannah123456789hannah123456789hannah123456789hannah123456789hannah123456789";
```

</details>

## Customer Impact

Greatly improved performance and massively decreased allocations.

## Regression

No.

## Testing

Local build, extensive set of assertive testing and benchmarking.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9508)