### PR TITLE
Minor Performance Optimization by Reduce hittest calculate for StylusPlugIn when the plugin list is empty

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/PenContexts.cs
@@ -502,7 +502,7 @@ namespace System.Windows.Input
                 elementHasCapture = false;  // force true hittesting to be done!
             }
             
-            if (!elementHasCapture && inputReport.Data != null && inputReport.Data.Length >= pointLength)
+            if (!elementHasCapture && inputReport.Data != null && inputReport.Data.Length >= pointLength && _plugInCollectionList.Count > 0)
             {
                 int[] data = inputReport.Data;
                 System.Diagnostics.Debug.Assert(data.Length % pointLength == 0);


### PR DESCRIPTION
Fixes # <!-- Issue Number -->

Main PR <!-- Link to PR if any that fixed this in the main branch. -->

## Description

The `TargetPlugInCollection` do some calculation to get the StylusPlugIn collection. And it can fast to check the plugin list is empty.

## Customer Impact

<!-- What is the impact to customers of not taking this fix? -->
The TargetPlugInCollection do some useless calculation.

## Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->
None.

## Testing

<!-- What kind of testing has been done with the fix. -->
Just CI.

## Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->
Low. The TargetPlugInCollection just contain some point calculation and it do not change any status and data, and it is the "pure" code. I just skipped the "pure" code calculation.
