### PR TITLE
Support range notifications

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ItemContainerGenerator.cs
@@ -2400,25 +2400,25 @@ namespace System.Windows.Controls
             switch (args.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    if (args.NewItems.Count != 1)
+                    if (args.NewItems.Count < 1)
                         throw new NotSupportedException(SR.RangeActionsNotSupported);
-                    OnItemAdded(args.NewItems[0], args.NewStartingIndex);
+                    OnItemsAdded(args.NewItems, args.NewStartingIndex);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    if (args.OldItems.Count != 1)
+                    if (args.OldItems.Count < 1)
                         throw new NotSupportedException(SR.RangeActionsNotSupported);
-                    OnItemRemoved(args.OldItems[0], args.OldStartingIndex);
+                    OnItemsRemoved(args.OldItems, args.OldStartingIndex);
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
                     // Don't check arguments if app targets 4.0, for compat ( 726682)
                     if (!FrameworkCompatibilityPreferences.TargetsDesktop_V4_0)
                     {
-                        if (args.OldItems.Count != 1)
+                        if (args.OldItems.Count < 1)
                             throw new NotSupportedException(SR.RangeActionsNotSupported);
                     }
-                    OnItemReplaced(args.OldItems[0], args.NewItems[0], args.NewStartingIndex);
+                    OnItemsReplaced(args.OldItems, args.NewItems, args.NewStartingIndex);
                     break;
 
                 case NotifyCollectionChangedAction.Move:
@@ -2443,6 +2443,86 @@ namespace System.Windows.Controls
             if (traceLevel >= PresentationTraceLevel.High)
             {
                 Verify();
+            }
+        }
+
+        // Called when an items are added to the items collection
+        void OnItemsAdded(IList items, int index)
+        {
+            if (_itemMap == null)
+            {
+                // reentrant call (from RemoveAllInternal) shouldn't happen,
+                // but if it does, don't crash
+                Debug.Assert(false, "unexpected reentrant call to OnItemAdded");
+                return;
+            }
+
+            ValidateAndCorrectIndex(items[0], ref index);
+
+            GeneratorPosition position = new GeneratorPosition(-1, 0);
+
+            // find the block containing the new item
+            ItemBlock block = _itemMap.Next;
+            int offsetFromBlockStart = index;
+            int unrealizedItemsSkipped = 0;     // distance since last realized item
+            while (block != _itemMap && offsetFromBlockStart >= block.ItemCount)
+            {
+                offsetFromBlockStart -= block.ItemCount;
+                position.Index += block.ContainerCount;
+                unrealizedItemsSkipped = (block.ContainerCount > 0) ? 0 : unrealizedItemsSkipped + block.ItemCount;
+                block = block.Next;
+            }
+
+            position.Offset = unrealizedItemsSkipped + offsetFromBlockStart + 1;
+            // the position is now correct, except when pointing into a realized block;
+            // that case is fixed below
+
+            // if it's an unrealized block, add the item by bumping the count
+            UnrealizedItemBlock uib = block as UnrealizedItemBlock;
+            if (uib != null)
+            {
+                MoveItems(uib, offsetFromBlockStart, items.Count, uib, offsetFromBlockStart + 1, 0);
+                uib.ItemCount += items.Count;
+            }
+
+            // if the item can be added to a previous unrealized block, do so
+            else if ((offsetFromBlockStart == 0 || block == _itemMap) &&
+                    ((uib = block.Prev as UnrealizedItemBlock) != null))
+            {
+                uib.ItemCount += items.Count;
+            }
+
+            // otherwise, create a new unrealized block
+            else
+            {
+                uib = new UnrealizedItemBlock();
+                uib.ItemCount = items.Count;
+
+                // split the current realized block, if necessary
+                RealizedItemBlock rib;
+                if (offsetFromBlockStart > 0 && (rib = block as RealizedItemBlock) != null)
+                {
+                    RealizedItemBlock newBlock = new RealizedItemBlock();
+                    MoveItems(rib, offsetFromBlockStart, rib.ItemCount - offsetFromBlockStart, newBlock, 0, offsetFromBlockStart);
+                    newBlock.InsertAfter(rib);
+                    position.Index += block.ContainerCount;
+                    position.Offset = 1;
+                    block = newBlock;
+                }
+
+                uib.InsertBefore(block);
+            }
+
+            // tell generators what happened
+            if (MapChanged != null)
+            {
+                MapChanged(null, index, items.Count, uib, 0, 0);
+            }
+
+            // tell layout what happened
+            if (ItemsChanged != null)
+            {
+                ItemsChanged(this, new ItemsChangedEventArgs(NotifyCollectionChangedAction.Add, position, items.Count, 0));
             }
         }
 
@@ -2526,6 +2606,15 @@ namespace System.Windows.Controls
             }
         }
 
+        // Called when items are removed from the items collection
+        // TODO this could probably be improved
+        void OnItemsRemoved(IList items, int itemIndex)
+        {
+            foreach (var item in items)
+            {
+                OnItemRemoved(item, itemIndex);
+            }
+        }
 
         // Called when an item is removed from the items collection
         void OnItemRemoved(object item, int itemIndex)
@@ -2588,6 +2677,35 @@ namespace System.Windows.Controls
                 if (group != null)
                 {
                     Parent.OnSubgroupBecameEmpty(group);
+                }
+            }
+        }
+
+        // this could probably be optimized
+        void OnItemsReplaced(IList oldItems, IList newItems, int index)
+        {
+            for (int i = 0; i < Math.Min(oldItems.Count, newItems.Count); i++)
+            {
+                OnItemReplaced(oldItems[i], newItems[i], index + i);
+            }
+
+            if (oldItems.Count > newItems.Count)
+            {
+                int offset = oldItems.Count - newItems.Count;
+                int removeIndex = newItems.Count + index;
+                for (int i = offset + 1; i < oldItems.Count; i++)
+                {
+                    OnItemRemoved(oldItems[i], removeIndex);
+                }
+            }
+            else if (newItems.Count > oldItems.Count)
+            {
+                int offset = newItems.Count - oldItems.Count;
+                int insertIndex = index + newItems.Count;
+                for (int i = offset + 1; i < oldItems.Count; i++)
+                {
+                    OnItemAdded(newItems[i], insertIndex);
+                    insertIndex++;
                 }
             }
         }


### PR DESCRIPTION
Fixes #52 

## Description

This adds support for range notifications coming from INotifyCollectionChanged for Add/Remove/Replace.
I hope I have covered all scenarios where it need to be adjusted. It works with and without `AllowsCrossThreadChanges`.

## Customer Impact

Customers can finally use ObservableCollections that implement range operations. Would also help unblock this: https://github.com/dotnet/runtime/issues/18087

## Testing

A test app that hopefully covers all scenarios, see here: https://github.com/Mrxx99/ObservableRangeWpfTestApp
Will look into DRTs.

## Risk

I am not aware of any, except of maybe regression bugs.
