### PR TITLE
Use MemoryExtensions.Split over string.Split to decrease allocations/improve perf

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/FixedTextSelectionProcessor.cs
@@ -491,32 +491,35 @@ namespace MS.Internal.Annotations.Anchoring
             ArgumentNullException.ThrowIfNull(locatorPart);
 
             if (FixedTextElementName != locatorPart.PartType)
-                throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), "locatorPart");
+                throw new ArgumentException(SR.Format(SR.IncorrectLocatorPartType, $"{locatorPart.PartType.Namespace}:{locatorPart.PartType.Name}"), nameof(locatorPart));
 
             string segmentValue = locatorPart.NameValuePairs[TextSelectionProcessor.SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)];
             if (segmentValue == null)
                 throw new ArgumentException(SR.Format(SR.InvalidLocatorPart, TextSelectionProcessor.SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)));
 
-            string[] values = segmentValue.Split(TextSelectionProcessor.Separator);
-            if (values.Length != 4)
+            ReadOnlySpan<char> segmentValueSpan = segmentValue.AsSpan();
+            Span<Range> splitRegions = stackalloc Range[5];
+
+            if (segmentValueSpan.Split(splitRegions, TextSelectionProcessor.Separator) != 4)
                 throw new ArgumentException(SR.Format(SR.InvalidLocatorPart, TextSelectionProcessor.SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)));
-            start = GetPoint(values[0], values[1]);
-            end = GetPoint(values[2], values[3]);
+
+            start = GetPoint(segmentValueSpan[splitRegions[0]], segmentValueSpan[splitRegions[1]]);
+            end = GetPoint(segmentValueSpan[splitRegions[2]], segmentValueSpan[splitRegions[3]]);
         }
 
         /// <summary>
-        /// Calculate Point out of string X and Y values
+        /// Calculates <see cref="Point"/> out of X and Y values supplied as a <see cref="string"/>.
         /// </summary>
-        /// <param name="xstr">x string value</param>
-        /// <param name="ystr">y string value</param>
-        /// <returns></returns>
-        private Point GetPoint(string xstr, string ystr)
+        /// <param name="xValue">x string value</param>
+        /// <param name="yValue">y string value</param>
+        /// <returns>Initialized <see cref="Point"/> structure.</returns>
+        private static Point GetPoint(ReadOnlySpan<char> xValue, ReadOnlySpan<char> yValue)
         {
             Point point;
-            if (xstr != null && !String.IsNullOrEmpty(xstr.Trim()) && ystr != null && !String.IsNullOrEmpty(ystr.Trim()))
+            if (!xValue.Trim().IsEmpty && !yValue.Trim().IsEmpty)
             {
-                double x = Double.Parse(xstr, NumberFormatInfo.InvariantInfo);
-                double y = Double.Parse(ystr, NumberFormatInfo.InvariantInfo);
+                double x = double.Parse(xValue, NumberFormatInfo.InvariantInfo);
+                double y = double.Parse(yValue, NumberFormatInfo.InvariantInfo);
                 point = new Point(x, y);
             }
             else

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Annotations/Anchoring/TextSelectionProcessor.cs
@@ -432,18 +432,18 @@ namespace MS.Internal.Annotations.Anchoring
         private static void GetLocatorPartSegmentValues(ContentLocatorPart locatorPart, int segmentNumber, out int startOffset, out int endOffset)
         {
             if (segmentNumber < 0)
-                throw new ArgumentException("segmentNumber");
+                throw new ArgumentException(nameof(segmentNumber));
 
-            string segmentString = locatorPart.NameValuePairs[SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)];
+            ReadOnlySpan<char> segmentString = locatorPart.NameValuePairs[SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)].AsSpan();
 
-            string[] values = segmentString.Split(Separator);
-            if (values.Length != 2)
+            Span<Range> splitRegions = stackalloc Range[3];
+            if (segmentString.Split(splitRegions, Separator) != 2)
             {
                 throw new ArgumentException(SR.Format(SR.InvalidLocatorPart, SegmentAttribute + segmentNumber.ToString(NumberFormatInfo.InvariantInfo)));
             }
 
-            startOffset = Int32.Parse(values[0], NumberFormatInfo.InvariantInfo);
-            endOffset = Int32.Parse(values[1], NumberFormatInfo.InvariantInfo);
+            startOffset = int.Parse(segmentString[splitRegions[0]], NumberFormatInfo.InvariantInfo);
+            endOffset = int.Parse(segmentString[splitRegions[1]], NumberFormatInfo.InvariantInfo);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
@@ -597,6 +597,8 @@ namespace System.Windows.Annotations
         {
             Invariant.Assert(reader != null, "No reader passed in.");
 
+            Span<Range> splitRegions = stackalloc Range[3];
+
             // Read all the attributes
             while (reader.MoveToNextAttribute())
             {
@@ -604,7 +606,7 @@ namespace System.Windows.Annotations
 
                 // Skip null and empty values - they will be treated the
                 // same as if they weren't specified at all
-                if (String.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                     continue;
 
                 switch (reader.LocalName)
@@ -627,27 +629,29 @@ namespace System.Windows.Annotations
                     #pragma warning restore 0618
 
                     case AnnotationXmlConstants.Attributes.TypeName:
-                        string[] typeName = value.Split(_Colon);
-                        if (typeName.Length == 1)
+                        ReadOnlySpan<char> typeName = value.AsSpan();
+                        int regionsLength = typeName.Split(splitRegions, Colon);
+
+                        if (regionsLength == 1)
                         {
-                            typeName[0] = typeName[0].Trim();
-                            if (String.IsNullOrEmpty(typeName[0]))
+                            ReadOnlySpan<char> firstPart = typeName[splitRegions[0]].Trim();
+                            if (firstPart.IsEmpty)
                             {
                                 // Just a string of whitespace (empty string doesn't get processed)
                                 throw new FormatException(SR.Format(SR.InvalidAttributeValue, AnnotationXmlConstants.Attributes.TypeName));
                             }
-                            _typeName = new XmlQualifiedName(typeName[0]);
+                            _typeName = new XmlQualifiedName(firstPart.ToString());
                         }
-                        else if (typeName.Length == 2)
+                        else if (regionsLength == 2)
                         {
-                            typeName[0] = typeName[0].Trim();
-                            typeName[1] = typeName[1].Trim();
-                            if (String.IsNullOrEmpty(typeName[0]) || String.IsNullOrEmpty(typeName[1]))
+                            ReadOnlySpan<char> firstPart = typeName[splitRegions[0]].Trim();
+                            ReadOnlySpan<char> secondPart = typeName[splitRegions[1]].Trim();
+                            if (firstPart.IsEmpty || secondPart.IsEmpty)
                             {
                                 // One colon, prefix or suffix is empty string or whitespace
                                 throw new FormatException(SR.Format(SR.InvalidAttributeValue, AnnotationXmlConstants.Attributes.TypeName));
                             }
-                            _typeName = new XmlQualifiedName(typeName[1], reader.LookupNamespace(typeName[0]));
+                            _typeName = new XmlQualifiedName(firstPart.ToString(), reader.LookupNamespace(secondPart.ToString()));
                         }
                         else
                         {
@@ -947,7 +951,7 @@ namespace System.Windows.Annotations
         /// <summary>
         /// Colon used to split the parts of a qualified name attribute value
         /// </summary>
-        private const char _Colon = ':';
+        private const char Colon = ':';
 
         #endregion Private Fields
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
@@ -630,11 +630,11 @@ namespace System.Windows.Annotations
 
                     case AnnotationXmlConstants.Attributes.TypeName:
                         ReadOnlySpan<char> typeName = value.AsSpan();
-                        int segmentsLength = typeName.Split(segments, Colon);
+                        int segmentsLength = typeName.Split(segments, Colon, StringSplitOptions.TrimEntries);
 
                         if (segmentsLength == 1) // Contains only name
                         {
-                            ReadOnlySpan<char> name = typeName[segments[0]].Trim();
+                            ReadOnlySpan<char> name = typeName[segments[0]];
                             if (name.IsEmpty)
                             {
                                 // Just a string of whitespace (empty string doesn't get processed)
@@ -644,8 +644,8 @@ namespace System.Windows.Annotations
                         }
                         else if (segmentsLength == 2) //Contains both namespace:name
                         {
-                            ReadOnlySpan<char> @namespace = typeName[segments[0]].Trim();
-                            ReadOnlySpan<char> name = typeName[segments[1]].Trim();
+                            ReadOnlySpan<char> @namespace = typeName[segments[0]];
+                            ReadOnlySpan<char> name = typeName[segments[1]];
                             if (@namespace.IsEmpty || name.IsEmpty)
                             {
                                 // One colon, prefix or suffix is empty string or whitespace

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
@@ -630,9 +630,9 @@ namespace System.Windows.Annotations
 
                     case AnnotationXmlConstants.Attributes.TypeName:
                         ReadOnlySpan<char> typeName = value.AsSpan();
-                        int regionsLength = typeName.Split(segments, Colon);
+                        int segmentsLength = typeName.Split(segments, Colon);
 
-                        if (regionsLength == 1) // Contains only name
+                        if (segmentsLength == 1) // Contains only name
                         {
                             ReadOnlySpan<char> name = typeName[segments[0]].Trim();
                             if (name.IsEmpty)
@@ -642,7 +642,7 @@ namespace System.Windows.Annotations
                             }
                             _typeName = new XmlQualifiedName(name.ToString());
                         }
-                        else if (regionsLength == 2) //Contains both namespace:name
+                        else if (segmentsLength == 2) //Contains both namespace:name
                         {
                             ReadOnlySpan<char> @namespace = typeName[segments[0]].Trim();
                             ReadOnlySpan<char> name = typeName[segments[1]].Trim();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Annotations/Annotation.cs
@@ -597,7 +597,7 @@ namespace System.Windows.Annotations
         {
             Invariant.Assert(reader != null, "No reader passed in.");
 
-            Span<Range> splitRegions = stackalloc Range[3];
+            Span<Range> segments = stackalloc Range[3];
 
             // Read all the attributes
             while (reader.MoveToNextAttribute())
@@ -630,28 +630,28 @@ namespace System.Windows.Annotations
 
                     case AnnotationXmlConstants.Attributes.TypeName:
                         ReadOnlySpan<char> typeName = value.AsSpan();
-                        int regionsLength = typeName.Split(splitRegions, Colon);
+                        int regionsLength = typeName.Split(segments, Colon);
 
-                        if (regionsLength == 1)
+                        if (regionsLength == 1) // Contains only name
                         {
-                            ReadOnlySpan<char> firstPart = typeName[splitRegions[0]].Trim();
-                            if (firstPart.IsEmpty)
+                            ReadOnlySpan<char> name = typeName[segments[0]].Trim();
+                            if (name.IsEmpty)
                             {
                                 // Just a string of whitespace (empty string doesn't get processed)
                                 throw new FormatException(SR.Format(SR.InvalidAttributeValue, AnnotationXmlConstants.Attributes.TypeName));
                             }
-                            _typeName = new XmlQualifiedName(firstPart.ToString());
+                            _typeName = new XmlQualifiedName(name.ToString());
                         }
-                        else if (regionsLength == 2)
+                        else if (regionsLength == 2) //Contains both namespace:name
                         {
-                            ReadOnlySpan<char> firstPart = typeName[splitRegions[0]].Trim();
-                            ReadOnlySpan<char> secondPart = typeName[splitRegions[1]].Trim();
-                            if (firstPart.IsEmpty || secondPart.IsEmpty)
+                            ReadOnlySpan<char> @namespace = typeName[segments[0]].Trim();
+                            ReadOnlySpan<char> name = typeName[segments[1]].Trim();
+                            if (@namespace.IsEmpty || name.IsEmpty)
                             {
                                 // One colon, prefix or suffix is empty string or whitespace
                                 throw new FormatException(SR.Format(SR.InvalidAttributeValue, AnnotationXmlConstants.Attributes.TypeName));
                             }
-                            _typeName = new XmlQualifiedName(firstPart.ToString(), reader.LookupNamespace(secondPart.ToString()));
+                            _typeName = new XmlQualifiedName(name.ToString(), reader.LookupNamespace(@namespace.ToString()));
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -12019,27 +12019,28 @@ namespace System.Windows.Controls
                 _flushDepth = 0;
                 _luThreshold = s_DefaultLayoutUpdatedThreshold;
 
-                string s = FrameworkCompatibilityPreferences.GetScrollingTraceFile();
-                if (!String.IsNullOrEmpty(s))
+                string trace = FrameworkCompatibilityPreferences.GetScrollingTraceFile();
+                if (!string.IsNullOrEmpty(trace))
                 {
-                    string[] a = s.Split(';');
-                    _fileName = a[0];
+                    Span<Range> splitRegions = stackalloc Range[4];
+                    ReadOnlySpan<char> traceSplits = trace.AsSpan();
+                    int regionsLength = traceSplits.Split(splitRegions, ';');
 
-                    if (a.Length > 1)
+                    _fileName = traceSplits[splitRegions[0]].ToString();
+
+                    if (regionsLength > 1)
                     {
-                        int flushDepth;
-                        if (Int32.TryParse(a[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out flushDepth))
+                        if (int.TryParse(traceSplits[splitRegions[1]], NumberStyles.Integer, CultureInfo.InvariantCulture, out int flushDepth))
                         {
                             _flushDepth = flushDepth;
                         }
                     }
 
-                    if (a.Length > 2)
+                    if (regionsLength > 2)
                     {
-                        int luThreshold;
-                        if (Int32.TryParse(a[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out luThreshold))
+                        if (int.TryParse(traceSplits[splitRegions[2]], NumberStyles.Integer, CultureInfo.InvariantCulture, out int luThreshold))
                         {
-                            _luThreshold = (luThreshold <= 0) ? Int32.MaxValue : luThreshold;
+                            _luThreshold = (luThreshold <= 0) ? int.MaxValue : luThreshold;
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextStore.cs
@@ -4675,16 +4675,18 @@ namespace System.Windows.Documents
                 _targetName = FrameworkCompatibilityPreferences.GetIMECompositionTraceTarget();
                 _flushDepth = 0;
 
-                string s = FrameworkCompatibilityPreferences.GetIMECompositionTraceFile();
-                if (!String.IsNullOrEmpty(s))
+                string trace = FrameworkCompatibilityPreferences.GetIMECompositionTraceFile();
+                if (!string.IsNullOrEmpty(trace))
                 {
-                    string[] a = s.Split(';');
-                    _fileName = a[0];
+                    Span<Range> splitRegions = stackalloc Range[3];
+                    ReadOnlySpan<char> traceSplits = trace.AsSpan();
+                    int regionsLength = traceSplits.Split(splitRegions, ';');
 
-                    if (a.Length > 1)
+                    _fileName = traceSplits[splitRegions[0]].ToString();
+
+                    if (regionsLength > 1)
                     {
-                        int flushDepth;
-                        if (Int32.TryParse(a[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out flushDepth))
+                        if (int.TryParse(traceSplits[splitRegions[1]], NumberStyles.Integer, CultureInfo.InvariantCulture, out int flushDepth))
                         {
                             _flushDepth = flushDepth;
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeDictionaryExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeDictionaryExtension.cs
@@ -95,7 +95,7 @@ namespace System.Windows
 
         // Build the Uri for the assembly:
         // /AssemblyName;Component/themes/<CurrentTheme>.<Color>.xaml
-        private static Uri GenerateUri(string assemblyName, string resourceName, string themeName)
+        private static Uri GenerateUri(string assemblyName, string resourceName, ReadOnlySpan<char> themeName)
         {
             StringBuilder uri = new StringBuilder(assemblyName.Length + 50);
 
@@ -113,11 +113,12 @@ namespace System.Windows
             uri.Append(resourceName);
             uri.Append(".xaml");
 
-            return new System.Uri(uri.ToString(), System.UriKind.RelativeOrAbsolute);
+            return new Uri(uri.ToString(), System.UriKind.RelativeOrAbsolute);
         }
 
         internal static Uri GenerateFallbackUri(ResourceDictionary dictionary, string resourceName)
         {
+            Span<Range> splitRegions = stackalloc Range[3];
             for (int i = 0; i < _themeDictionaryInfos.Count; i++)
             {
                 ThemeDictionaryInfo info = _themeDictionaryInfos[i];
@@ -131,8 +132,11 @@ namespace System.Windows
                 }
                 if ((ResourceDictionary)info.DictionaryReference.Target == dictionary)
                 {
-                    string themeName = resourceName.Split('/')[1];
-                    return GenerateUri(info.AssemblyName, resourceName, themeName);
+                    ReadOnlySpan<char> nameSpan = resourceName.AsSpan();
+                    if (nameSpan.Split(splitRegions, '/') < 2)
+                        throw new ArgumentOutOfRangeException();
+
+                    return GenerateUri(info.AssemblyName, resourceName, nameSpan[splitRegions[1]]);
                 }
             }
             return null;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeDictionaryExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeDictionaryExtension.cs
@@ -134,7 +134,7 @@ namespace System.Windows
                 {
                     ReadOnlySpan<char> nameSpan = resourceName.AsSpan();
                     if (nameSpan.Split(splitRegions, '/') < 2)
-                        throw new ArgumentOutOfRangeException();
+                        throw new IndexOutOfRangeException();
 
                     return GenerateUri(info.AssemblyName, resourceName, nameSpan[splitRegions[1]]);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -171,19 +171,20 @@ namespace System.Xaml
             return result;
         }
 
-        string GetPrefixForClrNs(string clrNs, string assemblyName)
+        private string GetPrefixForClrNs(string clrNs, string assemblyName)
         {
             if (string.IsNullOrEmpty(assemblyName))
             {
                 return KnownStrings.LocalPrefix;
             }
 
-            var sb = new StringBuilder();
-            foreach (string segment in clrNs.Split('.'))
+            StringBuilder sb = new();
+            ReadOnlySpan<char> values = clrNs.AsSpan();
+            foreach (Range segment in values.Split('.'))
             {
-                if (!string.IsNullOrEmpty(segment))
+                if (!values[segment].IsEmpty)
                 {
-                    sb.Append(char.ToLower(segment[0], TypeConverterHelper.InvariantEnglishUS));
+                    sb.Append(char.ToLower(values[segment][0], TypeConverterHelper.InvariantEnglishUS));
                 }
             }
 


### PR DESCRIPTION
## Description

Picks off most places where `string.Split` is used just for parts count or where additional operations are performed on the split strings so it makes sense to work with `ReadOnlySpan<char>`/`SpanSplitEnumerator<char>` instead.

### Using `string.Split` vs `SpanSplitEnumerator<char>` for counting

| Method   | updatedFilter        | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |--------------------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | Image(...))\|\*.\* [68] |  49.09 ns |   0.676 ns |    0.600 ns | 0.0172 |         672 B |         288 B |
| PR__EDIT | Image(...))\|\*.\* [68] |  17.23 ns |   0.075 ns |    0.066 ns |      - |         412 B |             - |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
[Arguments("Image Files(*.BMP;*.JPG;*.GIF)|*.BMP;*.JPG;*.GIF|All files (*.*)|*.*")]
public  int Original(string updatedFilter)
{
    string[] formats = updatedFilter.Split('|');

    return formats.Length; 
}

[Benchmark]
[Arguments("Image Files(*.BMP;*.JPG;*.GIF)|*.BMP;*.JPG;*.GIF|All files (*.*)|*.*")]
public int PR__EDIT(string updatedFilter)
{
    int formatsCount = 0;
    foreach (Range range in updatedFilter.AsSpan().Split('|'))
        formatsCount++;

    return formatsCount;
}
```

</details>

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build/CI.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9600)