### PR TITLE
Improve performance/decrease allocations in hWnd proxy for WindowsMenu

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -11,7 +11,6 @@
 using Microsoft.Win32.SafeHandles;
 using MS.Win32;
 using System;
-using System.Collections;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -1641,45 +1640,27 @@ namespace MS.Internal.AutomationProxies
             return UnsafeNativeMethods.SetWinEventHook(eventMin, eventMax, hmodWinEventProc, WinEventReentrancyFilter, idProcess, idThread, dwFlags);
         }
 
-        // this strips the mnemonic prefix for short cuts as well as leading spaces
-        // If we find && leave one & there.
-        internal static string StripMnemonic(string s)
+        /// <summary> Strips the mnemonic prefix for shortcuts as well as leading spaces. </summary>
+        /// <param name="value">The string to strip from.</param>
+        /// <returns> A <see langword="string"/> stripped of leading whitespaces / mnemonic prefix. </returns>
+        internal static string StripMnemonic(string value)
         {
-            // If there are no spaces or & then it's ok just return it
-            if (string.IsNullOrEmpty(s) || s.IndexOfAny(new char[2] { ' ', '&' }) < 0)
-            {
-                return s;
-            }
+            if (string.IsNullOrEmpty(value))
+                return value;
 
-            char[] ach = s.ToCharArray();
-            bool amper = false;
-            bool leadingSpace = false;
-            int dest = 0;
+            // Is there a '&' that we need to skip or ' ' that needs trimming?
+            int ampersandIndex = value.IndexOf('&');
+            if (value[0] != ' ' && ampersandIndex == -1)
+                return value;
 
-            for (int source = 0; source < ach.Length; source++)
-            {
-                // get rid of leading spaces
-                if (ach[source] == ' ' && leadingSpace == false)
-                {
-                    continue;
-                }
-                else
-                {
-                    leadingSpace = true;
-                }
+            // Trim leading whitespaces, check if we need to remove '&' as well
+            ReadOnlySpan<char> trimmed = value.AsSpan().TrimStart(' ');
+            if (ampersandIndex == -1)
+                return trimmed.ToString();
 
-                // get rid of &
-                if (ach[source] == '&' && amper == false)
-                {
-                    amper = true;
-                }
-                else
-                {
-                    ach[dest++] = ach[source];
-                }
-            }
-
-            return new string(ach, 0, dest);
+            // Update '&' index and slice it out
+            ampersandIndex -= (value.Length - trimmed.Length);
+            return string.Create(null, stackalloc char[128], $"{trimmed.Slice(0, ampersandIndex)}{trimmed.Slice(ampersandIndex + 1)}");
         }
 
         internal static void ThrowWin32ExceptionsIfError(int errorCode)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/Misc.cs
@@ -11,8 +11,8 @@
 using Microsoft.Win32.SafeHandles;
 using MS.Win32;
 using System;
+using System.Globalization;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Automation;
@@ -1660,7 +1660,7 @@ namespace MS.Internal.AutomationProxies
 
             // Update '&' index and slice it out
             ampersandIndex -= (value.Length - trimmed.Length);
-            return string.Create(null, stackalloc char[128], $"{trimmed.Slice(0, ampersandIndex)}{trimmed.Slice(ampersandIndex + 1)}");
+            return string.Create(CultureInfo.InvariantCulture, stackalloc char[128], $"{trimmed.Slice(0, ampersandIndex)}{trimmed.Slice(ampersandIndex + 1)}");
         }
 
         internal static void ThrowWin32ExceptionsIfError(int errorCode)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -27,7 +27,7 @@ using MS.Win32;
 namespace MS.Internal.AutomationProxies
 {
     // Win32 menu proxy
-    class WindowsMenu: ProxyHwnd
+    class WindowsMenu : ProxyHwnd
     {
         // ------------------------------------------------------
         //
@@ -1182,7 +1182,7 @@ namespace MS.Internal.AutomationProxies
                 if (_type == MenuItemType.Spacer)
                 {
                     _cControlType = ControlType.Separator;
-                    _sAutomationId = "Separator " + (_item + 1).ToString(CultureInfo.InvariantCulture); // This string is a non-localizable string
+                    _sAutomationId = string.Create(CultureInfo.InvariantCulture, $"Separator {_item + 1}"); // This string is a non-localizable string
                     _fIsContent = false;
                 }
                 else
@@ -1333,19 +1333,18 @@ namespace MS.Internal.AutomationProxies
                     string keyWin = SR.KeyWinKey;
 
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    string accelerator;
 
-                    if ((accelerator = AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), keyAlt + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), keyShift + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), keyWin + " + ", menuText, menuRawText, out pos)) != null)
+                    if (AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), $"{keyAlt} + ", menuText, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), $"{keyShift} + ", menuText, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), $"{keyWin} + ", menuText, menuRawText, out pos) != null)
                     {
                         return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
                     }
 
                     // Try to look for a Fxx
-                    accelerator = AccelatorFxx(menuText);
+                    string accelerator = AccelatorFxx(menuText);
                     if (!string.IsNullOrEmpty(accelerator))
                     {
                         pos = menuText.LastIndexOf(accelerator, StringComparison.OrdinalIgnoreCase);
@@ -1362,12 +1361,10 @@ namespace MS.Internal.AutomationProxies
                     }
 
                     // Look for a bunch of Predefined keyword
-                    string[] keywordsAccelerators = GetKeywordsAccelerators();
-
-                    for (int i = 0; i < keywordsAccelerators.Length; i++)
+                    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
+                        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
                         {
                             return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
                         }
@@ -1536,7 +1533,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     case MenuType.System:
                         {
-                            return SR.KeyAlt + " + " + SR.KeySpace;
+                            return $"{SR.KeyAlt} + {SR.KeySpace}";
                         }
                     case MenuType.Submenu:
                     case MenuType.SystemPopup:
@@ -1918,28 +1915,6 @@ namespace MS.Internal.AutomationProxies
                 return (Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_SEPARATOR) ||
                         Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_MENUBARBREAK) ||
                         Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_MENUBREAK));
-            }
-
-            //Gets the localized keywords accelerators
-            private string[] GetKeywordsAccelerators()
-            {
-                return new string[] {
-                    SR.KeyHome,
-                    SR.KeyEnd,
-                    SR.KeyDel,
-                    SR.KeyDelete,
-                    SR.KeyIns,
-                    SR.KeyInsert,
-                    SR.KeyPageUp,
-                    SR.KeyPageDown,
-                    SR.KeyEsc,
-                    SR.KeyScrLk,
-                    SR.KeyPause,
-                    SR.KeySysRq,
-                    SR.KeyPrtScn,
-                    SR.KeyTab,
-                    SR.KeyHelp,
-                };
             }
 
             // Retrieve type of menu item
@@ -2454,14 +2429,14 @@ namespace MS.Internal.AutomationProxies
                         // Found a combination "Ctrl+letter"
                         if (pos + cKeyChars + 2 == cMenuChars)
                         {
-                            // UperCase the letter, case Ctr+A
-                            return string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}", sCanonicalsKeyword, menuText.Substring(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 2)), Char.ToUpper(menuText[cMenuChars - 1], CultureInfo.InvariantCulture));
+                            // UperCase the letter, case Ctrl+A
+                            return $"{sCanonicalsKeyword}{menuText.AsSpan(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 2))}{char.ToUpper(menuText[cMenuChars - 1], CultureInfo.InvariantCulture)}";
                         }
                         else
                         {
                             // Take the remaining string from the Keyword
                             // Case Alt+Enter
-                            return sCanonicalsKeyword + menuRawText.Substring(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 1));
+                            return $"{sCanonicalsKeyword}{menuRawText.AsSpan(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 1))}";
                         }
                     }
                 }
@@ -2512,14 +2487,14 @@ namespace MS.Internal.AutomationProxies
 
                 if (result > 0)
                 {
-                    itemId = "Item " + result.ToString(CultureInfo.CurrentCulture);
+                    itemId = $"Item {result}";
                 }
                 else if (result == -1)
                 {
                     // since the "Application-defined 16-bit value that identifies the menu item", i.e.
                     // the MENUITEMINFO.wID, changes from instance to instance, I am using the position as
                     // the ID of the menu items.
-                    itemId = "Item " + (_item + 1).ToString(CultureInfo.CurrentCulture);
+                    itemId = $"Item {_item + 1}";
                 }
             }
 
@@ -2759,11 +2734,11 @@ namespace MS.Internal.AutomationProxies
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     string accelerator;
 
-                    if ((accelerator = AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), keyAlt + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), keyShift + " + ", menuText, menuRawText, out pos)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), keyWin + " + ", menuText, menuRawText, out pos)) != null)
+                    if ((accelerator = AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), $"{keyAlt} + ", menuText, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), $"{keyShift} + ", menuText, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), $"{keyWin} + ", menuText, menuRawText, out _)) != null)
                     {
                         return accelerator;
                     }
@@ -2776,14 +2751,12 @@ namespace MS.Internal.AutomationProxies
                     }
 
                     // Look for a bunch of Predefined keyword
-                    string[] keywordsAccelerators = GetKeywordsAccelerators();
-
-                    for (int i = 0; i < keywordsAccelerators.Length; i++)
+                    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
+                        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
                         {
-                            return keywordsAccelerators[i];
+                            return s_keywordsAccelerators[i];
                         }
                     }
 
@@ -2801,6 +2774,25 @@ namespace MS.Internal.AutomationProxies
             // ------------------------------------------------------
 
             #region Private Fields
+
+            /// <summary>
+            /// Retrieves the localized keywords accelerators.
+            /// </summary>
+            private static readonly string[] s_keywordsAccelerators = [SR.KeyHome,
+                                                                       SR.KeyEnd,
+                                                                       SR.KeyDel,
+                                                                       SR.KeyDelete,
+                                                                       SR.KeyIns,
+                                                                       SR.KeyInsert,
+                                                                       SR.KeyPageUp,
+                                                                       SR.KeyPageDown,
+                                                                       SR.KeyEsc,
+                                                                       SR.KeyScrLk,
+                                                                       SR.KeyPause,
+                                                                       SR.KeySysRq,
+                                                                       SR.KeyPrtScn,
+                                                                       SR.KeyTab,
+                                                                       SR.KeyHelp];
 
             private enum MenuItemType
             {
@@ -2863,7 +2855,7 @@ namespace MS.Internal.AutomationProxies
                 _cControlType = ControlType.MenuItem;
                 _item = item;
 
-                _sAutomationId = "Item " + (item).ToString(CultureInfo.CurrentCulture);
+                _sAutomationId = $"Item {item}";
 
                 // This is used only to return a HostRawElementProvider for this menu item
                 _hwndParent = hwndParent;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -8,6 +8,7 @@
 #pragma warning disable 1634, 1691
 
 using System;
+using System.Diagnostics;
 using System.Collections;
 using System.Globalization;
 using System.Text;
@@ -1334,25 +1335,24 @@ namespace MS.Internal.AutomationProxies
                         return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
                     }
 
-                    // Try to look for a Fxx
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    string accelerator = AccelatorFxx(menuText);
+                    // Try to look for an Fxx accelerator
+                    string accelerator = AccelatorFxx(menuRawText, out pos);
                     if (!string.IsNullOrEmpty(accelerator))
                     {
-                        pos = menuText.LastIndexOf(accelerator, StringComparison.OrdinalIgnoreCase);
                         if (pos >= 0)
                         {
-                            return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
+                            return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
                         }
                         else
                         {
                             // Wrong logic, we should be able to find the Fxx combination we just built
-                            System.Diagnostics.Debug.Assert(false, "Cannot find back the accelerator in the menu!");
+                            Debug.Assert(false, "Cannot find back the accelerator in the menu!");
                             return menuRawText;
                         }
                     }
 
-                    // Look for a bunch of Predefined keyword
+                    // Look for a bunch of Predefined keywords
+                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     for (int i = 0; i < s_keywordsAccelerators.Length; i++)
                     {
                         pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
@@ -2435,18 +2435,24 @@ namespace MS.Internal.AutomationProxies
             }
 
             // Search in a menu if the menu item string finishes with an accelerator
-            // of the form Fxx (F5, F12, etc)
-            private static string AccelatorFxx(string menuText)
+            // of the form Fxx (F5, F12, etc.)
+            /// <summary>
+            /// Searches <paramref name="menuText"/> for accelerators in Fxx format, where xx ranges from 1 to 12. 
+            /// </summary>
+            /// <param name="menuText">The menu string to search accelerator in.</param>
+            /// <param name="pos">Starting position of the accelerator in <paramref name="menuText"/>.</param>
+            /// <returns>The formatted accelerator in "F1" to "F12" format.</returns>
+            private static string AccelatorFxx(string menuText, out int pos)
             {
                 int cChars = menuText.Length;
-                int pos = cChars - 1;
+                pos = cChars - 1;
 
                 // Get the function key number
                 while (pos > 0 && cChars - pos <= 2 && char.IsDigit(menuText[pos]))
                     pos--;
 
                 // Check that it is the form Fxx
-                if (pos < cChars - 1 && pos > 0 && menuText [pos] == 'f')
+                if (pos < cChars - 1 && pos > 0 && char.ToUpperInvariant(menuText[pos]) == 'F')
                 {
                     int iKey = int.Parse(menuText.AsSpan(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
                     if (iKey > 0 && iKey <= 12)
@@ -2726,15 +2732,15 @@ namespace MS.Internal.AutomationProxies
                         return accelerator;
                     }
 
-                    // Try to look for a Fxx
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    accelerator = AccelatorFxx(menuText);
+                    // Try to look for an Fxx accelerator
+                    accelerator = AccelatorFxx(menuRawText, out _);
                     if (!string.IsNullOrEmpty(accelerator))
                     {
                         return accelerator;
                     }
 
-                    // Look for a bunch of Predefined keyword
+                    // Look for a bunch of Predefined keywords
+                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     for (int i = 0; i < s_keywordsAccelerators.Length; i++)
                     {
                         pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1353,10 +1353,11 @@ namespace MS.Internal.AutomationProxies
 
                     // Look for a bunch of Predefined keywords
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
+                    string[] keyWordAccelerators = GetKeywordsAccelerators();
+                    for (int i = 0; i < keyWordAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuText.LastIndexOf(keyWordAccelerators[i], StringComparison.OrdinalIgnoreCase);
+                        if (pos > 0 && pos + keyWordAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
                         {
                             return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
                         }
@@ -1907,6 +1908,28 @@ namespace MS.Internal.AutomationProxies
                 return (Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_SEPARATOR) ||
                         Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_MENUBARBREAK) ||
                         Misc.IsBitSet(menuItemInfo.fType, NativeMethods.MF_MENUBREAK));
+            }
+
+            /// <summary>
+            /// Retrieves the localized keywords accelerators for <see cref="CultureInfo.CurrentUICulture"/>.
+            /// </summary>
+            private static string[] GetKeywordsAccelerators()
+            {
+                return [SR.KeyHome,
+                        SR.KeyEnd,
+                        SR.KeyDel,
+                        SR.KeyDelete,
+                        SR.KeyIns,
+                        SR.KeyInsert,
+                        SR.KeyPageUp,
+                        SR.KeyPageDown,
+                        SR.KeyEsc,
+                        SR.KeyScrLk,
+                        SR.KeyPause,
+                        SR.KeySysRq,
+                        SR.KeyPrtScn,
+                        SR.KeyTab,
+                        SR.KeyHelp];
             }
 
             // Retrieve type of menu item
@@ -2741,12 +2764,13 @@ namespace MS.Internal.AutomationProxies
 
                     // Look for a bunch of Predefined keywords
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
+                    string[] keyWordAccelerators = GetKeywordsAccelerators();
+                    for (int i = 0; i < keyWordAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuText.LastIndexOf(keyWordAccelerators[i], StringComparison.OrdinalIgnoreCase);
+                        if (pos > 0 && pos + keyWordAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
                         {
-                            return s_keywordsAccelerators[i];
+                            return keyWordAccelerators[i];
                         }
                     }
 
@@ -2764,25 +2788,6 @@ namespace MS.Internal.AutomationProxies
             // ------------------------------------------------------
 
             #region Private Fields
-
-            /// <summary>
-            /// Retrieves the localized keywords accelerators.
-            /// </summary>
-            private static readonly string[] s_keywordsAccelerators = [SR.KeyHome,
-                                                                       SR.KeyEnd,
-                                                                       SR.KeyDel,
-                                                                       SR.KeyDelete,
-                                                                       SR.KeyIns,
-                                                                       SR.KeyInsert,
-                                                                       SR.KeyPageUp,
-                                                                       SR.KeyPageDown,
-                                                                       SR.KeyEsc,
-                                                                       SR.KeyScrLk,
-                                                                       SR.KeyPause,
-                                                                       SR.KeySysRq,
-                                                                       SR.KeyPrtScn,
-                                                                       SR.KeyTab,
-                                                                       SR.KeyHelp];
 
             private enum MenuItemType
             {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1322,23 +1322,16 @@ namespace MS.Internal.AutomationProxies
                         return menuRawText.Substring(0, pos);
                     }
 
-                    // Try to remove the Ctrl or Alt, etc at the end of the string if there
-                    // Be caution modifying this code, it must miror the code for AcceleratorKeyProperty
-
+                    // Be cautious modifying this code, it must mirror the code for AcceleratorKeyProperty
                     // Try to look for a combination Ctrl or Alt + something
-                    string keyCtrl = SR.KeyCtrl;
-                    string keyControl = SR.KeyControl;
-                    string keyAlt = SR.KeyAlt;
-                    string keyShift = SR.KeyShift;
-                    string keyWin = SR.KeyWinKey;
 
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
 
-                    if (AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out pos) != null ||
-                        AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out pos) != null ||
-                        AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), $"{keyAlt} + ", menuText, menuRawText, out pos) != null ||
-                        AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), $"{keyShift} + ", menuText, menuRawText, out pos) != null ||
-                        AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), $"{keyWin} + ", menuText, menuRawText, out pos) != null)
+                    if (AccelatorKeyCtrl(SR.KeyCtrl, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(SR.KeyControl, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(SR.KeyAlt, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(SR.KeyShift, menuRawText, out pos) != null ||
+                        AccelatorKeyCtrl(SR.KeyWinKey, menuRawText, out pos) != null)
                     {
                         return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
                     }
@@ -2411,41 +2404,40 @@ namespace MS.Internal.AutomationProxies
                 Input.SendKeyboardInput (Key.LeftAlt, false);
             }
 
-            // Search in a menu if the menu item string finishes with an accelerator
-            // of the form Ctrl+Am Control+Shift+K.
-            private static string AccelatorKeyCtrl(string sKeyword, string sCanonicalsKeyword, string menuText, string menuRawText, out int pos)
+            // Search in a menu if the menu item string finishes with an accelerator; e.g. Ctrl+A
+            private static string AccelatorKeyCtrl(string sKeyword, string menuRawText, out int pos)
             {
-                int cMenuChars = menuText.Length;
-                char ch;
+                int menuTextLength = menuRawText.Length;
+                int keywordLength = sKeyword.Length;
 
                 // Try to find the keyword
-               // Eg: Ctrl or Control; 4 == "ctrl".Length; 2 '+' or ' ' + one char
-                int cKeyChars = sKeyword.Length;
-                if ((pos = menuText.LastIndexOf(sKeyword, StringComparison.Ordinal)) >= 0 && pos + cKeyChars + 2 <= cMenuChars)
+                // e.g. "CTRL + A": 4 chars == "Ctrl"; 2 chars == ('+' or ' ') + one character
+                if ((pos = menuRawText.LastIndexOf(sKeyword, StringComparison.InvariantCultureIgnoreCase)) >= 0 && pos + keywordLength + 2 <= menuTextLength)
                 {
-                    ch = menuText [pos + cKeyChars];
+                    char ch = menuRawText[pos + keywordLength];
                     if (ch == '+' || ch == ' ')
                     {
-                        // Found a combination "Ctrl+letter"
-                        if (pos + cKeyChars + 2 == cMenuChars)
+                        // Found a combination of "Ctrl+Letter"
+                        if (pos + keywordLength + 2 == menuTextLength)
                         {
-                            // UperCase the letter, case Ctrl+A
-                            return $"{sCanonicalsKeyword}{menuText.AsSpan(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 2))}{char.ToUpper(menuText[cMenuChars - 1], CultureInfo.InvariantCulture)}";
+                            // Uppercase the letter, f.e. "Ctrl + a" to "Ctrl+A"
+                            return $"{sKeyword} + {char.ToUpperInvariant(menuRawText[menuTextLength - 1])}";
                         }
                         else
                         {
-                            // Take the remaining string from the Keyword
-                            // Case Alt+Enter
-                            return $"{sCanonicalsKeyword}{menuRawText.AsSpan(pos + cKeyChars + 1, cMenuChars - (pos + cKeyChars + 1))}";
+                            // Take the remaining string from the menuText
+                            // e.g. Alt+Enter
+                            return $"{sKeyword} + {menuRawText.AsSpan(pos + keywordLength + 1, menuTextLength - (pos + keywordLength + 1))}";
                         }
                     }
                 }
+
                 return null;
             }
 
             // Search in a menu if the menu item string finishes with an accelerator
             // of the form Fxx (F5, F12, etc)
-            private static string AccelatorFxx (string menuText)
+            private static string AccelatorFxx(string menuText)
             {
                 int cChars = menuText.Length;
                 int pos;
@@ -2722,23 +2714,16 @@ namespace MS.Internal.AutomationProxies
                         return menuRawText.Remove(0, pos + 1);
                     }
 
-                    // !!! Be caution modifying this code, it must miror the code for the Name Property
-
+                    // Be cautious modifying this code, it must mirror the code for the Name Property
                     // Try to look for a combination Ctrl or Alt + something
-                    string keyCtrl = SR.KeyCtrl;
-                    string keyControl = SR.KeyControl;
-                    string keyAlt = SR.KeyAlt;
-                    string keyShift = SR.KeyShift;
-                    string keyWin = SR.KeyWinKey;
-
                     string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     string accelerator;
 
-                    if ((accelerator = AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out _)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), $"{keyCtrl} + ", menuText, menuRawText, out _)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), $"{keyAlt} + ", menuText, menuRawText, out _)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), $"{keyShift} + ", menuText, menuRawText, out _)) != null ||
-                        (accelerator = AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), $"{keyWin} + ", menuText, menuRawText, out _)) != null)
+                    if ((accelerator = AccelatorKeyCtrl(SR.KeyCtrl, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(SR.KeyControl, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(SR.KeyAlt, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(SR.KeyShift, menuRawText, out _)) != null ||
+                        (accelerator = AccelatorKeyCtrl(SR.KeyWinKey, menuRawText, out _)) != null)
                     {
                         return accelerator;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1339,16 +1339,7 @@ namespace MS.Internal.AutomationProxies
                     string accelerator = AccelatorFxx(menuRawText, out pos);
                     if (!string.IsNullOrEmpty(accelerator))
                     {
-                        if (pos >= 0)
-                        {
-                            return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
-                        }
-                        else
-                        {
-                            // Wrong logic, we should be able to find the Fxx combination we just built
-                            Debug.Assert(false, "Cannot find back the accelerator in the menu!");
-                            return menuRawText;
-                        }
+                        return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
                     }
 
                     // Look for a bunch of Predefined keywords

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1343,14 +1343,13 @@ namespace MS.Internal.AutomationProxies
                     }
 
                     // Look for a bunch of Predefined keywords
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    string[] keyWordAccelerators = GetKeywordsAccelerators();
-                    for (int i = 0; i < keyWordAccelerators.Length; i++)
+                    string[] keywordAccelerators = GetKeywordsAccelerators();
+                    for (int i = 0; i < keywordAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(keyWordAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + keyWordAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuRawText.LastIndexOf(keywordAccelerators[i], StringComparison.InvariantCultureIgnoreCase);
+                        if (pos > 0 && pos + keywordAccelerators[i].Length == menuRawText.Length && (menuRawText[pos - 1] == '\a' || menuRawText[pos - 1] == '\t'))
                         {
-                            return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
+                            return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
                         }
                     }
 
@@ -2755,14 +2754,13 @@ namespace MS.Internal.AutomationProxies
                     }
 
                     // Look for a bunch of Predefined keywords
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-                    string[] keyWordAccelerators = GetKeywordsAccelerators();
-                    for (int i = 0; i < keyWordAccelerators.Length; i++)
+                    string[] keywordAccelerators = GetKeywordsAccelerators();
+                    for (int i = 0; i < keywordAccelerators.Length; i++)
                     {
-                        pos = menuText.LastIndexOf(keyWordAccelerators[i], StringComparison.OrdinalIgnoreCase);
-                        if (pos > 0 && pos + keyWordAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
+                        pos = menuRawText.LastIndexOf(keywordAccelerators[i], StringComparison.InvariantCultureIgnoreCase);
+                        if (pos > 0 && pos + keywordAccelerators[i].Length == menuRawText.Length && (menuRawText[pos - 1] == '\a' || menuRawText[pos - 1] == '\t'))
                         {
-                            return keyWordAccelerators[i];
+                            return keywordAccelerators[i];
                         }
                     }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -2458,10 +2458,10 @@ namespace MS.Internal.AutomationProxies
                 // Check that it is the form Fxx
                 if (pos < cChars - 1 && pos > 0 && menuText [pos] == 'f')
                 {
-                    int iKey = int.Parse(menuText.Substring(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
+                    int iKey = int.Parse(menuText.AsSpan(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
                     if (iKey > 0 && iKey <= 12)
                     {
-                        return "F" + iKey.ToString(CultureInfo.CurrentCulture);
+                        return $"F{iKey}";
                     }
                 }
                 return null;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1517,7 +1517,7 @@ namespace MS.Internal.AutomationProxies
                 {
                     case MenuType.System:
                         {
-                            return $"{SR.KeyAlt} + {SR.KeySpace}";
+                            return string.Create(CultureInfo.InvariantCulture, stackalloc char[32], $"{SR.KeyAlt} + {SR.KeySpace}");
                         }
                     case MenuType.Submenu:
                     case MenuType.SystemPopup:
@@ -2434,13 +2434,14 @@ namespace MS.Internal.AutomationProxies
                         if (pos + keywordLength + 2 == menuTextLength)
                         {
                             // Uppercase the letter, f.e. "Ctrl + a" to "Ctrl+A"
-                            return $"{sKeyword} + {char.ToUpperInvariant(menuRawText[menuTextLength - 1])}";
+                            return string.Create(CultureInfo.InvariantCulture, stackalloc char[24], $"{sKeyword} + {char.ToUpperInvariant(menuRawText[menuTextLength - 1])}");
                         }
                         else
                         {
                             // Take the remaining string from the menuText
                             // e.g. Alt+Enter
-                            return $"{sKeyword} + {menuRawText.AsSpan(pos + keywordLength + 1, menuTextLength - (pos + keywordLength + 1))}";
+                            return string.Create(CultureInfo.InvariantCulture, stackalloc char[48],
+                                                 $"{sKeyword} + {menuRawText.AsSpan(pos + keywordLength + 1, menuTextLength - (pos + keywordLength + 1))}");
                         }
                     }
                 }
@@ -2468,11 +2469,11 @@ namespace MS.Internal.AutomationProxies
                 // Check that it is the form Fxx
                 if (pos < cChars - 1 && pos > 0 && char.ToUpperInvariant(menuText[pos]) == 'F')
                 {
-                    int iKey = int.Parse(menuText.AsSpan(pos + 1, cChars - (pos + 1)), CultureInfo.InvariantCulture);
+                    ReadOnlySpan<char> key = menuText.AsSpan(pos + 1, cChars - (pos + 1));
+                    int iKey = int.Parse(key, CultureInfo.InvariantCulture);
+
                     if (iKey > 0 && iKey <= 12)
-                    {
-                        return $"F{iKey}";
-                    }
+                        return string.Create(CultureInfo.InvariantCulture, stackalloc char[3], $"F{key}");
                 }
 
                 return null;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -1325,18 +1325,17 @@ namespace MS.Internal.AutomationProxies
                     // Be cautious modifying this code, it must mirror the code for AcceleratorKeyProperty
                     // Try to look for a combination Ctrl or Alt + something
 
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
-
                     if (AccelatorKeyCtrl(SR.KeyCtrl, menuRawText, out pos) != null ||
                         AccelatorKeyCtrl(SR.KeyControl, menuRawText, out pos) != null ||
                         AccelatorKeyCtrl(SR.KeyAlt, menuRawText, out pos) != null ||
                         AccelatorKeyCtrl(SR.KeyShift, menuRawText, out pos) != null ||
                         AccelatorKeyCtrl(SR.KeyWinKey, menuRawText, out pos) != null)
                     {
-                        return menuRawText.Substring(0, SkipMenuSpaceChar(menuText, pos));
+                        return menuRawText.Substring(0, SkipMenuSpaceChar(menuRawText, pos));
                     }
 
                     // Try to look for a Fxx
+                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     string accelerator = AccelatorFxx(menuText);
                     if (!string.IsNullOrEmpty(accelerator))
                     {
@@ -2440,12 +2439,11 @@ namespace MS.Internal.AutomationProxies
             private static string AccelatorFxx(string menuText)
             {
                 int cChars = menuText.Length;
-                int pos;
+                int pos = cChars - 1;
 
                 // Get the function key number
-                for (pos = cChars - 1; pos > 0 && cChars - pos <= 2 && Char.IsDigit (menuText [pos]); pos--)
-                {
-                }
+                while (pos > 0 && cChars - pos <= 2 && char.IsDigit(menuText[pos]))
+                    pos--;
 
                 // Check that it is the form Fxx
                 if (pos < cChars - 1 && pos > 0 && menuText [pos] == 'f')
@@ -2456,6 +2454,7 @@ namespace MS.Internal.AutomationProxies
                         return $"F{iKey}";
                     }
                 }
+
                 return null;
             }
 
@@ -2716,7 +2715,6 @@ namespace MS.Internal.AutomationProxies
 
                     // Be cautious modifying this code, it must mirror the code for the Name Property
                     // Try to look for a combination Ctrl or Alt + something
-                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     string accelerator;
 
                     if ((accelerator = AccelatorKeyCtrl(SR.KeyCtrl, menuRawText, out _)) != null ||
@@ -2729,6 +2727,7 @@ namespace MS.Internal.AutomationProxies
                     }
 
                     // Try to look for a Fxx
+                    string menuText = menuRawText.ToLower(CultureInfo.InvariantCulture);
                     accelerator = AccelatorFxx(menuText);
                     if (!string.IsNullOrEmpty(accelerator))
                     {


### PR DESCRIPTION
## Description

- Replaces string concatenations with string interpolation throughout the whole proxy class.
- Also modifies `StripMnemonic` helper function from the `Misc` class used by other proxies with accelerators.
- Retrievals of `LocalizedName` and `AcceleratorKey` were highly optimized.

### AccelatorKeyCtrl benchmark
| Method   | findPattern | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size | Allocated [B] |
|--------- |------------ |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | Win+A       | 205.74 ns |   2.361 ns |    2.093 ns | 0.0277 |       4,753 B |         464 B |
| PR__EDIT | Win+A       |  97.97 ns |   0.519 ns |    0.485 ns | 0.0024 |       1,105 B |          40 B |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
[Arguments("Win+A")]
public string Original(string findPattern)
{
    int pos;
    string keyCtrl = "Ctrl";
    string keyControl = "Control";
    string keyAlt = "Alt";
    string keyShift = "Shift";
    string keyWin = "Win";

    string menuText = findPattern.ToLower(CultureInfo.InvariantCulture);
    string accelerator;

    if ((accelerator = AccelatorKeyCtrl(keyCtrl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, findPattern, out pos)) != null ||
        (accelerator = AccelatorKeyCtrl(keyControl.ToLower(CultureInfo.InvariantCulture), keyCtrl + " + ", menuText, findPattern, out pos)) != null ||
        (accelerator = AccelatorKeyCtrl(keyAlt.ToLower(CultureInfo.InvariantCulture), keyAlt + " + ", menuText, findPattern, out pos)) != null ||
        (accelerator = AccelatorKeyCtrl(keyShift.ToLower(CultureInfo.InvariantCulture), keyShift + " + ", menuText, findPattern, out pos)) != null ||
        (accelerator = AccelatorKeyCtrl(keyWin.ToLower(CultureInfo.InvariantCulture), keyWin + " + ", menuText, findPattern, out pos)) != null)
    {
        return accelerator;
    }

    return null;
}

[Benchmark]
[Arguments("Win+A")]
public string PR__EDIT(string findPattern)
{
    string accelerator;
    if ((accelerator = AccelatorKeyCtrlNew("Ctrl", findPattern, out _)) != null ||
      (accelerator = AccelatorKeyCtrlNew("Control", findPattern, out _)) != null ||
      (accelerator = AccelatorKeyCtrlNew("Alt", findPattern, out _)) != null ||
      (accelerator = AccelatorKeyCtrlNew("Shift", findPattern, out _)) != null ||
      (accelerator = AccelatorKeyCtrlNew("Win", findPattern, out _)) != null)
    {
        return accelerator;
    }

    return null;
}
```

</details>

### AccelatorFxx benchmark
| Method   | findPattern       | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size | Allocated [B] |
|--------- |------------------ |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | xxxxxxAAAxxxxxF11 |  53.52 ns |   1.108 ns |    1.758 ns | 0.0105 |       2,389 B |         176 B |
| PR__EDIT | xxxxxxAAAxxxxxF11 |  31.61 ns |   0.598 ns |    0.560 ns | 0.0052 |       1,338 B |          88 B |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
[Arguments("xxxxxxAAAxxxxxF11")]
public string Original(string findPattern)
{
    // Try to look for a Fxx
    int pos;
    string menuText = findPattern.ToLower(CultureInfo.InvariantCulture);
    string accelerator = AccelatorFxx(menuText);
    if (!string.IsNullOrEmpty(accelerator))
    {
        pos = menuText.LastIndexOf(accelerator, StringComparison.OrdinalIgnoreCase);
        if (pos >= 0)
        {
            return findPattern.Substring(0, pos);
        }
        else
        {
            // Wrong logic, we should be able to find the Fxx combination we just built
            System.Diagnostics.Debug.Assert(false, "Cannot find back the accelerator in the menu!");
            return findPattern;
        }
    }

    return null;
}

[Benchmark]
[Arguments("xxxxxxAAAxxxxxF11")]
public string PR__EDIT(string findPattern)
{
    // Try to look for a Fxx
    int pos;
    string accelerator = AccelatorFxxNew(findPattern, out pos);
    if (!string.IsNullOrEmpty(accelerator))
    {
        return findPattern.Substring(0, pos);
    }

    return null;
}
```

</details>

### StripMnemonic benchmark
| Method   | findPattern | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Allocated [B] |
|--------- |------------ |----------:|-----------:|------------:|-------:|--------------:|
| Original | wow F11     | 26.071 ns |  0.5511 ns |   0.8248 ns | 0.0067 |                 112 B |
| PR__EDIT | wow F11     |  2.992 ns |  0.0743 ns |   0.0695 ns |      - |                  - |
| Original |  \x20wow F11    | 25.000 ns |  0.4421 ns |   0.4135 ns | 0.0067 |              112 B |
| PR__EDIT |  \x20wow F11    |  9.294 ns |  0.2081 ns |   0.1737 ns | 0.0024 |                 40 B |
| Original | &wow F11    |  25.59 ns |   0.494 ns |    0.643 ns | 0.0067 |                112 B |
| PR__EDIT | &wow F11    |  16.69 ns |   0.259 ns |    0.242 ns | 0.0024 |                40 B |
| Original | \x20\x20\x20\x20\x20&wow F11 |  27.03 ns |   0.533 ns |    0.473 ns | 0.0076 |                 128 B |
| PR__EDIT | \x20\x20\x20\x20\x20&wow F11 |  17.36 ns |   0.328 ns |    0.291 ns | 0.0024 |               40 B |

### Find from list of pre-defined accelerators
| Method   | findPattern           | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size | Allocated [B] |
|--------- |---------------------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  wowo(...) \tTAB [45] |  828.5 ns |    9.83 ns |     9.19 ns | 0.0067 |         721 B |         112 B |
| PR__EDIT |  wowo(...) \tTAB [45] |  537.9 ns |    4.06 ns |     3.80 ns |      - |         485 B |             - |

<details><summary>Benchmark code</summary>

```csharp
private static readonly string[] s_keywordsAccelerators = ["Home", "End", "Delete", "Page Up", "Page Down", "Escape", "Insert", "Print Screen", "Tab"];

[Benchmark]
[Arguments(" wowowwowowowowowowowowwowowowowowowowow \tTAB")]
public string Original(string findPattern)
{
    int pos;
    string menuText = findPattern.ToLower(CultureInfo.InvariantCulture);
    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
    {
        pos = menuText.LastIndexOf(s_keywordsAccelerators[i], StringComparison.OrdinalIgnoreCase);
        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == menuText.Length && (menuText[pos - 1] == '\a' || menuText[pos - 1] == '\t'))
        {
            return s_keywordsAccelerators[i];
        }
    }

    return null;
}

[Benchmark]
[Arguments(" wowowwowowowowowowowowwowowowowowowowow \tTAB")]
public string PR__EDIT(string findPattern)
{
    int pos;
    for (int i = 0; i < s_keywordsAccelerators.Length; i++)
    {
        pos = findPattern.LastIndexOf(s_keywordsAccelerators[i], StringComparison.InvariantCultureIgnoreCase);
        if (pos > 0 && pos + s_keywordsAccelerators[i].Length == findPattern.Length && (findPattern[pos - 1] == '\a' || findPattern[pos - 1] == '\t'))
        {
            return s_keywordsAccelerators[i];
        }
    }

    return null;
}
```

</details>

## Customer Impact

Increased performance/decreased allocation when using the proxy.

## Regression

No.

## Testing

Local build, CI, extensive local assert testing.

## Risk

Should be low, however reviewers should check I haven't changed the output meaning of each operation (culture handling).
