### PR TITLE
Make sure to ContinueOnError when DesignTimeBuild is true

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft.WinFX.targets
@@ -205,7 +205,7 @@
         -->
         <PropertyGroup>
             <_IntellisenseOnlyCompile>false</_IntellisenseOnlyCompile>
-            <_IntellisenseOnlyCompile Condition="'$(BuildingProject)' != 'true'">true</_IntellisenseOnlyCompile>
+            <_IntellisenseOnlyCompile Condition="'$(BuildingProject)' != 'true' Or '$(DesignTimeBuild)' == 'true'">true</_IntellisenseOnlyCompile>
         </PropertyGroup>
 
         <MarkupCompilePass1


### PR DESCRIPTION
Fixes 

## Description

Avoids a design time build failure observed in IDE logs for dotnet/roslyn.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing

<!-- What kind of testing has been done with the fix. -->

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9604)