### PR TITLE
Decrease allocations in TextFindEngine/SelectionWordBreaker, improve performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Documents
                 }
             }
 
-            ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[2];
+            Span<UInt16> charType3 = stackalloc UInt16[2];
             ReadOnlySpan<char> sourceChars = [text[position - 1], text[position]];
 
             SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, sourceChars, charType3);
@@ -203,7 +203,7 @@ namespace System.Windows.Documents
         private static CharClass[] GetClasses(char[] text)
         {
             CharClass[] classes = new CharClass[text.Length];
-            ReadOnlySpan<UInt16> charType1 = stackalloc UInt16[1];
+            UInt16 charType1 = UInt16.MinValue;
 
             for (int i = 0; i < text.Length; i++)
             {
@@ -228,11 +228,11 @@ namespace System.Windows.Documents
                 }
                 else
                 {
-                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in ch), charType1);
+                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, [ch], new Span<UInt16>(ref charType1));
 
-                    if ((charType1[0] & SafeNativeMethods.C1_SPACE) != 0)
+                    if ((charType1 & SafeNativeMethods.C1_SPACE) != 0)
                     {
-                        if ((charType1[0] & SafeNativeMethods.C1_BLANK) != 0)
+                        if ((charType1 & SafeNativeMethods.C1_BLANK) != 0)
                         {
                             classification = CharClass.Blank | CharClass.WBF_ISWHITE;
                         }
@@ -241,7 +241,7 @@ namespace System.Windows.Documents
                             classification = CharClass.WhiteSpace | CharClass.WBF_ISWHITE;
                         }
                     }
-                    else if ((charType1[0] & SafeNativeMethods.C1_PUNCT) != 0 && !IsDiacriticOrKashida(ch))
+                    else if ((charType1 & SafeNativeMethods.C1_PUNCT) != 0 && !IsDiacriticOrKashida(ch))
                     {
                         classification = CharClass.Punctuation;
                     }
@@ -260,11 +260,11 @@ namespace System.Windows.Documents
         // Returns true if a char is a non-spacing diacritic or kashida.
         private static bool IsDiacriticOrKashida(char ch)
         {
-            ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[1];
+            UInt16 charType3 = UInt16.MinValue;
 
-            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new(in ch), charType3);
+            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, [ch], new Span<UInt16>(ref charType3));
 
-            return (charType3[0] & (SafeNativeMethods.C3_DIACRITIC | SafeNativeMethods.C3_NONSPACING | SafeNativeMethods.C3_VOWELMARK | SafeNativeMethods.C3_KASHIDA)) != 0;
+            return (charType3 & (SafeNativeMethods.C3_DIACRITIC | SafeNativeMethods.C3_NONSPACING | SafeNativeMethods.C3_VOWELMARK | SafeNativeMethods.C3_KASHIDA)) != 0;
         }
 
         // Returns true if a character falls within a specified code point range.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
@@ -76,7 +76,7 @@ namespace System.Windows.Documents
             ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[2];
             ReadOnlySpan<char> sourceChars = [text[position - 1], text[position]];
 
-            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, sourceChars, 2, charType3);
+            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, sourceChars, charType3);
 
             // Otherwise we're at a word boundary if the classes of the surrounding text differ.
             return IsWordBoundary(text[position - 1], text[position]) ||
@@ -228,7 +228,7 @@ namespace System.Windows.Documents
                 }
                 else
                 {
-                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in ch), 1, charType1);
+                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in ch), charType1);
 
                     if ((charType1[0] & SafeNativeMethods.C1_SPACE) != 0)
                     {
@@ -262,7 +262,7 @@ namespace System.Windows.Documents
         {
             ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[1];
 
-            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new(in ch), 1, charType3);
+            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new(in ch), charType3);
 
             return (charType3[0] & (SafeNativeMethods.C3_DIACRITIC | SafeNativeMethods.C3_NONSPACING | SafeNativeMethods.C3_VOWELMARK | SafeNativeMethods.C3_KASHIDA)) != 0;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/SelectionWordBreaker.cs
@@ -73,9 +73,10 @@ namespace System.Windows.Documents
                 }
             }
 
-            UInt16[] charType3 = new UInt16[2];
+            ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[2];
+            ReadOnlySpan<char> sourceChars = [text[position - 1], text[position]];
 
-            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new char[] { text[position - 1], text[position] }, 2, charType3);
+            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, sourceChars, 2, charType3);
 
             // Otherwise we're at a word boundary if the classes of the surrounding text differ.
             return IsWordBoundary(text[position - 1], text[position]) ||
@@ -202,6 +203,7 @@ namespace System.Windows.Documents
         private static CharClass[] GetClasses(char[] text)
         {
             CharClass[] classes = new CharClass[text.Length];
+            ReadOnlySpan<UInt16> charType1 = stackalloc UInt16[1];
 
             for (int i = 0; i < text.Length; i++)
             {
@@ -226,9 +228,7 @@ namespace System.Windows.Documents
                 }
                 else
                 {
-                    UInt16[] charType1 = new UInt16[1];
-
-                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new char[] { ch }, 1, charType1);
+                    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in ch), 1, charType1);
 
                     if ((charType1[0] & SafeNativeMethods.C1_SPACE) != 0)
                     {
@@ -260,9 +260,9 @@ namespace System.Windows.Documents
         // Returns true if a char is a non-spacing diacritic or kashida.
         private static bool IsDiacriticOrKashida(char ch)
         {
-            UInt16 []charType3 = new UInt16[1];
+            ReadOnlySpan<UInt16> charType3 = stackalloc UInt16[1];
 
-            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new char[] { ch }, 1, charType3);
+            SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE3, new(in ch), 1, charType3);
 
             return (charType3[0] & (SafeNativeMethods.C3_DIACRITIC | SafeNativeMethods.C3_NONSPACING | SafeNativeMethods.C3_VOWELMARK | SafeNativeMethods.C3_KASHIDA)) != 0;
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
@@ -104,20 +104,19 @@ namespace System.Windows.Documents
 
             if (matchWholeWord)
             {
-                ReadOnlySpan<UInt16> startCharType1 = stackalloc UInt16[1];
-                ReadOnlySpan<UInt16> endCharType1 = stackalloc UInt16[1];
-                ReadOnlySpan<char> startEndChars = [findPattern[0], findPattern[findPattern.Length - 1]];
+                UInt16 startCharType1 = UInt16.MinValue;
+                UInt16 endCharType1 = UInt16.MinValue;
 
                 // Get the character type for the start/end character of the find pattern.
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[0]), startCharType1);
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[1]), endCharType1);
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, [findPattern[0]], new Span<UInt16>(ref startCharType1));
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, [findPattern[findPattern.Length - 1]], new Span<UInt16>(ref endCharType1));
 
                 // Reset the finding whole word flag if FindPattern includes the space
                 // or blank character at the start or end position.
-                if ((startCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
-                    (startCharType1[0] & SafeNativeMethods.C1_BLANK) != 0 ||
-                    (endCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
-                    (endCharType1[0] & SafeNativeMethods.C1_BLANK) != 0)
+                if ((startCharType1 & SafeNativeMethods.C1_SPACE) != 0 ||
+                    (startCharType1 & SafeNativeMethods.C1_BLANK) != 0 ||
+                    (endCharType1 & SafeNativeMethods.C1_SPACE) != 0 ||
+                    (endCharType1 & SafeNativeMethods.C1_BLANK) != 0)
                 {
                     matchWholeWord = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
@@ -109,8 +109,8 @@ namespace System.Windows.Documents
                 ReadOnlySpan<char> startEndChars = [findPattern[0], findPattern[findPattern.Length - 1]];
 
                 // Get the character type for the start/end character of the find pattern.
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[0]), 1, startCharType1);
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[1]), 1, endCharType1);
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[0]), startCharType1);
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[1]), endCharType1);
 
                 // Reset the finding whole word flag if FindPattern includes the space
                 // or blank character at the start or end position.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextFindEngine.cs
@@ -104,20 +104,20 @@ namespace System.Windows.Documents
 
             if (matchWholeWord)
             {
-                UInt16[] findPatternStartCharType1 = new UInt16[1];
-                UInt16[] findPatternEndCharType1 = new UInt16[1];
-                char[] charFindPattern = findPattern.ToCharArray();
+                ReadOnlySpan<UInt16> startCharType1 = stackalloc UInt16[1];
+                ReadOnlySpan<UInt16> endCharType1 = stackalloc UInt16[1];
+                ReadOnlySpan<char> startEndChars = [findPattern[0], findPattern[findPattern.Length - 1]];
 
                 // Get the character type for the start/end character of the find pattern.
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new char[] { charFindPattern[0] }, 1, findPatternStartCharType1);
-                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new char[] { charFindPattern[findPattern.Length - 1] }, 1, findPatternEndCharType1);
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[0]), 1, startCharType1);
+                SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[1]), 1, endCharType1);
 
                 // Reset the finding whole word flag if FindPattern includes the space
                 // or blank character at the start or end position.
-                if ((findPatternStartCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
-                    (findPatternStartCharType1[0] & SafeNativeMethods.C1_BLANK) != 0 ||
-                    (findPatternEndCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
-                    (findPatternEndCharType1[0] & SafeNativeMethods.C1_BLANK) != 0)
+                if ((startCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
+                    (startCharType1[0] & SafeNativeMethods.C1_BLANK) != 0 ||
+                    (endCharType1[0] & SafeNativeMethods.C1_SPACE) != 0 ||
+                    (endCharType1[0] & SafeNativeMethods.C1_BLANK) != 0)
                 {
                     matchWholeWord = false;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
@@ -101,17 +101,15 @@ namespace MS.Win32
         public const UInt16 C3_IDEOGRAPH  = 0x0100;
         public const UInt16 C3_KASHIDA    = 0x0200;
 
-        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, ReadOnlySpan<UInt16> charTypes)
+        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, Span<UInt16> charTypes)
         {
             // Since we do not use [LibraryImport], Span<T> marshallers are not available by default
             fixed (char* ptrSourceString = sourceString)
+            fixed (ushort* ptrCharTypes = charTypes)
             {
-                fixed (ushort* ptrCharTypes = charTypes)
-                {
-                    if (!SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, sourceString.Length, ptrCharTypes))
-                        throw new Win32Exception(); //Initializes with Marshal.GetLastPInvokeError()
-                }
-            }         
+                if (!SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, sourceString.Length, ptrCharTypes))
+                    throw new Win32Exception(); //Initializes with Marshal.GetLastPInvokeError()
+            }        
 
             return true;
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
@@ -101,26 +101,19 @@ namespace MS.Win32
         public const UInt16 C3_IDEOGRAPH  = 0x0100;
         public const UInt16 C3_KASHIDA    = 0x0200;
 
-        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, int count, ReadOnlySpan<UInt16> charTypes)
+        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, ReadOnlySpan<UInt16> charTypes)
         {
-            bool win32Return;
             // Since we do not use [LibraryImport], Span<T> marshallers are not available by default
             fixed (char* ptrSourceString = sourceString)
             {
                 fixed (ushort* ptrCharTypes = charTypes)
                 {
-                    win32Return = SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, count, ptrCharTypes);
+                    if (!SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, sourceString.Length, ptrCharTypes))
+                        throw new Win32Exception(); //Initializes with Marshal.GetLastPInvokeError()
                 }
-            }
-            
-            int win32Error = Marshal.GetLastWin32Error();
+            }         
 
-            if (!win32Return)
-            {
-                throw new Win32Exception(win32Error);
-            }
-
-            return win32Return;
+            return true;
         }
         
         public static int GetSysColor(int nIndex)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
@@ -108,7 +108,7 @@ namespace MS.Win32
             fixed (ushort* ptrCharTypes = charTypes)
             {
                 if (!SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, sourceString.Length, ptrCharTypes))
-                    throw new Win32Exception(); //Initializes with Marshal.GetLastPInvokeError()
+                    throw new Win32Exception(); // Initializes with Marshal.GetLastPInvokeError()
             }        
 
             return true;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
@@ -101,10 +101,18 @@ namespace MS.Win32
         public const UInt16 C3_IDEOGRAPH  = 0x0100;
         public const UInt16 C3_KASHIDA    = 0x0200;
 
-        public static bool GetStringTypeEx(uint locale, uint infoType, char[] sourceString, int count,
-            UInt16[] charTypes)
+        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, int count, ReadOnlySpan<UInt16> charTypes)
         {
-            bool win32Return = SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, sourceString, count, charTypes);
+            bool win32Return;
+            // Since we do not use [LibraryImport], Span<T> marshallers are not available by default
+            fixed (char* ptrSourceString = sourceString)
+            {
+                fixed (ushort* ptrCharTypes = charTypes)
+                {
+                    win32Return = SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, count, ptrCharTypes);
+                }
+            }
+            
             int win32Error = Marshal.GetLastWin32Error();
 
             if (!win32Return)
@@ -115,9 +123,9 @@ namespace MS.Win32
             return win32Return;
         }
         
-            public static int GetSysColor(int nIndex)
+        public static int GetSysColor(int nIndex)
         {
-                return SafeNativeMethodsPrivate.GetSysColor(nIndex);
+            return SafeNativeMethodsPrivate.GetSysColor(nIndex);
         }
 
         public static bool IsClipboardFormatAvailable(int format)
@@ -201,11 +209,10 @@ namespace MS.Win32
             [DllImport(ExternDll.User32, SetLastError=true, CharSet=CharSet.Auto)]
             public static extern int GetCaretBlinkTime();
 
-            [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-            public static extern bool GetStringTypeEx(uint locale, uint infoType, char[] sourceString, int count,
-                [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] UInt16[] charTypes);
+            [DllImport(ExternDll.Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
+            public static unsafe extern bool GetStringTypeEx(uint locale, uint infoType, char* sourceString, int count, ushort* charTypes);
             
-            [DllImport(ExternDll.User32, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+            [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
             public static extern int GetSysColor(int nIndex);
 
             [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]

--- a/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/Common/DRT/TestServices/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/IntegrationTests/Common/DRT/TestServices/MS/Win32/SafeNativeMethodsOther.cs
@@ -124,21 +124,20 @@ namespace MS.Win32 {
         public const UInt16 C3_IDEOGRAPH  = 0x0100;
         public const UInt16 C3_KASHIDA    = 0x0200;
 
-        public static bool GetStringTypeEx(uint locale, uint infoType, char[] sourceString, int count,
-            UInt16[] charTypes)
+        public static unsafe bool GetStringTypeEx(uint locale, uint infoType, ReadOnlySpan<char> sourceString, Span<UInt16> charTypes)
         {
-            bool win32Return = SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, sourceString, count, charTypes);
-            int win32Error = Marshal.GetLastWin32Error();
-
-            if (!win32Return)
+            // Since we do not use [LibraryImport], Span<T> marshallers are not available by default
+            fixed (char* ptrSourceString = sourceString)
+            fixed (ushort* ptrCharTypes = charTypes)
             {
-                throw new Win32Exception(win32Error);
-            }
+                if (!SafeNativeMethodsPrivate.GetStringTypeEx(locale, infoType, ptrSourceString, sourceString.Length, ptrCharTypes))
+                    throw new Win32Exception(); // Initializes with Marshal.GetLastPInvokeError()
+            }        
 
-            return win32Return;
+            return true;
         }
         
-            public static int GetSysColor(int nIndex)
+        public static int GetSysColor(int nIndex)
         {
                 return SafeNativeMethodsPrivate.GetSysColor(nIndex);
         }
@@ -224,11 +223,10 @@ namespace MS.Win32 {
             [DllImport(ExternDll.User32, SetLastError=true, CharSet=CharSet.Auto)]
             public static extern int GetCaretBlinkTime();
 
-            [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-            public static extern bool GetStringTypeEx(uint locale, uint infoType, char[] sourceString, int count,
-                [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] UInt16[] charTypes);
+            [DllImport(ExternDll.Kernel32, SetLastError = true, CharSet = CharSet.Auto)]
+            public static unsafe extern bool GetStringTypeEx(uint locale, uint infoType, char* sourceString, int count, ushort* charTypes);
             
-            [DllImport(ExternDll.User32, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+            [DllImport(ExternDll.User32, CharSet = CharSet.Auto)]
             public static extern int GetSysColor(int nIndex);
 
             [DllImport(ExternDll.User32, ExactSpelling = true, CharSet = CharSet.Auto)]


### PR DESCRIPTION
## Description

Removes unnecessary allocations of temporary heap arrays when calling `GetStringTypeEx`, using stack-allocated space instead.
Also removes some unnecessary string copies in `TextFindEngine.Find(...)` method.

### Base replication of `Find` method
| Method   | findPattern          | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |--------------------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  this(...)e it  [92] |  58.53 ns |   1.161 ns |    1.193 ns | 0.0200 |         461 B |         336 B |
| PR__EDIT |  this(...)e it  [92] |  28.89 ns |   0.213 ns |    0.199 ns |      - |         350 B |             - |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
[Arguments(" this is a very long string, and yet its gonna be even longer string now, hope u can see it ")]
public UInt16 Original(string findPattern)
{
    UInt16[] findPatternStartCharType1 = new UInt16[1];
    UInt16[] findPatternEndCharType1 = new UInt16[1];
    char[] charFindPattern = findPattern.ToCharArray();

    // Get the character type for the start/end character of the find pattern.
    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new char[] { charFindPattern[0] }, 1, findPatternStartCharType1);
    SafeNativeMethods.GetStringTypeEx(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new char[] { charFindPattern[charFindPattern.Length - 1] }, 1, findPatternEndCharType1);

    return (ushort)(findPatternStartCharType1[0] + findPatternEndCharType1[0]);
}

[Benchmark]
[Arguments(" this is a very long string, and yet its gonna be even longer string now, hope u can see it ")]
public UInt16 PR__EDIT(string findPattern)
{
    ReadOnlySpan<UInt16> startCharType1 = stackalloc UInt16[1];
    ReadOnlySpan<UInt16> endCharType1 = stackalloc UInt16[1];
    ReadOnlySpan<char> startEndChars = [findPattern[0], findPattern[findPattern.Length - 1]];

    // Get the character type for the start/end character of the find pattern.
    SafeNativeMethods.GetStringTypeEx2(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[0]), startCharType1);
    SafeNativeMethods.GetStringTypeEx2(0 /* ignored */, SafeNativeMethods.CT_CTYPE1, new(in startEndChars[1]), endCharType1);

    return (ushort)(startCharType1[0] + endCharType1[0]);
}
```

</details>

## Customer Impact

Decreased allocations, improved performance.

## Regression

No.

## Testing

Local build, verifying the outputs of both functions.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9553)