### PR TITLE
Build changes to enable GenAPI in repo

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -50,7 +50,8 @@
   <PropertyGroup>
     <MicrosoftDotNetApiCompatVersion>9.0.0-beta.23621.2</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>9.0.0-beta.23621.2</MicrosoftDotNetCodeAnalysisPackageVersion>
-  </PropertyGroup>
+    <MicrosoftDotNetGenAPIVersion>9.0.0-beta.23621.2</MicrosoftDotNetGenAPIVersion>
+ </PropertyGroup>
   <!-- Sourcelink -->
   <PropertyGroup>
     <MicrosoftSourceLinkGitHubVersion>8.0.0-beta.23409.2</MicrosoftSourceLinkGitHubVersion>

--- a/eng/WpfArcadeSdk/tools/GenApi.props
+++ b/eng/WpfArcadeSdk/tools/GenApi.props
@@ -25,10 +25,13 @@
 
     <GlobalApiExclusionsFile Condition="'$(GlobalApiExclusionsFile)'==''">$(WpfArcadeSdkRoot)tools\GenApi\GlobalApiExclusions.txt</GlobalApiExclusionsFile>
     <GlobalAttrExclusionsFile Condition="'$(GlobalAttrExclusionsFile)'==''">$(WpfArcadeSdkRoot)tools\GenApi\GlobalAttrExclusions.txt</GlobalAttrExclusionsFile>
+    <GenAPIHeaderFile Condition="'$(GenAPIHeaderFile)'==''">$(WpfArcadeSdkRoot)tools\GenApi\GenAPIHeaderText.txt</GenAPIHeaderFile>
 
     <GenAPIExcludeMembers>true</GenAPIExcludeMembers>
     <GenAPIExcludeApiList Condition="'$(GlobalApiExclusionsFile)'!=''">$(GlobalApiExclusionsFile)</GenAPIExcludeApiList>
     <GenAPIExcludeAttributesList Condition="'$(GlobalAttrExclusionsFile)'!=''">$(GlobalAttrExclusionsFile)</GenAPIExcludeAttributesList>
+    <GenAPIHeader>$(GenAPIHeaderFile)</GenAPIHeader>
+
 
     <!-- 
       GenAPI is run on demand.  Note that making a public API change without the associated reference assembly change will result in an ApiCompat error. 
@@ -37,7 +40,8 @@
     <_GenerateReferenceAssemblySource>false</_GenerateReferenceAssemblySource>
     <_GenerateReferenceAssemblySource Condition="'$(GenerateReferenceAssemblySource)'=='true'
                                                         and '$(GenAPIEnabledProjects)'!=''
-                                                        and $(GenAPIEnabledProjects.Contains('$(MSBuildProjectName);'))">true</_GenerateReferenceAssemblySource>
+                                                        and $(GenAPIEnabledProjects.Contains('$(MSBuildProjectName);'))
+                                                        and !($(MSBuildProjectName.Contains('_wpftmp')))">true</_GenerateReferenceAssemblySource>
 
   </PropertyGroup>
 </Project>

--- a/eng/WpfArcadeSdk/tools/GenApi.targets
+++ b/eng/WpfArcadeSdk/tools/GenApi.targets
@@ -4,13 +4,30 @@
                       Condition="'$(_GenerateReferenceAssemblySource)'=='true'"/>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(_GenerateReferenceAssemblySource)'=='true'">
+  <PropertyGroup Condition="'$(_GenerateReferenceAssemblySource)'=='true'
+                                or $(MSBuildProjectName.Contains('_wpftmp'))">
     <!-- 
       By default, GenAPI's target (GenerateReferenceAssemblySource) generates code into $(TargetDir).
       Instead, WPF generates into the ref directory in the project's source tree.
     -->
     <GenAPITargetDir>$(MSBuildProjectDir)ref\</GenAPITargetDir>
+
+    <!-- 
+      Sets GenAPITargetDir for _wpftmp assemblies, these directories are not needed
+      and removed after generation.
+      This is a quick hack to avoid failures during GenerateReferenceAssemblySource for 
+      _wpftmp assemblies. Added this because once we set GenerateReferenceAssemblySource
+      parameter from CLI, it is enabled for temp assemblies as well, and we fail to filter
+      out those assemblies.
+     -->
+    <GenAPITargetDir Condition="'$(_GenerateReferenceAssemblySource)'=='false'">$(MSBuildProjectDir)ref\temp\</GenAPITargetDir>
+
     <GenAPITargetPath>$(GenAPITargetDir)$(AssemblyName).cs</GenAPITargetPath>
+
+    
+    <!-- Other GenAPI Task Parameters -->
+    <GenAPIExcludeCompilerGenerated>true</GenAPIExcludeCompilerGenerated>
+    <GenAPILangVersion>$(LangVersion)</GenAPILangVersion>
   </PropertyGroup>
 
   <Target Name="EnsureGenAPITargetDirectory"
@@ -18,5 +35,19 @@
         Condition="!Exists('$(GenAPITargetDir)')">
     <MakeDir Directories="$(GenAPITargetDir)" />
   </Target>
+
+  <!-- 
+    Target to remove ref files generated while building _wpftmp projects.
+    These files are generated when we call the GenerateTemporaryTargetAssembly task on
+    the main assembly.
+    PS : This is the part of the hack above, to delete the unwanted ref assembly files.
+  -->
+  <Target Name="RemoveTempGenAPITargetDirectory"
+        AfterTargets="GenerateReferenceAssemblySource"
+        Condition="'$(_GenerateReferenceAssemblySource)'=='false'">
+    <RemoveDir Directories="$(GenAPITargetDir)" />
+  </Target>
+
+
 
 </Project>

--- a/eng/WpfArcadeSdk/tools/GenApi/GenAPIHeaderText.txt
+++ b/eng/WpfArcadeSdk/tools/GenApi/GenAPIHeaderText.txt
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+

--- a/eng/WpfArcadeSdk/tools/GenApi/GlobalAttrExclusions.txt
+++ b/eng/WpfArcadeSdk/tools/GenApi/GlobalAttrExclusions.txt
@@ -69,5 +69,6 @@ T:System.Reflection.DefaultMemberAttribute
 T:System.Timers.TimersDescriptionAttribute
 
 // These do not need to be persisted in the implementation
-T:System.ComponentModel.EditorBrowsableAttribute
-T:System.ObsoleteAttribute
+// Remove ObsoleteAttribute and EditorBrowsableAttribute from this list to minimize
+// ref assembly changes on regeneration.
+// Add it back later.


### PR DESCRIPTION
## Description

- Added MicrosoftDotNetGenAPIVersion in Version.props to allow GenAPI to find the right task at build time.

- Add GenAPIHeaderFile and GenAPIHeader properties to GenApi.props to use .NET C# file header rather than auto generated header. Added GenAPIHeaderText.txt file with the header text.

- Added a condition in GenAPI.props, where we set _GenerateReferenceAssemblySource false when we are building a _wpftmp project

- Removed 2 attributes from GlobalAttrExclusions.txt to minimize the changes in ref assembly on regeneration. ( We will add them back in future after investigation )

- Added a hack where we generate ref assemblies for _wpftmp assemblies by setting a target dir, and then later after generation is complete deleted ref assembly files for these _wpftmp assemblies. I added this hack because, when we set the flag for generating ref assemblies using GenAPI, that flag gets enabled for temp assemblies as well, and while building, MSBuild can't find the location to generate the ref as that directory is no more present. So, as a quick fix, I set the target dir, in GenApi.targets and then delete it once the generation is complete. PS : We can find a better way to deal with this situation.

## Customer Impact
Developers contributing to WPF, can easily regenerate the reference assemblies and pick out the required changes to include in the reference assemblies

## Regression
Maybe. GenAPI would have been working initially, but this is not a code/product regression

## Testing
Locally regenerated the ref assemblies.

## Risk
N/A . This is an out of build process that needs to be done manually.
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9710)