### PR TITLE
Optimize retrieval of simple name from Assembly.FullName, fix up faulty methods

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/PresentationBuildTasks.csproj
@@ -85,6 +85,9 @@
     <Compile Include="$(WpfSharedDir)\MS\Internal\ResourceIDHelper.cs">
       <Link>Shared\MS\Internal\ResourceIDHelper.cs</Link>
     </Compile>
+    <Compile Include="$(WpfSharedDir)\MS\Internal\ReflectionUtils.cs">
+      <Link>Shared\MS\Internal\ReflectionUtils.cs</Link>
+    </Compile>
     <Compile Include="$(WpfSharedDir)\MS\Internal\SecurityHelper.cs">
       <Link>Shared\MS\Internal\SecurityHelper.cs</Link>
     </Compile>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontSource.cs
@@ -355,8 +355,8 @@ namespace MS.Internal.FontCache
         {
             string fontFilename = _fontUri.OriginalString.Substring(_fontUri.OriginalString.LastIndexOf('/') + 1).ToLowerInvariant();
 
-            var fontResourceAssembly = Assembly.GetExecutingAssembly();
-            ResourceManager rm = new ResourceManager($"{fontResourceAssembly.GetName().Name}.g", fontResourceAssembly);
+            Assembly fontResourceAssembly = Assembly.GetExecutingAssembly();
+            ResourceManager rm = new($"{ReflectionUtils.GetAssemblyPartialName(fontResourceAssembly)}.g", fontResourceAssembly);
 
             return rm?.GetStream($"fonts/{fontFilename}");
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ResourceManagerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ResourceManagerWrapper.cs
@@ -232,11 +232,10 @@ namespace MS.Internal.Resources
             {
                 if (_resourceSet == null)
                 {
-                    string manifestResourceName;
+                    //"$(AssemblyShortname).unlocalizable.g"
+                    string manifestResourceName = $"{ReflectionUtils.GetAssemblyPartialName(_assembly)}{UnLocalizableResourceNameSuffix}";
+                    ResourceManager manager = new(manifestResourceName, _assembly);
 
-                    manifestResourceName = ReflectionUtils.GetAssemblyPartialName(_assembly) + UnLocalizableResourceNameSuffix;
-
-                    ResourceManager manager = new ResourceManager(manifestResourceName, this._assembly);
                     _resourceSet = manager.GetResourceSet(CultureInfo.InvariantCulture, true, false);
                 }
 
@@ -254,11 +253,9 @@ namespace MS.Internal.Resources
             {
                 if (_resourceManager == null)
                 {
-                    string baseResourceName;  // Our build system always generate a resource base name "$(AssemblyShortname).g"
-
-                    baseResourceName = ReflectionUtils.GetAssemblyPartialName(_assembly) + LocalizableResourceNameSuffix;
-
-                    _resourceManager = new ResourceManager(baseResourceName, this._assembly);
+                    // Our build system always generate a resource base name "$(AssemblyShortname).g"
+                    string baseResourceName = $"{ReflectionUtils.GetAssemblyPartialName(_assembly)}{LocalizableResourceNameSuffix}";
+                    _resourceManager = new ResourceManager(baseResourceName, _assembly);
                 }
 
                 return _resourceManager;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ResourceManagerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Resources/ResourceManagerWrapper.cs
@@ -234,7 +234,7 @@ namespace MS.Internal.Resources
                 {
                     string manifestResourceName;
 
-                    manifestResourceName = SafeSecurityHelper.GetAssemblyPartialName(_assembly) + UnLocalizableResourceNameSuffix;
+                    manifestResourceName = ReflectionUtils.GetAssemblyPartialName(_assembly) + UnLocalizableResourceNameSuffix;
 
                     ResourceManager manager = new ResourceManager(manifestResourceName, this._assembly);
                     _resourceSet = manager.GetResourceSet(CultureInfo.InvariantCulture, true, false);
@@ -256,7 +256,7 @@ namespace MS.Internal.Resources
                 {
                     string baseResourceName;  // Our build system always generate a resource base name "$(AssemblyShortname).g"
 
-                    baseResourceName = SafeSecurityHelper.GetAssemblyPartialName(_assembly) + LocalizableResourceNameSuffix;
+                    baseResourceName = ReflectionUtils.GetAssemblyPartialName(_assembly) + LocalizableResourceNameSuffix;
 
                     _resourceManager = new ResourceManager(baseResourceName, this._assembly);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
-using MS.Win32;
-using System.Windows.Media;
 using System.Windows.Input;
+using System.Reflection;
+using MS.Internal;
+using MS.Win32;
 
 namespace System.Windows.Interop
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
@@ -419,7 +419,7 @@ namespace System.Windows.Interop
         /// <remarks>Not intended to be tested outside test code</remarks>
         internal static void SetPlatformSupportsTransparentChildWindowsForTestingOnly(bool value)
         {
-            if (string.Equals(ReflectionUtils.GetAssemblyPartialName(Assembly.GetEntryAssembly()), "drthwndsource", StringComparison.CurrentCultureIgnoreCase))
+            if (ReflectionUtils.GetAssemblyPartialName(Assembly.GetEntryAssembly()).Equals("drthwndsource", StringComparison.CurrentCultureIgnoreCase))
             {
                 _platformSupportsTransparentChildWindows = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSourceParameters.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using MS.Win32;
+using System.Windows.Media;
 using System.Windows.Input;
 
 namespace System.Windows.Interop
@@ -418,7 +419,7 @@ namespace System.Windows.Interop
         /// <remarks>Not intended to be tested outside test code</remarks>
         internal static void SetPlatformSupportsTransparentChildWindowsForTestingOnly(bool value)
         {
-            if (string.Equals(System.Reflection.Assembly.GetEntryAssembly().GetName().Name, "drthwndsource", StringComparison.CurrentCultureIgnoreCase))
+            if (string.Equals(ReflectionUtils.GetAssemblyPartialName(Assembly.GetEntryAssembly()), "drthwndsource", StringComparison.CurrentCultureIgnoreCase))
             {
                 _platformSupportsTransparentChildWindows = value;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -327,7 +327,7 @@ namespace System.Windows.Navigation
 
                     if (assembly != null)
                     {
-                        return (string.Equals(ReflectionUtils.GetAssemblyPartialName(assembly), assemblyName, StringComparison.OrdinalIgnoreCase));
+                        return ReflectionUtils.GetAssemblyPartialName(assembly).Equals(assemblyName, StringComparison.OrdinalIgnoreCase);
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Navigation/BaseUriHelper.cs
@@ -327,7 +327,7 @@ namespace System.Windows.Navigation
 
                     if (assembly != null)
                     {
-                        return (string.Equals(SafeSecurityHelper.GetAssemblyPartialName(assembly), assemblyName, StringComparison.OrdinalIgnoreCase));
+                        return (string.Equals(ReflectionUtils.GetAssemblyPartialName(assembly), assemblyName, StringComparison.OrdinalIgnoreCase));
                     }
                     else
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentsTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentsTrace.cs
@@ -117,8 +117,8 @@ namespace MS.Internal.Documents
         public DocumentsTrace(string switchName)
         {
 #if DEBUG
-            string name = ReflectionUtils.GetAssemblyPartialName(Assembly.GetCallingAssembly());
-            _switch = new BooleanSwitch(switchName, $"[{name}]");
+            ReadOnlySpan<char> shortAssemblyName = ReflectionUtils.GetAssemblyPartialName(Assembly.GetCallingAssembly());
+            _switch = new BooleanSwitch(switchName, $"[{shortAssemblyName}]");
 #endif
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentsTrace.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentsTrace.cs
@@ -117,7 +117,7 @@ namespace MS.Internal.Documents
         public DocumentsTrace(string switchName)
         {
 #if DEBUG
-            string name = SafeSecurityHelper.GetAssemblyPartialName( Assembly.GetCallingAssembly() );
+            string name = ReflectionUtils.GetAssemblyPartialName(Assembly.GetCallingAssembly());
             _switch = new BooleanSwitch(switchName, $"[{name}]");
 #endif
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Globalization;
 using XamlReaderHelper = System.Windows.Markup.XamlReaderHelper;
 using System.Runtime.CompilerServices;
+using MS.Internal;
 
 namespace System.Windows.Baml2006
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -2105,7 +2105,6 @@ namespace System.Windows.Baml2006
 
         // Providing the assembly short name may lead to ambiguity between two versions of the same assembly, but we need to
         // keep it this way since it is exposed publicly via the Namespace property, Baml2006ReaderInternal provides the full Assembly name.
-        // We need to avoid Assembly.GetName() so we run in PartialTrust without asserting.
         internal virtual ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly assembly)
         {
             string assemblyLongName = assembly.FullName;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006Reader.cs
@@ -2107,8 +2107,7 @@ namespace System.Windows.Baml2006
         // keep it this way since it is exposed publicly via the Namespace property, Baml2006ReaderInternal provides the full Assembly name.
         internal virtual ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly assembly)
         {
-            string assemblyLongName = assembly.FullName;
-            return assemblyLongName.AsSpan(0, assemblyLongName.IndexOf(','));
+            return ReflectionUtils.GetAssemblyPartialName(assembly);
         }
 
         // (prefix, namespaceUri)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006ReaderInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006ReaderInternal.cs
@@ -34,9 +34,9 @@ namespace System.Windows.Baml2006
         #endregion
 
         // Return the full assembly name, this includes the assembly version
-        internal override ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly asm)
+        internal override ReadOnlySpan<char> GetAssemblyNameForNamespace(Assembly assembly)
         {
-            return asm.FullName;
+            return assembly.FullName;
         }
 
         // When processing ResourceDictionary.Source we may find a Uri that references the

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
@@ -1610,14 +1610,14 @@ namespace System.Windows.Markup.Primitives
                 {
                     if (type.Namespace == null)
                     {
-                        result = $"{clrUriPrefix};assembly={type.Assembly.GetName().Name}";
+                        result = $"{clrUriPrefix};assembly={ReflectionUtils.GetAssemblyPartialName(type.Assembly)}";
                     }
                     else
                     {
                         Dictionary<string, string> namespaceToUri = GetMappingsFor(type.Assembly);
                         if (!namespaceToUri.TryGetValue(type.Namespace, out result))
                         {
-                            result = $"{clrUriPrefix}{type.Namespace};assembly={type.Assembly.GetName().Name}";
+                            result = $"{clrUriPrefix}{type.Namespace};assembly={ReflectionUtils.GetAssemblyPartialName(type.Assembly)}";
                         }
                     }
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Primitives/MarkupWriter.cs
@@ -1,17 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //  Contents:  XAML writer
 //
 
+using System.Xml.Serialization;
 using System.ComponentModel;
-using System.Reflection;
 using System.Collections;
+using System.Reflection;
+using MS.Internal;
 using System.Text;
 using System.Xml;
-using System.Xml.Serialization;
 
 namespace System.Windows.Markup.Primitives
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -2481,7 +2481,7 @@ namespace System.Windows.Markup
 
         private static bool IsInternalAllowedOnType(Type type)
         {
-            bool isInternalAllowed = ReflectionHelper.LocalAssemblyName == type.Assembly.GetName().Name ||
+            bool isInternalAllowed = ReflectionHelper.LocalAssemblyName == ReflectionUtils.GetAssemblyPartialName(type.Assembly) ||
                                      IsFriendAssembly(type.Assembly);
             _hasInternals = _hasInternals || isInternalAllowed;
             return isInternalAllowed;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -571,7 +571,7 @@ namespace System.Windows
                 }
                 else
                 {
-                    _assemblyName = SafeSecurityHelper.GetAssemblyPartialName(assembly);
+                    _assemblyName = ReflectionUtils.GetAssemblyPartialName(assembly);
                 }
             }
 
@@ -786,7 +786,7 @@ namespace System.Windows
                 }
 
                 assemblyName = sb.ToString();
-                string fullName = SafeSecurityHelper.GetFullAssemblyNameFromPartialName(_assembly, assemblyName);
+                string fullName = ReflectionUtils.GetFullAssemblyNameFromPartialName(_assembly, assemblyName);
 
                 assembly = null;
                 try

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemResources.cs
@@ -571,7 +571,7 @@ namespace System.Windows
                 }
                 else
                 {
-                    _assemblyName = ReflectionUtils.GetAssemblyPartialName(assembly);
+                    _assemblyName = ReflectionUtils.GetAssemblyPartialName(assembly).ToString();
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace MS.Internal
+{
+    internal static class ReflectionUtils
+    {
+        /// <summary>
+        ///  Given an assembly, returns the partial name of the assembly.
+        /// </summary>
+        internal static string GetAssemblyPartialName(Assembly assembly)
+        {
+            AssemblyName name = new(assembly.FullName);
+            return name.Name ?? string.Empty;
+        }
+
+        /// <summary>
+        ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
+        ///  with everything else from <paramref name="assembly"/>.
+        /// </summary>
+        internal static string GetFullAssemblyNameFromPartialName(Assembly assembly, string partialName)
+        {
+            AssemblyName name = new(assembly.FullName) { Name = partialName };
+            return name.FullName;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -5,8 +5,8 @@
 #nullable enable
 
 using System.Runtime.CompilerServices;
+using System.Reflection.Metadata;
 using System.Reflection;
-using System.Text;
 using System;
 
 namespace MS.Internal
@@ -67,13 +67,11 @@ namespace MS.Internal
                 UnescapeDirty(ref fullName);
 
             // Since having "," or "=" in the assembly name is very rare, we don't want to inline
+            // and we will fallback to the runtime implementation to handle such case for us
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void UnescapeDirty(ref ReadOnlySpan<char> dirtyName)
             {
-                StringBuilder sb = new(dirtyName.Length);
-                sb.Append(dirtyName);
-                sb.Replace("\\", null);
-                dirtyName = sb.ToString();
+                dirtyName = !AssemblyNameInfo.TryParse(dirtyName, out AssemblyNameInfo? result) ? ReadOnlySpan<char>.Empty : result.Name;
             }
 
             return fullName;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -6,10 +6,13 @@ using System.Reflection;
 
 namespace MS.Internal
 {
+    /// <summary>
+    /// Provides utilities for working with reflection efficiently.
+    /// </summary>
     internal static class ReflectionUtils
     {
         /// <summary>
-        ///  Given an assembly, returns the partial name of the assembly.
+        ///  Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
         /// </summary>
         internal static string GetAssemblyPartialName(Assembly assembly)
         {

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System;
 
 namespace MS.Internal
 {
@@ -14,10 +15,37 @@ namespace MS.Internal
         /// <summary>
         ///  Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
         /// </summary>
+#if !NETFX
+        internal static ReadOnlySpan<char> GetAssemblyPartialName(Assembly assembly)
+#else
         internal static string GetAssemblyPartialName(Assembly assembly)
+#endif
         {
+#if !NETFX
+            // We know that the input is trusted (it will be properly escaped, with ", " between tokens etc.)
+            // So we can allow ourselves to do a little trick, where we just find the first separator
+            // You cannot load an assembly (or define) where name is empty, it needs to be at least 1 character
+            // But we will keep this for consistency of the previous function, maybe I've missed a class
+            ReadOnlySpan<char> fullName = assembly.FullName;
+            if (fullName.IsEmpty)
+                return string.Empty;
+
+            ReadOnlySpan<char> nameSlice = fullName;
+            // Skip any escaped commas in the name
+            int escapedComma = fullName.LastIndexOf("\\,");
+            if (escapedComma != -1)
+                nameSlice = nameSlice.Slice(escapedComma + 2);
+
+            // Find the start of the next token (usually "Version")
+            int commaIndex = nameSlice.IndexOf(',');
+            if (commaIndex != -1)
+                fullName = fullName.Slice(0, fullName.Length - nameSlice.Length + commaIndex);
+
+            return fullName;
+#else
             AssemblyName name = new(assembly.FullName);
             return name.Name ?? string.Empty;
+#endif
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -16,7 +16,6 @@ namespace MS.Internal
     /// </summary>
     internal static class ReflectionUtils
     {
-
 #if !NETFX
         /// <summary>
         ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
+using System.Runtime.CompilerServices;
 using System.Reflection;
+using System.Text;
 using System;
 
 namespace MS.Internal
@@ -12,6 +16,23 @@ namespace MS.Internal
     /// </summary>
     internal static class ReflectionUtils
     {
+
+#if !NETFX
+        /// <summary>
+        ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
+        ///  with everything else from <paramref name="assembly"/>.
+        /// </summary>
+        internal static string GetFullAssemblyNameFromPartialName(Assembly assembly, string partialName)
+        {
+            ArgumentNullException.ThrowIfNull(assembly, nameof(assembly));
+            string? fullName = assembly.FullName;
+            ArgumentNullException.ThrowIfNull(fullName, nameof(Assembly.FullName));
+
+            AssemblyName name = new(fullName) { Name = partialName };
+            return name.FullName;
+        }
+#endif
+
         /// <summary>
         ///  Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
         /// </summary>
@@ -22,40 +43,45 @@ namespace MS.Internal
 #endif
         {
 #if !NETFX
+            ArgumentNullException.ThrowIfNull(assembly, nameof(assembly));
             // We know that the input is trusted (it will be properly escaped, with ", " between tokens etc.)
             // So we can allow ourselves to do a little trick, where we just find the first separator
             // You cannot load an assembly (or define) where name is empty, it needs to be at least 1 character
             // But we will keep this for consistency of the previous function, maybe I've missed a class
             ReadOnlySpan<char> fullName = assembly.FullName;
             if (fullName.IsEmpty)
-                return string.Empty;
+                return ReadOnlySpan<char>.Empty;
 
             ReadOnlySpan<char> nameSlice = fullName;
-            // Skip any escaped commas in the name
+            // Skip any escaped commas in the name if present
             int escapedComma = fullName.LastIndexOf("\\,");
             if (escapedComma != -1)
                 nameSlice = nameSlice.Slice(escapedComma + 2);
 
-            // Find the start of the next token (usually "Version")
+            // Find the real ending of the name section
             int commaIndex = nameSlice.IndexOf(',');
             if (commaIndex != -1)
                 fullName = fullName.Slice(0, fullName.Length - nameSlice.Length + commaIndex);
+
+            // Check if we need to unescape, this is very rare case so we can just do it the dirty way
+            if (escapedComma != -1 || fullName.Contains('\\'))
+                UnescapeDirty(ref fullName);
+
+            // Since having "," or "=" in the assembly name is very rare, we don't want to inline
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void UnescapeDirty(ref ReadOnlySpan<char> dirtyName)
+            {
+                StringBuilder sb = new(dirtyName.Length);
+                sb.Append(dirtyName);
+                sb.Replace("\\", null);
+                dirtyName = sb.ToString();
+            }
 
             return fullName;
 #else
             AssemblyName name = new(assembly.FullName);
             return name.Name ?? string.Empty;
 #endif
-        }
-
-        /// <summary>
-        ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
-        ///  with everything else from <paramref name="assembly"/>.
-        /// </summary>
-        internal static string GetFullAssemblyNameFromPartialName(Assembly assembly, string partialName)
-        {
-            AssemblyName name = new(assembly.FullName) { Name = partialName };
-            return name.FullName;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -54,7 +54,7 @@ namespace MS.Internal
 
             ReadOnlySpan<char> nameSlice = fullName;
             // Skip any escaped commas in the name if present
-            int escapedComma = fullName.LastIndexOf("\\,");
+            int escapedComma = fullName.LastIndexOf("\\,", StringComparison.Ordinal);
             if (escapedComma != -1)
                 nameSlice = nameSlice.Slice(escapedComma + 2);
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -58,39 +58,7 @@ namespace System.Xaml
         }
 #endif
 
-#if PRESENTATION_CORE || PRESENTATIONFRAMEWORK ||REACHFRAMEWORK || DEBUG
-
-#if !WINDOWS_BASE && !SYSTEM_XAML
-        /// <summary>
-        ///     Given an assembly, returns the partial name of the assembly.
-        /// </summary>
-        internal static string GetAssemblyPartialName(Assembly assembly)
-        {
-            AssemblyName name = new AssemblyName(assembly.FullName);
-            string partialName = name.Name;
-            return partialName ?? string.Empty;
-        }
-#endif
-
-#endif
-
 #if PRESENTATIONFRAMEWORK
-
-        /// <summary>
-        ///     Get the full assembly name by combining the partial name passed in
-        ///     with everything else from proto assembly.
-        /// </summary>
-        internal static string GetFullAssemblyNameFromPartialName(
-                                    Assembly protoAssembly,
-                                    string partialName)
-        {
-            AssemblyName name = new AssemblyName(protoAssembly.FullName)
-            {
-                Name = partialName
-            };
-            return name.FullName;
-        }
-
         internal static Point ClientToScreen(UIElement relativeTo, Point point)
         {
             GeneralTransform transform;

--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -504,7 +504,7 @@ namespace System.Xaml
 #if PBTCOMPILER
         internal static bool IsInternalAllowedOnType(Type type)
         {
-            return ((LocalAssemblyName == type.Assembly.GetName().Name) || IsFriendAssembly(type.Assembly));
+            return LocalAssemblyName == ReflectionUtils.GetAssemblyPartialName(type.Assembly) || IsFriendAssembly(type.Assembly);
         }
 #endif
 

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System.Xaml.csproj
@@ -24,6 +24,9 @@
     <Compile Include="$(WpfSharedDir)MS\Internal\Xaml\Parser\SpecialBracketCharacters.cs">
       <Link>Common\WPF\MS\Internal\Xaml\Parser\SpecialBracketCharacters.cs</Link>
     </Compile>
+    <Compile Include="$(WpfSharedDir)\MS\Internal\ReflectionUtils.cs">
+      <Link>Common\WPF\MS\Internal\ReflectionUtils.cs</Link>
+    </Compile>
     <Compile Include="$(WpfSharedDir)MS\Internal\SafeSecurityHelper.cs">
       <Link>Common\WPF\MS\Internal\SafeSecurityHelper.cs</Link>
     </Compile>

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/MS/Impl/XmlNsInfo.cs
@@ -12,6 +12,8 @@ using System.Runtime.CompilerServices;
 using System.Windows.Markup;
 using System.Xaml.Schema;
 
+using MS.Internal;
+
 namespace System.Xaml.MS.Impl
 {
     class XmlNsInfo
@@ -223,8 +225,7 @@ namespace System.Xaml.MS.Impl
                 xmlNamespaceList.Add(nsDef.XmlNamespace);
             }
 
-            string assemblyName = _fullyQualifyAssemblyName ?
-                assembly.FullName : XamlSchemaContext.GetAssemblyShortName(assembly);
+            string assemblyName = _fullyQualifyAssemblyName ? assembly.FullName : ReflectionUtils.GetAssemblyPartialName(assembly).ToString();
             foreach (KeyValuePair<string, IList<string>> clrToXmlNs in result)
             {
                 // Sort namespaces in preference order

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -1041,8 +1041,7 @@ namespace System.Xaml
 
             if (!assemblyMappings.TryGetValue(clrNs, out result))
             {
-                string assemblyName = FullyQualifyAssemblyNamesInClrNamespaces ?
-                    assembly.FullName : GetAssemblyShortName(assembly);
+                string assemblyName = FullyQualifyAssemblyNamesInClrNamespaces ? assembly.FullName : ReflectionUtils.GetAssemblyPartialName(assembly).ToString();
                 string xmlns = ClrNamespaceUriParser.GetUri(clrNs, assemblyName);
                 List<string> list = new List<string>();
                 list.Add(xmlns);
@@ -1200,14 +1199,6 @@ namespace System.Xaml
         #endregion
 
         #region Helper Methods
-
-        // Given an assembly, return the assembly short name.  We need to avoid Assembly.GetName() so we run in PartialTrust without asserting.
-        internal static string GetAssemblyShortName(Assembly assembly)
-        {
-            string assemblyLongName = assembly.FullName;
-            string assemblyShortName = assemblyLongName.Substring(0, assemblyLongName.IndexOf(','));
-            return assemblyShortName;
-        }
 
         internal static ConcurrentDictionary<K, V> CreateDictionary<K, V>()
         {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -786,7 +786,6 @@ namespace System.Xaml
                 return false;
             }
 
-            // Not using Assembly.GetName() because it doesn't work in partial-trust
             AssemblyName toAssemblyName = new AssemblyName(toAssembly.FullName);
             foreach (AssemblyName friend in friends)
             {

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlSchemaContext.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Text;
+using MS.Internal;
 using System.Threading;
 using System.Xaml.MS.Impl;
 using System.Xaml.Schema;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -53,9 +53,8 @@ namespace System.Windows
             }
 
             _resourceName = resourceName.ToLowerInvariant();
-            _hInstance = (HINSTANCE)Marshal.GetHINSTANCE(resourceAssembly.ManifestModule);
-            AssemblyName name = new(resourceAssembly.FullName);
-            _resourceManager = new ResourceManager($"{name.Name}.g", resourceAssembly);
+            _hInstance = Marshal.GetHINSTANCE(resourceAssembly.ManifestModule);
+            _resourceManager = new ResourceManager($"{ReflectionUtils.GetAssemblyPartialName(resourceAssembly)}.g", resourceAssembly);
         }
 
         public void Show(bool autoClose)

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/SplashScreen.cs
@@ -53,7 +53,7 @@ namespace System.Windows
             }
 
             _resourceName = resourceName.ToLowerInvariant();
-            _hInstance = Marshal.GetHINSTANCE(resourceAssembly.ManifestModule);
+            _hInstance = (HINSTANCE)Marshal.GetHINSTANCE(resourceAssembly.ManifestModule);
             _resourceManager = new ResourceManager($"{ReflectionUtils.GetAssemblyPartialName(resourceAssembly)}.g", resourceAssembly);
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/WindowsBase.csproj
@@ -34,6 +34,7 @@
     <Compile Include="MS\Internal\IO\Packaging\PackagingExtensions.cs" />
     <Compile Include="SR.cs" />
     <Compile Include="$(WpfSharedDir)\RefAssemblyAttrs.cs" />
+    <Compile Include="$(WpfSharedDir)\MS\Internal\ReflectionUtils.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\ResourceIDHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SecurityHelper.cs" />
     <Compile Include="$(WpfSharedDir)\MS\Internal\SafeSecurityHelper.cs" />


### PR DESCRIPTION
## Description

Optimizes retrieval of simple name from `Assembly.FullName` and removes all the weird ways used throughout to get it, this optimizes both startup and runtime performance.
- In `Baml2006Reader` and `XamlSchemaContext` the original method did not properly parse assembly names with properly escaped commas, a weird edge-case but still a valid one. This was there due to CAS anyways.
- Since we're in all cases as far as I know working with `RuntimeAssembly`, using `assembly.GetName().Name` is always the slowest, followed by `new AssemblyName(assembly.FullName).Name`.
- The original intention was to merely unify this behaviour, however given how slow it is and since there was already custom parsing done in Xaml/Baml, I've decided to roll our own.
- The two methods were moved from `SafeSecurityHelper` to its own `ReflectionUtils` static class.
- Since the input is trusted (`FullName` is already after `AssemblyName` parser sanization, and with `RuntimeAssembly` (even dynamic assemblies from `AssemblyBuilder`), we can just look for a separator, there should be no concerns with custom parsing.
- PBT on `net472` fallbacks to `new AssemblyName(assembly.FullName).Name`.

### Benchmarks for RuntimeAssembly

| Method       | assembly             | Mean [ns] | Error [ns] | StdDev | Gen0   | Code Size | Allocated |
|------------- |--------------------- |----------:|-----------:|--------:|-------:|----------:|----------:|
| GetName_Name | DataF(...)=null [75] | 762.18 ns |   4.407 ns |    4.123 ns | 0.0439 |       1,768 B |         736 B |
| AssemblyName | DataF(...)=null [75] | 382.63 ns |   4.307 ns |    4.028 ns | 0.0291 |         3,140 B |         488 B |
| PR_EDIT      | DataF(...)=null [75] |  10.25 ns |   0.045 ns |    0.038 ns |      - |       1,629 B |             - |
| GetName_Name | Syste(...)7798e [89] | 516.84 ns |   4.869 ns |    4.555 ns | 0.0362 |       1,761 B |         616 B |
| AssemblyName | Syste(...)7798e [89] | 387.02 ns |   3.930 ns |    3.676 ns | 0.0310 |         3,115 B |         520 B |
| PR_EDIT      | Syste(...)7798e [89] |  10.75 ns |   0.051 ns |    0.045 ns |      - |       1,629 B |             - |
| GetName_Name | Bench(...)cefc4 [84] | 739.83 ns |   7.599 ns |    6.736 ns | 0.0486 |       1,761 B |         816 B |
| AssemblyName | Bench(...)cefc4 [84] | 375.59 ns |   4.439 ns |    4.153 ns | 0.0300 |         3,140 B |         504 B |
| PR_EDIT      | Bench(...)cefc4 [84] |  10.76 ns |   0.078 ns |    0.073 ns |      - |       1,629 B |             - |

### Benchmark code
<details><summary>Benchmark code</summary>

```csharp
public static IEnumerable<Assembly> AssembliesToTest
{
    get
    {
        // DataFormatsBenchmark, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
        yield return AppDomain.CurrentDomain.GetAssemblies()[1];
        // System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
        yield return AppDomain.CurrentDomain.GetAssemblies()[0];
        // BenchmarkDotNet, Version=0.13.12.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4
        yield return AppDomain.CurrentDomain.GetAssemblies()[2];
    }
}

[Benchmark]
[ArgumentsSource(nameof(AssembliesToTest))]
public string AssemblyName(Assembly assembly)
{
    AssemblyName name = new AssemblyName(assembly.FullName);
    string partialName = name.Name;
    return (partialName != null) ? partialName : string.Empty;
}

[Benchmark]
[ArgumentsSource(nameof(AssembliesToTest))]
public string GetName_Name(Assembly assembly)
{
    return assembly.GetName().Name ?? string.Empty;
}

[Benchmark]
[ArgumentsSource(nameof(AssembliesToTest))]
public ReadOnlySpan<char> PR_EDIT(Assembly assembly)
{
    ReadOnlySpan<char> fullName = assembly.FullName;
    if (fullName.IsEmpty)
        return ReadOnlySpan<char>.Empty;

    ReadOnlySpan<char> nameSlice = fullName;
    // Skip any escaped commas in the name if present
    int escapedComma = fullName.LastIndexOf("\\,", StringComparison.Ordinal);
    if (escapedComma != -1)
        nameSlice = nameSlice.Slice(escapedComma + 2);

    // Find the real ending of the name section
    int commaIndex = nameSlice.IndexOf(',');
    if (commaIndex != -1)
        fullName = fullName.Slice(0, fullName.Length - nameSlice.Length + commaIndex);

    // Check if we need to unescape, this is very rare case so we can just do it the dirty way
    if (escapedComma != -1 || fullName.Contains('\\'))
        UnescapeDirty(ref fullName);

    // Since having "," or "=" in the assembly name is very rare, we don't want to inline
    [MethodImpl(MethodImplOptions.NoInlining)]
    static void UnescapeDirty(ref ReadOnlySpan<char> dirtyName)
    {
        StringBuilder sb = new(dirtyName.Length);
        sb.Append(dirtyName);
        sb.Replace("\\", null);
        dirtyName = sb.ToString();
    }

    return fullName;
}
```

</details>

## Customer Impact

Improved startup/runtime performance, decreased allocations.

## Regression

No.

## Testing

Local build, sample app run, assert tests.

```csharp
// Please put "allows ref struct" here, those ToString() hurt
// System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
// Expected "System.Private.CoreLib"
ReadOnlySpan<char> x1 = GetAssemblyPartialName(AppDomain.CurrentDomain.GetAssemblies()[0]);
Assert.AreEqual(x1.ToString(), AppDomain.CurrentDomain.GetAssemblies()[0].GetName().Name);

// Some additional tests to test consistency of the parser
AssemblyBuilder asm1 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("1"), AssemblyBuilderAccess.Run);
AssemblyBuilder asm2 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("\\,1\\="), AssemblyBuilderAccess.Run);
AssemblyBuilder asm3 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("\\,thisis\\,alsovalid.name"), AssemblyBuilderAccess.Run);
AssemblyBuilder asm4 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DataFormat\\,\\, Benchmark\\, Version\\=, Culture=neutral, PublicKeyToken=null"), AssemblyBuilderAccess.Run);
AssemblyBuilder asm5 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DataFormat\\,\\, Benchmark\\, Version\\=, Culture=neutral, PublicKeyToken=null"), AssemblyBuilderAccess.Run);
AssemblyBuilder asm6 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("\\,\\=+thisis\\,alsovalid.name"), AssemblyBuilderAccess.Run);
x1 = GetAssemblyPartialName(asm1);
Assert.AreEqual(x1.ToString(), asm1.GetName().Name);
x1 = GetAssemblyPartialName(asm2);
Assert.AreEqual(x1.ToString(), asm2.GetName().Name);
x1 = GetAssemblyPartialName(asm3);
Assert.AreEqual(x1.ToString(), asm3.GetName().Name);
x1 = GetAssemblyPartialName(asm4);
Assert.AreEqual(x1.ToString(), asm4.GetName().Name);
x1 = GetAssemblyPartialName(asm5);
Assert.AreEqual(x1.ToString(), asm5.GetName().Name);
x1 = GetAssemblyPartialName(asm6);
Assert.AreEqual(x1.ToString(), asm6.GetName().Name);
```

## Risk

In my mind it is low, all places I've tested are passing `RuntimeAssembly`, so there should be no surprises.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9739)