### PR TITLE
Replace boxing Hashtable in AdornerPresentationContext, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
@@ -579,7 +579,7 @@ namespace MS.Internal.Annotations.Component
         /// This is to control the relationships with TextSelection which lives in the same
         /// AdornerLayer. Will be removed when more flexible Z-ordering mechanism is available
         /// </summary>
-        private sealed class ZRange
+        private readonly struct ZRange
         {
             public ZRange(int min, int max)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
@@ -100,22 +100,14 @@ namespace MS.Internal.Annotations.Component
         /// BringToTop method. This will move the component to the top of its priority group. If there are other
         /// components with higher priority they will still be on top of that component. If more than
         /// one component type have the same ZLevel that means they all can stay on top of each other.
-        /// Setting IAnnotationComponent.ZOrder must be invoked only by the PrezentationContext
+        /// Setting IAnnotationComponent.ZOrder must be invoked only by the PresentationContext
         /// when the Z-order changes. It can not be set by application in v1.</remarks>
         internal static void SetTypeZLevel(Type type, int level)
         {
             Invariant.Assert(level >= 0, "level is < 0");
-
             Invariant.Assert(type != null, "type is null");
 
-            if (s_ZLevel.ContainsKey(type))
-            {
-                s_ZLevel[type] = level;
-            }
-            else
-            {
-                s_ZLevel.Add(type, level);
-            }
+            s_ZLevel[type] = level;
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Component/AdornerPresentationContext.cs
@@ -19,7 +19,6 @@ using System.Windows;
 using System.Windows.Annotations;
 using System.Windows.Documents;
 using System.Windows.Media;
-using System.Collections;
 
 namespace MS.Internal.Annotations.Component
 {
@@ -29,7 +28,7 @@ namespace MS.Internal.Annotations.Component
     /// for a different annotation component (located in the same adorner layer) works, but is slower than using the presentation context stored in the
     /// annotation component.
     /// </summary>
-    internal class AdornerPresentationContext : PresentationContext
+    internal sealed class AdornerPresentationContext : PresentationContext
     {
         #region Constructors
 
@@ -120,7 +119,7 @@ namespace MS.Internal.Annotations.Component
         /// <param name="max">max Z-order value for this level</param>
         internal static void SetZLevelRange(int level, int min, int max)
         {
-            if (s_ZRanges.ContainsKey(level) == false)
+            if (!s_ZRanges.ContainsKey(level))
             {
                 s_ZRanges.Add(level, new ZRange(min, max));
             }


### PR DESCRIPTION
## Description

Replaces two boxing `Hashtable` collections with generic `Dictionary<K, V>`, improving performance and decreasing allocations.
- There are no locks but I do not believe there are any thread-safety concerns as the collections are only set once per my code inspection and testing it with few sample apps, plus if it was a concern, even `Hashtable` would need lock for proper functionality in this scenario.
- Worst case, we could swap it to `ConcurrentDictionary<K, V>` which would still work out very well over boxing `Hashtable` in read-only context.
- ZRange is now a `readonly struct`, further decreasing memory footprint of the underlying collection.
- As `AdornerPresentationContext` is a derived class, I've sealed it.

### Base difference between boxing `Hashtable` and `Dictionary<K, V>`

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  339.5 ns |    6.56 ns |     5.81 ns | 0.1044 |       2,756 B |        1752 B |
| PR__EDIT |  202.3 ns |    4.02 ns |     6.38 ns | 0.0534 |       1,301 B |         896 B |

### More of a real use-case in `AdornerPresentationContext`

| Method   | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 1,269.0 ns |   20.86 ns |    18.49 ns | 0.3757 |       2,775 B |        6312 B |
| PR__EDIT |   773.8 ns |    5.49 ns |     4.58 ns | 0.0534 |       1,283 B |         896 B |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
public void Original()
{
    Hashtable ZRanges = new Hashtable();

    for (int i = 0; i < 10; i++)
        BenchV1(i, ZRanges);

    //200 is used for the second benchmark instead of ZRanges!.Count
    for (int i = 0; i < ZRanges!.Count; i++)
    {
        ZRange range = (ZRange)ZRanges[i];
        if (range != null)
            EmptyMethod(range);
    }
}

[Benchmark]
public void PR__EDIT()
{
    Dictionary<int, ZRangeStruct> ZRanges = new();

    for (int i = 0; i < 10; i++)
        BenchV2(i, ZRanges);

    //200 is used for the second benchmark instead of ZRanges!.Count
    for (int i = 0; i < ZRanges!.Count; i++)
    {
        if (ZRanges.TryGetValue(i, out ZRangeStruct range))
            EmptyMethod2(ref range);
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
private static int EmptyMethod(ZRange zRange) => zRange.Min;

//We use ref to prevent copy that doesn't happen in actual code
[MethodImpl(MethodImplOptions.NoInlining)]
private static int EmptyMethod2(ref ZRangeStruct zRange) => zRange.Min;

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private static void BenchV1(int level, Hashtable ZRanges)
{
    if (ZRanges[level] == null)
        ZRanges.Add(level, new ZRange(1, 2));
}

[MethodImpl(MethodImplOptions.AggressiveInlining)]
private static void BenchV2(int level, Dictionary<int, ZRangeStruct> ZRanges)
{
    if (!ZRanges.ContainsKey(level))
        ZRanges.Add(level, new ZRangeStruct(1, 2));
}
```
</details>

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, sample apps run.

## Risk

There is a small concern as per my first point, however again, very unlikely given how the code is written.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9552)