### PR TITLE
Improve start-up time by not figuring out NetFX version for AppContext switches

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
@@ -19,15 +19,19 @@ namespace System
     {
         public static void PopulateDefaultValues()
         {
-            string platformIdentifier, profile;
-            int version;
-
-            ParseTargetFrameworkName(out platformIdentifier, out profile, out version);
+#if NETFX
+            // Get Target Framework information
+            ParseTargetFrameworkName(out string platformIdentifier, out string profile, out int version);
 
             // Call into each library to populate their default switches
             PopulateDefaultValuesPartial(platformIdentifier, profile, version);
+#else
+            // Call into each library to populate their default switches
+            // ".NETCoreApp,Version=v3.0"
+            PopulateDefaultValuesPartial(".NETCoreApp", string.Empty, 30000);
+#endif
         }
-
+#if NETFX
         /// <summary>
         /// We have this separate method for getting the parsed elements out of the TargetFrameworkName so we can
         /// more easily support this on other platforms.
@@ -181,7 +185,7 @@ namespace System
 
             return true;
         }
-
+#endif
         // This is a partial method. Platforms (such as Desktop) can provide an implementation of it that will read override value
         // from whatever mechanism is available on that platform. If no implementation is provided, the compiler is going to remove the calls
         // to it from the code

--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
@@ -74,22 +74,7 @@ namespace System
         /// <returns>TargetFrameworkMoniker on .NET Framework and .NET Core 3.0+; null on .NET Core 2.2 or older runtimes</returns>
         private static string GetTargetFrameworkMoniker()
         {
-            try
-            {
-                var pSetupInformation = typeof(AppDomain).GetProperty("SetupInformation");
-                object appDomainSetup = pSetupInformation?.GetValue(AppDomain.CurrentDomain);
-                Type tAppDomainSetup = Type.GetType("System.AppDomainSetup");
-                var pTargetFrameworkName = tAppDomainSetup?.GetProperty("TargetFrameworkName");
-
-                return
-                    appDomainSetup != null ?
-                    pTargetFrameworkName?.GetValue(appDomainSetup) as string :
-                    null;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return AppContext.TargetFrameworkName;
         }
 
         // This code was a constructor copied from the FrameworkName class, which is located in System.dll.

--- a/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Common/src/System/AppContextDefaultValues.cs
@@ -71,10 +71,6 @@ namespace System
         /// <summary>
         ///  This is equivalent to calling <code>AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName</code>
         /// </summary>
-        /// <remarks>
-        /// <code>AppDomain.CurrentDomain.SetupInformation</code> is not available until .NET Core 3.0, but we 
-        /// have a need to run this code in .NET Core 2.2, we attempt to obtain this information via Reflection.
-        /// </remarks>
         /// <returns>TargetFrameworkMoniker on .NET Framework and .NET Core 3.0+; null on .NET Core 2.2 or older runtimes</returns>
         private static string GetTargetFrameworkMoniker()
         {


### PR DESCRIPTION
## Description

All WPF apps will spend now spend considerable time on startup evaluating whether they're running on NetFX or not by initializing `AppContextDefaultValues` in each assembly (`PresentationCore`/`PresentationFramework`/`WindowsBase`), querying `TargetFrameworkName` property via reflection on AppDomain/AppContext (depends which runtime, one forwards the other).

The only place where the check makes sense is in `PresentationBuildTasks` on net472, which can be easily opted-in by using a preprocessor macro, rest of the assemblies do not need it and can confidently init as `.NETCoreApp`, version doesn't matter.

- We can keep the current code for `PBT` on `net472` via preprocessor condition and omit it from core builds
- We do not need to retrieve `TargetFrameworkName` via reflection on any target framework anymore

While I could have removed the cases in core libraries for NetFX, I presume we can do it in a different PR that cleans-up the whole logic for all of them, this is supposed to be neat and clean in-place solution.

## Customer Impact

Improved start-up time, decreased start-up allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low, this merely removes basically dead code on core libraries.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9711)