### PR TITLE
Set default LangVersion to 12

### DIFF
--- a/eng/WpfArcadeSdk/Sdk/Sdk.props
+++ b/eng/WpfArcadeSdk/Sdk/Sdk.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <GenXmlStringTable>$(WpfArcadeSdkToolsDir)GenXmlStringTable.pl</GenXmlStringTable>
     <LangVersion Condition="'$(LangVersion)'=='' and ($(PreReleaseVersionLabel.Contains('rc')) or $(PreReleaseVersionLabel.Contains('preview')) or $(PreReleaseVersionLabel.Contains('alpha')))">preview</LangVersion>
-    <LangVersion Condition="'$(LangVersion)'==''">11</LangVersion>
+    <LangVersion Condition="'$(LangVersion)'==''">12</LangVersion>
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
     <IncludeDllSafeSearchPathAttribute Condition="'$(IncludeDllSafeSearchPathAttribute )'==''">true</IncludeDllSafeSearchPathAttribute>
 


### PR DESCRIPTION
Increate LangVersion to support c# 12 version features for rtm build
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9634)