### PR TITLE
Make sure Git pre-commit hook directory exists before copying script

### DIFF
--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -87,6 +87,10 @@ function InstallCustomWPFGitHooksFromLocalToolsPath {
     if (-not (Test-Path $WPFPreCommitGitHookDest)) {
          Write-Host "Installing WPF Git pre-commit hook..."
          try {
+            if (-not (Test-Path -Path $WPFPreCommitGitHookDest)) {
+              New-Item -ItemType Directory -Path $WPFPreCommitGitHookDest
+            }
+
             Copy-Item -Path $WPFPreCommitGitHookSource -Destination $WPFPreCommitGitHookDest 
          }
          catch {


### PR DESCRIPTION
## Description
When building the repo for the first time, installing the WPF Git pre-commit hook will fail because it tries to Copy-Item the script into a directory that does not exist.

This change adds a check for the directory and if it does not exist, will create it.

## Customer Impact
They'll continue to not have the pre-commit hook installed.

## Regression
Doesn't appear to be.

## Testing
Just build off a fresh repo and notice the prehook gets installed.

## Risk
None that I know of.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9678)