### PR TITLE
Add unit test to ensure the unsupported data types will use BinaryFormatter

### DIFF
--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/DataObjectTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/DataObjectTests.cs
@@ -46,7 +46,7 @@ public class DataObjectTests
         }
         finally
         {
-           
+            Clipboard.Clear();
         }
     }
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/DataObjectTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/BinaryFormat/DataObjectTests.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using PresentationCore.Tests.TestUtilities;
+using PresentationCore.Tests.FluentAssertions;
+using System.Formats.Nrbf;
+using System.Drawing;
+using System.Windows;
+using System.Threading;
+
+namespace PresentationCore.Tests.BinaryFormat;
+
+public class DataObjectTests
+{
+    [Theory]
+    [MemberData(nameof(DataObject_TestData_UnSupportedObjects))]
+    public void DataObject_UnSupportedObjects_SetData(object value)
+    {
+
+        // Create a thread to run the test logic
+        Thread testThread = new Thread(() => TestLogic(value));
+        testThread.SetApartmentState(ApartmentState.STA); // Set the thread to STA
+        testThread.Start();
+        testThread.Join(); // Wait for the thread to complete
+        
+    }
+
+    private void TestLogic(object value)
+    {
+        using BinaryFormatterScope formatterScope = new(enable: false);
+        DataObject dataObject = new();
+        dataObject.SetData(DataFormats.Serializable, value);
+
+        Clipboard.SetDataObject(dataObject, true);
+        IDataObject ClipboardDataObject = Clipboard.GetDataObject();
+        try
+        {
+            if (ClipboardDataObject != null)
+            {
+                Assert.Throws<System.Runtime.InteropServices.COMException>(() => ClipboardDataObject.GetData(DataFormats.Serializable));   
+            }
+            else
+            {
+                Assert.Fail("ClipboardDataObject is null.");
+            }
+        }
+        finally
+        {
+           
+        }
+    }
+
+    public static TheoryData<object> DataObject_TestData_UnSupportedObjects => new()
+    {
+        new SerializableData(),
+        new Dictionary<int, string>(),
+        new object(),
+        System.Drawing.Color.DeepSkyBlue, // Use a static property for Color
+        new System.Drawing.Pen(System.Drawing.Brushes.DeepSkyBlue, 1),
+        new System.Drawing.Bitmap(1, 1), // Use Bitmap instead of Image
+        new System.Drawing.Printing.PrintDocument(),
+        new System.Drawing.Printing.PrinterSettings(),
+        new System.Drawing.Printing.PageSettings(),
+        new System.Drawing.Printing.PaperSize(),
+        new System.Drawing.Printing.PaperSource(),
+        new System.Drawing.Printing.PrinterResolution(),
+    };
+}
+
+
+[Serializable] 
+public class SerializableData
+{
+    public string Name { get; set; }
+    public DateTime BirthDate { get; set; }
+    public int Age { get; set; }
+    public double Salary { get; set; }
+    public bool IsEmployed { get; set; }
+    public char Gender { get; set; }
+    public byte[] BinaryData { get; set; }
+
+    // Constructor
+    public SerializableData()
+    {
+        // Initialize properties with default values
+        Name = "John Doe";
+        BirthDate = DateTime.Now.AddYears(-30);
+        Age = 30;
+        Salary = 50000.0;
+        IsEmployed = true;
+        Gender = 'M';
+        BinaryData = new byte[] { 1, 2, 3, 4, 5 }; // Example binary data
+    }
+    
+
+}

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/PresentationCore.Tests.csproj
@@ -15,6 +15,7 @@
     </ProjectReference>
     <ProjectReference Include="$(WpfSourceDir)PresentationCore\PresentationCore.csproj" />
     <ProjectReference Include="$(WpfSourceDir)WindowsBase\WindowsBase.csproj" />
+    <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +26,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageReference Include="System.Formats.Nrbf" Version="$(SystemFormatsNrbfVersion)" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes # https://github.com/dotnet/wpf/issues/9491


### Description

Adding 12 new unit tests, which ensure that the unsupported data types will use BinaryFormatter and in the absence of System.Runtime.Serialization.Formatters package the Clipboard will throw an exception which is expected.

Outer exception:
DataObject stored in clipboard is invalid.

Inner exception is 
PlatformNotSupportedException: BinaryFormatter serialization and deserialization have been removed. See https://aka.ms/binaryformatter for more information.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9632)