### PR TITLE
Fix : Invalidate application resources once while syncing deffered thememode and resources

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -318,7 +318,7 @@ internal static class ThemeManager
 
     #region Internal Properties
 
-    internal static bool DeferSyncingThemeModeAndResources { get; set; } = true;
+    internal static bool DeferSyncingThemeModeAndResources { get; set; } = Standard.Utility.IsOSWindows10OrNewer ? true : false;
 
     internal static bool IsFluentThemeEnabled
     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -176,6 +176,13 @@ internal static class ThemeManager
         {
             Application.Current.ThemeMode = themeMode;
         }
+        else
+        {
+            // In case ThemeMode was not set and we did not include the 
+            // Fluent theme resources, we need to invalidate the resources,
+            // that were earlier deferred.
+            Application.Current.InvalidateResourceReferences(ResourcesChangeInfo.CatastrophicDictionaryChangeInfo);
+        }
     }
 
     internal static void ApplyStyleOnWindow(Window window)


### PR DESCRIPTION
Fixes : #9486 

## Description

To allow syncing between theme mode and resources, we have deffered app resource invalidation till the first window initializes. During which we see the current state of the app resources and sync both the properties.

However, currently this method checks if thememode needs to be changed or not, if yes then we apply the theme mode and that results in another invalidation call which takes care of all the previous invalidation calls.

However, if there is nothing to be set in thememode, we don't respond to any of the previous invalidation request and that results in wrong colors in the UI.

I have added that case in the SyncDeferredThemeModeAndResources method

## Customer Impact
Applications that update application resources while initialization will get the correct UI.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local testing
<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9512)