### PR TITLE
Replace SecurityHelper.AreStringTypesEqual with string.Equals for code quality

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/SiteOfOriginPart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/AppModel/SiteOfOriginPart.cs
@@ -18,7 +18,6 @@ using System.Windows.Resources;
 using System.IO;
 using System.Resources;
 using System.Globalization;
-using MS.Internal.PresentationCore;
 
 namespace MS.Internal.AppModel
 {
@@ -146,7 +145,7 @@ namespace MS.Internal.AppModel
                 // For performance reasons it is better to open local files directly
                 // rather than make a FileWebRequest.
                 Stream responseStream;
-                if (SecurityHelper.AreStringTypesEqual(_absoluteLocation.Scheme, Uri.UriSchemeFile))
+                if (string.Equals(_absoluteLocation.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
                 {
                     responseStream = HandleFileSource(onlyNeedContentType);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.IO.Packaging;
 using System.Globalization;
 using System.Net;
-using System.Security;
 using System.Text;
 using System.Windows;
 using System.Windows.Markup;
@@ -155,12 +154,12 @@ namespace System.Windows.Navigation
                 uri.IsAbsoluteUri && 
 
                 // Does the "outer" URI have the pack: scheme?
-                SecurityHelper.AreStringTypesEqual(uri.Scheme, System.IO.Packaging.PackUriHelper.UriSchemePack) &&
+                string.Equals(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) &&
 
                 // Does the "inner" URI have the application: scheme
-                SecurityHelper.AreStringTypesEqual(
-                    PackUriHelper.GetPackageUri(uri).GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped),
-                    _packageApplicationBaseUriEscaped);
+                string.Equals(PackUriHelper.GetPackageUri(uri).GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped),
+                              _packageApplicationBaseUriEscaped,
+                              StringComparison.OrdinalIgnoreCase);
         }
 
         // The method accepts a relative or absolute Uri and returns the appropriate assembly.
@@ -172,13 +171,12 @@ namespace System.Windows.Navigation
         // assembly name matches the text string in the first segment. otherwise, this method
         // would return EntryAssembly in the AppDomain.
         //
-        [FriendAccessAllowed]
         internal static void GetAssemblyAndPartNameFromPackAppUri(Uri uri, out Assembly assembly, out string partName)
         {
             // The input Uri is assumed to be a valid absolute pack application Uri.
             // The caller should guarantee that.
             // Perform a sanity check to make sure the assumption stays.
-            Debug.Assert(uri != null && uri.IsAbsoluteUri && SecurityHelper.AreStringTypesEqual(uri.Scheme, System.IO.Packaging.PackUriHelper.UriSchemePack) && IsPackApplicationUri(uri));
+            Debug.Assert(uri is not null && uri.IsAbsoluteUri && string.Equals(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) && IsPackApplicationUri(uri));
 
             // Generate a relative Uri which gets rid of the pack://application:,,, authority part.
             Uri partUri = new Uri(uri.AbsolutePath, UriKind.Relative);
@@ -189,7 +187,7 @@ namespace System.Windows.Navigation
 
             GetAssemblyNameAndPart(partUri, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
 
-            if (String.IsNullOrEmpty(assemblyName))
+            if (string.IsNullOrEmpty(assemblyName))
             {
                 // The uri doesn't contain ";component". it should map to the enty application assembly.
                 assembly = ResourceAssembly;
@@ -379,10 +377,9 @@ namespace System.Windows.Navigation
             return sUri;
         }
 
-        [FriendAccessAllowed]
         static internal Uri ConvertPackUriToAbsoluteExternallyVisibleUri(Uri packUri)
         {
-            Invariant.Assert(packUri.IsAbsoluteUri && SecurityHelper.AreStringTypesEqual(packUri.Scheme, PackAppBaseUri.Scheme));
+            Invariant.Assert(packUri.IsAbsoluteUri && string.Equals(packUri.Scheme, PackAppBaseUri.Scheme, StringComparison.OrdinalIgnoreCase));
 
             Uri relative = MakeRelativeToSiteOfOriginIfPossible(packUri);
 
@@ -400,10 +397,10 @@ namespace System.Windows.Navigation
         // object will not correctly resolve relative Uris in some cases.  This method
         // detects and fixes this by constructing a new Uri with an original string
         // that contains the scheme file://.
-        [FriendAccessAllowed]
         static internal Uri FixFileUri(Uri uri)
         {
-            if (uri != null && uri.IsAbsoluteUri && SecurityHelper.AreStringTypesEqual(uri.Scheme, Uri.UriSchemeFile) &&
+            if (uri is not null && uri.IsAbsoluteUri &&
+                string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase) &&
                 string.Compare(uri.OriginalString, 0, Uri.UriSchemeFile, 0, Uri.UriSchemeFile.Length, StringComparison.OrdinalIgnoreCase) != 0)
             {
                 return new Uri(uri.AbsoluteUri);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppModelKnownContentFactory.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.IO;
-using System.Security;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Navigation;
@@ -18,7 +17,6 @@ using MS.Internal.Navigation;
 using MS.Internal.Utility;
 using MS.Internal.Resources;
 using System.IO.Packaging;
-using MS.Internal.PresentationFramework;
 using System.ComponentModel;
 using System.Windows.Controls;
 
@@ -81,7 +79,7 @@ namespace MS.Internal.AppModel
 
             if (sandboxExternalContent)
             {
-                if (SecurityHelper.AreStringTypesEqual(baseUri.Scheme, BaseUriHelper.PackAppBaseUri.Scheme))
+                if (string.Equals(baseUri.Scheme, BaseUriHelper.PackAppBaseUri.Scheme, StringComparison.OrdinalIgnoreCase))
                 {
                     baseUri = BaseUriHelper.ConvertPackUriToAbsoluteExternallyVisibleUri(baseUri);
                 }
@@ -146,7 +144,7 @@ namespace MS.Internal.AppModel
                 return null;
             }
 
-            if (SecurityHelper.AreStringTypesEqual(baseUri.Scheme, BaseUriHelper.PackAppBaseUri.Scheme))
+            if (string.Equals(baseUri.Scheme, BaseUriHelper.PackAppBaseUri.Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 baseUri = BaseUriHelper.ConvertPackUriToAbsoluteExternallyVisibleUri(baseUri);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/AddressUtility.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationUI/MS/Internal/Documents/Application/AddressUtility.cs
@@ -7,9 +7,6 @@
 //    strings and Uri objects.
 using System;
 using System.Globalization;
-using System.Text.RegularExpressions;
-using MS.Internal.WindowsBase;
-
 
 namespace MS.Internal.Documents
 {
@@ -31,14 +28,7 @@ namespace MS.Internal.Documents
         /// <returns>Whether or not it is a mailto URI</returns>
         internal static bool IsMailtoUri(Uri mailtoUri)
         {
-            if (mailtoUri != null)
-            {
-                return SecurityHelper.AreStringTypesEqual(
-                    mailtoUri.Scheme,
-                    Uri.UriSchemeMailto);
-            }
-
-            return false;
+            return mailtoUri is not null && string.Equals(mailtoUri.Scheme, Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SecurityHelper.cs
@@ -221,16 +221,6 @@ internal static class SecurityHelper
         }
 #endif
 
-#if PRESENTATION_CORE || PRESENTATIONFRAMEWORK || WINDOWS_BASE
-
-        internal static bool AreStringTypesEqual(string m1, string m2)
-        {
-            return (string.Equals(m1, m2, StringComparison.OrdinalIgnoreCase));
-        }
-
-#endif //PRESENTATION_CORE || PRESENTATIONFRAMEWORK || WINDOWS_BASE
-
-
 #if WINDOWS_BASE
         ///
         /// Read and return a registry value.

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/BindUriHelper.cs
@@ -16,22 +16,21 @@ using System.Windows.Navigation; // BaseUriHelper
 using MS.Win32;
 #endif
 
-using System.Security;
 // The functionality in this class is shared across framework and core. The functionality in core
 // is a subset of the functionality in framework, so rather than create a dependency from core to
 // framework we have choses to duplicate this chunk of  code.
 #if PRESENTATION_CORE
 namespace MS.Internal.PresentationCore
 #elif PRESENTATIONFRAMEWORK
-using MS.Internal.PresentationFramework; // SecurityHelper
+using MS.Internal.PresentationFramework;
 
 namespace MS.Internal.Utility
 #elif PBTCOMPILER
-using MS.Internal.PresentationBuildTasks // SecurityHelper
+using MS.Internal.PresentationBuildTasks
 
 namespace MS.Internal.Utility
 #elif REACHFRAMEWORK
-using MS.Internal.ReachFramework; // SecurityHelper
+using MS.Internal.ReachFramework;
 
 namespace MS.Internal.Utility
 #else
@@ -88,7 +87,7 @@ namespace MS.Internal.Utility
         static internal bool DoSchemeAndHostMatch(Uri first, Uri second)
         {
             // Check that both the scheme and the host match. 
-           return (SecurityHelper.AreStringTypesEqual(first.Scheme, second.Scheme) && first.Host.Equals(second.Host) == true);
+            return string.Equals(first.Scheme, second.Scheme, StringComparison.OrdinalIgnoreCase) && string.Equals(first.Host, second.Host);
         }
 
         static internal Uri GetResolvedUri(Uri baseUri, Uri orgUri)
@@ -103,7 +102,7 @@ namespace MS.Internal.Utility
             {
                 // if the orgUri is an absolute Uri, don't need to resolve it again.
                 
-                Uri baseuri = (baseUri == null) ? BindUriHelper.BaseUri : baseUri;
+                Uri baseuri = baseUri ?? BindUriHelper.BaseUri;
 
 #if CF_Envelope_Activation_Enabled
                 bool isContainer = false ;
@@ -166,7 +165,7 @@ namespace MS.Internal.Utility
                 if (sourceZone == targetZone)
                 {
                     // We don't send any referer when going cross-scheme
-                    if (SecurityHelper.AreStringTypesEqual(sourceUri.Scheme, destinationUri.Scheme))
+                    if (string.Equals(sourceUri.Scheme, destinationUri.Scheme, StringComparison.OrdinalIgnoreCase))
                     {
                         // HTTPHeader requires the referer uri to be escaped. 
                         referer = sourceUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);


### PR DESCRIPTION
## Description

One of the few leftover remnants from CAS times is the `SecurityHelper.AreStringTypesEqual` that just calls case-insensitive `string.Equals`. There is no reason for this method as it has even lost the original comment throughout the removals and just makes newcomers wonder why is it there.

## Customer Impact

Few bytes less in size of all libraries.

## Regression

No.

## Testing

Local build.

## Risk

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9521)