### PR TITLE
[Fix] Don't ignore application resource invalidations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1736,12 +1736,12 @@ namespace System.Windows
             
             // Sync needs to be performed only under the following conditions:
             //  - the resource change event raised is due to a collection change
-            //      i.e. it is not a IsResourceAddOperation
+            //      i.e. it is not a IsIndividualResourceAddOperation
             //  - the event is not raised due to the change in Application.ThemeMode
             //      i.e. SkipAppThemeModeSyncing is set to true
             //  - if application's ThemeMode and Resources sync is enabled.
             //      i.e. IsAppThemeModeSyncEnabled is set to true
-            if (!info.IsResourceAddOperation
+            if (!info.IsIndividualResourceAddOperation
                     && !ThemeManager.SkipAppThemeModeSyncing 
                     && ThemeManager.IsAppThemeModeSyncEnabled)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1741,8 +1741,7 @@ namespace System.Windows
             //      i.e. SkipAppThemeModeSyncing is set to true
             //  - if application's ThemeMode and Resources sync is enabled.
             //      i.e. IsAppThemeModeSyncEnabled is set to true
-            if (!info.IsIndividualResourceAddOperation
-                    && !ThemeManager.SkipAppThemeModeSyncing 
+            if (!ThemeManager.SkipAppThemeModeSyncing 
                     && ThemeManager.IsAppThemeModeSyncEnabled)
             {
                 ThemeManager.SyncThemeMode();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -1734,12 +1734,18 @@ namespace System.Windows
         {
             _resourcesInitialized = true;
             
-            if(!ThemeManager.IgnoreAppResourcesChange)
+            // Sync needs to be performed only under the following conditions:
+            //  - the resource change event raised is due to a collection change
+            //      i.e. it is not a IsResourceAddOperation
+            //  - the event is not raised due to the change in Application.ThemeMode
+            //      i.e. SkipAppThemeModeSyncing is set to true
+            //  - if application's ThemeMode and Resources sync is enabled.
+            //      i.e. IsAppThemeModeSyncEnabled is set to true
+            if (!info.IsResourceAddOperation
+                    && !ThemeManager.SkipAppThemeModeSyncing 
+                    && ThemeManager.IsAppThemeModeSyncEnabled)
             {
-                if(ThemeManager.SyncThemeModeAndResources())
-                {
-                    return;
-                }
+                ThemeManager.SyncThemeMode();
             }
             
             // Invalidate ResourceReference properties on all the windows.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourcesChangeInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourcesChangeInfo.cs
@@ -199,6 +199,11 @@ namespace System.Windows
             get { return _key != null || (_newDictionaries != null && _newDictionaries.Count > 0); }
         }
 
+        internal bool IsIndividualResourceAddOperation
+        {
+            get { return _key != null; }
+        }
+
         // This member is used to identify the container when a style change happens
         internal DependencyObject Container
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourcesChangeInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ResourcesChangeInfo.cs
@@ -199,11 +199,6 @@ namespace System.Windows
             get { return _key != null || (_newDictionaries != null && _newDictionaries.Count > 0); }
         }
 
-        internal bool IsIndividualResourceAddOperation
-        {
-            get { return _key != null; }
-        }
-
         // This member is used to identify the container when a style change happens
         internal DependencyObject Container
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -20,7 +20,7 @@ internal static class ThemeManager
     {
         if(IsFluentThemeEnabled)
         {
-            IgnoreAppResourcesChange = true;
+            SkipAppThemeModeSyncing = true;
 
             try
             {
@@ -53,7 +53,7 @@ internal static class ThemeManager
             }
             finally
             {
-                IgnoreAppResourcesChange = false;
+                SkipAppThemeModeSyncing = false;
             }
 
         }
@@ -77,7 +77,7 @@ internal static class ThemeManager
 
     internal static void OnApplicationThemeChanged(ThemeMode oldThemeMode, ThemeMode newThemeMode)
     {
-        IgnoreAppResourcesChange = true;
+        SkipAppThemeModeSyncing = true;
 
         try
         {
@@ -108,7 +108,7 @@ internal static class ThemeManager
         }
         finally
         {
-            IgnoreAppResourcesChange = false;
+            SkipAppThemeModeSyncing = false;
         }
     }
 
@@ -126,10 +126,8 @@ internal static class ThemeManager
         ApplyFluentOnWindow(window);
     }
 
-    internal static bool SyncThemeModeAndResources()
+    internal static bool SyncThemeMode()
     {
-        if(DeferSyncingThemeModeAndResources) return true;
-
        ThemeMode themeMode = GetThemeModeFromResourceDictionary(Application.Current.Resources);
 
         if(Application.Current.ThemeMode != themeMode)
@@ -140,8 +138,10 @@ internal static class ThemeManager
         return false;
     }
 
-    internal static void SyncDeferredThemeModeAndResources()
+    internal static void SyncThemeModeAndResources()
     {
+        // Since, this is called from window there is a possiblity that the application
+        // instance is null. Hence, we need to check for null.
         if(Application.Current == null) return;
 
         ThemeMode themeMode = Application.Current.ThemeMode;
@@ -311,7 +311,7 @@ internal static class ThemeManager
 
     #region Internal Properties
 
-    internal static bool DeferSyncingThemeModeAndResources { get; set; } = true;
+    internal static bool IsAppThemeModeSyncEnabled { get; set; } = false;
 
     internal static bool IsFluentThemeEnabled
     {
@@ -324,7 +324,7 @@ internal static class ThemeManager
 
     internal static bool DeferredAppThemeLoading { get; set; } = false;
 
-    internal static bool IgnoreAppResourcesChange { get; set; } = false;
+    internal static bool SkipAppThemeModeSyncing { get; set; } = false;
 
     internal static double DefaultFluentThemeFontSize => 14;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeManager.cs
@@ -141,7 +141,8 @@ internal static class ThemeManager
     {
         // Since, this is called from window there is a possiblity that the application
         // instance is null. Hence, we need to check for null.
-        if(Application.Current == null) return;
+        if(Application.Current == null) 
+            return;
 
         ThemeMode themeMode = Application.Current.ThemeMode;
         var rd = Application.Current.Resources;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -2553,10 +2553,10 @@ namespace System.Windows
 
             if (Standard.Utility.IsOSWindows10OrNewer)
             {
-                if(ThemeManager.DeferSyncingThemeModeAndResources)
+                if(!ThemeManager.IsAppThemeModeSyncEnabled)
                 {
-                    ThemeManager.DeferSyncingThemeModeAndResources = false;
-                    ThemeManager.SyncDeferredThemeModeAndResources();
+                    ThemeManager.SyncThemeModeAndResources();
+                    ThemeManager.IsAppThemeModeSyncEnabled = true;
                 }
 
                 if(ThemeManager.IsFluentThemeEnabled)


### PR DESCRIPTION
Fixes : #9486 

## Description

This is another variation of the fix for above issue. 

Currently, when we get an Application Resource invalidation request, we check if there is a need to update the ThemeMode property due to the change in the Application.Resources . In the case, when ThemeMode property needs to be updated we returned true after sync, and when we get true, we did not do further invalidation of the resources for the original request.

Ignoring the original request results in incoherent UI, as the values changed are not getting properly reflected in the visual tree.

So, the core fix here is that I have removed the `return` statement and let all the invalidation's take place. Apart from this, I have also renamed the flags and methods to make it a bit easier to understand. Moreover, as an optimization, I have added a check to avoid syncing when the `info.IsResourceAddOperation == true` as this indicates that a single value is changed and not the merged dictionaries, where we are loading our fluent theme dictionaries. 

## Customer Impact
Applications that update application resources while initialization will get the correct UI.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
Yes
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local testing
<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9527)