### PR TITLE
Optimize performance of GetHashCode for ContentType comparers, remove allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -337,13 +337,11 @@ namespace MS.Internal
             }            
 
             /// <summary>
-            /// We lower case the results of ToString() because it returns the original
-            /// casing passed into the constructor.  ContentTypes that are equal (which
-            /// ignores casing) must have the same hash code.
+            /// ContentTypes that are equal (which ignores casing) must have the same hash code.
             /// </summary>
             public int GetHashCode(ContentType obj)
             {
-                return obj.ToString().ToUpperInvariant().GetHashCode();
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ToString());
             }
         }
 
@@ -366,13 +364,11 @@ namespace MS.Internal
             }
 
             /// <summary>
-            /// We lower case the results of ToString() because it returns the original
-            /// casing passed into the constructor.  ContentTypes that are equal (which
-            /// ignores casing) must have the same hash code.
+            /// ContentTypes that are equal (which ignores casing) must have the same hash code.
             /// </summary>
             public int GetHashCode(ContentType obj)
             {
-                return obj._type.ToUpperInvariant().GetHashCode() ^ obj._subType.ToUpperInvariant().GetHashCode();
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(obj._type) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(obj._subType);
             }
         }
         #endregion Nested Classes


### PR DESCRIPTION
## Description

Removes allocations for `ContentType`'s `WeakComparer` and `StrongComparer` (which are used in the related dictionaries).
- We will use `StringComparer.OrdinalIgnoreCase.GetHashCode(src)` instead of `src.ToUpperInvariant.GetHashCode()` as that creates a new string everytime just so we can retrieve HashCode out of it.
- This will reduce allocations to zero and also save about 40ns (depending on length, it scales up) per invocation while preserving functionality.

### Benchmarks

| Method  | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  34.736 ns |  0.2199 ns |   0.2057 ns | 0.0038 |         392 B |          64 B |
| PR_EDIT  | 8.620 ns |  0.0279 ns |   0.0247 ns |      - |         330 B |             - |

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  70.84 ns |   1.404 ns |    1.379 ns | 0.0110 |         394 B |         184 B |
| PR_EDIT  |  41.27 ns |   0.127 ns |    0.113 ns |      - |         316 B |             - |

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  183.5 ns |    2.76 ns |     2.58 ns | 0.0310 |         394 B |         520 B |
| PR_EDIT  | 132.4 ns |    0.40 ns |     0.35 ns |      - |         333 B |             - |

### Benchmark code

```csharp
//First invocation
return "aBCD".ToUpperInvariant().GetHashCode() ^ "xDDAH".ToUpperInvariant().GetHashCode();
return StringComparer.OrdinalIgnoreCase.GetHashCode("aBCD") ^ StringComparer.OrdinalIgnoreCase.GetHashCode("xDDAH");

//Second invocation
return "aBCDnowimagineifthisisLongstring".ToUpperInvariant().GetHashCode() ^ "xDDAHaBCDnowimagineifthisisLongstring".ToUpperInvariant().GetHashCode();
return StringComparer.OrdinalIgnoreCase.GetHashCode("aBCDnowimagineifthisisLongstring") ^ StringComparer.OrdinalIgnoreCase.GetHashCode("xDDAHaBCDnowimagineifthisisLongstring");

//Third invocation
return "aBCDnowimagineifthisisLongstringWeNeedthistobewaylongeeeeeeerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr".ToUpperInvariant().GetHashCode() ^
"xDDAHaBCDnowimagineifthisisLongstringaBCDnowimagineifthisisLongstringWeNeedthistobewaylongeeeeeeerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr".ToUpperInvariant().GetHashCode();
return StringComparer.OrdinalIgnoreCase.GetHashCode("aBCDnowimagineifthisisLongstringWeNeedthistobewaylongeeeeeeerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr") ^ 
StringComparer.OrdinalIgnoreCase.GetHashCode("xDDAHaBCDnowimagineifthisisLongstringaBCDnowimagineifthisisLongstringWeNeedthistobewaylongeeeeeeerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr");
```

## Customer Impact

Increased performance, including start-up performance, decreased allocations.

## Regression

No.

## Testing

Local build, assert test:

```csharp
int hashCode1 = "áBCD".ToUpperInvariant().GetHashCode() ^ "xDDAH".ToUpperInvariant().GetHashCode();
int hashCode2 = StringComparer.OrdinalIgnoreCase.GetHashCode("ÁBCD") ^ StringComparer.OrdinalIgnoreCase.GetHashCode("xDDAH");
Assert.AreEqual(hashCode1, hashCode2);
```

## Risk

Low.