### PR TITLE
Remove unnecessary array allocations in SelectionProcessor/SubTreeProcessor

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/DataIdProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/DataIdProcessor.cs
@@ -198,7 +198,7 @@ namespace MS.Internal.Annotations.Anchoring
             ArgumentNullException.ThrowIfNull(locatorPart);
             ArgumentNullException.ThrowIfNull(startNode);
 
-            if (DataIdElementName != locatorPart.PartType)
+            if (s_dataIdElementName != locatorPart.PartType)
                 throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), "locatorPart");
 
             // Initial value
@@ -235,10 +235,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => new(in s_dataIdElementName);
 
         #endregion Public Methods
 
@@ -412,7 +409,7 @@ namespace MS.Internal.Annotations.Anchoring
             if ((nodeId == null) || (nodeId.Length == 0))
                 return null;
 
-            ContentLocatorPart part = new ContentLocatorPart(DataIdElementName);
+            ContentLocatorPart part = new ContentLocatorPart(s_dataIdElementName);
 
             part.NameValuePairs.Add(ValueAttributeName, nodeId);
             return part;
@@ -454,17 +451,10 @@ namespace MS.Internal.Annotations.Anchoring
         ///     This is internal and available to the processor that
         ///     is closely aligned with this handler.
         /// </summary>
-        private static readonly XmlQualifiedName DataIdElementName = new XmlQualifiedName("DataId", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
+        private static readonly XmlQualifiedName s_dataIdElementName = new("DataId", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
 
         //the name of the value attribute
         private const String ValueAttributeName = "Value";
-
-        // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames =
-                new XmlQualifiedName[]
-                {
-                    DataIdElementName
-                };
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedPageProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedPageProcessor.cs
@@ -174,7 +174,7 @@ namespace MS.Internal.Annotations.Anchoring
             ArgumentNullException.ThrowIfNull(locatorPart);
             ArgumentNullException.ThrowIfNull(startNode);
 
-            if (PageNumberElementName != locatorPart.PartType)
+            if (s_pageNumberElementName != locatorPart.PartType)
                 throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), "locatorPart");
 
             // Initial value
@@ -251,10 +251,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => new(in s_pageNumberElementName);
 
         #endregion Public Methods
 
@@ -325,7 +322,7 @@ namespace MS.Internal.Annotations.Anchoring
         {
             Debug.Assert(page >= 0, "page can not be negative");
 
-            ContentLocatorPart part = new ContentLocatorPart(PageNumberElementName);
+            ContentLocatorPart part = new ContentLocatorPart(s_pageNumberElementName);
 
             part.NameValuePairs.Add(ValueAttributeName, page.ToString(NumberFormatInfo.InvariantInfo));
             return part;
@@ -345,12 +342,7 @@ namespace MS.Internal.Annotations.Anchoring
         private static readonly String ValueAttributeName = "Value";
 
         // Name of the locator part produced by this processor.
-        private static readonly XmlQualifiedName PageNumberElementName = new XmlQualifiedName("PageNumber", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
-
-        // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames = new XmlQualifiedName[] {
-            PageNumberElementName
-        };
+        private static readonly XmlQualifiedName s_pageNumberElementName = new("PageNumber", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
 
         // Specifies whether the processor should use the logical tree to resolve locator parts.
         // If this is false (the default) only visible pages will be found.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
@@ -204,7 +204,7 @@ namespace MS.Internal.Annotations.Anchoring
             if (fp == null)
                 throw new ArgumentException(SR.StartNodeMustBeFixedPageProxy, "startNode");
 
-            ContentLocatorPart part = new ContentLocatorPart(FixedTextElementName);
+            ContentLocatorPart part = new ContentLocatorPart(s_fixedTextElementName);
             if (fp.Segments.Count == 0)
             {
                 part.NameValuePairs.Add(TextSelectionProcessor.CountAttribute, 1.ToString(NumberFormatInfo.InvariantInfo));
@@ -371,10 +371,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
 
         #endregion Public Methods
 
@@ -501,7 +498,7 @@ namespace MS.Internal.Annotations.Anchoring
         {
             ArgumentNullException.ThrowIfNull(locatorPart);
 
-            if (FixedTextElementName != locatorPart.PartType)
+            if (s_fixedTextElementName != locatorPart.PartType)
                 throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), "locatorPart");
 
             string segmentValue = locatorPart.NameValuePairs[TextSelectionProcessor.SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)];
@@ -624,14 +621,10 @@ namespace MS.Internal.Annotations.Anchoring
         #region Private Fields
 
         // Name of locator part element
-        private static readonly XmlQualifiedName FixedTextElementName = new XmlQualifiedName("FixedTextRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
+        private static readonly XmlQualifiedName s_fixedTextElementName = new("FixedTextRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
 
         // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames =
-                new XmlQualifiedName[]
-                {
-                    FixedTextElementName
-                };
+        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = [s_fixedTextElementName];
 
         #endregion Private Fields
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
@@ -371,7 +371,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => new(in s_fixedTextElementName);
 
         #endregion Public Methods
 
@@ -622,9 +622,6 @@ namespace MS.Internal.Annotations.Anchoring
 
         // Name of locator part element
         private static readonly XmlQualifiedName s_fixedTextElementName = new("FixedTextRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
-
-        // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = [s_fixedTextElementName];
 
         #endregion Private Fields
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
@@ -32,6 +32,7 @@ using System.Xml;
 using MS.Utility;
 using MS.Internal.Documents;
 using MS.Internal.PtsHost;
+using System.Runtime.InteropServices;
 
 namespace MS.Internal.Annotations.Anchoring
 {
@@ -93,11 +94,11 @@ namespace MS.Internal.Annotations.Anchoring
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
         /// <exception cref="ArgumentException">selection start or end point can not be resolved to a page</exception>
-        public override IList<DependencyObject> GetSelectedNodes(Object selection)
+        public override ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection)
         {
             IList<TextSegment> textSegments = CheckSelection(selection);
 
-            IList<DependencyObject> pageEl = new List<DependencyObject>();
+            List<DependencyObject> pageEl = new();
 
             Point start;
             Point end;
@@ -108,14 +109,14 @@ namespace MS.Internal.Annotations.Anchoring
                 TextSelectionHelper.GetPointerPage(startPointer, out startPage);
                 start = TextSelectionHelper.GetPointForPointer(startPointer);
                 if (startPage == int.MinValue)
-                    throw new ArgumentException(SR.Format(SR.SelectionDoesNotResolveToAPage, "start"), "selection");
+                    throw new ArgumentException(SR.Format(SR.SelectionDoesNotResolveToAPage, "start"), nameof(selection));
 
                 int endPage = int.MinValue;
                 ITextPointer endPointer = segment.End.CreatePointer(LogicalDirection.Backward);
                 TextSelectionHelper.GetPointerPage(endPointer, out endPage);
                 end = TextSelectionHelper.GetPointForPointer(endPointer);
                 if (endPage == int.MinValue)
-                    throw new ArgumentException(SR.Format(SR.SelectionDoesNotResolveToAPage, "end"), "selection");
+                    throw new ArgumentException(SR.Format(SR.SelectionDoesNotResolveToAPage, "end"), nameof(selection));
 
                 int firstPage = pageEl.Count;
                 int numOfPages = endPage - startPage;
@@ -149,7 +150,7 @@ namespace MS.Internal.Annotations.Anchoring
                 }
             }
 
-            return pageEl;
+            return CollectionsMarshal.AsSpan(pageEl);
         }
 
         /// <summary>
@@ -160,7 +161,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the parent element of the selection; can be null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override UIElement GetParent(Object selection)
+        public override UIElement GetParent(object selection)
         {
             CheckAnchor(selection);
             return TextSelectionHelper.GetParent(selection);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -356,16 +356,16 @@ namespace MS.Internal.Annotations.Anchoring
             VerifyAccess();
             ArgumentNullException.ThrowIfNull(selection);
 
-            ICollection nodes = null;
+            ReadOnlySpan<DependencyObject> nodes;
             SelectionProcessor selProcessor = GetSelectionProcessor(selection.GetType());
 
             if (selProcessor != null)
             {
-                nodes = (ICollection)selProcessor.GetSelectedNodes(selection);
+                nodes = selProcessor.GetSelectedNodes(selection);
             }
             else
             {
-                throw new ArgumentException("Unsupported Selection", "selection");
+                throw new ArgumentException("Unsupported Selection", nameof(selection));
             }
 
             IList<ContentLocatorBase> returnLocators = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -202,15 +202,12 @@ namespace MS.Internal.Annotations.Anchoring
             ArgumentNullException.ThrowIfNull(processor);
             ArgumentNullException.ThrowIfNull(selectionType);
 
-            XmlQualifiedName[] locatorPartTypes = processor.GetLocatorPartTypes();
+            ReadOnlySpan<XmlQualifiedName> locatorPartTypes = processor.GetLocatorPartTypes();
             _selectionProcessors[selectionType] = processor;
 
-            if (locatorPartTypes != null)
+            foreach (XmlQualifiedName type in locatorPartTypes)
             {
-                foreach (XmlQualifiedName type in locatorPartTypes)
-                {
-                    _locatorPartHandlers[type] = processor;
-                }
+                _locatorPartHandlers[type] = processor;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/LocatorManager.cs
@@ -105,23 +105,20 @@ namespace MS.Internal.Annotations.Anchoring
         /// <param name="processorId">string id used to specify this processor as 
         /// the SubTreeProcessorIdProperty value</param>
         /// <exception cref="ArgumentNullException">if the processor or processorId are null</exception>
-        public void RegisterSubTreeProcessor(SubTreeProcessor processor, String processorId)
+        public void RegisterSubTreeProcessor(SubTreeProcessor processor, string processorId)
         {
             VerifyAccess();
 
             ArgumentNullException.ThrowIfNull(processor);
             ArgumentNullException.ThrowIfNull(processorId);
 
-            XmlQualifiedName[] locatorPartTypes = processor.GetLocatorPartTypes();
+            ReadOnlySpan<XmlQualifiedName> locatorPartTypes = processor.GetLocatorPartTypes();
 
             _subtreeProcessors[processorId] = processor;
 
-            if (locatorPartTypes != null)
+            foreach (XmlQualifiedName typeName in locatorPartTypes)
             {
-                foreach (XmlQualifiedName typeName in locatorPartTypes)
-                {
-                    _locatorPartHandlers[typeName] = processor;
-                }
+                _locatorPartHandlers[typeName] = processor;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/PathNode.cs
@@ -151,11 +151,8 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the instance referring to the root of the tree; its 
         /// children/descendants only include the nodes between the root and 
         /// all of the nodes</returns>
-        /// <exception cref="ArgumentNullException">nodes is null</exception>
-        internal static PathNode BuildPathForElements(ICollection nodes)
+        internal static PathNode BuildPathForElements(ReadOnlySpan<DependencyObject> nodes)
         {
-            ArgumentNullException.ThrowIfNull(nodes);
-
             PathNode firstPathNode = null;
             foreach (DependencyObject node in nodes)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SelectionProcessor.cs
@@ -130,7 +130,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public abstract XmlQualifiedName[] GetLocatorPartTypes();
+        public abstract ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes();
 
         #endregion Public Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SelectionProcessor.cs
@@ -77,7 +77,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public abstract IList<DependencyObject> GetSelectedNodes(Object selection);
+        public abstract ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection);
 
         /// <summary>
         ///     Gets the parent element of this selection.
@@ -86,7 +86,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the parent element of the selection; can be null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public abstract UIElement GetParent(Object selection);
+        public abstract UIElement GetParent(object selection);
 
         /// <summary>
         ///     Gets the anchor point for the selection

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SubTreeProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/SubTreeProcessor.cs
@@ -150,7 +150,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public abstract XmlQualifiedName[] GetLocatorPartTypes();
+        public abstract ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes();
 
         #endregion Public Methods
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionHelper.cs
@@ -26,6 +26,7 @@ using System.Windows.Media;
 using System.Xml;
 using MS.Internal.Documents;
 using MS.Utility;
+using System.Runtime.InteropServices;
 
 
 namespace MS.Internal.Annotations.Anchoring
@@ -110,17 +111,12 @@ namespace MS.Internal.Annotations.Anchoring
         /// null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public static IList<DependencyObject> GetSelectedNodes(Object selection)
+        public static ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection)
         {
             ArgumentNullException.ThrowIfNull(selection);
 
-            IList<TextSegment> segments;
-            ITextPointer start = null;
-            ITextPointer end = null;
-
-            CheckSelection(selection, out start, out end, out segments);
-
-            IList<DependencyObject> list = new List<DependencyObject>();
+            CheckSelection(selection, out ITextPointer start, out ITextPointer end, out _);
+            List<DependencyObject> list = new();
 
             // If the selection is of length 0, then we simply add the parent of the
             // text container and return.
@@ -128,7 +124,7 @@ namespace MS.Internal.Annotations.Anchoring
             {
                 list.Add(((TextPointer)start).Parent);
 
-                return list;
+                return CollectionsMarshal.AsSpan(list);
             }
 
             TextPointer current = (TextPointer)start.CreatePointer();
@@ -144,7 +140,7 @@ namespace MS.Internal.Annotations.Anchoring
                 current.MoveToNextContextPosition(LogicalDirection.Forward);
             }
 
-            return list;
+            return CollectionsMarshal.AsSpan(list);
         }
 
         /// <summary>
@@ -154,15 +150,11 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the parent element of the selection; can be null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public static UIElement GetParent(Object selection)
+        public static UIElement GetParent(object selection)
         {
             ArgumentNullException.ThrowIfNull(selection);
 
-            ITextPointer start = null;
-            ITextPointer end = null;
-            IList<TextSegment> segments;
-
-            CheckSelection(selection, out start, out end, out segments);
+            CheckSelection(selection, out ITextPointer start, out _, out _);
 
             return GetParent(start);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
@@ -302,7 +302,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => new(in s_characterRangeElementName);
 
         #endregion Public Methods
 
@@ -554,9 +554,6 @@ namespace MS.Internal.Annotations.Anchoring
         //------------------------------------------------------
 
         #region Private Fields
-
-        // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = [s_characterRangeElementName];
 
         // Optional DPV - used in printing case when there is no viewer available
         private DocumentPageView _targetPage = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
@@ -89,7 +89,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override IList<DependencyObject> GetSelectedNodes(Object selection)
+        public override ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection)
         {
             return TextSelectionHelper.GetSelectedNodes(selection);
         }
@@ -101,7 +101,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the parent element of the selection; can be null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override UIElement GetParent(Object selection)
+        public override UIElement GetParent(object selection)
         {
             return TextSelectionHelper.GetParent(selection);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
@@ -158,7 +158,7 @@ namespace MS.Internal.Annotations.Anchoring
             if (elementEnd.CompareTo(start) < 0)
                 throw new ArgumentException(SR.InvalidStartNodeForTextSelection, "startNode");
 
-            ContentLocatorPart part = new ContentLocatorPart(CharacterRangeElementName);
+            ContentLocatorPart part = new ContentLocatorPart(s_characterRangeElementName);
 
             int startOffset = 0;
             int endOffset = 0;
@@ -199,7 +199,7 @@ namespace MS.Internal.Annotations.Anchoring
             ArgumentNullException.ThrowIfNull(startNode);
             ArgumentNullException.ThrowIfNull(locatorPart);
 
-            if (CharacterRangeElementName != locatorPart.PartType)
+            if (s_characterRangeElementName != locatorPart.PartType)
                 throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), "locatorPart");
 
             // First we extract the offset and length of the
@@ -302,10 +302,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
 
         #endregion Public Methods
 
@@ -420,7 +417,7 @@ namespace MS.Internal.Annotations.Anchoring
         internal const Char Separator = ',';
 
         // Name of locator part element
-        internal static readonly XmlQualifiedName CharacterRangeElementName = new XmlQualifiedName("CharacterRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
+        internal static readonly XmlQualifiedName s_characterRangeElementName = new("CharacterRange", AnnotationXmlConstants.Namespaces.BaseSchemaNamespace);
 
         #endregion Internal Fields
 
@@ -559,11 +556,7 @@ namespace MS.Internal.Annotations.Anchoring
         #region Private Fields
 
         // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames =
-                new XmlQualifiedName[]
-                {
-                    CharacterRangeElementName
-                };
+        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = [s_characterRangeElementName];
 
         // Optional DPV - used in printing case when there is no viewer available
         private DocumentPageView _targetPage = null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
@@ -190,7 +190,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     the locator parts this processor can generate.  This processor
         ///     does not resolve these ContentLocatorParts - only generates them.
         /// </summary>
-        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => ReadOnlySpan<XmlQualifiedName>.Empty;
 
         #endregion Public Methods
 
@@ -287,9 +287,6 @@ namespace MS.Internal.Annotations.Anchoring
         //------------------------------------------------------
 
         #region Private Fields
-
-        // ContentLocator part types understood by this processor
-        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = Array.Empty<XmlQualifiedName>();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
@@ -79,12 +79,12 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>a list containing the selection</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override IList<DependencyObject> GetSelectedNodes(Object selection)
+        public override ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection)
         {
             // Verify selection is a service provider that provides ITextView
             VerifySelection(selection);
 
-            return new DependencyObject[] { (DependencyObject)selection };
+            return new DependencyObject[1] { (DependencyObject)selection };
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the selection itself</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override UIElement GetParent(Object selection)
+        public override UIElement GetParent(object selection)
         {
             // Verify selection is a service provider that provides ITextView
             VerifySelection(selection);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextViewSelectionProcessor.cs
@@ -155,7 +155,7 @@ namespace MS.Internal.Annotations.Anchoring
                 endOffset = -1;
             }
 
-            ContentLocatorPart part = new ContentLocatorPart(TextSelectionProcessor.CharacterRangeElementName);// DocumentPageViewLocatorPart();
+            ContentLocatorPart part = new ContentLocatorPart(TextSelectionProcessor.s_characterRangeElementName);// DocumentPageViewLocatorPart();
             part.NameValuePairs.Add(TextSelectionProcessor.CountAttribute, 1.ToString(NumberFormatInfo.InvariantInfo));
             part.NameValuePairs.Add(TextSelectionProcessor.SegmentAttribute + 0.ToString(NumberFormatInfo.InvariantInfo), startOffset.ToString(NumberFormatInfo.InvariantInfo) + TextSelectionProcessor.Separator + endOffset.ToString(NumberFormatInfo.InvariantInfo));
             part.NameValuePairs.Add(TextSelectionProcessor.IncludeOverlaps, Boolean.TrueString);
@@ -190,10 +190,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     the locator parts this processor can generate.  This processor
         ///     does not resolve these ContentLocatorParts - only generates them.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
 
         #endregion Public Methods
 
@@ -292,7 +289,7 @@ namespace MS.Internal.Annotations.Anchoring
         #region Private Fields
 
         // ContentLocator part types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames = Array.Empty<XmlQualifiedName>();
+        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = Array.Empty<XmlQualifiedName>();
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
@@ -177,7 +177,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => ReadOnlySpan<XmlQualifiedName>.Empty;
 
         #endregion Public Methods
 
@@ -204,9 +204,6 @@ namespace MS.Internal.Annotations.Anchoring
         //------------------------------------------------------
 
         #region Private Fields
-
-        // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = Array.Empty<XmlQualifiedName>();
 
         #endregion Private Fields        
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
@@ -177,10 +177,7 @@ namespace MS.Internal.Annotations.Anchoring
         ///     Returns a list of XmlQualifiedNames representing the
         ///     the locator parts this processor can resolve/generate.
         /// </summary>
-        public override XmlQualifiedName[] GetLocatorPartTypes()
-        {
-            return (XmlQualifiedName[])LocatorPartTypeNames.Clone();
-        }
+        public override ReadOnlySpan<XmlQualifiedName> GetLocatorPartTypes() => s_locatorPartTypeNames;
 
         #endregion Public Methods
 
@@ -209,7 +206,7 @@ namespace MS.Internal.Annotations.Anchoring
         #region Private Fields
 
         // ContentLocatorPart types understood by this processor
-        private static readonly XmlQualifiedName[] LocatorPartTypeNames = Array.Empty<XmlQualifiedName>();
+        private static readonly XmlQualifiedName[] s_locatorPartTypeNames = Array.Empty<XmlQualifiedName>();
 
         #endregion Private Fields        
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TreeNodeSelectionProcessor.cs
@@ -83,9 +83,9 @@ namespace MS.Internal.Annotations.Anchoring
         /// null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override IList<DependencyObject> GetSelectedNodes(Object selection)
+        public override ReadOnlySpan<DependencyObject> GetSelectedNodes(object selection)
         {
-            return new DependencyObject[] { GetParent(selection) };
+            return new DependencyObject[1] { GetParent(selection) };
         }
 
         /// <summary>
@@ -95,12 +95,11 @@ namespace MS.Internal.Annotations.Anchoring
         /// <returns>the parent element of the selection; can be null</returns>
         /// <exception cref="ArgumentNullException">selection is null</exception>
         /// <exception cref="ArgumentException">selection is of wrong type</exception>
-        public override UIElement GetParent(Object selection)
+        public override UIElement GetParent(object selection)
         {
             ArgumentNullException.ThrowIfNull(selection);
 
-            UIElement element = selection as UIElement;
-            if (element == null)
+            if (selection is not UIElement element)
             {
                 throw new ArgumentException(SR.WrongSelectionType, nameof(selection));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/LocatorPart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/LocatorPart.cs
@@ -365,7 +365,7 @@ namespace System.Windows.Annotations
             string corePrefix = namespaceManager.LookupPrefix(AnnotationXmlConstants.Namespaces.CoreSchemaNamespace);
             string prefix = namespaceManager.LookupPrefix(this.PartType.Namespace);
             string res = prefix == null ? "" : (prefix + ":");
-            res += $"{TextSelectionProcessor.CharacterRangeElementName.Name}/{corePrefix}:{AnnotationXmlConstants.Elements.Item}";
+            res += $"{TextSelectionProcessor.s_characterRangeElementName.Name}/{corePrefix}:{AnnotationXmlConstants.Elements.Item}";
 
             int startOffset;
             int endOffset;


### PR DESCRIPTION
## Description

Removes unnecessary static array allocations of `XmlQualifiedName` and their subsequent clones on getters, replacing it with simple `ReadOnlySpan<XmlQualifiedName>` returning a reference to a static field.

Also replaces `GetSelectedNodes` to return a `ReadOnlySpan<DependencyObject>` which can then be used in `BuildPathForElements` for faster enumeration and strongly-typed access.

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, CI.

## Risk

Low.
