### PR TITLE
Use string.Equals over string.Compare in ContentType for improved performance

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/MS/Internal/ContentType.cs
@@ -258,8 +258,8 @@ namespace MS.Internal
                 // safe comparison because the _type and _subType strings have been restricted to
                 // ASCII characters, digits, and a small set of symbols.  This is not a safe comparison
                 // for the broader set of strings that have not been restricted in the same way.
-                result = (String.Compare(_type, contentType.TypeComponent, StringComparison.OrdinalIgnoreCase) == 0 &&
-                          String.Compare(_subType, contentType.SubTypeComponent, StringComparison.OrdinalIgnoreCase) == 0);
+                result = string.Equals(_type, contentType.TypeComponent, StringComparison.OrdinalIgnoreCase) &&
+                         string.Equals(_subType, contentType.SubTypeComponent, StringComparison.OrdinalIgnoreCase);
             }           
             return result;
         }


### PR DESCRIPTION
## Description

Replaces two uses of `string.Compare` in `ContentType` which is used for equality check with `string.Equals`.

### Difference in the last character

| Method  | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original | 36.525 ns |  0.7577 ns |   0.7781 ns |         446 B |             - |
| PR_EDIT  |  4.873 ns |  0.0175 ns |   0.0155 ns |         467 B |             - |

### Difference in 5th character

| Method   |  Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original |   4.627 ns |  0.0493 ns |   0.0437 ns |         446 B |             - |
| PR_EDIT  |  2.668 ns |  0.0138 ns |   0.0129 ns |         467 B |             - |

### Benchmark source strings
```csharp
//First invocation (last char is different)
return string.Compare("someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase) == 0;
return string.Equals("someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase);

//Second invocation (5th char is different)
return string.Compare("some0veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"some1veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase) == 0;
return string.Equals("some0veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"some1veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase);
```

## Customer Impact

Improved performance.

## Regression

No.

## Testing

Local build.

## Risk

None, you can't ruin anything with this swap.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9724)