### PR TITLE
Icon Support for Windows 10

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Fonts.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Fonts.xaml
@@ -8,5 +8,5 @@
     Copyright (c) Microsoft Corporation. All Rights Reserved.
 -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <FontFamily x:Key="SegoeFluentIcons">Segoe Fluent Icons</FontFamily>
+    <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
 </ResourceDictionary>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Calendar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Calendar.xaml
@@ -350,7 +350,7 @@
                                     <Button.Content>
                                         <TextBlock
                                             FontSize="8"
-                                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             >&#xEDDB;</TextBlock>
                                     </Button.Content>
                                 </Button>
@@ -371,7 +371,7 @@
                                     <Button.Content>
                                         <TextBlock
                                             FontSize="8"
-                                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             >&#xEDDC;</TextBlock>
                                     </Button.Content>
                                 </Button>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/CheckBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/CheckBox.xaml
@@ -78,7 +78,7 @@
                                             FontSize="{StaticResource CheckBoxIconSize}"
                                             FontWeight="Bold"
                                             Foreground="{DynamicResource CheckBoxCheckGlyphForeground}"
-                                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             Visibility="Collapsed"
                                             Text="{StaticResource CheckBoxCheckedGlyph}" />
                                     </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -232,7 +232,7 @@
                                             FontSize="{StaticResource ComboBoxChevronSize}"
                                             Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
                                             RenderTransformOrigin="0.5, 0.5"
-                                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             Text ="{StaticResource ComboBoxChevronDownGlyph}">
                                             <TextBlock.RenderTransform>
                                                 <RotateTransform Angle="0" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -457,7 +457,7 @@
                                 VerticalAlignment="Center"
                                 FontSize="12"
                                 Opacity="0"
-                                FontFamily="{DynamicResource SegoeFluentIcons}"
+                                FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                 Text="&#xE8CB;" />
                         </Grid>
                         <VisualStateManager.VisualStateGroups>
@@ -700,7 +700,7 @@
                                         VerticalAlignment="Center"
                                         FontSize="{StaticResource DataGridCheckBoxIconSize}"
                                         FontWeight="Bold"
-                                        FontFamily="{DynamicResource SegoeFluentIcons}"
+                                        FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                         Text="{StaticResource DataGridCheckBoxCheckedGlyph}"
                                         Visibility="Collapsed">
                                         <TextBlock.Foreground>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
@@ -169,7 +169,7 @@
                                             Margin="{StaticResource DatePickerCalendarButtonPadding}"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
-                                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                             FontSize="{StaticResource DatePickerCalendarButtonIconSize}"
                                             Foreground="{TemplateBinding Foreground}"
                                             Text="{StaticResource CalendarGlyph}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -51,7 +51,7 @@
                     x:Name="ControlChevronIcon"
                     FontSize="{StaticResource ExpanderChevronSize}"
                     Foreground="{TemplateBinding Foreground}"
-                    FontFamily="{DynamicResource SegoeFluentIcons}"
+                    FontFamily="{DynamicResource SymbolThemeFontFamily}"
                     HorizontalAlignment="Center"
                     Text="{StaticResource ExpanderChevronDownGlyph}" />
             </Grid>
@@ -111,7 +111,7 @@
                     x:Name="ControlChevronIcon"
                     FontSize="{StaticResource ExpanderChevronSize}"
                     Foreground="{TemplateBinding Foreground}"
-                    FontFamily="{DynamicResource SegoeFluentIcons}"
+                    FontFamily="{DynamicResource SymbolThemeFontFamily}"
                     HorizontalAlignment="Center"
                     Text="{StaticResource ExpanderChevronUpGlyph}" />
             </Grid>
@@ -171,7 +171,7 @@
                         x:Name="ControlChevronIcon"
                         FontSize="{StaticResource ExpanderChevronSize}"
                         Foreground="{TemplateBinding Foreground}"
-                        FontFamily="{DynamicResource SegoeFluentIcons}"
+                        FontFamily="{DynamicResource SymbolThemeFontFamily}"
                         HorizontalAlignment="Center"
                         Text="{StaticResource ExpanderChevronLeftGlyph}" />
             </Grid>
@@ -231,7 +231,7 @@
                     x:Name="ControlChevronIcon"
                     FontSize="{StaticResource ExpanderChevronSize}"
                     Foreground="{TemplateBinding Foreground}"
-                    FontFamily="{DynamicResource SegoeFluentIcons}"
+                    FontFamily="{DynamicResource SymbolThemeFontFamily}"
                     HorizontalAlignment="Center"
                     Text="{StaticResource ExpanderChevronRightGlyph}" />
             </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -232,7 +232,7 @@
                         x:Name="CheckBoxIcon"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        FontFamily="{DynamicResource SegoeFluentIcons}"
+                        FontFamily="{DynamicResource SymbolThemeFontFamily}"
                         FontSize="16"
                         Text=""
                         TextAlignment="Center" />
@@ -326,7 +326,7 @@
                             x:Name="Chevron"
                             Margin="0,3,0,0"
                             VerticalAlignment="Center"
-                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                             FontSize="{TemplateBinding FontSize}"
                             Text="{StaticResource MenuItemChevronRightGlyph}" />
                     </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
@@ -47,7 +47,7 @@
                             VerticalAlignment="Center"
                             FontSize="{TemplateBinding FontSize}"
                             Foreground="{TemplateBinding Foreground}"
-                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                             Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
                     </Border>
                     <ControlTemplate.Triggers>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TextBox.xaml
@@ -188,7 +188,7 @@
                         <Button.Content>
                             <TextBlock
                                 FontSize="{TemplateBinding FontSize}"
-                                FontFamily="{DynamicResource SegoeFluentIcons}"
+                                FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                 >&#xE894;</TextBlock>
                         </Button.Content>
                     </Button>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolBar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolBar.xaml
@@ -165,7 +165,7 @@
                                 Margin="0"
                                 VerticalAlignment="Bottom"
                                 Foreground="{TemplateBinding Foreground}"
-                                FontFamily="{DynamicResource SegoeFluentIcons}"
+                                FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                 Text="{StaticResource ToolBarChevronDownGlyph}" />
                             <ContentPresenter />
                         </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TreeViewItem.xaml
@@ -38,7 +38,7 @@
                             x:Name="ChevronIcon"
                             VerticalAlignment="Center"
                             FontSize="{StaticResource TreeViewItemChevronSize}"
-                            FontFamily="{DynamicResource SegoeFluentIcons}"
+                            FontFamily="{DynamicResource SymbolThemeFontFamily}"
                             HorizontalAlignment="Center"
                             Text="{StaticResource TreeViewChevronRightGlyph}" />
                     </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -14,7 +14,7 @@
     </Setter>
   </Style>
   <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
-  <FontFamily x:Key="SegoeFluentIcons">Segoe Fluent Icons</FontFamily>
+  <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
   <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
   <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
   <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
@@ -956,12 +956,12 @@
                 <Button x:Name="PART_HeaderButton" Grid.Column="0" Margin="-6,0,0,0" Padding="6,2" HorizontalAlignment="Left" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource CalendarViewForeground}" />
                 <Button x:Name="PART_PreviousButton" Grid.Column="1" Width="26" Height="26" Margin="0,0,8,0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Previous" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
                 <Button x:Name="PART_NextButton" Grid.Column="2" Width="26" Height="26" Margin="0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Next" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
               </Grid>
@@ -1090,7 +1090,7 @@
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource CheckBoxHeight}" Height="{StaticResource CheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Border x:Name="StrokeBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                   <Grid>
-                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SegoeFluentIcons}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
+                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
                   </Grid>
                 </Border>
               </Border>
@@ -1335,7 +1335,7 @@
                     <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
                       <TextBlock.RenderTransform>
                         <RotateTransform Angle="0" />
                       </TextBlock.RenderTransform>
@@ -1795,7 +1795,7 @@
                 <ColumnDefinition Width="Auto" MinWidth="32" />
               </Grid.ColumnDefinitions>
               <!-- <ContentPresenter Content="{TemplateBinding Content}" /> -->
-              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SegoeFluentIcons}" Text="" />
+              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="" />
             </Grid>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SortStates">
@@ -1961,7 +1961,7 @@
             <BulletDecorator.Bullet>
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource DataGridCheckBoxHeight}" Height="{StaticResource DataGridCheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Grid>
-                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
+                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
                     <TextBlock.Foreground>
                       <SolidColorBrush Color="{DynamicResource TextOnAccentFillColorPrimary}" />
                     </TextBlock.Foreground>
@@ -2150,7 +2150,7 @@
                   <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
                   <Button x:Name="PART_Button" Grid.Column="1" Width="{StaticResource DatePickerCalendarButtonHeight}" Height="{StaticResource DatePickerCalendarButtonHeight}" Margin="{StaticResource DatePickerCalendarButtonMargin}" Padding="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" AutomationProperties.Name="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}" Cursor="Arrow" Focusable="True" IsTabStop="True">
                     <!--  WPF overrides paddings for button  -->
-                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
+                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
                   </Button>
                 </Grid>
               </Border>
@@ -2224,7 +2224,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2257,7 +2257,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2290,7 +2290,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2323,7 +2323,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2911,7 +2911,7 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
-          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="16" Text="" TextAlignment="Center" />
+          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
         <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
@@ -2960,7 +2960,7 @@
           <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
-            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
+            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
         </Grid>
       </Border>
@@ -3439,7 +3439,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RepeatButton}">
           <Border x:Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" Margin="{TemplateBinding Margin}" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6">
-            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -4150,7 +4150,7 @@
           <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
           <Button x:Name="ClearButton" Grid.Column="1" MinWidth="{StaticResource TextBoxClearButtonHeight}" MinHeight="{StaticResource TextBoxClearButtonHeight}" Margin="{StaticResource TextBoxClearButtonMargin}" Padding="{StaticResource TextBoxClearButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}" Cursor="Arrow" IsTabStop="False" Foreground="{DynamicResource TextControlButtonForeground}">
             <Button.Content>
-              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
             </Button.Content>
           </Button>
         </Grid>
@@ -4424,7 +4424,7 @@
         <ControlTemplate TargetType="{x:Type ToggleButton}">
           <Border x:Name="Border" Background="{TemplateBinding Background}" CornerRadius="0,3,3,0" SnapsToDevicePixels="true">
             <Grid>
-              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ToolBarChevronDownGlyph}" />
+              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ToolBarChevronDownGlyph}" />
               <ContentPresenter />
             </Grid>
           </Border>
@@ -4573,7 +4573,7 @@
             <Grid.RenderTransform>
               <RotateTransform Angle="0" />
             </Grid.RenderTransform>
-            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
+            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsChecked" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -14,7 +14,7 @@
     </Setter>
   </Style>
   <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
-  <FontFamily x:Key="SegoeFluentIcons">Segoe Fluent Icons</FontFamily>
+  <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
   <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
   <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
   <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
@@ -928,12 +928,12 @@
                 <Button x:Name="PART_HeaderButton" Grid.Column="0" Margin="-6,0,0,0" Padding="6,2" HorizontalAlignment="Left" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource CalendarViewForeground}" />
                 <Button x:Name="PART_PreviousButton" Grid.Column="1" Width="26" Height="26" Margin="0,0,8,0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Previous" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
                 <Button x:Name="PART_NextButton" Grid.Column="2" Width="26" Height="26" Margin="0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Next" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
               </Grid>
@@ -1062,7 +1062,7 @@
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource CheckBoxHeight}" Height="{StaticResource CheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Border x:Name="StrokeBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                   <Grid>
-                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SegoeFluentIcons}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
+                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
                   </Grid>
                 </Border>
               </Border>
@@ -1307,7 +1307,7 @@
                     <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
                       <TextBlock.RenderTransform>
                         <RotateTransform Angle="0" />
                       </TextBlock.RenderTransform>
@@ -1767,7 +1767,7 @@
                 <ColumnDefinition Width="Auto" MinWidth="32" />
               </Grid.ColumnDefinitions>
               <!-- <ContentPresenter Content="{TemplateBinding Content}" /> -->
-              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SegoeFluentIcons}" Text="" />
+              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="" />
             </Grid>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SortStates">
@@ -1933,7 +1933,7 @@
             <BulletDecorator.Bullet>
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource DataGridCheckBoxHeight}" Height="{StaticResource DataGridCheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Grid>
-                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
+                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
                     <TextBlock.Foreground>
                       <SolidColorBrush Color="{DynamicResource TextOnAccentFillColorPrimary}" />
                     </TextBlock.Foreground>
@@ -2122,7 +2122,7 @@
                   <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
                   <Button x:Name="PART_Button" Grid.Column="1" Width="{StaticResource DatePickerCalendarButtonHeight}" Height="{StaticResource DatePickerCalendarButtonHeight}" Margin="{StaticResource DatePickerCalendarButtonMargin}" Padding="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" AutomationProperties.Name="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}" Cursor="Arrow" Focusable="True" IsTabStop="True">
                     <!--  WPF overrides paddings for button  -->
-                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
+                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
                   </Button>
                 </Grid>
               </Border>
@@ -2196,7 +2196,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2229,7 +2229,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2262,7 +2262,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2295,7 +2295,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2883,7 +2883,7 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
-          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="16" Text="" TextAlignment="Center" />
+          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
         <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
@@ -2932,7 +2932,7 @@
           <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
-            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
+            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
         </Grid>
       </Border>
@@ -3411,7 +3411,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RepeatButton}">
           <Border x:Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" Margin="{TemplateBinding Margin}" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6">
-            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -4122,7 +4122,7 @@
           <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
           <Button x:Name="ClearButton" Grid.Column="1" MinWidth="{StaticResource TextBoxClearButtonHeight}" MinHeight="{StaticResource TextBoxClearButtonHeight}" Margin="{StaticResource TextBoxClearButtonMargin}" Padding="{StaticResource TextBoxClearButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}" Cursor="Arrow" IsTabStop="False" Foreground="{DynamicResource TextControlButtonForeground}">
             <Button.Content>
-              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
             </Button.Content>
           </Button>
         </Grid>
@@ -4396,7 +4396,7 @@
         <ControlTemplate TargetType="{x:Type ToggleButton}">
           <Border x:Name="Border" Background="{TemplateBinding Background}" CornerRadius="0,3,3,0" SnapsToDevicePixels="true">
             <Grid>
-              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ToolBarChevronDownGlyph}" />
+              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ToolBarChevronDownGlyph}" />
               <ContentPresenter />
             </Grid>
           </Border>
@@ -4545,7 +4545,7 @@
             <Grid.RenderTransform>
               <RotateTransform Angle="0" />
             </Grid.RenderTransform>
-            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
+            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsChecked" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -14,7 +14,7 @@
     </Setter>
   </Style>
   <Style x:Key="{x:Static SystemParameters.FocusVisualStyleKey}" BasedOn="{StaticResource DefaultControlFocusVisualStyle}" />
-  <FontFamily x:Key="SegoeFluentIcons">Segoe Fluent Icons</FontFamily>
+  <FontFamily x:Key="SymbolThemeFontFamily">Segoe Fluent Icons, Segoe MDL2 Assets</FontFamily>
   <Color x:Key="TextFillColorLightPrimary">#FFFFFF</Color>
   <Color x:Key="TextFillColorLightSecondary">#C5FFFFFF</Color>
   <Color x:Key="TextFillColorLightTertiary">#87FFFFFF</Color>
@@ -951,12 +951,12 @@
                 <Button x:Name="PART_HeaderButton" Grid.Column="0" Margin="-6,0,0,0" Padding="6,2" HorizontalAlignment="Left" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" FontSize="14" FontWeight="Bold" Foreground="{DynamicResource CalendarViewForeground}" />
                 <Button x:Name="PART_PreviousButton" Grid.Column="1" Width="26" Height="26" Margin="0,0,8,0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Previous" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
                 <Button x:Name="PART_NextButton" Grid.Column="2" Width="26" Height="26" Margin="0" Padding="0" HorizontalAlignment="Right" VerticalAlignment="Center" Background="Transparent" BorderBrush="Transparent" Focusable="True" AutomationProperties.Name="Next" Foreground="{DynamicResource CalendarViewButtonForeground}">
                   <Button.Content>
-                    <TextBlock FontSize="8" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+                    <TextBlock FontSize="8" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
                   </Button.Content>
                 </Button>
               </Grid>
@@ -1085,7 +1085,7 @@
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource CheckBoxHeight}" Height="{StaticResource CheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Border x:Name="StrokeBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                   <Grid>
-                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SegoeFluentIcons}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
+                    <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource CheckBoxIconSize}" FontWeight="Bold" Foreground="{DynamicResource CheckBoxCheckGlyphForeground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Visibility="Collapsed" Text="{StaticResource CheckBoxCheckedGlyph}" />
                   </Grid>
                 </Border>
               </Border>
@@ -1330,7 +1330,7 @@
                     <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
-                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ComboBoxChevronDownGlyph}">
+                    <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
                       <TextBlock.RenderTransform>
                         <RotateTransform Angle="0" />
                       </TextBlock.RenderTransform>
@@ -1790,7 +1790,7 @@
                 <ColumnDefinition Width="Auto" MinWidth="32" />
               </Grid.ColumnDefinitions>
               <!-- <ContentPresenter Content="{TemplateBinding Content}" /> -->
-              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SegoeFluentIcons}" Text="" />
+              <TextBlock x:Name="SortIcon" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12" Opacity="0" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="" />
             </Grid>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SortStates">
@@ -1956,7 +1956,7 @@
             <BulletDecorator.Bullet>
               <Border x:Name="ControlBorderIconPresenter" Width="{StaticResource DataGridCheckBoxHeight}" Height="{StaticResource DataGridCheckBoxWidth}" HorizontalAlignment="Left" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
                 <Grid>
-                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
+                  <TextBlock x:Name="ControlIcon" Margin="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{StaticResource DataGridCheckBoxIconSize}" FontWeight="Bold" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource DataGridCheckBoxCheckedGlyph}" Visibility="Collapsed">
                     <TextBlock.Foreground>
                       <SolidColorBrush Color="{DynamicResource TextOnAccentFillColorPrimary}" />
                     </TextBlock.Foreground>
@@ -2145,7 +2145,7 @@
                   <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
                   <Button x:Name="PART_Button" Grid.Column="1" Width="{StaticResource DatePickerCalendarButtonHeight}" Height="{StaticResource DatePickerCalendarButtonHeight}" Margin="{StaticResource DatePickerCalendarButtonMargin}" Padding="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Top" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" AutomationProperties.Name="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type DatePicker}}}" Cursor="Arrow" Focusable="True" IsTabStop="True">
                     <!--  WPF overrides paddings for button  -->
-                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
+                    <TextBlock Margin="{StaticResource DatePickerCalendarButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{StaticResource DatePickerCalendarButtonIconSize}" Foreground="{TemplateBinding Foreground}" Text="{StaticResource CalendarGlyph}" />
                   </Button>
                 </Grid>
               </Border>
@@ -2219,7 +2219,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronDownGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2252,7 +2252,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronUpGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2285,7 +2285,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronLeftGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2318,7 +2318,7 @@
         <Grid.RenderTransform>
           <RotateTransform Angle="0" />
         </Grid.RenderTransform>
-        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
+        <TextBlock x:Name="ControlChevronIcon" FontSize="{StaticResource ExpanderChevronSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource ExpanderChevronRightGlyph}" />
       </Grid>
     </Grid>
     <ControlTemplate.Triggers>
@@ -2906,7 +2906,7 @@
           <ColumnDefinition Width="Auto" SharedSizeGroup="Shortcut" />
         </Grid.ColumnDefinitions>
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
-          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="16" Text="" TextAlignment="Center" />
+          <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
         <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
         <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
@@ -2955,7 +2955,7 @@
           <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
           <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
-            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SegoeFluentIcons}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
+            <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
         </Grid>
       </Border>
@@ -3436,7 +3436,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RepeatButton}">
           <Border x:Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" Margin="{TemplateBinding Margin}" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6">
-            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+            <TextBlock Margin="0,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{Binding Path=Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -4147,7 +4147,7 @@
           <!--  Buttons and Icons have no padding from the main element to allow absolute positions if height is larger than the text entry zone  -->
           <Button x:Name="ClearButton" Grid.Column="1" MinWidth="{StaticResource TextBoxClearButtonHeight}" MinHeight="{StaticResource TextBoxClearButtonHeight}" Margin="{StaticResource TextBoxClearButtonMargin}" Padding="{StaticResource TextBoxClearButtonPadding}" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Background="Transparent" BorderBrush="Transparent" Command="{Binding Path=TemplateButtonCommand, RelativeSource={RelativeSource TemplatedParent}}" Cursor="Arrow" IsTabStop="False" Foreground="{DynamicResource TextControlButtonForeground}">
             <Button.Content>
-              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SegoeFluentIcons}"></TextBlock>
+              <TextBlock FontSize="{TemplateBinding FontSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}"></TextBlock>
             </Button.Content>
           </Button>
         </Grid>
@@ -4421,7 +4421,7 @@
         <ControlTemplate TargetType="{x:Type ToggleButton}">
           <Border x:Name="Border" Background="{TemplateBinding Background}" CornerRadius="0,3,3,0" SnapsToDevicePixels="true">
             <Grid>
-              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SegoeFluentIcons}" Text="{StaticResource ToolBarChevronDownGlyph}" />
+              <TextBlock Margin="0" VerticalAlignment="Bottom" Foreground="{TemplateBinding Foreground}" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ToolBarChevronDownGlyph}" />
               <ContentPresenter />
             </Grid>
           </Border>
@@ -4570,7 +4570,7 @@
             <Grid.RenderTransform>
               <RotateTransform Angle="0" />
             </Grid.RenderTransform>
-            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SegoeFluentIcons}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
+            <TextBlock x:Name="ChevronIcon" VerticalAlignment="Center" FontSize="{StaticResource TreeViewItemChevronSize}" FontFamily="{DynamicResource SymbolThemeFontFamily}" HorizontalAlignment="Center" Text="{StaticResource TreeViewChevronRightGlyph}" />
           </Grid>
           <ControlTemplate.Triggers>
             <Trigger Property="IsChecked" Value="True">


### PR DESCRIPTION
## Description
The following changes enables icon support for various controls when styled using Fluent theme on Windows 10. Also, it updates the resource value used by the `SegoeFluentIcons`.
<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers can use icon support controls in windows 10 with Fluent theme.
Developers also need to update the fluent key value to `SymbolThemeFontFamily` in their application if used earlier.
<!-- What is the impact to customers of not taking this fix? -->

## Regression
_None_
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
Local Build Pass
Sample Application Testing on Windows 10 and Windows 11
<!-- What kind of testing has been done with the fix. -->

## Risk
Low
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9543)