### PR TITLE
Improve startup and runtime performance by removing XamlTypeInvoker dead code

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/ExceptionStringTable.txt
@@ -249,7 +249,6 @@ DeferredLoad=Deferred load threw an exception.
 DeferredSave=Save of deferred-load content threw an exception.
 FactoryReturnedNull=The factory method '{0}' that matches the specified binding constraints returned null.
 ConstructorInvocation=The invocation of the constructor on type '{0}' that matches the specified binding constraints threw an exception.
-NoDefaultConstructor=No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.
 NoConstructor=No matching constructor found on type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.
 DeferringLoaderInstanceNull=Cannot get a XamlDeferringLoader from XamlValueConverter '{0}' because its ConverterInstance property is null.
 TypeConverterFailed2=Failed to convert '{0}' to type '{1}'.

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/Strings.resx
@@ -618,9 +618,6 @@
   <data name="NoConstructorWithNArugments" space_="preserve">
     <value>A Constructor for '{0}' with '{1}' arguments was not found.</value>
   </data>
-  <data name="NoDefaultConstructor" space_="preserve">
-    <value>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</value>
-  </data>
   <data name="NoElementUsage" space_="preserve">
     <value>'{0}' is not allowed in element usage.</value>
   </data>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.cs.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Konstruktor pro {0} s {1} argumenty nebyl nalezen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Pro typ {0} nebyl nalezen žádný výchozí konstruktor. Chcete-li zkonstruovat tento typ, můžete použít direktivy Arguments nebo FactoryMethod.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">{0} není povoleno v použití elementu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.de.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Ein Konstruktor für "{0}" mit {1}-Argumenten wurde nicht gefunden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Für den Typ "{0}" wurde kein Standardkonstruktor gefunden. Der Typ kann mit der Arguments- oder der FactoryMethod-Direktive erstellt werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">"{0}" ist nicht für Elementverwendung zulässig.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.es.xlf
@@ -837,11 +837,6 @@
         <target state="translated">No se encontró ningún constructor para '{0}' con '{1}' argumentos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">No se encontró ningún constructor predeterminado para el tipo '{0}'. Puede usar las directivas Arguments o FactoryMethod para construir este tipo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">No se permite '{0}' en el uso de elementos.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.fr.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Un constructeur pour '{0}' avec '{1}' des arguments est introuvable.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Aucun constructeur par défaut n'a été trouvé pour le type '{0}'. Vous pouvez utiliser les directives Arguments ou FactoryMethod pour construire ce type.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">'{0}' n'est pas autorisé dans l'utilisation d'élément.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.it.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Non è stato trovato alcun costruttore per '{0}' con gli argomenti '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Non è stato trovato alcun costruttore predefinito per il tipo '{0}'. È possibile usare le direttive Arguments o FactoryMethod per la costruzione del tipo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">'{0}' non consentito nella sintassi degli elementi.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ja.xlf
@@ -837,11 +837,6 @@
         <target state="translated">'{1}' 個の引数を持つ '{0}' のコンストラクターが見つかりませんでした。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">型 '{0}' に既定のコンストラクターが見つかりません。この型は、引数または FactoryMethod ディレクティブを使用して構築できます。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">要素では '{0}' を使用できません。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ko.xlf
@@ -837,11 +837,6 @@
         <target state="translated">'{1}' 인수가 포함된 '{0}'에 대한 생성자를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">'{0}' 형식에 대한 기본 생성자를 찾을 수 없습니다. Arguments 또는 FactoryMethod 지시문을 사용하여 이 형식을 생성할 수 있습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">'{0}'은(는) 요소에 사용할 수 없습니다.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pl.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Nie odnaleziono konstruktora dla „{0}” o następującej liczbie argumentów: {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Nie odnaleziono domyślnego konstruktora dla typu „{0}”. Do skonstruowania tego typu można użyć dyrektywy Arguments lub FactoryMethod.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">"{0}": niedozwolone użycie w odniesieniu do elementu.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.pt-BR.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Não foi encontrado um Construtor para '{0}' com '{1}' argumentos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Nenhum construtor padrão encontrado para o tipo '{0}'. Você pode usar a diretiva Arguments ou FactoryMethod para construir esse tipo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">'{0}' não é permitido na utilização do elemento.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.ru.xlf
@@ -837,11 +837,6 @@
         <target state="translated">Конструктор для "{0}" с аргументами "{1}" не найден.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">Не обнаружено конструктора по умолчанию для типа "{0}". Можно использовать директивы Arguments или FactoryMethod для формирования этого типа.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">"{0}" не допускается при использовании элемента.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.tr.xlf
@@ -837,11 +837,6 @@
         <target state="translated">'{1}' bağımsız değişkenle '{0}' için Oluşturucu bulunamadı.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">'{0}' türü için varsayılan oluşturucu bulunamadı. Bu türü oluşturmak için Arguments veya FactoryMethod yönergelerini kullanabilirsiniz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">Öğe kullanımında '{0}' kullanılmasına izin verilmez.</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hans.xlf
@@ -837,11 +837,6 @@
         <target state="translated">未找到“{0}”的带有“{1}”参数的构造函数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">未找到类型“{0}”的默认构造函数。可以使用 Arguments 或 FactoryMethod 指令来构造此类型。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">元素用法中不允许使用“{0}”。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/Resources/xlf/Strings.zh-Hant.xlf
@@ -837,11 +837,6 @@
         <target state="translated">找不到使用於 '{0}' 具有 '{1}' 引數的建構函式。</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoDefaultConstructor">
-        <source>No default constructor found for type '{0}'. You can use the Arguments or FactoryMethod directives to construct this type.</source>
-        <target state="translated">找不到型別 '{0}' 的預設建構函式。您可以使用 Arguments 或 FactoryMethod 指示詞來建構此型別。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoElementUsage">
         <source>'{0}' is not allowed in element usage.</source>
         <target state="translated">項目使用方式中不允許 '{0}'。</target>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs
@@ -23,10 +23,6 @@ namespace System.Xaml.Schema
         internal MethodInfo EnumeratorMethod { get; set; }
         private XamlType _xamlType;
 
-        private Action<object> _constructorDelegate;
-
-        private ThreeValuedBool _isPublic;
-
         // vvvvv---- Unused members.  Servicing policy is to retain these anyway.  -----vvvvv
         private ThreeValuedBool _isInSystemXaml;
         // ^^^^^----- End of unused members.  -----^^^^^
@@ -129,14 +125,7 @@ namespace System.Xaml.Schema
         public virtual object CreateInstance(object[] arguments)
         {
             ThrowIfUnknown();
-            if (!_xamlType.UnderlyingType.IsValueType && (arguments == null || arguments.Length == 0))
-            {
-                object result = DefaultCtorXamlActivator.CreateInstance(this);
-                if (result != null)
-                {
-                    return result;
-                }
-            }
+
             return Activator.CreateInstance(_xamlType.UnderlyingType, arguments);
         }
 
@@ -243,19 +232,6 @@ namespace System.Xaml.Schema
         }
         // ^^^^^----- End of unused members.  -----^^^^^
 
-        private bool IsPublic
-        {
-            get
-            {
-                if (_isPublic == ThreeValuedBool.NotSet)
-                {
-                    Type type = _xamlType.UnderlyingType.UnderlyingSystemType;
-                    _isPublic = type.IsVisible ? ThreeValuedBool.True : ThreeValuedBool.False;
-                }
-                return _isPublic == ThreeValuedBool.True;
-            }
-        }
-
         private bool IsUnknown
         {
             get { return _xamlType == null || _xamlType.UnderlyingType == null; }
@@ -266,82 +242,6 @@ namespace System.Xaml.Schema
             if (IsUnknown)
             {
                 throw new NotSupportedException(SR.NotSupportedOnUnknownType);
-            }
-        }
-
-        private static class DefaultCtorXamlActivator
-        {
-            private static ThreeValuedBool s_securityFailureWithCtorDelegate;
-            private static ConstructorInfo s_actionCtor =
-                typeof(Action<object>).GetConstructor(new Type[] { typeof(Object), typeof(IntPtr) });
-
-
-            public static object CreateInstance(XamlTypeInvoker type)
-            {
-                if (!EnsureConstructorDelegate(type))
-                {
-                    return null;
-                }
-                object inst = CallCtorDelegate(type);
-                return inst;
-            }
-#pragma warning disable SYSLIB0050
-            private static object CallCtorDelegate(XamlTypeInvoker type)
-            {
-                object inst = FormatterServices.GetUninitializedObject(type._xamlType.UnderlyingType);
-                InvokeDelegate(type._constructorDelegate, inst);
-                return inst;
-            }
-#pragma warning restore SYSLIB0050
-            private static void InvokeDelegate(Action<object> action, object argument)
-            {
-                action.Invoke(argument);
-            }
-
-            // returns true if a delegate is available, false if not
-            private static bool EnsureConstructorDelegate(XamlTypeInvoker type)
-            {
-                if (type._constructorDelegate != null)
-                {
-                    return true;
-                }
-                if (!type.IsPublic)
-                {
-                    return false;
-                }
-                if (s_securityFailureWithCtorDelegate == ThreeValuedBool.NotSet)
-                {
-                    s_securityFailureWithCtorDelegate =
-                        ThreeValuedBool.False;
-                }
-                if (s_securityFailureWithCtorDelegate == ThreeValuedBool.True)
-                {
-                    return false;
-                }
-
-                Type underlyingType = type._xamlType.UnderlyingType.UnderlyingSystemType;
-                // Look up public ctors only, for equivalence with Activator.CreateInstance
-                ConstructorInfo tConstInfo = underlyingType.GetConstructor(Type.EmptyTypes);
-                if (tConstInfo == null)
-                {
-                    // Throwing MissingMethodException for equivalence with Activator.CreateInstance
-                    throw new MissingMethodException(SR.Format(SR.NoDefaultConstructor, underlyingType.FullName));
-                }
-                if ((tConstInfo.IsSecurityCritical && !tConstInfo.IsSecuritySafeCritical) ||
-                    (tConstInfo.Attributes & MethodAttributes.HasSecurity) == MethodAttributes.HasSecurity ||
-                    (underlyingType.Attributes & TypeAttributes.HasSecurity) == TypeAttributes.HasSecurity)
-                {
-                    // We don't want to bypass security checks for a critical or demanding ctor,
-                    // so just treat it as if it were non-public
-                    type._isPublic = ThreeValuedBool.False;
-                    return false;
-                }
-                IntPtr constPtr = tConstInfo.MethodHandle.GetFunctionPointer();
-                // This requires Reflection Permission
-                Action<object> ctorDelegate = ctorDelegate =
-                    (Action<object>)s_actionCtor.Invoke(new object[] { null, constPtr });
-                type._constructorDelegate = ctorDelegate;
-                return true;
             }
         }
     }


### PR DESCRIPTION
## Description
Removes XamlTypeInvoker dead code. This code is hit when creating an instance of a non-known type from XAML/BAML. Removing this code improves both startup and runtime performance.

Known types are types in an hard-coded list that makes them more optimized by WPF. This includes types from WPF and some BCL common types (Like int, bool, string, etc). Everything else is a non-known type so things like custom controls are non-known types.

The reason this is dead code is because `DefaultCtorXamlActivator.EnsureConstructorDelegate` always returns false because of this condition here:
https://github.com/dotnet/wpf/blob/e500f8e58e439566ca68cdeff09303fb6f46110a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/Schema/XamlTypeInvoker.cs#L330

Since the removal of CAS from .Net, `ConstructorInfo.IsSecurityCritical` always returns true and `ConstructorInfo.IsSecuritySafeCritical` always returns false so the the condition is always true which means that the whole `DefaultCtorXamlActivator` class doesn't do anything.

Here's the .Net code for `ConstructorInfo.IsSecurityCritical` and `ConstructorInfo.IsSecuritySafeCritical` which always return constants:
https://github.com/dotnet/runtime/blob/a349912e4f8610f39a6ac3cb73d8d4d0968ccec4/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs#L228-L230


 #### Benchmarks
I benchmarked a new WPF from the Visual Studio template where I added an empty class like `public class CustomLabel : Label { }` and I added this control 20 times in the XAML of the main window. This PR shaves about 30-40 ms when starting the app.

There's a small cache per-type that skips some of the code so I also benchmarked a new WPF from the Visual Studio template where I added 20 empty classes like `public class CustomLabel1 : Label { }` and I added each control in the XAML of the main window. This PR shaves about 50-60 ms when starting the app.

I expect more complex apps with more non-known type in XAML to have even bigger performance gain. Projects that have a ton of non-known types are third-party control vendors (Like DevExpress, Telerik, etc) because they have a ton of custom controls.

## Customer Impact
Better startup and runtime performance.

## Regression
No.

## Testing
Local testing using sample app that hits this specific code.

## Risk
Low.