### PR TITLE
Replace Hashtable with Dictionary<K, V> in CollectionViewGroupInternal

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;       // Debug
 using System.Windows;           // DependencyProperty.UnsetValue
 using System.Windows.Data;      // CollectionViewGroup
 using System.Windows.Threading; // Dispatcher
+using System.Collections.Generic;
 
 namespace MS.Internal.Data
 {
@@ -523,19 +524,20 @@ namespace MS.Internal.Data
         internal void AddSubgroupToMap(object nameKey, CollectionViewGroupInternal subgroup)
         {
             Debug.Assert(subgroup != null);
-            if (nameKey == null)
-            {
-                // use null name place holder.
-                nameKey = _nullGroupNameKey;
-            }
+
+            // Use null name place holder.
+            nameKey ??= s_nullGroupNameKey;
+
             if (_nameToGroupMap == null)
             {
-                _nameToGroupMap = new Hashtable();
+                _nameToGroupMap = new Dictionary<object, WeakReference>();
             }
+
             // Add to the map. Use WeakReference to avoid memory leaks
             // in case some one calls ProtectedItems.Remove instead of
             // CollectionViewGroupInternal.Remove
             _nameToGroupMap[nameKey] = new WeakReference(subgroup);
+
             ScheduleMapCleanup();
         }
 
@@ -545,27 +547,20 @@ namespace MS.Internal.Data
         private void RemoveSubgroupFromMap(CollectionViewGroupInternal subgroup)
         {
             Debug.Assert(subgroup != null);
+
             if (_nameToGroupMap == null)
-            {
                 return;
-            }
-            object keyToBeRemoved = null;
 
             // Search for the subgroup in the map.
-            foreach (object key in _nameToGroupMap.Keys)
+            foreach (KeyValuePair<object, WeakReference> item in _nameToGroupMap)
             {
-                WeakReference weakRef = _nameToGroupMap[key] as WeakReference;
-                if (weakRef != null &&
-                    weakRef.Target == subgroup)
+                if (item.Value.Target == subgroup)
                 {
-                    keyToBeRemoved = key;
+                    _nameToGroupMap.Remove(item.Key);
                     break;
                 }
             }
-            if (keyToBeRemoved != null)
-            {
-                _nameToGroupMap.Remove(keyToBeRemoved);
-            }
+
             ScheduleMapCleanup();
         }
 
@@ -576,18 +571,16 @@ namespace MS.Internal.Data
         {
             if (_nameToGroupMap != null)
             {
-                if (nameKey == null)
-                {
-                    // use null name place holder.
-                    nameKey = _nullGroupNameKey;
-                }
+                // Use null name place holder.
+                nameKey ??= s_nullGroupNameKey;
+
                 // Find and return the subgroup
-                WeakReference weakRef = _nameToGroupMap[nameKey] as WeakReference;
-                if (weakRef != null)
+                if (_nameToGroupMap.TryGetValue(nameKey, out WeakReference weakRef))
                 {
-                    return (weakRef.Target as CollectionViewGroupInternal);
+                    return weakRef.Target as CollectionViewGroupInternal;
                 }
             }
+
             return null;
         }
 
@@ -600,28 +593,20 @@ namespace MS.Internal.Data
             if (!_mapCleanupScheduled)
             {
                 _mapCleanupScheduled = true;
-                Dispatcher.CurrentDispatcher.BeginInvoke(
-                    (Action)delegate ()
+                Dispatcher.CurrentDispatcher.BeginInvoke(() =>
+                {
+                    _mapCleanupScheduled = false;
+                    if (_nameToGroupMap != null)
                     {
-                        _mapCleanupScheduled = false;
-                        if (_nameToGroupMap != null)
+                        foreach (KeyValuePair<object, WeakReference> item in _nameToGroupMap)
                         {
-                            ArrayList keysToBeRemoved = new ArrayList();
-                            foreach (object key in _nameToGroupMap.Keys)
+                            if (!item.Value.IsAlive)
                             {
-                                WeakReference weakRef = _nameToGroupMap[key] as WeakReference;
-                                if (weakRef == null || !weakRef.IsAlive)
-                                {
-                                    keysToBeRemoved.Add(key);
-                                }
-                            }
-                            foreach (object key in keysToBeRemoved)
-                            {
-                                _nameToGroupMap.Remove(key);
+                                _nameToGroupMap.Remove(item.Key);
                             }
                         }
-                    },
-                    DispatcherPriority.ContextIdle);
+                    }
+                }, DispatcherPriority.ContextIdle);
             }
         }
 
@@ -756,16 +741,18 @@ namespace MS.Internal.Data
         //
         //------------------------------------------------------
 
-        GroupDescription _groupBy;
-        CollectionViewGroupInternal _parentGroup;
-        IComparer _groupComparer;
-        int _fullCount = 1;
-        int _lastIndex;
-        int _version;       // for detecting stale enumerators
-        Hashtable _nameToGroupMap; // To cache the mapping between name and subgroup
-        bool _mapCleanupScheduled = false;
-        bool _isExplicit;
-        static NamedObject _nullGroupNameKey = new NamedObject("NullGroupNameKey");
+        private readonly CollectionViewGroupInternal _parentGroup;
+        private readonly bool _isExplicit;
+
+        private GroupDescription _groupBy;
+        private IComparer _groupComparer;
+        private int _fullCount = 1;
+        private int _lastIndex;
+        private int _version;       // for detecting stale enumerators
+
+        private static readonly NamedObject s_nullGroupNameKey = new("NullGroupNameKey");
+        private Dictionary<object, WeakReference> _nameToGroupMap; // To cache the mapping between name and subgroup
+        private bool _mapCleanupScheduled = false;
 
         #endregion Private fields
 
@@ -867,7 +854,7 @@ namespace MS.Internal.Data
             {
                 if (_toRemove == null)
                 {
-                    _toRemove = new System.Collections.Generic.List<CollectionViewGroupInternal>();
+                    _toRemove = new List<CollectionViewGroupInternal>();
                 }
                 _toRemove.Add(group);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
@@ -528,10 +528,8 @@ namespace MS.Internal.Data
             // Use null name place holder.
             nameKey ??= s_nullGroupNameKey;
 
-            if (_nameToGroupMap == null)
-            {
-                _nameToGroupMap = new Dictionary<object, WeakReference>();
-            }
+            // The dictionary is not initialized until first addition 
+            _nameToGroupMap ??= new Dictionary<object, WeakReference>();
 
             // Add to the map. Use WeakReference to avoid memory leaks
             // in case some one calls ProtectedItems.Remove instead of

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Data/CollectionViewGroupInternal.cs
@@ -877,7 +877,7 @@ namespace MS.Internal.Data
                 }
             }
 
-            System.Collections.Generic.List<CollectionViewGroupInternal> _toRemove;
+            private List<CollectionViewGroupInternal> _toRemove;
         }
 
         #endregion Private classes


### PR DESCRIPTION
## Description

Replaces `Hashtable` that serves as a group name map with `Dictionary<object, WeakReference>`, improving performance and decreasing allocations. Also removes now useless enumerations on removals, making the whole process more efficient.

- No thread-safety concerns here, it is expected for all access to be synchronized by the classes using the view.
- `Dictionary<K, V>`'s enumeration allows for removals, so the complexity goes from O(2n) to O(n).

### Basic benchmark working between/after

| Method   | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 1,180.2 ns |   20.00 ns |    23.81 ns | 0.1068 |       7,128 B |        1792 B |
| PR__EDIT |   592.5 ns |   11.76 ns |    13.54 ns | 0.0334 |       3,472 B |         560 B |

<details><summary>Benchmark code</summary>

```csharp
[Benchmark]
public void Original()
{
    Hashtable _nameToGroupMap = new();

    AddSubgroupToMapOld(_nameToGroupMap, "A1", subGroupA1);
    AddSubgroupToMapOld(_nameToGroupMap, "A2", subGroupA2);
    AddSubgroupToMapOld(_nameToGroupMap, "A3", subGroupA5);
    AddSubgroupToMapOld(_nameToGroupMap, "A4", subGroupA6);

    CollectionViewGroupInternal subGroupA1Clone = GetSubgroupFromMapOld(_nameToGroupMap, "A1");
    CollectionViewGroupInternal subGroupA2Clone = GetSubgroupFromMapOld(_nameToGroupMap, "A2");

    RemoveSubgroupFromMapOld(_nameToGroupMap, subGroupA2Clone);
    RemoveSubgroupFromMapOld(_nameToGroupMap, subGroupA1Clone);

    RemoveSubgroupFromMapOld(_nameToGroupMap, subGroupA5);
    RemoveSubgroupFromMapOld(_nameToGroupMap, subGroupA6);
}

[Benchmark]
public void PR__EDIT()
{
    Dictionary<object, WeakReference> _nameToGroupMap = new();

    AddSubgroupToMap(_nameToGroupMap, "A1", subGroupA1);
    AddSubgroupToMap(_nameToGroupMap, "A2", subGroupA2);
    AddSubgroupToMap(_nameToGroupMap, "A3", subGroupA5);
    AddSubgroupToMap(_nameToGroupMap, "A4", subGroupA6);

    CollectionViewGroupInternal subGroupA1Clone = GetSubgroupFromMap(_nameToGroupMap, "A1");
    CollectionViewGroupInternal subGroupA2Clone = GetSubgroupFromMap(_nameToGroupMap, "A2");

    RemoveSubgroupFromMap(_nameToGroupMap, subGroupA2Clone);
    RemoveSubgroupFromMap(_nameToGroupMap, subGroupA1Clone);

    RemoveSubgroupFromMap(_nameToGroupMap, subGroupA5);
    RemoveSubgroupFromMap(_nameToGroupMap, subGroupA6);
}

// Including ScheduleMapCleanup that's for the purpose of the benchmark running synchronously

public static void ScheduleMapCleanup(Dictionary<object, WeakReference> _nameToGroupMap)
{
    if (_nameToGroupMap != null)
    {
        foreach (KeyValuePair<object, WeakReference> item in _nameToGroupMap)
        {
            if (!item.Value.IsAlive)
            {
                _nameToGroupMap.Remove(item.Key);
            }
        }
    }
}

public static void ScheduleMapCleanupOld(Hashtable _nameToGroupMap)
{
    if (_nameToGroupMap != null)
    {
        ArrayList keysToBeRemoved = new ArrayList();
        foreach (object key in _nameToGroupMap.Keys)
        {
            WeakReference weakRef = _nameToGroupMap[key] as WeakReference;
            if (weakRef == null || !weakRef.IsAlive)
            {
                keysToBeRemoved.Add(key);
            }
        }
        foreach (object key in keysToBeRemoved)
        {
            _nameToGroupMap.Remove(key);
        }
    }
}
```

</details>

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, testing grouping using custom `GroupDescription` with a sample app.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9603)