### PR TITLE
Optimize conversion of ModifierKeys enum from/to string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -9,18 +9,16 @@ using System.Globalization;             // for CultureInfo
 namespace System.Windows.Input
 {
     /// <summary>
-    /// Key Converter class for converting between a string and the Type of a Modifiers
+    /// Converter class for converting between a <see langword="string"/> and <see cref="ModifierKeys"/>.
     /// </summary>
-    /// <ExternalAPI/> 
     public class ModifierKeysConverter : TypeConverter
     {
         /// <summary>
-        /// CanConvertFrom()
+        /// Used to check whether we can convert a <see langword="string"/> into a <see cref="ModifierKeys"/>.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="sourceType"></param>
-        /// <returns></returns>
-        /// <ExternalAPI/> 
+        ///<param name="context">ITypeDescriptorContext</param>
+        ///<param name="sourceType">type to convert from</param>
+        ///<returns><see langword="true"/> if the given <paramref name="sourceType"/> can be converted from, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string
@@ -28,11 +26,11 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// TypeConverter method override. 
+        /// Used to check whether we can convert specified value to <see langword="string"/>.
         /// </summary>
         /// <param name="context">ITypeDescriptorContext</param>
         /// <param name="destinationType">Type to convert to</param>
-        /// <returns>true if conversion is possible</returns>
+        /// <returns><see langword="true"/> if conversion to <see langword="string"/> is possible, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // We can convert to a string
@@ -43,17 +41,16 @@ namespace System.Windows.Input
             if (context is null || context.Instance is not ModifierKeys modifiers)
                 return false;
 
-            return IsDefinedModifierKeys(modifiers);           
+            return IsDefinedModifierKeys(modifiers);
         }
 
         /// <summary>
-        /// ConvertFrom()
+        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="ModifierKeys"/> represensation.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="culture"></param>
-        /// <param name="source"></param>
-        /// <returns></returns>
-        /// <ExternalAPI/> 
+        /// <param name="context">Parser Context</param>
+        /// <param name="culture">Culture Info</param>
+        /// <param name="source">ModifierKeys String</param>
+        /// <returns>A <see cref="ModifierKeys"/> representing the <see langword="string"/> specified by <paramref name="source"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object source)
         {
             if (source is not string stringSource)
@@ -88,18 +85,17 @@ namespace System.Windows.Input
                 };
             }
 
-            return modifiers;        
+            return modifiers;
         }
 
         /// <summary>
-        /// ConvertTo()
+        /// Converts a <paramref name="value"/> of <see cref="ModifierKeys"/> to its <see langword="string"/> represensation.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="culture"></param>
-        /// <param name="value"></param>
-        /// <param name="destinationType"></param>
-        /// <returns></returns>
-        /// <ExternalAPI/> 
+        /// <param name="context">Serialization Context</param>
+        /// <param name="culture">Culture Info</param>
+        /// <param name="value">ModifierKeys value</param>
+        /// <param name="destinationType">Type to Convert</param>
+        /// <returns>A <see langword="string"/> representing the <see cref="ModifierKeys"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
@@ -148,8 +144,11 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        ///     Check for Valid enum, as any int can be casted to the enum.
+        /// Check whether values in <paramref name="modifierKeys"/> are valid, as any number can be casted to the enum.
         /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the given <paramref name="modifierKeys"/> are all members of <see cref="ModifierKeys"/>, <see langword="false"/> otherwise.
+        /// </returns>
         public static bool IsDefinedModifierKeys(ModifierKeys modifierKeys)
         {
             return modifierKeys == ModifierKeys.None || (((int)modifierKeys & ~(int)ModifiersAllBitsSet) == 0);

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -109,6 +109,22 @@ namespace System.Windows.Input
             if (!IsDefinedModifierKeys(modifiers))
                 throw new InvalidEnumArgumentException(nameof(value), (int)modifiers, typeof(ModifierKeys));
 
+            // This is a fast path for when only a single modifier (or none) is set, which is a very common scenario.
+            // Therefore we want a fast path with an allocation free return, taking advantage of interned strings.
+            return modifiers switch
+            {
+                ModifierKeys.None => string.Empty,
+                ModifierKeys.Control => "Ctrl",
+                ModifierKeys.Alt => "Alt",
+                ModifierKeys.Shift => "Shift",
+                ModifierKeys.Windows => "Windows",
+                // Since we were not able to match a single modifier alone, there must be multiple modifiers involved.
+                _ => ConvertMultipleModifiers(modifiers),
+            };
+        }
+
+        private static string ConvertMultipleModifiers(ModifierKeys modifiers)
+        {
             // Ctrl+Alt+Windows+Shift is the maximum char length, though the composition of such value is improbable
             Span<char> modifierSpan = stackalloc char[22];
             int totalLength = 0;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -34,17 +34,15 @@ namespace System.Windows.Input
         /// <returns>true if conversion is possible</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            // We can convert to a string.
-            if (destinationType == typeof(string))
-            {
-                // When invoked by the serialization engine we can convert to string only for known type
-                if (context != null && context.Instance != null && 
-					context.Instance is ModifierKeys)
-                {
-                    return (IsDefinedModifierKeys((ModifierKeys)context.Instance));
-                }
-            }
-            return false;
+            // We can convert to a string
+            if (destinationType != typeof(string))
+                return false;
+
+            // When invoked by the serialization engine we can convert to string only for known type
+            if (context is null || context.Instance is not ModifierKeys modifiers)
+                return false;
+
+            return IsDefinedModifierKeys(modifiers);           
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -151,10 +151,13 @@ namespace System.Windows.Input
         /// </summary>
         public static bool IsDefinedModifierKeys(ModifierKeys modifierKeys)
         {
-            return (modifierKeys == ModifierKeys.None || (((int)modifierKeys & ~((int)ModifierKeysFlag)) == 0));
+            return modifierKeys == ModifierKeys.None || (((int)modifierKeys & ~(int)ModifiersAllBitsSet) == 0);
         }
 
-        private static ModifierKeys ModifierKeysFlag  =  ModifierKeys.Windows | ModifierKeys.Shift | 
-                                                         ModifierKeys.Alt     | ModifierKeys.Control ;
+        /// <summary>
+        /// Specifies all bits of the <see cref="ModifierKeys"/> enum set.
+        /// </summary>
+        private const ModifierKeys ModifiersAllBitsSet = ModifierKeys.Windows | ModifierKeys.Shift | ModifierKeys.Alt | ModifierKeys.Control;
+
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Globalization;
+using System.Runtime.CompilerServices;  // for MethodImplAttribute
+using System.ComponentModel;            // for TypeConverter
+using System.Globalization;             // for CultureInfo
 
 namespace System.Windows.Input
 {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/ModifierKeysConverter.cs
@@ -22,15 +22,8 @@ namespace System.Windows.Input
         /// <ExternalAPI/> 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            // We can only handle string.
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            // We can only handle string
+            return sourceType == typeof(string);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #7502

## Description

Parsing optimization for `ModifierKeys` and its conversion from/to string. Conversion **from** is now alloc-free, conversion to is either free or reduced by a big margin (see benchmarks).

- `ConvertFrom` is now fully flying on `ReadOnlySpan<char>` instead of multiple substrings and trims on string instances.
- `ConvertTo` is now within 2 procs, fast-path and slow-path. The only allocated string instance is with multiple modifiers.
- Strings in `ConvertTo` will now be interned with the rest since we use `StringComparison.OrdinalIgnoreCase`.
- `ModifierKeysFlag` static field is now a compile-time constant, saving memory and providing speed-up.
- The JITTed codegen takes up less memory as we removed few things.
- Adds/completes code documentation for the whole class.

### `ConvertFrom` Benchmark for all possible modifiers

| Method   | source               | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size | Allocated |
|--------- |--------------------- |----------:|-----------:|------------:|-------:|----------:|----------:|
| Original | CTRL (...)+ ALT [24] | 101.55 ns |   1.790 ns |    1.587 ns | 0.0224 |       2,662 B |         376 B |
| PR__EDIT | CTRL (...)+ ALT [24] |  34.68 ns |   0.218 ns |    0.182 ns |      - |       1,891 B |             - |
| Original | Ctrl (...)+ Alt [28] | 147.59 ns |   1.616 ns |    1.512 ns | 0.0319 |       2,640 B |         536 B |
| PR__EDIT | Ctrl (...)+ Alt [28] |  35.19 ns |   0.483 ns |    0.451 ns |      - |       1,891 B |             - |

### `ConvertTo` benchmark for different scenarios
| Method    | value | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|---------- |------ |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original  | None  | 1.0984 ns |  0.0108 ns |   0.0090 ns |      - |         685 B |             - |
| PR__EDIT  | None  | 0.8665 ns |  0.0078 ns |   0.0066 ns |      - |         238 B |             - |
| Original  | Shift | 1.1785 ns |  0.0149 ns |   0.0132 ns |      - |         780 B |             - |
| PR__EDIT  | Shift | 0.8840 ns |  0.0209 ns |   0.0196 ns |      - |         255 B |             - |
| Original | 3     | 10.517 ns |  0.1322 ns |   0.1104 ns | 0.0043 |       1,134 B |          72 B |
| PR__EDIT | 3     |  9.546 ns |  0.1713 ns |   0.1518 ns | 0.0024 |         756 B |          40 B |
| Original  | 15    | 39.23 ns |   0.828 ns |    0.886 ns | 0.0176 |       1,137 B |         296 B |
| PR__EDIT  | 15    | 11.88 ns |   0.194 ns |    0.181 ns |  0.0043 |  753 B      |   72 B |

## Customer Impact

Increased performance, zero/reduced allocations, less static memory.

## Regression

No.

## Testing

Local build, CI, assert tests:
```csharp
//ConvertTo
string x1 = Original(ModifierKeys.None);
string x2 = PR__EDIT(ModifierKeys.None);
Assert.AreEqual(x1, x2);
x1 = Original(ModifierKeys.Shift);
x2 = PR__EDIT(ModifierKeys.Shift);
Assert.AreEqual(x1, x2);
x1 = Original(ModifierKeys.Shift | ModifierKeys.Alt);
x2 = PR__EDIT(ModifierKeys.Shift | ModifierKeys.Alt);
Assert.AreEqual(x1, x2);
x1 = Original(ModifierKeys.Control | ModifierKeys.Alt);
x2 = PR__EDIT(ModifierKeys.Control | ModifierKeys.Alt);
Assert.AreEqual(x1, x2);
x1 = Original(ModifierKeys.Windows | ModifierKeys.Alt);
x2 = PR__EDIT(ModifierKeys.Windows | ModifierKeys.Alt);
Assert.AreEqual(x1, x2);
x1 = Original(ModifierKeys.Windows | ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift);
x2 = Original(ModifierKeys.Windows | ModifierKeys.Alt | ModifierKeys.Control | ModifierKeys.Shift);
Assert.AreEqual(x1, x2);

//ConvertFrom
ModifierKeys x1 = Original("CTRL + ");
ModifierKeys x2 = PR__EDIT("CTRL + ");
Assert.AreEqual(x1, x2);
x1 = Original("CTRL");
x2 = PR__EDIT("CTRL");
Assert.AreEqual(x1, x2);
x1 = Original(" ALT + SHIFT ");
x2 = PR__EDIT(" ALT + SHIFT ");
Assert.AreEqual(x1, x2);
x1 = Original("WIN + WINDOWS");
x2 = PR__EDIT("WIN + WINDOWS");
Assert.AreEqual(x1, x2);
x1 = Original("   ");
x2 = PR__EDIT("   ");
Assert.AreEqual(x1, x2);
x1 = Original("CTRL + WIN + SHIFT + ALT");
x2 = PR__EDIT("CTRL + WIN + SHIFT + ALT");
Assert.AreEqual(x1, x2);
x1 = Original("CTRL ++ WIN");
x2 = PR__EDIT("CTRL ++ WIN");
Assert.AreEqual(x1, x2);
x1 = Original("ALT+WIN");
x2 = PR__EDIT("ALT+WIN");
Assert.AreEqual(x1, x2);
```

## Risk

Low.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9683)