### PR TITLE
Added ThemeMode and ThemeModeConverter reference docs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -970,8 +970,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// The ThemeMode property is used to set the Fluent theme mode of the application.
-        /// Setting this property controls if Fluent is loaded in Light, Dark or System mode. 
+        /// Gets or sets the Fluent theme mode of the application.
+        /// </summary>
+        /// <remarks>
+        /// Setting this property controls if Fluent theme is loaded in Light, Dark or System mode. 
         /// It also controls the application of backdrop and darkmode on window.
         /// The four values for the ThemeMode enum are :
         ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
@@ -981,14 +983,12 @@ namespace System.Windows
         ///
         /// These values are predefined in <see cref="ThemeMode"/> struct
         /// The default value is <see cref="ThemeMode.None"/>.
-        /// </summary>
-        /// <remarks>
         ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
         ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
         ///     controls within are in light mode or vice versa.
         ///     
-        ///     Setting this property will load the Fluent theme dictionaries in the application resources.
-        ///     So, if you are setting this property, it is preferrable to not include Fluent theme dictionaries
+        ///     Setting this property loads the Fluent theme dictionaries in the application resources.
+        ///     So, if you set this property, it is preferrable to not include Fluent theme dictionaries
         ///     in the application resources manually. If you do, the Fluent theme dictionaries added in the application
         ///     resources will take precedence over the ones added by setting this property.
         ///     

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -976,13 +976,13 @@ namespace System.Windows
         /// Setting this property controls if Fluent theme is loaded in Light, Dark or System mode. 
         /// It also controls the application of backdrop and darkmode on window.
         /// The four values for the ThemeMode enum are :
-        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded. However, if <see cref="Application.ThemeMode"/> is not None, 
-        ///         then the window will appear as defined in <see cref="Application.ThemeMode"/>.
+        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
         ///     <see cref="ThemeMode.System"/> - Fluent theme is loaded based on the system theme.
         ///     <see cref="ThemeMode.Light"/> - Fluent theme is loaded in Light mode.
         ///     <see cref="ThemeMode.Dark"/> - Fluent theme is loaded in Dark mode.
         ///
         /// These values are predefined in <see cref="ThemeMode"/> struct
+        ///
         /// The default value is <see cref="ThemeMode.None"/>.
         ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
         ///     Syncing is done in order to avoid UI inconsistencies, for example, if the application is in dark mode 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -976,7 +976,8 @@ namespace System.Windows
         /// Setting this property controls if Fluent theme is loaded in Light, Dark or System mode. 
         /// It also controls the application of backdrop and darkmode on window.
         /// The four values for the ThemeMode enum are :
-        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
+        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded. However, if <see cref="Application.ThemeMode"/> is not None, 
+        ///         then the window will appear as defined in <see cref="Application.ThemeMode"/>.
         ///     <see cref="ThemeMode.System"/> - Fluent theme is loaded based on the system theme.
         ///     <see cref="ThemeMode.Light"/> - Fluent theme is loaded in Light mode.
         ///     <see cref="ThemeMode.Dark"/> - Fluent theme is loaded in Dark mode.
@@ -984,8 +985,8 @@ namespace System.Windows
         /// These values are predefined in <see cref="ThemeMode"/> struct
         /// The default value is <see cref="ThemeMode.None"/>.
         ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
-        ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
-        ///     controls within are in light mode or vice versa.
+        ///     Syncing is done in order to avoid UI inconsistencies, for example, if the application is in dark mode 
+        ///     but the windows are in light mode or vice versa. 
         ///     
         ///     Setting this property loads the Fluent theme dictionaries in the application resources.
         ///     So, if you set this property, it is preferrable to not include Fluent theme dictionaries

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -969,6 +969,31 @@ namespace System.Windows
             set { Resources = value; }
         }
 
+        /// <summary>
+        /// The ThemeMode property is used to set the Fluent theme mode of the application.
+        /// Setting this property controls if Fluent is loaded in Light, Dark or System mode. 
+        /// It also controls the application of backdrop and darkmode on window.
+        /// The four values for the ThemeMode enum are :
+        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
+        ///     <see cref="ThemeMode.System"/> - Fluent theme is loaded based on the system theme.
+        ///     <see cref="ThemeMode.Light"/> - Fluent theme is loaded in Light mode.
+        ///     <see cref="ThemeMode.Dark"/> - Fluent theme is loaded in Dark mode.
+        ///
+        /// These values are predefined in <see cref="ThemeMode"/> struct
+        /// The default value is <see cref="ThemeMode.None"/>.
+        /// </summary>
+        /// <remarks>
+        ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
+        ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
+        ///     controls within are in light mode or vice versa.
+        ///     
+        ///     Setting this property will load the Fluent theme dictionaries in the application resources.
+        ///     So, if you are setting this property, it is preferrable to not include Fluent theme dictionaries
+        ///     in the application resources manually. If you do, the Fluent theme dictionaries added in the application
+        ///     resources will take precedence over the ones added by setting this property.
+        ///     
+        ///     This property is experimental and may be removed in future versions.
+        /// </remarks>
         [Experimental("WPF0001")]
         [TypeConverter(typeof(ThemeModeConverter))]
         public ThemeMode ThemeMode

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemColors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemColors.cs
@@ -348,6 +348,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   System accent color that is set by the user in OS settings.
+        /// </summary>
         public static Color AccentColor
         {
             get
@@ -356,6 +359,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Light shade of system accent color.
+        /// </summary>
         public static Color AccentColorLight1
         {
             get
@@ -364,6 +370,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        /// Lighter shade of system accent color.
+        /// </summary>
         public static Color AccentColorLight2
         {
             get
@@ -372,6 +381,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        /// Lightest shade of system accent color.
+        /// </summary>
         public static Color AccentColorLight3
         {
             get
@@ -380,6 +392,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        /// Dark shade of system accent color.
+        /// </summary>
         public static Color AccentColorDark1
         {
             get
@@ -388,6 +403,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        /// Darker shade of system accent color.
+        /// </summary>
         public static Color AccentColorDark2
         {
             get
@@ -396,6 +414,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        /// Darkest shade of system accent color.
+        /// </summary>
         public static Color AccentColorDark3
         {
             get
@@ -894,6 +915,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColor System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorKey
         {
             get
@@ -907,6 +931,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorLight1 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight1Key
         {
             get
@@ -920,6 +947,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorLight2 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight2Key
         {
             get
@@ -933,6 +963,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColorLight3 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight3Key
         {
             get
@@ -946,6 +979,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorDark1 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark1Key
         {
             get
@@ -959,6 +995,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorDark2 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark2Key
         {
             get
@@ -972,6 +1011,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColorDark3 System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark3Key
         {
             get
@@ -1361,6 +1403,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to system accent color ( )
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorBrush
         {
             get
@@ -1376,6 +1424,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorLight1"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorLight1Brush
         {
             get
@@ -1391,6 +1445,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorLight2"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorLight2Brush
         {
             get
@@ -1406,6 +1466,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorLight3"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorLight3Brush
         {
             get
@@ -1421,6 +1487,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorDark1"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorDark1Brush
         {
             get
@@ -1436,6 +1508,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorDark2"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorDark2Brush
         {
             get
@@ -1451,6 +1529,12 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///   Brush corresponding to <see cref="AccentColorDark3"/> color
+        /// </summary>
+        /// <remarks>
+        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        /// </remarks>
         public static SolidColorBrush AccentColorDark3Brush
         {
             get
@@ -1996,6 +2080,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorBrush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorBrushKey
         {
             get
@@ -2009,6 +2096,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColorLight1Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight1BrushKey
         {
             get
@@ -2022,6 +2112,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorLight2Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight2BrushKey
         {
             get
@@ -2035,6 +2128,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorLight3Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorLight3BrushKey
         {
             get
@@ -2048,6 +2144,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColorDark1Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark1BrushKey
         {
             get
@@ -2061,6 +2160,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///    AccentColorDark2Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark2BrushKey
         {
             get
@@ -2074,6 +2176,9 @@ namespace System.Windows
             }
         }
 
+        /// <summary>
+        ///     AccentColorDark3Brush System Resource Key
+        /// </summary>
         public static ResourceKey AccentColorDark3BrushKey
         {
             get

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemColors.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemColors.cs
@@ -349,7 +349,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   System accent color that is set by the user in OS settings.
+        ///   Gets the system accent color that's set by the user in OS settings.
         /// </summary>
         public static Color AccentColor
         {
@@ -360,7 +360,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Light shade of system accent color.
+        ///   Gets the light shade of the system accent color.
         /// </summary>
         public static Color AccentColorLight1
         {
@@ -371,7 +371,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Lighter shade of system accent color.
+        ///     Gets the lighter shade of the system accent color.
         /// </summary>
         public static Color AccentColorLight2
         {
@@ -382,7 +382,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Lightest shade of system accent color.
+        ///     Gets the lightest shade of the system accent color.
         /// </summary>
         public static Color AccentColorLight3
         {
@@ -393,7 +393,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Dark shade of system accent color.
+        ///     Gets the dark shade of the system accent color.
         /// </summary>
         public static Color AccentColorDark1
         {
@@ -404,7 +404,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Darker shade of system accent color.
+        ///     Gets the darker shade of the system accent color.
         /// </summary>
         public static Color AccentColorDark2
         {
@@ -415,7 +415,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Darkest shade of system accent color.
+        ///     Gets the darkest shade of the system accent color.
         /// </summary>
         public static Color AccentColorDark3
         {
@@ -916,7 +916,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColor System Resource Key
+        ///    Gets the <see cref="AccentColor" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorKey
         {
@@ -932,7 +932,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorLight1 System Resource Key
+        ///      Gets the <see cref="AccentColorLight1" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight1Key
         {
@@ -948,7 +948,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorLight2 System Resource Key
+        ///      Gets the <see cref="AccentColorLight2" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight2Key
         {
@@ -964,7 +964,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColorLight3 System Resource Key
+        ///     Gets the <see cref="AccentColorLight3" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight3Key
         {
@@ -980,7 +980,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorDark1 System Resource Key
+        ///      Gets the <see cref="AccentColorDark1" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark1Key
         {
@@ -996,7 +996,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorDark2 System Resource Key
+        ///      Gets the <see cref="AccentColorDark2" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark2Key
         {
@@ -1012,7 +1012,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColorDark3 System Resource Key
+        ///     Gets the <see cref="AccentColorDark3" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark3Key
         {
@@ -1404,10 +1404,11 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to system accent color ( )
+        ///   Gets the brush corresponding to the <see cref="AccentColor"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   <see cref="AccentColor"/> is the system accent color that's set by the user in OS settings. 
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorBrush
         {
@@ -1425,10 +1426,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorLight1"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorLight1"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorLight1Brush
         {
@@ -1446,10 +1447,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorLight2"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorLight2"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorLight2Brush
         {
@@ -1467,10 +1468,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorLight3"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorLight3"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorLight3Brush
         {
@@ -1488,10 +1489,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorDark1"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorDark1"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorDark1Brush
         {
@@ -1509,10 +1510,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorDark2"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorDark2"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorDark2Brush
         {
@@ -1530,10 +1531,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///   Brush corresponding to <see cref="AccentColorDark3"/> color
+        ///   Gets the brush corresponding to the <see cref="AccentColorDark3"/> color.
         /// </summary>
         /// <remarks>
-        ///   When <see cref="SystemParameters.HighContrast"/> is true, it returns <see cref="SystemColors.HighlightTextBrush"/>.
+        ///   When <see cref="SystemParameters.HighContrast"/> is <see langword="true" />, this property returns <see cref="SystemColors.HighlightTextBrush"/>.
         /// </remarks>
         public static SolidColorBrush AccentColorDark3Brush
         {
@@ -2081,7 +2082,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorBrush System Resource Key
+        ///     Gets the <see cref="AccentColorBrush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorBrushKey
         {
@@ -2097,7 +2098,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColorLight1Brush System Resource Key
+        ///    Gets the <see cref="AccentColorLight1Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight1BrushKey
         {
@@ -2113,7 +2114,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorLight2Brush System Resource Key
+        ///     Gets the <see cref="AccentColorLight2Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight2BrushKey
         {
@@ -2129,7 +2130,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorLight3Brush System Resource Key
+        ///     Gets the <see cref="AccentColorLight3Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorLight3BrushKey
         {
@@ -2145,7 +2146,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColorDark1Brush System Resource Key
+        ///    Gets the <see cref="AccentColorDark1Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark1BrushKey
         {
@@ -2161,7 +2162,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///    AccentColorDark2Brush System Resource Key
+        ///    Gets the <see cref="AccentColorDark2Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark2BrushKey
         {
@@ -2177,7 +2178,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        ///     AccentColorDark3Brush System Resource Key
+        ///     Gets the <see cref="AccentColorDark3Brush" /> system resource key.
         /// </summary>
         public static ResourceKey AccentColorDark3BrushKey
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
@@ -31,8 +31,8 @@ namespace System.Windows
     public readonly struct ThemeMode : IEquatable<ThemeMode>
     {
         /// <summary>
-        /// Predefined theme mode : None.
-        /// This is the default value for Application.ThemeMode and Window.ThemeMode
+        /// Predefined theme mode: None.
+        /// This is the default value for <see cref="Application.ThemeMode"/> and <see cref="Window.ThemeMode"/>
         /// and it means that Fluent theme will not be applied on the Application or Window.
         /// </summary>
         /// <remarks>
@@ -40,24 +40,24 @@ namespace System.Windows
         /// even if Window.ThemeMode is set to None, the Fluent theme will be applied on the Window.
         /// </remarks>
         public static ThemeMode None => new ThemeMode();
-        
+
         /// <summary>
-        /// Predefined theme mode : Light.
-        /// Whenever this mode is set on Application or Window, 
+        /// Predefined theme mode: Light.
+        /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent Light theme will be applied.
         /// </summary>
         public static ThemeMode Light => new ThemeMode("Light");
         
         /// <summary>
-        /// Predefined theme mode : Dark.
-        /// Whenever this mode is set on Application or Window,
+        /// Predefined theme mode: Dark.
+        /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent Dark theme will be applied.
         /// </summary>
         public static ThemeMode Dark => new ThemeMode("Dark");
-        
+
         /// <summary>
         /// Perdefined theme mode : System.
-        /// Whenever this mode is set on Application or Window,
+        /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent theme will be applied based on the system theme.
         /// </summary>
         public static ThemeMode System => new ThemeMode("System");

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
@@ -19,47 +19,53 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Windows
 {
     /// <summary>
-    /// ThemeMode structure describes the Fluent theme mode to be applied
-    /// on Application or a Window.
+    /// Describes the Fluent theme mode to apply to an application or window.
     /// </summary>
     /// <remarks>
     /// This is an experimental API and may be modified or removed in future releases.
     /// Since this is an experimental API, rather than creating a new instance of ThemeMode,
-    /// use the static properties Light, Dark, System and None.
+    /// use the static properties Light, Dark, System, and None.
     /// </remarks>
     [Experimental("WPF0001")]
     public readonly struct ThemeMode : IEquatable<ThemeMode>
     {
         /// <summary>
-        /// Predefined theme mode: None.
-        /// This is the default value for <see cref="Application.ThemeMode"/> and <see cref="Window.ThemeMode"/>
-        /// and it means that Fluent theme will not be applied on the Application or Window.
+        /// Gets the None predefined theme mode.
         /// </summary>
         /// <remarks>
-        /// In case, when <see cref="Application.ThemeMode"/> is not set to None,
-        /// even if <see cref="Window.ThemeMode"/> is set to None, the Fluent theme will be applied on the Window.
+        /// This is the default value for <see cref="Application.ThemeMode"/> and <see cref="Window.ThemeMode"/>
+        /// and it means that Fluent theme will not be applied on the Application or Window.
+        ///
+        /// When <see cref="Application.ThemeMode"/> is not set to <see cref="None"/>,
+        /// even if <see cref="Window.ThemeMode"/> is set to <see cref="None">, the Fluent theme will be applied on the window.
         /// </remarks>
         public static ThemeMode None => new ThemeMode();
 
         /// <summary>
-        /// Predefined theme mode: Light.
+        /// Gets the Light predefined theme mode.
+        /// </summary>
+        /// <remarks>
         /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent Light theme will be applied.
-        /// </summary>
+        /// </remarks>
         public static ThemeMode Light => new ThemeMode("Light");
         
         /// <summary>
-        /// Predefined theme mode: Dark.
+        /// Gets the Dark predefined theme mode.
+        /// </summary>
+        /// <remarks>
         /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent Dark theme will be applied.
-        /// </summary>
+        /// </remarks>
         public static ThemeMode Dark => new ThemeMode("Dark");
 
         /// <summary>
-        /// Perdefined theme mode : System.
+        /// Get the System predefined theme mode.
+        /// </summary>
+        /// <remarks>
         /// Whenever this mode is set on <see cref="Application"/> or <see cref="Window"/>,
         /// Fluent theme will be applied based on the system theme.
-        /// </summary>
+        /// </remarks>
         public static ThemeMode System => new ThemeMode("System");
 
         /// <summary>
@@ -70,29 +76,29 @@ namespace System.Windows
         /// <summary>
         /// Creates a new ThemeMode object with the specified value.
         /// </summary>
-        /// <param name="value">Name of theme mode</param>
+        /// <param name="value">The name of the theme mode</param>
         public ThemeMode(string value) => _value = value;
-        
+
         /// <summary>
-        /// Checks whether the ThemeMode object is equal to another ThemeMode object.
+        /// Checks whether this instance is equal to another ThemeMode object.
         /// </summary>
         /// <param name="other">ThemeMode object to compare with</param>
         /// <returns>
-        /// Returns true when the ThemeMode objects are equal, and false otherwise.
+        /// <see langword="true"/> if the ThemeMode objects are equal; <see langword="false"/> otherwise.
         /// </returns>
         public bool Equals(ThemeMode other) => string.Equals(Value, other.Value, StringComparison.Ordinal);
 
         /// <summary>
-        /// Checks whether the object is equal to another ThemeMode object.
+        /// Checks whether this instance  is equal to another ThemeMode object.
         /// </summary>
         /// <param name="obj">ThemeMode object to compare with.</param>
         /// <returns>
-        /// Returns true when the ThemeMode objects are equal, and false otherwise.
+        /// <see langword="true"/> if the ThemeMode objects are equal; <see langword="false"/> otherwise.
         /// </returns>
         public override bool Equals(object obj) => obj is ThemeMode other && Equals(other);
 
         /// <summary>
-        /// Compute hash code for this object.
+        /// Computes the hash code for this object.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode() => _value != null ? StringComparer.Ordinal.GetHashCode(_value) : 0;
@@ -100,22 +106,20 @@ namespace System.Windows
         /// <summary>
         /// Checks whether two ThemeMode objects are equal.
         /// </summary>
-        /// <param name="left">First ThemeMode object to compare</param>
-        /// <param name="right">Second ThemeMode object to compare</param>
+        /// <param name="left">The first ThemeMode object to compare.</param>
+        /// <param name="right">The second ThemeMode object to compare.</param>
         /// <returns>
-        /// Returns true when both the ThemeMode objects are equal, 
-        /// and false otherwise.
+        /// <see langword="true"/> if the ThemeMode objects are equal; <see langword="false"/> otherwise.
         /// </returns>
         public static bool operator ==(ThemeMode left, ThemeMode right) => left.Equals(right);
 
         /// <summary>
         /// Checks whether two ThemeMode objects are not equal.
         /// </summary>
-        /// <param name="left">First ThemeMode object to compare</param>
-        /// <param name="right">Second ThemeMode object to compare</param>
+        /// <param name="left">The first ThemeMode object to compare.</param>
+        /// <param name="right">The second ThemeMode object to compare.</param>
         /// <returns>
-        /// Returns true when the ThemeMode objects are not equal, 
-        /// and false otherwise.
+        /// <see langword="true"/> if the ThemeMode objects are not equal; <see langword="false"/> otherwise.
         /// </returns>
         public static bool operator !=(ThemeMode left, ThemeMode right) => !left.Equals(right);
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 
@@ -14,29 +18,113 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Windows
 {
+    /// <summary>
+    /// ThemeMode structure describes the Fluent theme mode to be applied
+    /// on Application or a Window.
+    /// </summary>
+    /// <remarks>
+    /// This is an experimental API and may be modified or removed in future releases.
+    /// Since this is an experimental API, rather than creating a new instance of ThemeMode,
+    /// use the static properties Light, Dark, System and None.
+    /// </remarks>
     [Experimental("WPF0001")]
     public readonly struct ThemeMode : IEquatable<ThemeMode>
     {
+        /// <summary>
+        /// Predefined theme mode : None.
+        /// This is the default value for Application.ThemeMode and Window.ThemeMode
+        /// and it means that Fluent theme will not be applied on the Application or Window.
+        /// </summary>
+        /// <remarks>
+        /// In case, when Application.ThemeNode is not set to None,
+        /// even if Window.ThemeMode is set to None, the Fluent theme will be applied on the Window.
+        /// </remarks>
         public static ThemeMode None => new ThemeMode();
+        
+        /// <summary>
+        /// Predefined theme mode : Light.
+        /// Whenever this mode is set on Application or Window, 
+        /// Fluent Light theme will be applied.
+        /// </summary>
         public static ThemeMode Light => new ThemeMode("Light");
+        
+        /// <summary>
+        /// Predefined theme mode : Dark.
+        /// Whenever this mode is set on Application or Window,
+        /// Fluent Dark theme will be applied.
+        /// </summary>
         public static ThemeMode Dark => new ThemeMode("Dark");
+        
+        /// <summary>
+        /// Perdefined theme mode : System.
+        /// Whenever this mode is set on Application or Window,
+        /// Fluent theme will be applied based on the system theme.
+        /// </summary>
         public static ThemeMode System => new ThemeMode("System");
 
-
+        /// <summary>
+        /// Gets the value of the ThemeMode.
+        /// </summary>
         public string Value => _value ?? "None";
 
+        /// <summary>
+        /// Creates a new ThemeMode object with the specified value.
+        /// </summary>
+        /// <param name="value">Name of theme mode</param>
         public ThemeMode(string value) => _value = value;
         
+        /// <summary>
+        /// Checks whether the ThemeMode object is equal to another ThemeMode object.
+        /// </summary>
+        /// <param name="other">ThemeMode object to compare with</param>
+        /// <returns>
+        /// Returns true when the ThemeMode objects are equal, and false otherwise.
+        /// </returns>
         public bool Equals(ThemeMode other) => string.Equals(Value, other.Value, StringComparison.Ordinal);
 
+        /// <summary>
+        /// Checks whether the object is equal to another ThemeMode object.
+        /// </summary>
+        /// <param name="obj">ThemeMode object to compare with.</param>
+        /// <returns>
+        /// Returns true when the ThemeMode objects are equal, and false otherwise.
+        /// </returns>
         public override bool Equals(object obj) => obj is ThemeMode other && Equals(other);
 
+        /// <summary>
+        /// Compute hash code for this object.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode() => _value != null ? StringComparer.Ordinal.GetHashCode(_value) : 0;
 
+        /// <summary>
+        /// Checks whether two ThemeMode objects are equal.
+        /// </summary>
+        /// <param name="left">First ThemeMode object to compare</param>
+        /// <param name="right">Second ThemeMode object to compare</param>
+        /// <returns>
+        /// Returns true when both the ThemeMode objects are equal, 
+        /// and false otherwise.
+        /// </returns>
         public static bool operator ==(ThemeMode left, ThemeMode right) => left.Equals(right);
 
+        /// <summary>
+        /// Checks whether two ThemeMode objects are not equal.
+        /// </summary>
+        /// <param name="left">First ThemeMode object to compare</param>
+        /// <param name="right">Second ThemeMode object to compare</param>
+        /// <returns>
+        /// Returns true when the ThemeMode objects are not equal, 
+        /// and false otherwise.
+        /// </returns>
         public static bool operator !=(ThemeMode left, ThemeMode right) => !left.Equals(right);
 
+        /// <summary>
+        /// Creates a string representation of the ThemeMode object.
+        /// </summary>
+        /// <returns>
+        /// A string representation of this object.
+        /// </returns>
         public override string ToString() => Value;
 
         private readonly string _value;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeMode.cs
@@ -36,8 +36,8 @@ namespace System.Windows
         /// and it means that Fluent theme will not be applied on the Application or Window.
         /// </summary>
         /// <remarks>
-        /// In case, when Application.ThemeNode is not set to None,
-        /// even if Window.ThemeMode is set to None, the Fluent theme will be applied on the Window.
+        /// In case, when <see cref="Application.ThemeMode"/> is not set to None,
+        /// even if <see cref="Window.ThemeMode"/> is set to None, the Fluent theme will be applied on the Window.
         /// </remarks>
         public static ThemeMode None => new ThemeMode();
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
@@ -20,8 +20,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Windows
 {
     /// <summary>
-    /// ThemeModeConverter - Converter class for converting instances 
-    /// of other types to and from ThemeMode instances.
+    /// Converts instances of other types to and from ThemeMode instances.
     /// </summary>
     [Experimental("WPF0001")]
     public class ThemeModeConverter: TypeConverter
@@ -30,12 +29,12 @@ namespace System.Windows
         #region Public Methods
 
         /// <summary>
-        /// CanConvertFrom - Returns whether or not this class can convert from a given type.
+        /// Determines whether or not this class can convert from a given type.
         /// </summary>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
         /// <param name="sourceType">The Type being queried for support.</param>
         /// <returns>
-        /// bool - True if thie converter can convert from the provided type, false if not.
+        /// <see langword="true" /> if the converter can convert from the provided type; otherwise, <see langword="false" />.
         /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext typeDescriptorContext, Type sourceType)
         {
@@ -43,12 +42,12 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// CanConvertTo - Returns whether or not this class can convert to a given type.
+        /// Determines whether or not this class can convert to a given type.
         /// </summary>
         /// <param name="typeDescriptorContext"> The ITypeDescriptorContext for this call. </param>
         /// <param name="destinationType"> The Type being queried for support. </param>
         /// <returns>
-        /// bool - True if this converter can convert to the provided type, false if not.
+        /// <see langword="true" /> if this converter can convert to the provided type; otherwise, <see langword="false" />.
         /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext typeDescriptorContext, Type destinationType) 
         {
@@ -57,16 +56,16 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// ConvertFrom - Attempts to convert to a ThemeMode from the given object
+        /// Attempts to convert to a ThemeMode from the specified object
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// An ArgumentNullException is thrown if the example object is null.
+        /// The example object is <see langword="null" />.
         /// </exception>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
         /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
         /// <param name="source">The object to convert to a ThemeMode.</param>
         /// <returns>
-        /// ThemeMode instance which was constructed.
+        /// The new ThemeMode instance.
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, 
                                            CultureInfo cultureInfo, 
@@ -81,21 +80,20 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// ConvertTo - Attempts to convert a ThemeMode to the given type
+        /// Attempts to convert a ThemeMode object to the specified type.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        /// An ArgumentNullException is thrown if the example object is null.
+        /// <paramref name="value" />  is <see langword="null" />.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// An ArgumentException is thrown if the object is not null and is not a ThemeMode,
-        /// or if the destinationType isn't one of the valid destination types.
+        /// <paramref name="value" /> is not a ThemeMode, or <paramref name="destinationType" /> isn't a valid destination type.
         /// </exception>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
         /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
         /// <param name="value">The ThemeMode to convert.</param>
         /// <param name="destinationType">The type to which to convert the ThemeMode instance.</param>
         /// <returns>
-        /// The object which was constructoed.
+        /// The newly constructed object.
         /// </returns>
         public override object ConvertTo(ITypeDescriptorContext typeDescriptorContext, 
                                          CultureInfo cultureInfo,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.ComponentModel;
 
@@ -15,25 +19,55 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Windows
 {
+    /// <summary>
+    /// ThemeModeConverter - Converter class for converting instances 
+    /// of other types to and from ThemeMode instances.
+    /// </summary>
     [Experimental("WPF0001")]
-
     public class ThemeModeConverter: TypeConverter
     {
 
         #region Public Methods
 
+        /// <summary>
+        /// CanConvertFrom - Returns whether or not this class can convert from a given type.
+        /// </summary>
+        /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
+        /// <param name="sourceType">The Type being queried for support.</param>
+        /// <returns>
+        /// bool - True if thie converter can convert from the provided type, false if not.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext typeDescriptorContext, Type sourceType)
         {
            return Type.GetTypeCode(sourceType) == TypeCode.String;
         }
 
+        /// <summary>
+        /// CanConvertTo - Returns whether or not this class can convert to a given type.
+        /// </summary>
+        /// <param name="typeDescriptorContext"> The ITypeDescriptorContext for this call. </param>
+        /// <param name="destinationType"> The Type being queried for support. </param>
+        /// <returns>
+        /// bool - True if this converter can convert to the provided type, false if not.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext typeDescriptorContext, Type destinationType) 
         {
             // We can convert to an InstanceDescriptor or to a string.
             return destinationType == typeof(InstanceDescriptor) || destinationType == typeof(string);
         }
 
-
+        /// <summary>
+        /// ConvertFrom - Attempts to convert to a ThemeMode from the given object
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// An ArgumentNullException is thrown if the example object is null.
+        /// </exception>
+        /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
+        /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
+        /// <param name="source">The object to convert to a ThemeMode.</param>
+        /// <returns>
+        /// ThemeMode instance which was constructed.
+        /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, 
                                            CultureInfo cultureInfo, 
                                            object source)
@@ -46,6 +80,21 @@ namespace System.Windows
             throw GetConvertFromException(source);
         }
 
+        /// <summary>
+        /// ConvertTo - Attempts to convert a ThemeMode to the given type
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// An ArgumentNullException is thrown if the example object is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// An ArgumentException is thrown if the object is not null and is not a ThemeMode,
+        /// or if the destinationType isn't one of the valid destination types.
+        /// </exception>
+        /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
+        /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
+        /// <param name="value">The ThemeMode to convert.</param>
+        /// <param name="destinationType">The type to which to convert the ThemeMode instance.</param>
+        /// <returns></returns>
         public override object ConvertTo(ITypeDescriptorContext typeDescriptorContext, 
                                          CultureInfo cultureInfo,
                                          object value,
@@ -67,7 +116,7 @@ namespace System.Windows
             }
             throw GetConvertToException(value, destinationType);
         }
-        #endregion 
 
+        #endregion 
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
@@ -56,16 +56,16 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Attempts to convert to a ThemeMode from the specified object
+        /// Attempts to convert to a <see cref="ThemeMode"/> from the specified object
         /// </summary>
         /// <exception cref="ArgumentNullException">
         /// The example object is <see langword="null" />.
         /// </exception>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
         /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
-        /// <param name="source">The object to convert to a ThemeMode.</param>
+        /// <param name="source">The object to convert to a <see cref="ThemeMode"/>.</param>
         /// <returns>
-        /// The new ThemeMode instance.
+        /// The new <see cref="ThemeMode"/> instance.
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext typeDescriptorContext, 
                                            CultureInfo cultureInfo, 
@@ -80,17 +80,17 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Attempts to convert a ThemeMode object to the specified type.
+        /// Attempts to convert a <see cref="ThemeMode"/> object to the specified type.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="value" />  is <see langword="null" />.
         /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="value" /> is not a ThemeMode, or <paramref name="destinationType" /> isn't a valid destination type.
+        /// <exception cref="NotSupportedException">
+        /// <paramref name="value" /> is <see langword="null" /> or not a <see cref="ThemeMode"/>, or <paramref name="destinationType" /> isn't a valid destination type.
         /// </exception>
         /// <param name="typeDescriptorContext">The ITypeDescriptorContext for this call.</param>
         /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
-        /// <param name="value">The ThemeMode to convert.</param>
+        /// <param name="value">The <see cref="ThemeMode"/> to convert.</param>
         /// <param name="destinationType">The type to which to convert the ThemeMode instance.</param>
         /// <returns>
         /// The newly constructed object.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/ThemeModeConverter.cs
@@ -94,7 +94,9 @@ namespace System.Windows
         /// <param name="cultureInfo">The CultureInfo which is respected when converting.</param>
         /// <param name="value">The ThemeMode to convert.</param>
         /// <param name="destinationType">The type to which to convert the ThemeMode instance.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// The object which was constructoed.
+        /// </returns>
         public override object ConvertTo(ITypeDescriptorContext typeDescriptorContext, 
                                          CultureInfo cultureInfo,
                                          object value,

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -563,8 +563,10 @@ namespace System.Windows
         #region Public Properties
 
         /// <summary>
-        /// The ThemeMode property is used to set the Fluent theme mode of the application.
-        /// Setting this property controls if Fluent is loaded in Light, Dark or System mode. 
+        /// Gets or sets the Fluent theme mode of the window.
+        /// </summary>
+        /// <remarks>
+        /// Setting this property controls if Fluent theme is loaded in Light, Dark or System mode. 
         /// It also controls the application of backdrop and darkmode on window.
         /// The four values for the ThemeMode enum are :
         ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
@@ -574,15 +576,14 @@ namespace System.Windows
         ///
         /// These values are predefined in <see cref="ThemeMode"/> struct
         /// The default value is <see cref="ThemeMode.None"/>.
-        /// </summary>
-        /// <remarks>
-        ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
+        ///     
+        /// <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
         ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
         ///     controls within are in light mode or vice versa.
         ///     
-        ///     Setting this property will load the Fluent theme dictionaries in the application resources.
-        ///     So, if you are setting this property, it is preferrable to not include Fluent theme dictionaries
-        ///     in the application resources manually. If you do, the Fluent theme dictionaries added in the application
+        ///     Setting this property loads the Fluent theme dictionaries in the window resources.
+        ///     So, if you set this property, it is preferrable to not include Fluent theme dictionaries
+        ///     in the window resources manually. If you do, the Fluent theme dictionaries added in the window
         ///     resources will take precedence over the ones added by setting this property.
         ///     
         ///     This property is experimental and may be removed in future versions.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -562,6 +562,31 @@ namespace System.Windows
         //---------------------------------------------------
         #region Public Properties
 
+        /// <summary>
+        /// The ThemeMode property is used to set the Fluent theme mode of the application.
+        /// Setting this property controls if Fluent is loaded in Light, Dark or System mode. 
+        /// It also controls the application of backdrop and darkmode on window.
+        /// The four values for the ThemeMode enum are :
+        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
+        ///     <see cref="ThemeMode.System"/> - Fluent theme is loaded based on the system theme.
+        ///     <see cref="ThemeMode.Light"/> - Fluent theme is loaded in Light mode.
+        ///     <see cref="ThemeMode.Dark"/> - Fluent theme is loaded in Dark mode.
+        ///
+        /// These values are predefined in <see cref="ThemeMode"/> struct
+        /// The default value is <see cref="ThemeMode.None"/>.
+        /// </summary>
+        /// <remarks>
+        ///     <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
+        ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
+        ///     controls within are in light mode or vice versa.
+        ///     
+        ///     Setting this property will load the Fluent theme dictionaries in the application resources.
+        ///     So, if you are setting this property, it is preferrable to not include Fluent theme dictionaries
+        ///     in the application resources manually. If you do, the Fluent theme dictionaries added in the application
+        ///     resources will take precedence over the ones added by setting this property.
+        ///     
+        ///     This property is experimental and may be removed in future versions.
+        /// </remarks>
         [Experimental("WPF0001")]
         [TypeConverter(typeof(ThemeModeConverter))]
         public ThemeMode ThemeMode

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -578,8 +578,8 @@ namespace System.Windows
         /// The default value is <see cref="ThemeMode.None"/>.
         ///     
         /// <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.
-        ///     Syncing is done in order to avoid UI inconsistencies, where the window is in dark mode but the 
-        ///     controls within are in light mode or vice versa.
+        ///     Syncing is done in order to avoid UI inconsistencies, for example, if the application is in dark mode 
+        ///     but the windows are in light mode or vice versa. 
         ///     
         ///     Setting this property loads the Fluent theme dictionaries in the window resources.
         ///     So, if you set this property, it is preferrable to not include Fluent theme dictionaries

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -569,12 +569,14 @@ namespace System.Windows
         /// Setting this property controls if Fluent theme is loaded in Light, Dark or System mode. 
         /// It also controls the application of backdrop and darkmode on window.
         /// The four values for the ThemeMode enum are :
-        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded.
+        ///     <see cref="ThemeMode.None"/> - No Fluent theme is loaded. However, if <see cref="Application.ThemeMode"/> is not None, 
+        ///         then the window will appear as defined in <see cref="Application.ThemeMode"/>.
         ///     <see cref="ThemeMode.System"/> - Fluent theme is loaded based on the system theme.
         ///     <see cref="ThemeMode.Light"/> - Fluent theme is loaded in Light mode.
         ///     <see cref="ThemeMode.Dark"/> - Fluent theme is loaded in Dark mode.
-        ///
-        /// These values are predefined in <see cref="ThemeMode"/> struct
+        /// 
+        /// These values are predefined in <see cref="ThemeMode"/> struct.
+        /// 
         /// The default value is <see cref="ThemeMode.None"/>.
         ///     
         /// <see cref="ThemeMode"/> and <see cref="Resources"/> are designed to be in sync with each other.


### PR DESCRIPTION
## Description
Adds the API reference docs for ThemeMode and ThemeModeConverter APIs introduced in .NET 9. This will be used to generate the .NET 9 reference API docs.

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

## Customer Impact
Developers using ThemeMode and ThemeModeConverter in their applications can refer to the docs to understand how to use the given APIs
<!-- What is the impact to customers of not taking this fix? -->

## Regression
N/A
<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

## Testing
N/A
<!-- What kind of testing has been done with the fix. -->

## Risk
N/A
<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9721)