### PR TITLE
Replace boxing Hashtable in ManagedWndProcTracker with Dictionary<K, V>

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -37,10 +37,9 @@ namespace MS.Win32
 
         internal static void UnhookHwndSubclass(HwndSubclass subclass)
         {
-            // If we're exiting the AppDomain, ignore this call.
-            // Since this can be called from multiple threads,
-            // we want to be sure to get the freshest value possible.
-            if (Volatile.Read(ref s_exiting))
+            // if exiting the AppDomain, ignore this call.  This avoids changing
+            // the list during the loop in OnAppDomainProcessExit
+            if (s_exiting)
                 return;
 
             lock (s_hwndList)
@@ -58,9 +57,7 @@ namespace MS.Win32
             // the DefaultWindowProc.
             //DbgUserBreakPoint();
 
-            // While this is only gonna be called once (guranteed by ShutDownListener),
-            // we want to make sure this is written as fast as possible to avoid waiting for lock.
-            Volatile.Write(ref s_exiting, true);
+            s_exiting = true;
 
             lock (s_hwndList)
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -37,9 +37,10 @@ namespace MS.Win32
 
         internal static void UnhookHwndSubclass(HwndSubclass subclass)
         {
-            // if exiting the AppDomain, ignore this call.  This avoids changing
-            // the list during the loop in OnAppDomainProcessExit
-            if (s_exiting)
+            // If we're exiting the AppDomain, ignore this call.
+            // Since this can be called from multiple threads,
+            // we want to be sure to get the freshest value possible.
+            if (Volatile.Read(ref s_exiting))
                 return;
 
             lock (s_hwndList)
@@ -57,7 +58,9 @@ namespace MS.Win32
             // the DefaultWindowProc.
             //DbgUserBreakPoint();
 
-            s_exiting = true;
+            // While this is only gonna be called once (guranteed by ShutDownListener),
+            // we want to make sure this is written as fast as possible to avoid waiting for lock.
+            Volatile.Write(ref s_exiting, true);
 
             lock (s_hwndList)
             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -94,7 +94,7 @@ namespace MS.Win32
                     // Just in case, restore the DefaultWindowProc.
                     HookUpDefWindowProc(hwnd);
                 }
-}
+            }
         }
 
         private static void HookUpDefWindowProc(IntPtr hwnd)
@@ -125,7 +125,7 @@ namespace MS.Win32
                         UnsafeNativeMethods.PostMessage(new HandleRef(null, hwnd), WindowMessage.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
                     }
                 }
-                catch(System.ComponentModel.Win32Exception e)
+                catch (System.ComponentModel.Win32Exception e)
                 {
                     // We failed to change the window proc.  Now what?
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/ManagedWndProcTracker.cs
@@ -3,7 +3,6 @@
 
 //#define LOGGING
 
-using System.Collections;
 using System.Runtime.InteropServices;
 using MS.Internal;
 using MS.Internal.Interop;
@@ -21,14 +20,14 @@ namespace MS.Win32
 
         internal static void TrackHwndSubclass(HwndSubclass subclass, IntPtr hwnd)
         {
-            lock (_hwndList)
+            lock (s_hwndList)
             {
                 // We use HwndSubclass as the key and the hwnd ptr as the value.
                 // This supports the case where two (or more) HwndSubclasses
                 // get attached to the same Hwnd.  At AppDomain shutdown, we may
                 // end up sending the Detach message to the Hwnd more than once,
                 // but that won't cause any harm.
-                _hwndList[subclass] = hwnd;
+                s_hwndList[subclass] = hwnd;
             }
 
 #if LOGGING
@@ -43,9 +42,9 @@ namespace MS.Win32
             if (_exiting)
                 return;
 
-            lock (_hwndList)
+            lock (s_hwndList)
             {
-                _hwndList.Remove(subclass);
+                s_hwndList.Remove(subclass);
             }
         }
 
@@ -60,14 +59,14 @@ namespace MS.Win32
 
             _exiting = true;
 
-            lock (_hwndList)
+            lock (s_hwndList)
             {
-                foreach (DictionaryEntry entry in _hwndList)
+                foreach (KeyValuePair<HwndSubclass, IntPtr> entry in s_hwndList)
                 {
-                    IntPtr hwnd = (IntPtr)entry.Value;
+                    IntPtr hwnd = entry.Value;
 
-                    int windowStyle = UnsafeNativeMethods.GetWindowLong(new HandleRef(null,hwnd), NativeMethods.GWL_STYLE);
-                    if((windowStyle & NativeMethods.WS_CHILD) != 0)
+                    int windowStyle = UnsafeNativeMethods.GetWindowLong(new HandleRef(null, hwnd), NativeMethods.GWL_STYLE);
+                    if ((windowStyle & NativeMethods.WS_CHILD) != 0)
                     {
                         // Tell all the HwndSubclass WndProcs for WS_CHILD windows
                         // to detach themselves. This is particularly important when
@@ -86,8 +85,8 @@ namespace MS.Win32
                         // of Hwnd subclasses.
 
                         UnsafeNativeMethods.SendMessage(hwnd, HwndSubclass.DetachMessage,
-                                                            IntPtr.Zero /* wildcard */,
-                                                            (IntPtr) 2 /* force and forward */);
+                                                        IntPtr.Zero /* wildcard */,
+                                                        2 /* force and forward */);
                     }
 
                     // the last WndProc on the chain might be managed as well
@@ -239,7 +238,7 @@ namespace MS.Win32
         private static IntPtr _cachedDefWindowProcA = IntPtr.Zero;
         private static IntPtr _cachedDefWindowProcW = IntPtr.Zero;
 
-        private static Hashtable _hwndList = new Hashtable(10);
+        private static readonly Dictionary<HwndSubclass, IntPtr> s_hwndList = new(10);
         private static bool _exiting = false;
     }
 }


### PR DESCRIPTION
## Description

Replaces boxing `Hashtable` with generic `Dictionary<HwndSubclass, IntPtr>` and improves overall performance.
- Since all operations are under a lock, there are no thread-safety concerns with replacing `Hashtable`.
- I've also added some more comments for clarity on the class.
- I've felt like the memory fence on `s_exiting` can help because the reads can come from multiple threads.
- Usings for `SecurityHelper` were removed as those are not needed since CAS removal.

## Customer Impact

Decreased allocations, improved performance.

## Regression

No.

## Testing

Local build/sample app run.

## Risk

Low, the swap is safe.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9532)