### PR TITLE
Remove unused CAS resource strings and its translations from all libraries

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -2035,9 +2035,6 @@
   <data name="SearchText" xml:space="preserve">
     <value>Search</value>
   </data>
-  <data name="SecurityExceptionForSettingSandboxExternalToTrue" xml:space="preserve">
-    <value>Cannot set SandboxExternalContent to true in partial trust.</value>
-  </data>
   <data name="SeekNegative" xml:space="preserve">
     <value>Cannot set seek pointer to a negative position.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1210,9 +1210,6 @@
   <data name="InvalidPartName" xml:space="preserve">
     <value>The part name does not correspond to its content type.</value>
   </data>
-  <data name="InvalidPermissionType" xml:space="preserve">
-    <value>Permission type is not valid. Expected '{0}'.</value>
-  </data>
   <data name="InvalidPressureValue" xml:space="preserve">
     <value>Pressure must be a value between 0 and 1.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/Strings.resx
@@ -1210,9 +1210,6 @@
   <data name="InvalidPartName" xml:space="preserve">
     <value>The part name does not correspond to its content type.</value>
   </data>
-  <data name="InvalidPermissionStateValue" xml:space="preserve">
-    <value>PermissionState value '{0}' is not valid for this Permission.</value>
-  </data>
   <data name="InvalidPermissionType" xml:space="preserve">
     <value>Permission type is not valid. Expected '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Název součásti neodpovídá typu jejího obsahu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Hodnota PermissionState {0} není pro toto oprávnění platná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Název součásti neodpovídá typu jejího obsahu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Tlak musí být hodnota v rozsahu 0 až 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.cs.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Vyhledat</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Vlastnost SandboxExternalContent nelze nastavit na hodnotu true v částečném vztahu důvěryhodnosti.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Vyhledávací ukazatel nelze nastavit do záporné polohy.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Suche</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">SandboxExternalContent kann bei Verwendung mit teilweiser Vertrauenswürdigkeit nicht auf "true" festgelegt werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Der Suchzeiger kann nicht auf eine negative Position festgelegt werden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Der Teilname entspricht nicht dessen Inhaltstyp.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Der PermissionState-Wert "{0}" ist für diese Berechtigung nicht gültig.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.de.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Der Teilname entspricht nicht dessen Inhaltstyp.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Der Druck muss einen Wert zwischen 0 und 1 besitzen.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">El nombre de la parte no se corresponde con su tipo de contenido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">La presión debe ser un valor comprendido entre 0 y 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Búsqueda</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">No se puede establecer SandboxExternalContent en verdadero en una confianza parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">No se puede establecer el puntero de llamada en una posición negativa.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.es.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">El nombre de la parte no se corresponde con su tipo de contenido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">El valor de PermissionState '{0}' no es válido para este permiso.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Le nom de partie ne correspond pas à son type de contenu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Pressure doit être une valeur comprise entre 0 et 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Recherche</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossible d'affecter à SandboxExternalContent la valeur true en situation de confiance partielle.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Impossible de définir le pointeur de recherche avec une position négative.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.fr.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Le nom de partie ne correspond pas à son type de contenu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valeur de PermissionState '{0}' non valide pour cette autorisation.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Nome di parte non corrispondente al tipo di contenuto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">La pressione deve essere un valore compreso tra 0 e 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Ricerca</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossibile impostare SandboxExternalContent su true in condizioni di attendibilità parziale.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Impossibile impostare il puntatore di posizionamento su una posizione negativa.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.it.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Nome di parte non corrispondente al tipo di contenuto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valore PermissionState '{0}' non valido per l'autorizzazione corrente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">検索対象</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">部分的な信頼では、SandboxExternalContent を true に設定できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">負の位置にシーク ポインターを設定できません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">パート名がコンテンツの種類に対応していません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 値 '{0}' は、このアクセス許可に対して無効です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ja.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">パート名がコンテンツの種類に対応していません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Pressure は、0 と 1 の間の値でなければなりません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">부분 이름이 해당 콘텐츠 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">압력은 0과 1 사이의 값이어야 합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">부분 이름이 해당 콘텐츠 형식과 일치하지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 값 '{0}'은(는) 이 권한에 대해 올바르지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ko.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">검색</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">부분 신뢰에서 SandboxExternalContent를 true로 설정할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">검색 포인터를 음의 위치로 설정할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Wyszukiwanie</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Nie można ustawić właściwości SandboxExternalContent na true w częściowej relacji zaufania.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Wskaźnika wyszukiwania nie można ustawić na pozycji ujemnej.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Nazwa części nie odpowiada typowi jej zawartości.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Nacisk musi mieć wartość pomiędzy 0 a 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pl.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Nazwa części nie odpowiada typowi jej zawartości.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Wartość PermissionState „{0}” jest nieprawidłowa dla tego uprawnienia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">O nome da parte não corresponde ao seu tipo de conteúdo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">O valor de PermissionState '{0}' não é válido para esta Permissão.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Pesquisa</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Não é possível definir SandboxExternalContent como verdadeiro em confiança parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Não é possível definir um ponteiro de busca como uma posição negativa.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.pt-BR.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">O nome da parte não corresponde ao seu tipo de conteúdo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">A pressão deve ser um valor entre 0 e 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Найти</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Не удается задать значение "true" для SandboxExternalContent при частично доверительных отношениях.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Невозможно установить указатель поиска в отрицательную позицию.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Имя компонента не соответствует типу содержимого.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Значение PermissionState "{0}" недопустимо для данного разрешения.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.ru.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Имя компонента не соответствует типу содержимого.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Нажим может принимать значения от 0 до 1.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Bölüm adı içerik türüyle uyumlu değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">'{0}' PermissionState değeri bu İzin için geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">Arama</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Kısmi güvende SandboxExternalContent true olarak ayarlanamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">Arama işaretçisi negatif konuma ayarlanamaz.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.tr.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">Bölüm adı içerik türüyle uyumlu değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">Basınç 0 ile 1 arasında bir değer olmalıdır.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">搜索</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">无法在部分信任中将 SandboxExternalContent 设置为 true。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">无法将查找指针设置到负位置。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">部分名称与其内容类型不一致。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">权限类型无效。应为“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">压力必须是介于 0 和 1 之间的值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hans.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">部分名称与其内容类型不一致。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值“{0}”对于此 Permission 无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">权限类型无效。应为“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">部分名稱未對應到其內容類型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">使用權限類型無效。應該是 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPressureValue">
         <source>Pressure must be a value between 0 and 1.</source>
         <target state="translated">壓力必須是介於 0 到 1 之間的值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -1782,11 +1782,6 @@
         <target state="translated">部分名稱未對應到其內容類型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值 '{0}' 對此權限無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">使用權限類型無效。應該是 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/Resources/xlf/Strings.zh-Hant.xlf
@@ -2847,11 +2847,6 @@
         <target state="translated">搜尋</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">在部分信任的情況下，無法將 SandboxExternalContent 設定為 True。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekNegative">
         <source>Cannot set seek pointer to a negative position.</source>
         <target state="translated">無法搜尋負值位置的指標。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -3996,9 +3996,6 @@ Do you want to replace it?</value>
   <data name="Freezable_CantBeFrozen" xml:space="preserve">
     <value>Specified value of type '{0}' must have IsFrozen set to false to modify.</value>
   </data>
-  <data name="InvalidPermissionType" xml:space="preserve">
-    <value>Permission type is not valid. Expected '{0}'.</value>
-  </data>
   <data name="SecurityExceptionForSettingSandboxExternalToTrue" xml:space="preserve">
     <value>Cannot set SandboxExternalContent to true in partial trust.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -3996,9 +3996,6 @@ Do you want to replace it?</value>
   <data name="Freezable_CantBeFrozen" xml:space="preserve">
     <value>Specified value of type '{0}' must have IsFrozen set to false to modify.</value>
   </data>
-  <data name="SecurityExceptionForSettingSandboxExternalToTrue" xml:space="preserve">
-    <value>Cannot set SandboxExternalContent to true in partial trust.</value>
-  </data>
   <data name="StringEmpty" xml:space="preserve">
     <value>Parameter cannot be a zero-length string.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/Strings.resx
@@ -3996,9 +3996,6 @@ Do you want to replace it?</value>
   <data name="Freezable_CantBeFrozen" xml:space="preserve">
     <value>Specified value of type '{0}' must have IsFrozen set to false to modify.</value>
   </data>
-  <data name="InvalidPermissionStateValue" xml:space="preserve">
-    <value>PermissionState value '{0}' is not valid for this Permission.</value>
-  </data>
   <data name="InvalidPermissionType" xml:space="preserve">
     <value>Permission type is not valid. Expected '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -4818,11 +4818,6 @@ Chcete ho nahradit?</target>
         <target state="translated">Parametr {0} má hodnotu {1}, která není v platném rozsahu {2} až {3}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Vlastnost SandboxExternalContent nelze nastavit na hodnotu true v částečném vztahu důvěryhodnosti.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Nelze vyhledat danou pozici.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -2413,11 +2413,6 @@ Chcete ho nahradit?</target>
         <target state="translated">Typ {0} není platným typem třídy PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Neplatná hodnota Point.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.cs.xlf
@@ -2413,11 +2413,6 @@ Chcete ho nahradit?</target>
         <target state="translated">Typ {0} není platným typem třídy PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Hodnota PermissionState {0} není pro toto oprávnění platná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -2413,11 +2413,6 @@ Möchten Sie das Element ersetzen?</target>
         <target state="translated">Typ "{0}" ist kein gültiger PageFunction-Typ.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Der PermissionState-Wert "{0}" ist für diese Berechtigung nicht gültig.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -2413,11 +2413,6 @@ Möchten Sie das Element ersetzen?</target>
         <target state="translated">Typ "{0}" ist kein gültiger PageFunction-Typ.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Ungültiger Point-Wert.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.de.xlf
@@ -4818,11 +4818,6 @@ Möchten Sie das Element ersetzen?</target>
         <target state="translated">Der Parameter "{0}" besitzt den Wert "{1}", der sich nicht im gültigen Bereich zwischen "{2}" und "{3}" befindet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">SandboxExternalContent kann bei Verwendung mit teilweiser Vertrauenswürdigkeit nicht auf "true" festgelegt werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Eine Suche zur angegebenen Position kann nicht ausgeführt werden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">El tipo '{0}' no es un tipo PageFunction válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Valor de Point no válido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">El parámetro "{0}" tiene el valor "{1}", que no se encuentra dentro del intervalo válido comprendido entre "{2}" y "{3}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">No se puede establecer SandboxExternalContent en verdadero en una confianza parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">No se puede realizar una llamada en la posición especificada.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.es.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">El tipo '{0}' no es un tipo PageFunction válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">El valor de PermissionState '{0}' no es válido para este permiso.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -4818,11 +4818,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Le paramètre '{0}' a la valeur '{1}', laquelle se trouve en dehors de la plage valide comprise entre '{2}' et '{3}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossible d'affecter à SandboxExternalContent la valeur true en situation de confiance partielle.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Impossible de rechercher la position donnée.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -2413,11 +2413,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Le type '{0}' n'est pas un type PageFunction valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valeur de PermissionState '{0}' non valide pour cette autorisation.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.fr.xlf
@@ -2413,11 +2413,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Le type '{0}' n'est pas un type PageFunction valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Valeur Point non valide.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -2413,11 +2413,6 @@ Sostituirlo?</target>
         <target state="translated">Il tipo '{0}' non è un tipo PageFunction valido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valore PermissionState '{0}' non valido per l'autorizzazione corrente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -4818,11 +4818,6 @@ Sostituirlo?</target>
         <target state="translated">Il valore '{1}' del parametro '{0}' non è compreso nell'intervallo valido da '{2}' a '{3}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossibile impostare SandboxExternalContent su true in condizioni di attendibilità parziale.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Impossibile raggiungere la posizione specificata.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.it.xlf
@@ -2413,11 +2413,6 @@ Sostituirlo?</target>
         <target state="translated">Il tipo '{0}' non è un tipo PageFunction valido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Valore Point non valido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">型 '{0}' は、有効な PageFunction 型ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">無効な Point 値です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">型 '{0}' は、有効な PageFunction 型ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 値 '{0}' は、このアクセス許可に対して無効です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ja.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">'{0}' パラメーターには値 '{1}' があります。これは、'{2}' から '{3}' の有効な範囲内にありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">部分的な信頼では、SandboxExternalContent を true に設定できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">指定された位置をシークできません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">'{0}' 유형이 올바른 PageFunction 유형이 아닙니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 값 '{0}'은(는) 이 권한에 대해 올바르지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">'{0}' 매개 변수에 '{1}' 값이 있으며 해당 값이 유효한 '{2}' ~ '{3}' 범위에 있지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">부분 신뢰에서 SandboxExternalContent를 true로 설정할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">지정한 위치를 찾을 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ko.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">'{0}' 유형이 올바른 PageFunction 유형이 아닙니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Point 값이 잘못되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -2413,11 +2413,6 @@ Czy chcesz go zastąpić?</target>
         <target state="translated">Typ „{0}” nie jest prawidłowym typem elementu PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Wartość PermissionState „{0}” jest nieprawidłowa dla tego uprawnienia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -2413,11 +2413,6 @@ Czy chcesz go zastąpić?</target>
         <target state="translated">Typ „{0}” nie jest prawidłowym typem elementu PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Nieprawidłowa wartość Point.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pl.xlf
@@ -4818,11 +4818,6 @@ Czy chcesz go zastąpić?</target>
         <target state="translated">Parametr „{0}” ma wartość „{1}”, która nie należy do zakresu prawidłowych wartości od „{2}” do „{3}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Nie można ustawić właściwości SandboxExternalContent na true w częściowej relacji zaufania.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Nie można przejść do podanej pozycji.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -4818,11 +4818,6 @@ Deseja substituí-lo?</target>
         <target state="translated">O parâmetro '{0}' tem o valor '{1}', que não está no intervalo válido de '{2}' a '{3}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Não é possível definir SandboxExternalContent como verdadeiro em confiança parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Não é possível buscar até determinada posição.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -2413,11 +2413,6 @@ Deseja substituí-lo?</target>
         <target state="translated">O tipo '{0}' não é um tipo PageFunction válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Valor de Point inválido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.pt-BR.xlf
@@ -2413,11 +2413,6 @@ Deseja substituí-lo?</target>
         <target state="translated">O tipo '{0}' não é um tipo PageFunction válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">O valor de PermissionState '{0}' não é válido para esta Permissão.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">Тип "{0}" не является действительным типом PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Значение PermissionState "{0}" недопустимо для данного разрешения.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">Тип "{0}" не является действительным типом PageFunction.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Недопустимое значение Point.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.ru.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">Параметр "{0}" имеет значение "{1}", лежащее вне допустимого диапазона от "{2}" до "{3}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Не удается задать значение "true" для SandboxExternalContent при частично доверительных отношениях.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Не удается выполнить поиск заданной позиции.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -2413,11 +2413,6 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">'{0}' türü geçerli bir PageFunction türü değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">Geçersiz Point değeri.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -4818,11 +4818,6 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">'{0}' parametresi '{2}' - '{3}' geçerli aralığı dışında kalan '{1}' değerine sahip.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Kısmi güvende SandboxExternalContent true olarak ayarlanamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">Verilen konumda aranamıyor.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.tr.xlf
@@ -2413,11 +2413,6 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">'{0}' türü geçerli bir PageFunction türü değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">'{0}' PermissionState değeri bu İzin için geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">类型“{0}”不是有效的 PageFunction 类型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值“{0}”对于此 Permission 无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">权限类型无效。应为“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">类型“{0}”不是有效的 PageFunction 类型。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">权限类型无效。应为“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">无效的 Point 值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hans.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">“{0}”参数具有值“{1}”，该值不在“{2}”至“{3}”的有效范围内。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">无法在部分信任中将 SandboxExternalContent 设置为 true。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">无法找到给定位置。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">型別 '{0}' 不是有效的 PageFunction 型別。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值 '{0}' 對此權限無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">使用權限類型無效。應該是 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -4818,11 +4818,6 @@ Do you want to replace it?</source>
         <target state="translated">'{0}' 參數的值為 '{1}'，其不在 '{2}' 到 '{3}' 的有效範圍內。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">在部分信任的情況下，無法將 SandboxExternalContent 設定為 True。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SeekFailed">
         <source>Cannot seek to given position.</source>
         <target state="translated">無法搜尋至指定位置。</target>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/Resources/xlf/Strings.zh-Hant.xlf
@@ -2413,11 +2413,6 @@ Do you want to replace it?</source>
         <target state="translated">型別 '{0}' 不是有效的 PageFunction 型別。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">使用權限類型無效。應該是 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPoint">
         <source>Invalid Point value.</source>
         <target state="translated">無效的 Point 值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -352,7 +352,6 @@ ExpectedQualifiedTypeName=Type name '{0}' is not assembly-qualified. You can obt
 ExpectedQualifiedAssemblyName=Assembly name '{0}' is not fully qualified. The Name, Version, Culture, and PublicKeyToken must all be provided.
 
 ; XamlLoadPermission
-SecurityXmlUnexpectedTag=Invalid security XML. Unexpected tag '{0}', expected '{1}'.
 SecurityXmlUnexpectedValue=Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.
 SecurityXmlMissingAttribute=Invalid security XML. Missing expected attribute '{0}'.
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -351,9 +351,6 @@ ShouldOverrideMethod=Method '{0}' is not supported by default. It can be impleme
 ExpectedQualifiedTypeName=Type name '{0}' is not assembly-qualified. You can obtain this value from System.Type.AssemblyQualifiedName.
 ExpectedQualifiedAssemblyName=Assembly name '{0}' is not fully qualified. The Name, Version, Culture, and PublicKeyToken must all be provided.
 
-; XamlLoadPermission
-SecurityXmlMissingAttribute=Invalid security XML. Missing expected attribute '{0}'.
-
 ; XamlServices
 StringIsNullOrEmpty=The string is null or empty.
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -352,7 +352,6 @@ ExpectedQualifiedTypeName=Type name '{0}' is not assembly-qualified. You can obt
 ExpectedQualifiedAssemblyName=Assembly name '{0}' is not fully qualified. The Name, Version, Culture, and PublicKeyToken must all be provided.
 
 ; XamlLoadPermission
-SecurityXmlUnexpectedValue=Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.
 SecurityXmlMissingAttribute=Invalid security XML. Missing expected attribute '{0}'.
 
 ; XamlServices

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -352,7 +352,6 @@ ExpectedQualifiedTypeName=Type name '{0}' is not assembly-qualified. You can obt
 ExpectedQualifiedAssemblyName=Assembly name '{0}' is not fully qualified. The Name, Version, Culture, and PublicKeyToken must all be provided.
 
 ; XamlLoadPermission
-ExpectedLoadPermission=Expected permission of type XamlLoadPermission.
 SecurityXmlUnexpectedTag=Invalid security XML. Unexpected tag '{0}', expected '{1}'.
 SecurityXmlUnexpectedValue=Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.
 SecurityXmlMissingAttribute=Invalid security XML. Missing expected attribute '{0}'.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -372,9 +372,6 @@
   <data name="ExpandPositionalParametersinTypeWithNoDefaultConstructor" space_="preserve">
     <value>Cannot write positional parameters in the current state.  The writer cannot write the positional parameters in attribute form because the writer has started to write elements, nor can the writer expand the positional parameters due to the lack of a default constructor on the markup extension that contains the positional parameters.  Try moving the positional parameter member earlier in the node stream, to a place where XamlXmlWriter can still write attributes.</value>
   </data>
-  <data name="ExpectedLoadPermission" space_="preserve">
-    <value>Expected permission of type XamlLoadPermission.</value>
-  </data>
   <data name="ExpectedObjectMarkupInfo" space_="preserve">
     <value>Expected value of type ObjectMarkupInfo.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -801,9 +801,6 @@
   <data name="SecurityXmlMissingAttribute" space_="preserve">
     <value>Invalid security XML. Missing expected attribute '{0}'.</value>
   </data>
-  <data name="SecurityXmlUnexpectedValue" space_="preserve">
-    <value>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</value>
-  </data>
   <data name="ServiceTypeAlreadyAdded" space_="preserve">
     <value>This serviceType is already registered to another service.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -450,9 +450,6 @@
   <data name="InvalidExpression" space_="preserve">
     <value>Invalid expression: '{0}'</value>
   </data>
-  <data name="InvalidPermissionStateValue" space_="preserve">
-    <value>PermissionState value '{0}' is not valid for this Permission.</value>
-  </data>
   <data name="InvalidPermissionType" space_="preserve">
     <value>Permission type is not valid. Expected '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -789,9 +789,6 @@
   <data name="SchemaContextNull" space_="preserve">
     <value>SchemaContext cannot be null.</value>
   </data>
-  <data name="SecurityExceptionForSettingSandboxExternalToTrue" space_="preserve">
-    <value>Cannot set SandboxExternalContent to true in partial trust.</value>
-  </data>
   <data name="ServiceTypeAlreadyAdded" space_="preserve">
     <value>This serviceType is already registered to another service.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -450,9 +450,6 @@
   <data name="InvalidExpression" space_="preserve">
     <value>Invalid expression: '{0}'</value>
   </data>
-  <data name="InvalidPermissionType" space_="preserve">
-    <value>Permission type is not valid. Expected '{0}'.</value>
-  </data>
   <data name="InvalidTypeArgument" space_="preserve">
     <value>Type argument '{0}' is not a valid type.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -801,9 +801,6 @@
   <data name="SecurityXmlMissingAttribute" space_="preserve">
     <value>Invalid security XML. Missing expected attribute '{0}'.</value>
   </data>
-  <data name="SecurityXmlUnexpectedTag" space_="preserve">
-    <value>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</value>
-  </data>
   <data name="SecurityXmlUnexpectedValue" space_="preserve">
     <value>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -798,9 +798,6 @@
   <data name="SecurityExceptionForSettingSandboxExternalToTrue" space_="preserve">
     <value>Cannot set SandboxExternalContent to true in partial trust.</value>
   </data>
-  <data name="SecurityXmlMissingAttribute" space_="preserve">
-    <value>Invalid security XML. Missing expected attribute '{0}'.</value>
-  </data>
   <data name="ServiceTypeAlreadyAdded" space_="preserve">
     <value>This serviceType is already registered to another service.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Neplatný výraz: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Hodnota PermissionState {0} není pro toto oprávnění platná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -427,11 +427,6 @@
         <target state="translated">V aktuálním stavu nelze zapsat poziční parametry. Modul pro zápis nemůže zapsat poziční parametry do formuláře atributů, protože modul pro zápis začal zapisovat elementy, a nemůže ani rozbalit poziční atributy z důvodu chybějícího výchozího konstruktoru pro rozšíření značek, které obsahuje tyto poziční parametry. Zkuste přesunout člena pozičních parametrů více dopředu v datovém proudu uzlu na místo, kde modul XamlXmlWriter ještě může zapisovat atributy.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Bylo očekáváno oprávnění typu XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Byla očekávána hodnota typu ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Vlastnost SandboxExternalContent nelze nastavit na hodnotu true v částečném vztahu důvěryhodnosti.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">Neplatné zabezpečení XML. Chybí očekávaný atribut {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Tento objekt serviceType je již registrován u jiné služby.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Neplatné zabezpečení XML. Chybí očekávaný atribut {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">Neplatné zabezpečení XML. Neočekávaná hodnota {0} v atributu {1}, byla očekávána hodnota {2}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Tento objekt serviceType je již registrován u jiné služby.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">Hodnota SchemaContext nesmí být Null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Vlastnost SandboxExternalContent nelze nastavit na hodnotu true v částečném vztahu důvěryhodnosti.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Tento objekt serviceType je již registrován u jiné služby.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Neplatné zabezpečení XML. Chybí očekávaný atribut {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">Neplatné zabezpečení XML. Neočekávaná značka {0}, byla očekávána značka {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">Neplatné zabezpečení XML. Neočekávaná hodnota {0} v atributu {1}, byla očekávána hodnota {2}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Neplatný výraz: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">Argument typu {0} nemá platný typ.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">SandboxExternalContent kann bei Verwendung mit teilweiser Vertrauenswürdigkeit nicht auf "true" festgelegt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">Ungültiges Sicherheits-XML. Das erwartete Attribut "{0}" ist nicht vorhanden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Dieses serviceType-Element ist bereits für einen anderen Dienst registriert.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Ungültiger Ausdruck: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">Das Typargument "{0}" ist kein gültiger Typ.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext darf nicht NULL sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">SandboxExternalContent kann bei Verwendung mit teilweiser Vertrauenswürdigkeit nicht auf "true" festgelegt werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Dieses serviceType-Element ist bereits für einen anderen Dienst registriert.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Ungültiger Ausdruck: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Der PermissionState-Wert "{0}" ist für diese Berechtigung nicht gültig.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Ungültiges Sicherheits-XML. Das erwartete Attribut "{0}" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">Ungültiges Sicherheits-XML. Unerwarteter Wert "{0}" in Attribut "{1}", erwartet wurde "{2}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Dieses serviceType-Element ist bereits für einen anderen Dienst registriert.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Im aktuellen Zustand können keine Positionsparameter geschrieben werden. Die Positionsparameter können nicht in Attributform geschrieben werden, da vom Writer mit dem Schreiben von Elementen begonnen wurde, und die Positionsparameter können aufgrund eines fehlenden Standardkonstruktors in der Markuperweiterung, die die Positionsparameter enthält, nicht erweitert werden. Verschieben Sie den Positionsparametermember im Knotenstream weiter nach vorne an eine Position, an der von XamlXmlWriter nach wie vor Attribute geschrieben werden können.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Es wurde eine Berechtigung vom Typ "XamlLoadPermission" erwartet.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Es wurde ein Wert vom Typ "ObjectMarkupInfo" erwartet.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Ungültiges Sicherheits-XML. Das erwartete Attribut "{0}" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">Ungültiges Sicherheits-XML. Unerwartetes Tag "{0}", erwartet wurde "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">Ungültiges Sicherheits-XML. Unerwarteter Wert "{0}" in Attribut "{1}", erwartet wurde "{2}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expresión no válida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">El valor de PermissionState '{0}' no es válido para este permiso.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expresión no válida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">El argumento de tipo '{0}' no es un tipo válido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">No se puede establecer SandboxExternalContent en verdadero en una confianza parcial.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">XML de seguridad no válido. Falta el atributo esperado '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Este serviceType está ya registrado en otro servicio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de seguridad no válido. Falta el atributo esperado '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">XML de seguridad no válido. Valor '{0}' no esperado en el atributo '{1}'; se esperaba '{2}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Este serviceType está ya registrado en otro servicio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -427,11 +427,6 @@
         <target state="translated">No se pueden escribir parámetros posicionales en el estado actual. El escritor no puede escribir los parámetros posicionales en forma de atributo porque ha comenzado a escribir elementos, y tampoco puede expandir los parámetros posicionales debido a la falta de un constructor predeterminado en la extensión de marcado que contiene los parámetros posicionales. Intente mover el miembro de parámetros posicionales a una posición anterior en el flujo del nodo donde XamlXmlWriter pueda escribir aún atributos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Se espera el permiso de tipo XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Se espera un valor de tipo ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de seguridad no válido. Falta el atributo esperado '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">XML de seguridad no válido. Etiqueta '{0}' no esperada; se esperaba '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">XML de seguridad no válido. Valor '{0}' no esperado en el atributo '{1}'; se esperaba '{2}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext no puede ser NULL.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">No se puede establecer SandboxExternalContent en verdadero en una confianza parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Este serviceType está ya registrado en otro servicio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expression non valide : '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">L'argument de type '{0}' n'est pas un type valide.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Impossible d'écrire des paramètres positionnels dans l'état actuel. L'enregistreur ne peut pas écrire les paramètres positionnels sous forme d'attribut, car il a commencé à écrire des éléments. L'enregistreur ne peut pas non plus développer les paramètres positionnels en raison de l'absence d'un constructeur par défaut sur l'extension de balisage qui contient les paramètres positionnels. Essayez de déplacer le membre de paramètre positionnel plus haut dans le flux de nœud, à un endroit où XamlXmlWriter peut encore écrire des attributs.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Autorisation attendue de type XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Valeur attendue de type ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de sécurité non valide. Attribut attendu manquant '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">XML de sécurité non valide. Balise '{0}' inattendue, '{1}' attendu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">XML de sécurité non valide. Valeur '{0}' inattendue dans l'attribut '{1}', '{2}' attendu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Impossible d'affecter à SandboxExternalContent la valeur true en situation de confiance partielle.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">XML de sécurité non valide. Attribut attendu manquant '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ce serviceType est déjà inscrit sur un autre service.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext ne peut pas être null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossible d'affecter à SandboxExternalContent la valeur true en situation de confiance partielle.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ce serviceType est déjà inscrit sur un autre service.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expression non valide : '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valeur de PermissionState '{0}' non valide pour cette autorisation.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de sécurité non valide. Attribut attendu manquant '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">XML de sécurité non valide. Valeur '{0}' inattendue dans l'attribut '{1}', '{2}' attendu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ce serviceType est déjà inscrit sur un autre service.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Espressione non valida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">L'argomento di tipo '{0}' non è un tipo valido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML di sicurezza non valido. Attributo previsto '{0}' mancante.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">XML di sicurezza non valido. Tag imprevisto '{0}', previsto '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">XML di sicurezza non valido. Valore imprevisto '{0}' nell'attributo '{1}', previsto '{2}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Impossibile impostare SandboxExternalContent su true in condizioni di attendibilità parziale.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">XML di sicurezza non valido. Attributo previsto '{0}' mancante.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Questo serviceType è già registrato in un altro servizio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Impossibile scrivere parametri posizionali nello stato corrente. Il writer non può scrivere i parametri posizionali in forma di attributo perché è già stata avviata la scrittura di elementi, né espandere i parametri posizionali a causa della mancanza di un costruttore predefinito sull'estensione di markup contenente i parametri posizionali. Provare a spostare il membro del parametro posizionale in una posizione precedente nel flusso del nodo dove XamlXmlWriter è ancora in grado di scrivere attributi.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Prevista autorizzazione di tipo XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Previsto valore di tipo ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Espressione non valida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valore PermissionState '{0}' non valido per l'autorizzazione corrente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML di sicurezza non valido. Attributo previsto '{0}' mancante.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">XML di sicurezza non valido. Valore imprevisto '{0}' nell'attributo '{1}', previsto '{2}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Questo serviceType è già registrato in un altro servizio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext non può essere null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Impossibile impostare SandboxExternalContent su true in condizioni di attendibilità parziale.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Questo serviceType è già registrato in un altro servizio.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -557,11 +557,6 @@
         <target state="translated">無効な式: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 値 '{0}' は、このアクセス許可に対して無効です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -557,11 +557,6 @@
         <target state="translated">無効な式: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">型引数 '{0}' は有効な型ではありません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">部分的な信頼では、SandboxExternalContent を true に設定できません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">無効なセキュリティ XML です。必要な属性 '{0}' がありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">この serviceType は、既に別のサービスに登録されています。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -427,11 +427,6 @@
         <target state="translated">現在の状態では位置指定パラメーターを出力できません。ライターは要素の出力を開始しているため、属性形式の位置指定パラメーターを書き出すことはできません。また、位置指定パラメーターを含むマークアップ拡張に既定のコンストラクターがないため、位置指定パラメーターを展開することもできません。位置指定パラメーター メンバーをノード ストリームの前の方へ移動して、XamlXmlWriter が属性を出力できる位置に配置してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">XamlLoadPermission 型のアクセス許可が必要です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">ObjectMarkupInfo 型の値が必要です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">無効なセキュリティ XML です。必要な属性 '{0}' がありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">無効なセキュリティ XML です。属性 '{1}' に予期しない値 '{0}' があります。'{2}' が必要です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">この serviceType は、既に別のサービスに登録されています。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext を null にすることはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">部分的な信頼では、SandboxExternalContent を true に設定できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">この serviceType は、既に別のサービスに登録されています。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">無効なセキュリティ XML です。必要な属性 '{0}' がありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">無効なセキュリティ XML です。タグ '{0}' は予期されていません。'{1}' が必要です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">無効なセキュリティ XML です。属性 '{1}' に予期しない値 '{0}' があります。'{2}' が必要です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">보안 XML이 잘못되었습니다. 필요한 특성 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">보안 XML이 잘못되었습니다. 예기치 못한 '{0}' 태그입니다. '{1}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">보안 XML이 잘못되었습니다. '{1}' 특성에 예기치 못한 '{0}' 값이 있습니다. '{2}'이(가) 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -427,11 +427,6 @@
         <target state="translated">현재 상태에서 위치 매개 변수를 쓸 수 없습니다. 작성기가 요소를 쓰기 시작했기 때문에 특성 형식으로 위치 매개 변수를 쓰지 못할 뿐 아니라 위치 매개 변수를 포함하는 태그 확장에서 기본 생성자가 없기 때문에 작성기가 위치 매개 변수를 확장할 수도 없습니다. 노드 스트림의 초반에 XamlXmlWriter가 특성을 쓸 수 있는 위치로 위치 매개 변수 멤버를 이동해 보십시오.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">XamlLoadPermission 형식의 권한이 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">ObjectMarkupInfo 형식의 값이 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -557,11 +557,6 @@
         <target state="translated">'{0}' 식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">형식 인수 {0}이(가) 올바른 형식이 아닙니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">부분 신뢰에서 SandboxExternalContent를 true로 설정할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">보안 XML이 잘못되었습니다. 필요한 특성 '{0}'이(가) 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">이 serviceType이 다른 서비스에 이미 등록되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -557,11 +557,6 @@
         <target state="translated">'{0}' 식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 값 '{0}'은(는) 이 권한에 대해 올바르지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext는 null일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">부분 신뢰에서 SandboxExternalContent를 true로 설정할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">이 serviceType이 다른 서비스에 이미 등록되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">보안 XML이 잘못되었습니다. 필요한 특성 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">보안 XML이 잘못되었습니다. '{1}' 특성에 예기치 못한 '{0}' 값이 있습니다. '{2}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">이 serviceType이 다른 서비스에 이미 등록되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Brak oczekiwanego atrybutu „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Nieoczekiwany tag „{0}”, oczekiwano tagu „{1}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Nieoczekiwana wartość „{0}” w atrybucie „{1}”, oczekiwano wartości „{2}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Nieprawidłowe wyrażenie: „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">Argument typu „{0}” nie jest prawidłowym typem.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Nie można zapisać parametrów pozycyjnych w bieżącym stanie. Moduł zapisujący nie może zapisać parametrów pozycyjnych w formie atrybutu, ponieważ został uruchomiony w trybie zapisywania elementów, i nie może rozwinąć parametrów pozycyjnych z powodu braku domyślnego konstruktora w rozszerzeniu znacznika, które zawiera parametry pozycyjne. Spróbuj przenieść element członkowski parametrów pozycyjnych do miejsca znajdującego się wcześniej w strumieniu węzłów, takiego, w którym obiekt XamlXmlWriter będzie mógł nadal zapisywać atrybuty.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Oczekiwano uprawnienia typu XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Oczekiwano wartości typu ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Brak oczekiwanego atrybutu „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Nieoczekiwana wartość „{0}” w atrybucie „{1}”, oczekiwano wartości „{2}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ten typ serviceType jest już zarejestrowany przez inną usługę.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Nieprawidłowe wyrażenie: „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Wartość PermissionState „{0}” jest nieprawidłowa dla tego uprawnienia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Nie można ustawić właściwości SandboxExternalContent na true w częściowej relacji zaufania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">Nieprawidłowy kod XML zabezpieczeń. Brak oczekiwanego atrybutu „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ten typ serviceType jest już zarejestrowany przez inną usługę.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">Właściwość SchemaContext nie może mieć wartości null.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Nie można ustawić właściwości SandboxExternalContent na true w częściowej relacji zaufania.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Ten typ serviceType jest już zarejestrowany przez inną usługę.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de segurança inválido. Atributo esperado ausente '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">XML de segurança inválido. Marca '{0}' inesperada; esperava-se '{1}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">XML de segurança inválido. Valor '{0}' inesperado no atributo '{1}', esperava-se '{2}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Não é possível definir SandboxExternalContent como verdadeiro em confiança parcial.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">XML de segurança inválido. Atributo esperado ausente '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">O serviceType já está registrado em outro serviço.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext não pode ser nulo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Não é possível definir SandboxExternalContent como verdadeiro em confiança parcial.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">O serviceType já está registrado em outro serviço.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expressão inválida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">O valor de PermissionState '{0}' não é válido para esta Permissão.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">O tipo de permissão não é válido. '{0}' esperado.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Expressão inválida: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">O tipo de permissão não é válido. '{0}' esperado.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">O argumento de tipo '{0}' não é um tipo válido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">XML de segurança inválido. Atributo esperado ausente '{0}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">XML de segurança inválido. Valor '{0}' inesperado no atributo '{1}', esperava-se '{2}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">O serviceType já está registrado em outro serviço.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Não é possível gravar parâmetros posicionais no estado atual. O gravador não pode gravar os parâmetros posicionais na forma de atributo, pois começou a gravar elementos; ele também não pode expandir os parâmetros posicionais devido à ausência de um construtor padrão na extensão de marcação que contém os parâmetros. Tente mover o associado de parâmetro posicional para uma posição anterior no fluxo do nó, para um local em que XamlXmlWriter ainda possa gravar atributos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Esperada permissão do tipo XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Esperado valor do tipo ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Недопустимое выражение: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">Аргумент типа "{0}" не является допустимым.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Недействительный XML безопасности. Отсутствует обязательный атрибут "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">Недействительный XML безопасности. Непредвиденное значение "{0}" в атрибуте "{1}"; требуется "{2}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Этот тип serviceType уже зарегистрирован для другой службы.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">Свойство SchemaContext не может быть неопределенным (null).</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Не удается задать значение "true" для SandboxExternalContent при частично доверительных отношениях.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Этот тип serviceType уже зарегистрирован для другой службы.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Недопустимое выражение: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Значение PermissionState "{0}" недопустимо для данного разрешения.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Не удается записать позиционные параметры в текущем состоянии.  Запись позиционных параметров в форме атрибутов невозможна, поскольку объект записи уже начал записывать элементы, либо он не может развернуть позиционные параметры из-за отсутствия конструктора по умолчанию в расширении разметки, содержащем позиционные параметры.  Попробуйте переместить член позиционного параметра ближе к началу потока узлов туда, где XamlXmlWriter все еще записывает атрибуты.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Ожидалось разрешение типа XamlLoadPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">Ожидалось значение типа ObjectMarkupInfo.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Недействительный XML безопасности. Отсутствует обязательный атрибут "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">Недействительный XML безопасности. Непредвиденный тег "{0}"; требуется "{1}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">Недействительный XML безопасности. Непредвиденное значение "{0}" в атрибуте "{1}"; требуется "{2}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Не удается задать значение "true" для SandboxExternalContent при частично доверительных отношениях.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">Недействительный XML безопасности. Отсутствует обязательный атрибут "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Этот тип serviceType уже зарегистрирован для другой службы.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Geçersiz güvenlik XML'si. Beklenen '{0}' özniteliği eksik.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">Geçersiz güvenlik XML'si. '{1}' özniteliğinde '{0}' değeri beklenmiyordu; '{2}' bekleniyordu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Bu serviceType başka bir hizmete zaten kaydedildi.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Geçersiz ifade: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">'{0}' PermissionState değeri bu İzin için geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">İzin türü geçerli değil. Beklenen: '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -557,11 +557,6 @@
         <target state="translated">Geçersiz ifade: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">İzin türü geçerli değil. Beklenen: '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">'{0}' tür bağımsız değişkeni geçerli bir tür değil.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext null olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">Kısmi güvende SandboxExternalContent true olarak ayarlanamaz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Bu serviceType başka bir hizmete zaten kaydedildi.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -427,11 +427,6 @@
         <target state="translated">Geçerli durumda konum parametreleri yazılamıyor. Yazıcı öznitelik formuna konum parametrelerini yazamıyor çünkü yazıcı öğeleri yazmaya başladı ancak konum parametrelerini içeren işaretleme uzantısında varsayılan oluşturucunun bulunmaması nedeniyle yazıcı konum parametrelerini genişletemedi. Konum parametresi üyesini düğüm akışında XamlXmlWriter'ın hala öznitelikleri yazabildiği önceki bir yere taşımayı deneyin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">Beklenen XamlLoadPermission türündeki izin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">ObjectMarkupInfo türünün beklenen değeri.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">Geçersiz güvenlik XML'si. Beklenen '{0}' özniteliği eksik.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">Geçersiz güvenlik XML'si. '{0}' etiketi beklenmiyordu; '{1}' bekleniyordu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">Geçersiz güvenlik XML'si. '{1}' özniteliğinde '{0}' değeri beklenmiyordu; '{2}' bekleniyordu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">Kısmi güvende SandboxExternalContent true olarak ayarlanamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">Geçersiz güvenlik XML'si. Beklenen '{0}' özniteliği eksik.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">Bu serviceType başka bir hizmete zaten kaydedildi.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">无法在部分信任中将 SandboxExternalContent 设置为 true。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">安全 XML 无效。缺少要求的特性“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已注册到其他服务。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -557,11 +557,6 @@
         <target state="translated">无效的表达式:“{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">权限类型无效。应为“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">类型参数“{0}”不是有效的类型。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">安全 XML 无效。缺少要求的特性“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">安全 XML 无效。意外标记“{0}”，应为“{1}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">安全 XML 无效。特性“{1}”中的意外值“{0}”，应为“{2}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -557,11 +557,6 @@
         <target state="translated">无效的表达式:“{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值“{0}”对于此 Permission 无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">权限类型无效。应为“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">安全 XML 无效。缺少要求的特性“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">安全 XML 无效。特性“{1}”中的意外值“{0}”，应为“{2}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已注册到其他服务。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext 不能为 null。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">无法在部分信任中将 SandboxExternalContent 设置为 true。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已注册到其他服务。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -427,11 +427,6 @@
         <target state="translated">无法在当前状态下写入位置参数。编写器无法以特性的形式写入位置参数，因为编写器是为写入元素而启动的；编写器也无法展开位置参数，原因是包含位置参数的标记扩展中缺少默认构造函数。尝试在节点流中向前移动位置参数成员，将其放置在 XamlXmlWriter 仍可以写入特性的位置。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">类型 XamlLoadPermission 的预期权限。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">类型 ObjectMarkupInfo 的预期值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">無效的安全性 XML。遺漏所需的屬性 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedValue">
-        <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
-        <target state="translated">無效的安全性 XML。屬性 '{1}' 中有未預期的值 '{0}'，應該是 '{2}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已在其他服務登錄。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -557,11 +557,6 @@
         <target state="translated">無效的運算式: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">使用權限類型無效。應該是 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidTypeArgument">
         <source>Type argument '{0}' is not a valid type.</source>
         <target state="translated">型別引數 '{0}' 不是有效的型別。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1142,11 +1142,6 @@
         <target state="translated">無效的安全性 XML。遺漏所需的屬性 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlUnexpectedTag">
-        <source>Invalid security XML. Unexpected tag '{0}', expected '{1}'.</source>
-        <target state="translated">無效的安全性 XML。未預期的標記 '{0}'，應該是 '{1}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SecurityXmlUnexpectedValue">
         <source>Invalid security XML. Unexpected value '{0}' in attribute '{1}', expected '{2}'.</source>
         <target state="translated">無效的安全性 XML。屬性 '{1}' 中有未預期的值 '{0}'，應該是 '{2}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -427,11 +427,6 @@
         <target state="translated">無法寫入處於目前狀態的位置參數。寫入器無法以屬性形式寫入位置參數，因為寫入器已開始寫入項目，而且寫入器也無法展開此位置參數，因為包含此位置參數的標記延伸上沒有預設建構函式。請嘗試將先前節點資料流中的位置參數成員，移到 XamlXmlWriter 仍然可以寫入屬性的地方。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ExpectedLoadPermission">
-        <source>Expected permission of type XamlLoadPermission.</source>
-        <target state="translated">必須是 XamlLoadPermission 類型的權限。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ExpectedObjectMarkupInfo">
         <source>Expected value of type ObjectMarkupInfo.</source>
         <target state="translated">必須是型別 ObjectMarkupInfo 的值。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -557,11 +557,6 @@
         <target state="translated">無效的運算式: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值 '{0}' 對此權限無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">使用權限類型無效。應該是 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1122,11 +1122,6 @@
         <target state="translated">SchemaContext 不可為 null。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityExceptionForSettingSandboxExternalToTrue">
-        <source>Cannot set SandboxExternalContent to true in partial trust.</source>
-        <target state="translated">在部分信任的情況下，無法將 SandboxExternalContent 設定為 True。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已在其他服務登錄。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -1137,11 +1137,6 @@
         <target state="translated">在部分信任的情況下，無法將 SandboxExternalContent 設定為 True。</target>
         <note />
       </trans-unit>
-      <trans-unit id="SecurityXmlMissingAttribute">
-        <source>Invalid security XML. Missing expected attribute '{0}'.</source>
-        <target state="translated">無效的安全性 XML。遺漏所需的屬性 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ServiceTypeAlreadyAdded">
         <source>This serviceType is already registered to another service.</source>
         <target state="translated">此 serviceType 已在其他服務登錄。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1542,9 +1542,6 @@
   <data name="InvalidPermissionState" xml:space="preserve">
     <value>Permission state is not valid.</value>
   </data>
-  <data name="TargetNotMediaPermissionLevel" xml:space="preserve">
-    <value>Target is not a MediaPermission.</value>
-  </data>
   <data name="BadXml" xml:space="preserve">
     <value>'{0}' attribute is not valid XML.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1746,9 +1746,6 @@
   <data name="Enumerator_VerifyContext" xml:space="preserve">
     <value>No current object to return.</value>
   </data>
-  <data name="InvalidPermissionType" xml:space="preserve">
-    <value>Permission type is not valid. Expected '{0}'.</value>
-  </data>
   <data name="StringEmpty" xml:space="preserve">
     <value>Parameter cannot be a zero-length string.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1545,9 +1545,6 @@
   <data name="BadXml" xml:space="preserve">
     <value>'{0}' attribute is not valid XML.</value>
   </data>
-  <data name="InvalidPermissionLevel" xml:space="preserve">
-    <value>Permission level is not valid.</value>
-  </data>
   <data name="XCRChoiceOnlyInAC" xml:space="preserve">
     <value>Choice is valid only in AlternateContent.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1539,9 +1539,6 @@
   <data name="ReachOutOfRange" xml:space="preserve">
     <value>'{0}' index is beyond maximum '{1}'.</value>
   </data>
-  <data name="InvalidPermissionState" xml:space="preserve">
-    <value>Permission state is not valid.</value>
-  </data>
   <data name="BadXml" xml:space="preserve">
     <value>'{0}' attribute is not valid XML.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1746,9 +1746,6 @@
   <data name="Enumerator_VerifyContext" xml:space="preserve">
     <value>No current object to return.</value>
   </data>
-  <data name="InvalidPermissionStateValue" xml:space="preserve">
-    <value>PermissionState value '{0}' is not valid for this Permission.</value>
-  </data>
   <data name="InvalidPermissionType" xml:space="preserve">
     <value>Permission type is not valid. Expected '{0}'.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/Strings.resx
@@ -1542,9 +1542,6 @@
   <data name="InvalidPermissionState" xml:space="preserve">
     <value>Permission state is not valid.</value>
   </data>
-  <data name="TargetNotWebBrowserPermissionLevel" xml:space="preserve">
-    <value>Target is not a WebBrowserPermission.</value>
-  </data>
   <data name="TargetNotMediaPermissionLevel" xml:space="preserve">
     <value>Target is not a MediaPermission.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Identifikátor URI součásti není platný podle pravidel definovaných ve specifikaci Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Stav oprávnění je neplatný.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Zadané priorita není platná.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">Cíl není MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">Cíl není WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Vlákno nemůže čekat na operace, které jsou už spuštěné ve stejném vlákně.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Stav oprávnění je neplatný.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Hodnota PermissionState {0} není pro toto oprávnění platná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Identifikátor URI součásti není platný podle pravidel definovaných ve specifikaci Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Úroveň oprávnění je neplatná.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Stav oprávnění je neplatný.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Parametr nemůže být řetězec o nulové délce.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">Cíl není MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Vlákno nemůže čekat na operace, které jsou už spuštěné ve stejném vlákně.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.cs.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Stav oprávnění je neplatný.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Typ oprávnění je neplatný. Očekávaný typ je {0}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Zadané priorita není platná.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Teil-URI ist gemäß den in den Open Packaging-Konventionen definierten Regeln ungültig.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Ungültiger Berechtigungszustand.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Die angegebene Priorität ist ungültig.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Ungültiger Berechtigungszustand.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Die angegebene Priorität ist ungültig.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">Das Ziel ist kein MediaPermission-Objekt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">Das Ziel ist kein WebBrowserPermission-Objekt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Ein Thread kann nicht auf Vorgänge warten, die bereits im gleichen Thread ausgeführt werden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Der Parameter darf keine Zeichenfolge mit der Länge Null sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">Das Ziel ist kein MediaPermission-Objekt.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Ein Thread kann nicht auf Vorgänge warten, die bereits im gleichen Thread ausgeführt werden.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Teil-URI ist gemäß den in den Open Packaging-Konventionen definierten Regeln ungültig.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Ungültige Berechtigungsebene.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Ungültiger Berechtigungszustand.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.de.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Ungültiger Berechtigungszustand.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Der PermissionState-Wert "{0}" ist für diese Berechtigung nicht gültig.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Ungültiger Berechtigungstyp. Erwartet wurde "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Estado de permiso no válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">La prioridad especificada no es válida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -827,11 +827,6 @@
         <target state="translated">El URI de la parte no es válido según las reglas definidas en la especificación de Convenciones de empaquetado abierto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Nivel de permiso no válido.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Estado de permiso no válido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Estado de permiso no válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">El valor de PermissionState '{0}' no es válido para este permiso.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">El tipo de permiso no es válido. Se esperaba '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -827,11 +827,6 @@
         <target state="translated">El URI de la parte no es válido según las reglas definidas en la especificación de Convenciones de empaquetado abierto.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Estado de permiso no válido.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">La prioridad especificada no es válida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">El destino no es un elemento MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">El destino no es un elemento WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un subproceso no puede esperar en las operaciones que ya se están ejecutando en el mismo subproceso.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.es.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">El parámetro no puede ser una cadena de longitud cero.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">El destino no es un elemento MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un subproceso no puede esperar en las operaciones que ya se están ejecutando en el mismo subproceso.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -827,11 +827,6 @@
         <target state="translated">L'URI du composant est non valide, conformément aux règles définies dans la spécification Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Niveau d'autorisation non valide.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">État d'autorisation non valide.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Le paramètre ne peut pas être une chaîne nulle.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">La cible n'est pas un MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un thread ne peut pas attendre sur des opérations déjà en cours d'exécution sur le même thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -827,11 +827,6 @@
         <target state="translated">L'URI du composant est non valide, conformément aux règles définies dans la spécification Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">État d'autorisation non valide.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Priorité spécifiée non valide.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -832,11 +832,6 @@
         <target state="translated">État d'autorisation non valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Priorité spécifiée non valide.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">La cible n'est pas un MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">La cible n'est pas un WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un thread ne peut pas attendre sur des opérations déjà en cours d'exécution sur le même thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.fr.xlf
@@ -832,11 +832,6 @@
         <target state="translated">État d'autorisation non valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valeur de PermissionState '{0}' non valide pour cette autorisation.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Type d'autorisation non valide. Type attendu '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Il parametro non può essere una stringa di lunghezza zero.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">La destinazione non è un elemento MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un thread non può mettersi in attesa per operazioni già in esecuzione sullo stesso thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -827,11 +827,6 @@
         <target state="translated">L'URI della parte non è valido in base alle regole definite nella specifica Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Stato di autorizzazione non valido</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">La priorità specificata non è valida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">La destinazione non è un elemento MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">La destinazione non è un elemento WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Un thread non può mettersi in attesa per operazioni già in esecuzione sullo stesso thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Stato di autorizzazione non valido</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">La priorità specificata non è valida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -827,11 +827,6 @@
         <target state="translated">L'URI della parte non è valido in base alle regole definite nella specifica Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Livello di autorizzazione non valido</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Stato di autorizzazione non valido</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.it.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Stato di autorizzazione non valido</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Valore PermissionState '{0}' non valido per l'autorizzazione corrente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Tipo di autorizzazione non valido. Previsto '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">パラメーターを長さゼロの文字列にすることはできません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">ターゲットは MediaPermission ではありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">スレッドは、同じスレッドで既に実行されている操作を待機することはできません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -827,11 +827,6 @@
         <target state="translated">パート URI は、Open Packaging Conventions 仕様で定義されたルールにより無効です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">アクセス許可の状態が有効ではありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定された優先順位は無効です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">ターゲットは MediaPermission ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">ターゲットは WebBrowserPermission ではありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">スレッドは、同じスレッドで既に実行されている操作を待機することはできません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -827,11 +827,6 @@
         <target state="translated">パート URI は、Open Packaging Conventions 仕様で定義されたルールにより無効です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">アクセス許可のレベルが有効ではありません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">アクセス許可の状態が有効ではありません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -832,11 +832,6 @@
         <target state="translated">アクセス許可の状態が有効ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定された優先順位は無効です。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ja.xlf
@@ -832,11 +832,6 @@
         <target state="translated">アクセス許可の状態が有効ではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 値 '{0}' は、このアクセス許可に対して無効です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">アクセス許可の種類が無効です。'{0}' を指定してください。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">매개 변수 문자열의 길이는 0일 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">대상이 MediaPermission이 아닙니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">스레드는 같은 스레드에서 이미 실행 중인 작업에 대해 대기할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Open Packaging Conventions 사양에 정의된 규칙을 기준으로 파트 URI가 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">권한 상태가 잘못되었습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">지정한 속성이 잘못되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">대상이 MediaPermission이 아닙니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">대상이 WebBrowserPermission이 아닙니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">스레드는 같은 스레드에서 이미 실행 중인 작업에 대해 대기할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -832,11 +832,6 @@
         <target state="translated">권한 상태가 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">지정한 속성이 잘못되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -832,11 +832,6 @@
         <target state="translated">권한 상태가 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 값 '{0}'은(는) 이 권한에 대해 올바르지 않습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">사용 권한 형식이 잘못되었습니다. '{0}'이(가) 필요합니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ko.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Open Packaging Conventions 사양에 정의된 규칙을 기준으로 파트 URI가 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">권한 수준이 잘못되었습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">권한 상태가 잘못되었습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Identyfikator URI części jest nieprawidłowy według specyfikacji otwartych konwencji pakietów.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Nieprawidłowy poziom uprawnień.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Nieprawidłowy stan uprawnień.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">Obiekt docelowy nie jest typu MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">Obiekt docelowy nie jest typu WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Wątek nie może czekać na operacje już uruchomione w tym samym wątku.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Nieprawidłowy stan uprawnień.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Wartość PermissionState „{0}” jest nieprawidłowa dla tego uprawnienia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Nieprawidłowy stan uprawnień.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Nieprawidłowy typ uprawnień. Oczekiwano „{0}”.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Określony priorytet jest nieprawidłowy.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Identyfikator URI części jest nieprawidłowy według specyfikacji otwartych konwencji pakietów.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Nieprawidłowy stan uprawnień.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Określony priorytet jest nieprawidłowy.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pl.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Parametr nie może być ciągiem o zerowej długości.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">Obiekt docelowy nie jest typu MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Wątek nie może czekać na operacje już uruchomione w tym samym wątku.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -827,11 +827,6 @@
         <target state="translated">O URI da parte não é válido de acordo com aas regras definidas na especificação Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Estado de permissão inválido.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">A prioridade especificada não é válida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">O destino não é uma MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">O destino não é uma WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Um thread não pode aguardar operações que já estão em execução no mesmo thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -827,11 +827,6 @@
         <target state="translated">O URI da parte não é válido de acordo com aas regras definidas na especificação Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Nível de permissão inválido.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Estado de permissão inválido.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Estado de permissão inválido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">A prioridade especificada não é válida.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Estado de permissão inválido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">O valor de PermissionState '{0}' não é válido para esta Permissão.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">O tipo de permissão não é válido. Era esperado '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.pt-BR.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">O parâmetro não pode ser uma cadeia de caracteres de comprimento zero.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">O destino não é uma MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Um thread não pode aguardar operações que já estão em execução no mesmo thread.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -827,11 +827,6 @@
         <target state="translated">URI части является недопустимым согласно правилам, определенным в спецификации Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">Отсутствуют соответствующие права доступа.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">Недопустимое состояние прав доступа.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">Конечный объект не является MediaPermission.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">Конечный объект не является WebBrowserPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Поток не может ожидать операции, которые уже выполняются в том же потоке.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Параметр не может представлять собой строку нулевой длины.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">Конечный объект не является MediaPermission.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Поток не может ожидать операции, которые уже выполняются в том же потоке.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Недопустимое состояние прав доступа.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">Значение PermissionState "{0}" недопустимо для данного разрешения.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -827,11 +827,6 @@
         <target state="translated">URI части является недопустимым согласно правилам, определенным в спецификации Open Packaging Conventions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">Недопустимое состояние прав доступа.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Указан недопустимый приоритет.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.ru.xlf
@@ -832,11 +832,6 @@
         <target state="translated">Недопустимое состояние прав доступа.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">Недопустимый тип разрешений. Требуется "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Указан недопустимый приоритет.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">Hedef bir MediaPermission değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">Hedef bir WebBrowserPermission değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Bir iş parçacığı aynı iş parçacığı üzerinde çalışmakta olan işlemlerde bekleyemez.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Bölüm URI'si Açık Paketleme Kuralları belirtiminde tanımlanan kurallara göre geçerli değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">İzin düzeyi geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">İzin durumu geçerli değil.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -827,11 +827,6 @@
         <target state="translated">Bölüm URI'si Açık Paketleme Kuralları belirtiminde tanımlanan kurallara göre geçerli değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">İzin durumu geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Belirtilen öncelik geçerli değil.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">Parametre sıfır uzunlukta bir dize olamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">Hedef bir MediaPermission değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">Bir iş parçacığı aynı iş parçacığı üzerinde çalışmakta olan işlemlerde bekleyemez.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -832,11 +832,6 @@
         <target state="translated">İzin durumu geçerli değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">'{0}' PermissionState değeri bu İzin için geçerli değil.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.tr.xlf
@@ -832,11 +832,6 @@
         <target state="translated">İzin durumu geçerli değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">İzin türü geçerli değil. Beklenen '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">Belirtilen öncelik geçerli değil.</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -832,11 +832,6 @@
         <target state="translated">权限状态无效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值“{0}”对于此 Permission 无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">权限类型无效。应为“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">参数不能为零长度的字符串。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">目标不是 MediaPermission。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">线程无法等待已在同一线程上运行的操作。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">目标不是 MediaPermission。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">目标不是 WebBrowserPermission。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">线程无法等待已在同一线程上运行的操作。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -827,11 +827,6 @@
         <target state="translated">根据开放打包约定规范中定义的规则，部分 URI 无效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">权限级别无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">权限状态无效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -827,11 +827,6 @@
         <target state="translated">根据开放打包约定规范中定义的规则，部分 URI 无效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">权限状态无效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定的优先级无效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hans.xlf
@@ -832,11 +832,6 @@
         <target state="translated">权限状态无效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">权限类型无效。应为“{0}”。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定的优先级无效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -827,11 +827,6 @@
         <target state="translated">根據開放式封裝慣例 (Open Packaging Convention) 規格中所定義的規則，組件 URI 無效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionLevel">
-        <source>Permission level is not valid.</source>
-        <target state="translated">使用權限等級無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionState">
         <source>Permission state is not valid.</source>
         <target state="translated">使用權限狀態無效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -2242,11 +2242,6 @@
         <target state="translated">參數不能是零長度字串。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotMediaPermissionLevel">
-        <source>Target is not a MediaPermission.</source>
-        <target state="translated">目標並非 MediaPermission。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">執行緒無法等待已在相同執行緒上執行的作業。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -827,11 +827,6 @@
         <target state="translated">根據開放式封裝慣例 (Open Packaging Convention) 規格中所定義的規則，組件 URI 無效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionState">
-        <source>Permission state is not valid.</source>
-        <target state="translated">使用權限狀態無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定的優先順序無效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -2247,11 +2247,6 @@
         <target state="translated">目標並非 MediaPermission。</target>
         <note />
       </trans-unit>
-      <trans-unit id="TargetNotWebBrowserPermissionLevel">
-        <source>Target is not a WebBrowserPermission.</source>
-        <target state="translated">目標並非 WebBrowserPermission。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ThreadMayNotWaitOnOperationsAlreadyExecutingOnTheSameThread">
         <source>A thread cannot wait on operations already running on the same thread.</source>
         <target state="translated">執行緒無法等待已在相同執行緒上執行的作業。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -832,11 +832,6 @@
         <target state="translated">使用權限狀態無效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionType">
-        <source>Permission type is not valid. Expected '{0}'.</source>
-        <target state="translated">使用權限類型無效。應該是 '{0}'。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPriority">
         <source>Specified priority is not valid.</source>
         <target state="translated">指定的優先順序無效。</target>

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/Resources/xlf/Strings.zh-Hant.xlf
@@ -832,11 +832,6 @@
         <target state="translated">使用權限狀態無效。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidPermissionStateValue">
-        <source>PermissionState value '{0}' is not valid for this Permission.</source>
-        <target state="translated">PermissionState 值 '{0}' 對此權限無效。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidPermissionType">
         <source>Permission type is not valid. Expected '{0}'.</source>
         <target state="translated">使用權限類型無效。應該是 '{0}'。</target>


### PR DESCRIPTION
Fixes #1668

## Description

Remove unused and obsolete CAS resource strings + translations from `WindowsBase`, `PresentationFramework`, `PresentationCore `and `System.Xaml`. This was long overdue since CAS removal and the types from `System.Security.Permissions` but never done. I've separated each one into separate commits.

`SecurityExceptionForSettingSandboxExternalToTrue` is from `SecurityHelper.ThrowExceptionIfSettingTrueInPartialTrust`, also a removed method part of CAS removal. This should cover the full issue description.

## Customer Impact

Decreased file size; cleaner resource strings for developers.

## Regression

No.

## Testing

Local build.

## Risk

Low.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9698)