### PR TITLE
[release/9.0-preview7] Invalidate App Resources irrespective of ThemeModeSync

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -176,6 +176,11 @@ internal static class ThemeManager
         {
             Application.Current.ThemeMode = themeMode;
         }
+
+        // Since we have deferred the app resource changes invalidation during this time,
+        // we need to invalidate the resources now. Since, there can be multiple invalidations over the time,
+        // we will do a catastrophic invalidation here.
+        Application.Current.InvalidateResourceReferences(ResourcesChangeInfo.CatastrophicDictionaryChangeInfo);
     }
 
     internal static void ApplyStyleOnWindow(Window window)
@@ -311,7 +316,7 @@ internal static class ThemeManager
 
     #region Internal Properties
 
-    internal static bool DeferSyncingThemeModeAndResources { get; set; } = true;
+    internal static bool DeferSyncingThemeModeAndResources { get; set; } = Standard.Utility.IsOSWindows10OrNewer ? true : false;
 
     internal static bool IsFluentThemeEnabled
     {


### PR DESCRIPTION
Fixes : #9486 

## Description

To allow syncing between theme mode and resources, we have deferred app resource invalidation till the first window initializes 
On the first window's initialization we sync the application's theme mode and resources.

However, since all the calls to app resource invalidation are ignored meanwhile, we do a complete invalidation of the application resources, so that all the values that may have needed reevaluation get evaluated now.

## Customer Impact
Applications that update application resources while initialization will now get the correct UI
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes. Found via compat-lab testing
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local testing (compat-lab applications)
<!-- What kind of testing has been done with the fix. -->

## Risk
Low-Medium Risk
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9512)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9518)