### PR TITLE
Optimize conversion of Key enum from/to string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -45,10 +45,10 @@ namespace System.Windows.Input
                 return false;
 
             // When invoked by the serialization engine we can convert to string only for known type
-            if (context is null || context.Instance is not Key key)
+            if (context is null || context.Instance is null)
                 return false;
 
-            return IsDefinedKey(key);
+            return IsDefinedKey((Key)context.Instance);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -22,14 +22,8 @@ namespace System.Windows.Input
         /// <ExternalAPI/> 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            // We can only handle string
+            return sourceType == typeof(string);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -8,14 +8,9 @@
 // to the *Type* that the string represents and vice-versa
 //
 
-using System;
 using System.ComponentModel;    // for TypeConverter
 using System.Globalization;     // for CultureInfo
-using System.Reflection;
-using System.Windows;
-using System.Windows.Input;
-using System.Windows.Markup;
-using MS.Utility;
+
 using MS.Internal.WindowsBase;
 
 namespace System.Windows.Input

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -132,16 +132,16 @@ namespace System.Windows.Input
                     throw new ArgumentException(SR.Format(SR.CannotConvertStringToType, keyToken.ToString(), typeof(Key)));
             }
 
-            // Special path for F1-F9 (switch would take 600 B in code size for no benefit)
-            char secondChar = keyToken[1];
-            if (keyToken.Length == 2 && firstChar == 'F' && (secondChar > '0' && secondChar <= '9'))
-                return Key.F1 + secondChar - '1';
-
             // It is a special key or an invalid one, we're gonna find out
             switch (keyToken.Length)
             {
                 case 2:
-                    if (keyToken.Equals("BS", StringComparison.OrdinalIgnoreCase))
+                    // Special path for F1-F9 (switch would take 600 B in code size for no benefit)
+                    char secondChar = keyToken[1];
+                    if (firstChar == 'F' && (secondChar > '0' && secondChar <= '9'))
+                        return Key.F1 + secondChar - '1';
+                    // We've got one more special case for Key.Back/Backspace -> "BS"
+                    if (firstChar == 'B' && (secondChar is 'S' or 's'))
                         return Key.Back;
                     break;
                 case 3:

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Input
             if (context is null || context.Instance is not Key key)
                 return false;
 
-            return key >= Key.None && key <= Key.DeadCharProcessed;
+            return IsDefinedKey(key);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -123,10 +123,10 @@ namespace System.Windows.Input
             // If this is a single-character we're dealing with, match digits/letters
             if (keyToken.Length == 1 && char.IsLetterOrDigit(firstChar))
             {
-                // Match a digit (0-9) or an ASCII letter (lower/uppercase)
-                if (char.IsDigit(firstChar) && (firstChar >= '0' && firstChar <= '9'))
+                // Match an ASCII digit or an ASCII letter (lower/uppercase)
+                if (char.IsAsciiDigit(firstChar)) // 0 - 9
                     return Key.D0 + firstChar - '0';
-                else if (char.IsLetter(firstChar) && (firstChar >= 'A' && firstChar <= 'Z'))
+                else if (char.IsAsciiLetterUpper(firstChar)) // A - Z
                     return Key.A + firstChar - 'A';
                 else
                     throw new ArgumentException(SR.Format(SR.CannotConvertStringToType, keyToken.ToString(), typeof(Key)));

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -1,17 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//
-//
-// Description: KeyConverter - Converts a Key string
-// to the *Type* that the string represents and vice-versa
-//
-
 using System.ComponentModel;    // for TypeConverter
 using System.Globalization;     // for CultureInfo
-
-using MS.Internal.WindowsBase;
 
 namespace System.Windows.Input
 {
@@ -25,7 +17,7 @@ namespace System.Windows.Input
         ///</summary>
         ///<param name="context">ITypeDescriptorContext</param>
         ///<param name="sourceType">type to convert from</param>
-        ///<returns><see langword="true"/> if the given <paramref name="sourceType"/> can be converted from, <see langword="false"/> otherwise.</returns>
+        ///<returns><see langword="true"/> if the given <paramref name="sourceType"/> can be converted, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             // We can only handle string
@@ -52,7 +44,7 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="Key"/> represensation.
+        /// Converts <paramref name="source"/> of <see langword="string"/> type to its <see cref="Key"/> representation.
         /// </summary>
         /// <param name="context">Parser Context</param>
         /// <param name="culture">Culture Info</param>
@@ -68,7 +60,7 @@ namespace System.Windows.Input
         }
 
         /// <summary>
-        /// Converts a <paramref name="value"/> of <see cref="Key"/> to its <see langword="string"/> represensation.
+        /// Converts a <paramref name="value"/> of <see cref="Key"/> type to its <see langword="string"/> representation.
         /// </summary>
         /// <param name="context">Serialization Context</param>
         /// <param name="culture">Culture Info</param>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Input/KeyConverter.cs
@@ -34,18 +34,15 @@ namespace System.Windows.Input
         /// <returns>true if conversion is possible</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            // We can convert to a string.
-            // We can convert to an InstanceDescriptor or to a string.
-            if (destinationType == typeof(string))
-            {
-                // When invoked by the serialization engine we can convert to string only for known type
-                if (context != null && context.Instance != null)
-                {
-                    Key key = (Key)context.Instance;
-                    return ((int)key >= (int)Key.None && (int)key <= (int)Key.DeadCharProcessed);
-                }
-            }
-            return false;
+            // We can convert to a string
+            if (destinationType != typeof(string))
+                return false;
+
+            // When invoked by the serialization engine we can convert to string only for known type
+            if (context is null || context.Instance is not Key key)
+                return false;
+
+            return key >= Key.None && key <= Key.DeadCharProcessed;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Parsing optimization for `Key` and its conversion from/to string. Conversion from is now alloc-free, conversion to is either untouched or free.

- `ConvertFrom` is now allocation free, optimizing performance from x4 for normal keys to x20 for F1-F12 keys.
   - The code-size of the method has increased but I think it is an acceptable compromise.
- `ConvertTo` is pretty much unchanged however F10-F12 were added to switch as those are interned.
- Adds/completes code documentation for the whole class.

### ConvertFrom benchmarks (code size is not real here 'cause depth is set to 1)
| Method      | source | Mean [ns]  | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|------------ |------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original | \x20F5\x20 | 170.052 ns |  1.7088 ns |   1.5984 ns | 0.0048 |         291 B |          80 B |
| PR__EDIT    | \x20F5\x20 |   9.761 ns |  0.0319 ns |   0.0298 ns |      - |       4,689 B |             - |
| Original | F5     | 184.430 ns |  3.5985 ns |   3.3661 ns | 0.0029 |         291 B |          48 B |
| PR__EDIT    | F5     |   3.748 ns |  0.0134 ns |   0.0119 ns |      - |       4,315 B |             - |
| Original | \x20A\x20  | 22.271 ns |  0.2355 ns |   0.1967 ns | 0.0043 |         291 B |          72 B |
| PR__EDIT    | \x20A\x20  | 10.832 ns |  0.0123 ns |   0.0109 ns |      - |       4,792 B |             - |
| Original | Play   | 23.951 ns |  0.3515 ns |   0.3288 ns | 0.0048 |         291 B |          80 B |
| PR__EDIT    | Play   |  4.095 ns |  0.0124 ns |   0.0110 ns |      - |       4,171 B |             - |
| Original | A      | 16.815 ns |  0.1958 ns |   0.1832 ns | 0.0029 |         291 B |          48 B |
| PR__EDIT    | A      |  4.148 ns |  0.0086 ns |   0.0077 ns |      - |       4,402 B |             - |

### ConvertTo benchmarks
| Method            | source | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|------------------ |------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original| Back   |  2.264 ns |  0.0123 ns |   0.0109 ns |      - |         465 B |             - |
| PR__EDIT| Back   |  2.252 ns |  0.0123 ns |   0.0109 ns |      - |         545 B |             - |
| Original| F10    | 14.026 ns |  0.2135 ns |   0.1892 ns | 0.0014 |         473 B |          24 B |
| PR__EDIT| F10    |  2.460 ns |  0.0082 ns |   0.0068 ns |      - |         567 B |             - |
| Original| A      |  5.766 ns |  0.1288 ns |   0.1204 ns | 0.0014 |         381 B |          24 B |
| PR__EDIT| A      |  5.257 ns |  0.1345 ns |   0.1439 ns | 0.0014 |         553 B |          24 B |

## Customer Impact

Increased performance, zero/reduced allocations.

## Regression

No.

## Testing

Local build, CI, assert tests:
```csharp
// ConvertFrom Tests
Key x1 = (Key)oldKeyConverter.ConvertFrom(null, null, "F5");
Key x2 = (Key)newKeyConverter.ConvertFrom(null, null, "F5");
Assert.AreEqual(x1, x2);
x1 = (Key)oldKeyConverter.ConvertFrom(null, null, " BS");
x2 = (Key)newKeyConverter.ConvertFrom(null, null, " BS");
Assert.AreEqual(x1, x2);
x1 = (Key)oldKeyConverter.ConvertFrom(null, null, "A ");
x2 = (Key)newKeyConverter.ConvertFrom(null, null, "A ");
Assert.AreEqual(x1, x2);
x1 = (Key)oldKeyConverter.ConvertFrom(null, null, " Question ");
x2 = (Key)newKeyConverter.ConvertFrom(null, null, " Question ");
Assert.AreEqual(x1, x2);
x1 = (Key)oldKeyConverter.ConvertFrom(null, null, " OemQUEstion ");
x2 = (Key)newKeyConverter.ConvertFrom(null, null, " OemQUEstion ");
Assert.AreEqual(x1, x2);
x1 = (Key)oldKeyConverter.ConvertFrom(null, null, "  ");
x2 = (Key)newKeyConverter.ConvertFrom(null, null, "  ");
Assert.AreEqual(x1, x2);
// Invalid single character specified that is not a key
Assert.ThrowsException<ArgumentException>(() => oldKeyConverter.ConvertFrom(null, null, " á "));
Assert.ThrowsException<ArgumentException>(() => newKeyConverter.ConvertFrom(null, null, " á "));
// This is a case where 
// "NotSupportedException(SR.Format(SR.Unsupported_Key, fullName))"
// was expected but it is a dead code
Assert.ThrowsException<ArgumentException>(() => oldKeyConverter.ConvertFrom(null, null, " áb "));
Assert.ThrowsException<ArgumentException>(() => newKeyConverter.ConvertFrom(null, null, " áb "));

// CanConvertTo Tests
StandardContextImpl context = new StandardContextImpl();
context.Instance = (int)1;
bool x6 = oldKeyConverter.CanConvertTo(context, typeof(string));
bool x7 = newKeyConverter.CanConvertTo(context, typeof(string));
Assert.AreEqual(x6, x7);
context.Instance = (Key)1;
x6 = oldKeyConverter.CanConvertTo(context, typeof(string));
x7 = newKeyConverter.CanConvertTo(context, typeof(string));
Assert.AreEqual(x6, x7);
context.Instance = (byte)1;
Assert.ThrowsException<InvalidCastException>(() => oldKeyConverter.CanConvertTo(context, typeof(string)));
Assert.ThrowsException<InvalidCastException>(() => newKeyConverter.CanConvertTo(context, typeof(string)));

// ConvertTo Tests
string x3 = (string)oldKeyConverter.ConvertTo(null, null, Key.A, typeof(string));
string x4 = (string)newKeyConverter.ConvertTo(null, null, Key.A, typeof(string));
Assert.AreEqual(x3, x4);

x3 = (string)oldKeyConverter.ConvertTo(null, null, Key.F10, typeof(string));
x4 = (string)newKeyConverter.ConvertTo(null, null, Key.F10, typeof(string));
Assert.AreEqual(x3, x4);

x3 = (string)oldKeyConverter.ConvertTo(null, null, Key.Back, typeof(string));
x4 = (string)newKeyConverter.ConvertTo(null, null, Key.Back, typeof(string));
Assert.AreEqual(x3, x4);

x3 = (string)oldKeyConverter.ConvertTo(null, null, Key.DeadCharProcessed, typeof(string));
x4 = (string)newKeyConverter.ConvertTo(null, null, Key.DeadCharProcessed, typeof(string));
Assert.AreEqual(x3, x4);

x3 = (string)oldKeyConverter.ConvertTo(null, null, Key.None, typeof(string));
x4 = (string)newKeyConverter.ConvertTo(null, null, Key.None, typeof(string));
Assert.AreEqual(x3, x4);

//Null destinationType
Assert.ThrowsException<ArgumentNullException>(() => (string)oldKeyConverter.ConvertTo(null, null, (Key)(-1), null));
Assert.ThrowsException<ArgumentNullException>(() => (string)newKeyConverter.ConvertTo(null, null, (Key)(-1), null));
//Invalid destinationType
Assert.ThrowsException<NotSupportedException>(() => (string)oldKeyConverter.ConvertTo(null, null, (Key)(-1), typeof(Int32)));
Assert.ThrowsException<NotSupportedException>(() => (string)newKeyConverter.ConvertTo(null, null, (Key)(-1), typeof(Int32)));
//Value out of range
Assert.ThrowsException<NotSupportedException>(() => (string)oldKeyConverter.ConvertTo(null, null, (Key)(-1), typeof(string)));
Assert.ThrowsException<NotSupportedException>(() => (string)newKeyConverter.ConvertTo(null, null, (Key)(-1), typeof(string)));
//Value is null
Assert.ThrowsException<NotSupportedException>(() => (string)oldKeyConverter.ConvertTo(null, null, null, typeof(string)));
Assert.ThrowsException<NotSupportedException>(() => (string)newKeyConverter.ConvertTo(null, null, null, typeof(string)));
```

## Risk

Low, changes have been thoroughly tested.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9697)