### PR TITLE
Improve start-up time by not using LINQ-Reflection combo for AccessibilityFeatures

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -226,16 +226,15 @@ namespace System.Windows
             {
                 // If a flag is set to false, we also must ensure the prior accessibility switches are also false.
                 // Otherwise we should inform the developer, via an exception, to enable all the flags.
-                var orderedFlagValues =
-                typeof(AccessibilitySwitches).GetProperties(System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)
-                .Where(x => x.Name.EndsWith("CompatibleAccessibilityFeatures"))
-                .OrderBy(x => x.Name.Remove(x.Name.IndexOf("CompatibleAccessibilityFeatures", 0)), StringComparer.OrdinalIgnoreCase)
-                .Select(x => (bool)x.GetValue(null));
+                bool netFx47 = UseNetFx47CompatibleAccessibilityFeatures;
+                bool netFx471 = UseNetFx471CompatibleAccessibilityFeatures;
+                bool netFx472 = UseNetFx472CompatibleAccessibilityFeatures;
 
                 bool? lastFlag = null;
                 bool foundInvalidSwitchState = false;
+                ReadOnlySpan<bool> orderedFlagValues = [netFx47, netFx471, netFx472];
 
-                foreach (var flag in orderedFlagValues)
+                foreach (bool flag in orderedFlagValues)
                 {
                     if (foundInvalidSwitchState = (!flag && lastFlag == true))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/AccessibilitySwitches.cs
@@ -224,28 +224,17 @@ namespace System.Windows
         {
             if (Interlocked.CompareExchange(ref s_SwitchesVerified, 1, 0) == 0)
             {
-                // If a flag is set to false, we also must ensure the prior accessibility switches are also false.
-                // Otherwise we should inform the developer, via an exception, to enable all the flags.
                 bool netFx47 = UseNetFx47CompatibleAccessibilityFeatures;
                 bool netFx471 = UseNetFx471CompatibleAccessibilityFeatures;
                 bool netFx472 = UseNetFx472CompatibleAccessibilityFeatures;
 
-                bool? lastFlag = null;
-                bool foundInvalidSwitchState = false;
-                ReadOnlySpan<bool> orderedFlagValues = [netFx47, netFx471, netFx472];
-
-                foreach (bool flag in orderedFlagValues)
-                {
-                    if (foundInvalidSwitchState = (!flag && lastFlag == true))
-                    {
-                        break;
-                    }
-
-                    lastFlag = flag;
-                }
-
-                if (foundInvalidSwitchState)
-                {
+                // If a flag is set to false, we also must ensure the prior accessibility switches are also false.
+                // Otherwise we should inform the developer, via an exception, to enable all the flags.
+                if (!((netFx47 == false && netFx471 == false && netFx472 == false) ||
+                      (netFx47 == false && netFx471 == false && netFx472 == true) ||
+                      (netFx47 == false && netFx471 == true && netFx472 == true) ||
+                      (netFx47 == true && netFx471 == true && netFx472 == true)))
+                { 
                     // Dispatch an EventLog and error throw so we get loaded UI, then the crash.
                     // This ensures the WER dialog shows.
                     DispatchOnError(dispatcher, SR.CombinationOfAccessibilitySwitchesNotSupported);


### PR DESCRIPTION
## Description

All WPF apps will spend now spend considerable time on startup verifying legacy accessibility switches setting. First it uses reflection to gather `UseNetFx47CompatibleAccessibilityFeatures` / `UseNetFx471CompatibleAccessibilityFeatures` / `UseNetFx472CompatibleAccessibilityFeatures`, then it orders and creates an array to go through its values, which is just a major overkill and this early it results in a big JITTing overhead besides other things.

As I personally don't think those properties are gonna grow in the direction where we would need such an over-engineered solution, I've decided to simplify it. This will improve the start-up time of all WPF apps.

## Customer Impact

Improved start-up time, decreased start-up allocations.

## Regression

No.

## Testing

Local build.

## Risk

Low, this removes an over-engineered solution for a simple logic evaluation.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9712)