### PR TITLE
Remove SafeSecurityHelper.GetCultureInfoByIetfLanguageTag proxy for code quality

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/CultureMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/CultureMapper.cs
@@ -60,7 +60,7 @@ namespace MS.Internal.TextFormatting
                             try
                             {
                                 CultureInfo culture = CultureInfo.CreateSpecificCulture(cultureName);
-                                specificCulture = SafeSecurityHelper.GetCultureInfoByIetfLanguageTag(culture.IetfLanguageTag);
+                                specificCulture = CultureInfo.GetCultureInfoByIetfLanguageTag(culture.IetfLanguageTag);
                             }
                             catch (ArgumentException)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/XmlLanguage.cs
@@ -197,7 +197,7 @@ namespace System.Windows.Markup
                 {
                     // Even if we previously failed to find an EquivalentCulture, we retry, if only to
                     //   capture inner exception.
-                    _equivalentCulture = SafeSecurityHelper.GetCultureInfoByIetfLanguageTag(lowerCaseTag);
+                    _equivalentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag(lowerCaseTag);
                 }
                 catch (ArgumentException e)
                 {
@@ -251,7 +251,7 @@ namespace System.Windows.Markup
                         {
                             // note that it's important that we use culture.Name, not culture.IetfLanguageTag, here
                             culture = CultureInfo.CreateSpecificCulture(culture.Name);
-                            _specificCulture = SafeSecurityHelper.GetCultureInfoByIetfLanguageTag(culture.IetfLanguageTag);
+                            _specificCulture = CultureInfo.GetCultureInfoByIetfLanguageTag(culture.IetfLanguageTag);
                         }
                         catch (ArgumentException e)
                         {
@@ -272,9 +272,7 @@ namespace System.Windows.Markup
         {
             if (_compatibleCulture == null)
             {
-                CultureInfo culture = null;
-
-                if (!TryGetEquivalentCulture(out culture))
+                if (!TryGetEquivalentCulture(out CultureInfo culture))
                 {
                     string languageTag = IetfLanguageTag;
                     
@@ -291,7 +289,7 @@ namespace System.Windows.Markup
                         {
                             try
                             {
-                                culture = SafeSecurityHelper.GetCultureInfoByIetfLanguageTag(languageTag);
+                                culture = CultureInfo.GetCultureInfoByIetfLanguageTag(languageTag);
                             }
                             catch (ArgumentException)
                             {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -282,19 +282,6 @@ namespace System.Xaml
         }
 #endif //!REACHFRAMEWORK
 
-#if PRESENTATION_CORE
-
-        /// <summary>
-        ///     This function is a wrapper for CultureInfo.GetCultureInfoByIetfLanguageTag().
-        ///     The wrapper works around a bug in that routine, which causes it to throw
-        ///     a SecurityException in Partial Trust.
-        /// </summary>
-        static internal CultureInfo GetCultureInfoByIetfLanguageTag(string languageTag)
-        {
-            return CultureInfo.GetCultureInfoByIetfLanguageTag(languageTag);
-        }
-#endif //PRESENTATIONCORE
-
         internal const string IMAGE = "image";
     }
 


### PR DESCRIPTION
## Description

Removes the `SafeSecurityHelper.GetCultureInfoByIetfLanguageTag` method and replaces it directly with `CultureInfo.GetCultureInfoByIetfLanguageTag`.

One of the few leftover remnants from CAS times, there is no reason for this proxy method anymore.

## Customer Impact

Few bytes less in size of PresentationCore.

## Regression

No.

## Testing

Local build.

## Risk

None.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9733)