### PR TITLE
Replace StringBuilder in DateTimeValueSerializer with format constants

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -1,11 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
 using System.ComponentModel;
 using System.Globalization;
-using System.Diagnostics;
 
 namespace System.Windows.Markup
 {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -48,14 +48,12 @@ namespace System.Windows.Markup
                 return DateTime.MinValue;
             }
 
-            // Get a DateTimeFormatInfo and set the formatting style for round-tripping
-            // and to trim the string.
-            DateTimeFormatInfo dateTimeFormatInfo = (DateTimeFormatInfo)TypeConverterHelper.InvariantEnglishUS.GetFormat(typeof(DateTimeFormatInfo))!;
+            // Set the formatting style for round-tripping and to trim the string.
             const DateTimeStyles DateTimeStyles = DateTimeStyles.RoundtripKind
-                      | DateTimeStyles.NoCurrentDateDefault
-                      | DateTimeStyles.AllowLeadingWhite
-                      | DateTimeStyles.AllowTrailingWhite;
-            return DateTime.Parse(value, dateTimeFormatInfo, DateTimeStyles);
+                                                | DateTimeStyles.NoCurrentDateDefault
+                                                | DateTimeStyles.AllowLeadingWhite
+                                                | DateTimeStyles.AllowTrailingWhite;
+            return DateTime.Parse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles);
         }
 
         /// <summary>
@@ -106,7 +104,7 @@ namespace System.Windows.Markup
             formatSpan.AppendLiteral("K");
 
             // We've finally got our format string built, we can create the string.
-            return dateTime.ToString(formatSpan.ToString(), CultureInfo.InvariantCulture);
+            return dateTime.ToString(formatSpan.ToString(), DateTimeFormatInfo.InvariantInfo);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Text;
+using System.ComponentModel;
+using System.Globalization;
 using System.Xaml;
 
 namespace System.Windows.Markup
@@ -19,11 +19,9 @@ namespace System.Windows.Markup
     public class DateTimeValueSerializer : ValueSerializer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:System.ComponentModel.DateTimeConverter"></see> class.
+        /// Initializes a new instance of the <see cref="DateTimeConverter" /> class.
         /// </summary>
-        public DateTimeValueSerializer()
-        {
-        }
+        public DateTimeValueSerializer() { }
 
         /// <summary>
         /// Indicate that we do convert DateTime's from string.
@@ -36,7 +34,7 @@ namespace System.Windows.Markup
         public override bool CanConvertToString(object? value, IValueSerializerContext? context) => value is DateTime;
 
         /// <summary>
-        /// Converts the given value object to a <see cref="T:System.DateTime"></see>.
+        /// Converts the given value object to a <see cref="DateTime" />.
         /// </summary>
         public override object ConvertFromString(string value, IValueSerializerContext? context)
         {
@@ -61,17 +59,18 @@ namespace System.Windows.Markup
         }
 
         /// <summary>
-        /// Converts the given value object to a <see cref="T:System.DateTime"></see> using the arguments.
+        /// Converts the given value object to a <see cref="DateTime" /> using the arguments.
         /// </summary>
         public override string ConvertToString(object? value, IValueSerializerContext? context)
         {
-            if (value is null || !(value is DateTime dateTime))
+            if (value is not DateTime dateTime)
             {
                 throw GetConvertToException(value, typeof(string));
             }
 
             // Build up the format string to be used in DateTime.ToString()
-            var formatString = new StringBuilder("yyyy-MM-dd");
+            DefaultInterpolatedStringHandler formatSpan = new(5, 0, CultureInfo.CurrentCulture, stackalloc char[38]);
+            formatSpan.AppendLiteral("yyyy-MM-dd");
             if (dateTime.TimeOfDay == TimeSpan.Zero)
             {
                 // The time portion of this DateTime is exactly at midnight.
@@ -80,7 +79,7 @@ namespace System.Windows.Markup
                 // we'll have to include the time.
                 if (dateTime.Kind != DateTimeKind.Unspecified)
                 {
-                    formatString.Append("'T'HH':'mm");
+                    formatSpan.AppendLiteral("'T'HH':'mm");
                 }
             }
             else
@@ -88,15 +87,15 @@ namespace System.Windows.Markup
                 long digitsAfterSecond = dateTime.Ticks % 10000000;
                 int second = dateTime.Second;
                 // We're going to write out at least the hours/minutes
-                formatString.Append("'T'HH':'mm");
+                formatSpan.AppendLiteral("'T'HH':'mm");
                 if (second != 0 || digitsAfterSecond != 0)
                 {
                     // need to write out seconds
-                    formatString.Append("':'ss");
+                    formatSpan.AppendLiteral("':'ss");
                     if (digitsAfterSecond != 0)
                     {
                         // need to write out digits after seconds
-                        formatString.Append("'.'FFFFFFF");
+                        formatSpan.AppendLiteral("'.'FFFFFFF");
                     }
                 }
             }
@@ -104,10 +103,10 @@ namespace System.Windows.Markup
             // Add the format specifier that indicates we want the DateTimeKind to be
             // included in the output formulation -- UTC gets written out with a "Z",
             // and Local gets written out with e.g. "-08:00" for Pacific Standard Time.
-            formatString.Append('K');
+            formatSpan.AppendLiteral("K");
 
             // We've finally got our format string built, we can create the string.
-            return dateTime.ToString(formatString.ToString(), TypeConverterHelper.InvariantEnglishUS);
+            return dateTime.ToString(formatSpan.ToString(), CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Windows/Markup/DateTimeValueSerializer.cs
@@ -116,10 +116,10 @@ namespace System.Windows.Markup
             // Note: Technically there's no way this should ever fail, MinSupportedDateTime/MaxSupportedDateTime
             // on InvariantCulture is the same as the Min/Max value for DateTime itself, that means
             // we covered ArgumentOutOfRangeException from ToString(); and FormatException is covered here.
-            if (!dateTime.TryFormat(dateTimeSpan, out _, formatSpan.Slice(0, formatLength), DateTimeFormatInfo.InvariantInfo))
+            if (!dateTime.TryFormat(dateTimeSpan, out int charsWritten, formatSpan.Slice(0, formatLength), DateTimeFormatInfo.InvariantInfo))
                 Debug.Assert(false, "TryFormat has failed");
 
-            return new string(dateTimeSpan);
+            return new string(dateTimeSpan.Slice(0, charsWritten));
         }
     }
 }


### PR DESCRIPTION
## Description

Replaces `StringBuilder` with simple on-stack build as we easily know the maximum length of the format string and don't need to therefore have two heap allocations when we can just have one.

Also replaces the awful virtual call to `GetFormat` for `DateTimeFormatInfo` on `InvariantCulture` and a sad nullability annotation with the very simple, static property of `DateTimeFormatInfo.InvariantInfo`.

### Basic method run

| Method   | value               | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-------------------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | 10/10/1999 00:01:07 | 110.30 ns |   1.214 ns |    1.013 ns | 0.0210 |       3,211 B |         352 B |
| PR__EDIT | 10/10/1999 00:01:07 |  70.24 ns |   0.380 ns |    0.355 ns | 0.0038 |       1,739 B |          64 B |

### Benchmark source param

```csharp
public static IEnumerable<DateTime> RandomTime
{
    get
    {
        yield return new DateTime(1999, 10, 10, 0, 1, 7, 123, 456, DateTimeKind.Utc);
    }
}
```

## Customer Impact

Increased performance, decreased allocations.

## Regression

No.

## Testing

Local build, benchmark assert test.

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9643)