### PR TITLE
Setting RuntimeIdentifier to win-x64 incase PlatformTarget is not available

### DIFF
--- a/eng/wpf-debug.targets
+++ b/eng/wpf-debug.targets
@@ -12,7 +12,8 @@
 
   <PropertyGroup>
     <WpfConfig Condition="'$(WpfConfig)'==''">Debug</WpfConfig>
-    <RuntimeIdentifier>win-$(PlatformTarget)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' == ''">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(PlatformTarget)' != ''">win-$(PlatformTarget)</RuntimeIdentifier>
     
     <WpfArtifactsPackagesCommonPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\'))\artifacts\packaging</WpfArtifactsPackagesCommonPath>
     <WpfPlatformTargetArtifactsDirectory Condition="'$(PlatformTarget)'=='x64'">x64\</WpfPlatformTargetArtifactsDirectory>


### PR DESCRIPTION
## Description

Setting `RuntimeIdentifier` to win-x64 incase `PlatformTarget` is not explicitly mentioned

## Customer Impact

Developer needs to add `PlatformTarget` explicitly when trying to link local build

## Regression

NA

## Testing

NA

## Risk

Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9646)