### PR TITLE
Cleanup rest of string.Compare[Ordinal] equality checks and replace it with string.Equals

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/MarkupCompiler.cs
@@ -1364,14 +1364,14 @@ namespace MS.Internal
 
         private bool SwitchStatementSupported()
         {
-            return (IsLanguageCSharp || (CompilerInfo != null && (string.Compare(CompilerInfo.GetLanguages()[0], JSCRIPT, StringComparison.OrdinalIgnoreCase) == 0)));
+            return IsLanguageCSharp || (CompilerInfo != null && string.Equals(CompilerInfo.GetLanguages()[0], JSCRIPT, StringComparison.OrdinalIgnoreCase));
         }
 
         private bool IsInternalAccessSupported
         {
             get
             {
-                return (CompilerInfo == null || (string.Compare(CompilerInfo.GetLanguages()[0], JSHARP, StringComparison.OrdinalIgnoreCase) != 0));
+                return CompilerInfo == null || !string.Equals(CompilerInfo.GetLanguages()[0], JSHARP, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -2112,7 +2112,7 @@ namespace MS.Internal
         private bool IsLanguageSupported(string language)
         {
             _language = language;
-            _isLangCSharp = string.Compare(language, CSHARP, StringComparison.OrdinalIgnoreCase) == 0;
+            _isLangCSharp = string.Equals(language, CSHARP, StringComparison.OrdinalIgnoreCase);
 
             if (IsLanguageCSharp)
             {
@@ -2121,7 +2121,7 @@ namespace MS.Internal
             }
             else
             {
-                _isLangVB = string.Compare(language, VB, StringComparison.OrdinalIgnoreCase) == 0;
+                _isLangVB = string.Equals(language, VB, StringComparison.OrdinalIgnoreCase);
                 if (IsLanguageVB)
                 {
                     _codeProvider = new Microsoft.VisualBasic.VBCodeProvider();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/MarkupCompiler/ParserExtension.cs
@@ -497,7 +497,7 @@ namespace MS.Internal
                             {
                                 // This direct comparison is ok to do in pass2 as it has already been validated in pass1.
                                 // This is to avoid a costly instantiation of the CodeDomProvider in pass2.
-                                _isInternalRoot = string.Compare("public", xmlReader.Value.Trim(), StringComparison.OrdinalIgnoreCase) != 0;
+                                _isInternalRoot = !string.Equals("public", xmlReader.Value.Trim(), StringComparison.OrdinalIgnoreCase);
                             }
                         }
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/CompilerWrapper.cs
@@ -261,7 +261,7 @@ namespace MS.Internal
 
                     if (asmReference != null)
                     {
-                        if (String.Compare(asmReference.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals(asmReference.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
                         {
                             // Set the local assembly file to markupCompiler
                             _mc.LocalAssemblyFile = asmReference;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/MS/Internal/Tasks/IncrementalCompileAnalyzer.cs
@@ -350,7 +350,7 @@ namespace MS.Internal.Tasks
                 }
                 else  // Both source and target strings are not empty.
                 {
-                    IsSettingModified = String.Compare(textSource, textTarget, StringComparison.OrdinalIgnoreCase) == 0 ? false : true;
+                    IsSettingModified = !string.Equals(textSource, textTarget, StringComparison.OrdinalIgnoreCase);
                 }
             }
 
@@ -426,7 +426,7 @@ namespace MS.Internal.Tasks
                     {
                         for (int j = 0; j < numLocalTypeXamls; j++)
                         {
-                            if (String.Compare(xamlfile.Path, CompilerLocalReference.LocalMarkupPages[j].FilePath, StringComparison.OrdinalIgnoreCase) == 0)
+                            if (string.Equals(xamlfile.Path, CompilerLocalReference.LocalMarkupPages[j].FilePath, StringComparison.OrdinalIgnoreCase))
                             {
                                 addToList = false;
                                 break;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/FileClassifier.cs
@@ -329,25 +329,19 @@ namespace Microsoft.Build.Tasks.Windows
         // <returns></returns>
         private bool IsItemLocalizable(ITaskItem fileItem)
         {
-            bool isLocalizable = false;
-
             // if the default culture is not set, by default all
             // the items are not localizable.
+            bool isLocalizable = false;
 
-            if (Culture != null && Culture.Equals("") == false)
+            if (!string.IsNullOrEmpty(Culture))
             {
-                string localizableString;
+                string localizableString = fileItem.GetMetadata(SharedStrings.Localizable);
 
                 // Default culture is set, by default the item is localizable
-                // unless it is set as false in the Localizable attribute.
-
-                isLocalizable = true;
-
-                localizableString = fileItem.GetMetadata(SharedStrings.Localizable);
-
-                if (localizableString != null && String.Compare(localizableString, "false", StringComparison.OrdinalIgnoreCase) ==0 )
+                // unless it is set as false in the Localizable attribute.         
+                if (!string.Equals(localizableString, "false", StringComparison.OrdinalIgnoreCase))
                 {
-                    isLocalizable = false;
+                    isLocalizable = true;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/GenerateTemporaryTargetAssembly.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Tasks.Windows
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public override bool Execute()
         {
-            if (string.Compare(IncludePackageReferencesDuringMarkupCompilation, "false", StringComparison.OrdinalIgnoreCase) != 0)
+            if (!string.Equals(IncludePackageReferencesDuringMarkupCompilation, "false", StringComparison.OrdinalIgnoreCase))
             {
                 return ExecuteGenerateTemporaryTargetAssemblyWithPackageReferenceSupport();
             }
@@ -638,7 +638,7 @@ namespace Microsoft.Build.Tasks.Windows
             {
                 XmlElement nodeGroup = root.ChildNodes[i] as XmlElement;
 
-                if (nodeGroup != null && String.Compare(nodeGroup.Name, groupName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (nodeGroup != null && string.Equals(nodeGroup.Name, groupName, StringComparison.OrdinalIgnoreCase))
                 {
                     //
                     // This is ItemGroup element.
@@ -651,7 +651,7 @@ namespace Microsoft.Build.Tasks.Windows
                         {
                             XmlElement nodeItem = nodeGroup.ChildNodes[j] as XmlElement;
 
-                            if (nodeItem != null && String.Compare(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase) == 0)
+                            if (nodeItem != null && string.Equals(nodeItem.Name, sItemName, StringComparison.OrdinalIgnoreCase))
                             {
                                 // This is the item that need to remove.
                                 // Add it into the temporary array list.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationBuildTasks/Microsoft/Build/Tasks/Windows/MarkupCompilePass1.cs
@@ -1545,7 +1545,7 @@ namespace Microsoft.Build.Tasks.Windows
 
                 string xamlInputFullPath = TaskHelper.CreateFullFilePath(inputXamlItem.ItemSpec, SourceDir);
 
-                if (String.Compare(localTypeXamlFile, xamlInputFullPath, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(localTypeXamlFile, xamlInputFullPath, StringComparison.OrdinalIgnoreCase))
                 {
                     //
                     // Got this file from the original XamlFile TaskItem list.
@@ -1710,27 +1710,19 @@ namespace Microsoft.Build.Tasks.Windows
         //
         private bool IsItemLocalizable(ITaskItem ti)
         {
-            bool bIsLocalizable;
+            // if UICulture is not set, all baml files are not localizable.
+            // The Localizable metadata value is ignored for this case.
+            bool bIsLocalizable = false;
 
-            if (String.IsNullOrEmpty(UICulture))
-            {
-                // if UICulture is not set, all baml files are not localizable.
-                // The Localizable metadate value is ignored for this case.
-                bIsLocalizable = false;
-            }
-            else
-            {
-                string strLocalizable;
+            if (!string.IsNullOrEmpty(UICulture))
+            { 
+                string strLocalizable = ti.GetMetadata(SharedStrings.Localizable);
 
                 // if UICulture is set, by default all the baml files are localizable unless
                 // an explicit value "false" is set to Localizable metadata.
-                bIsLocalizable = true;
-
-                strLocalizable = ti.GetMetadata(SharedStrings.Localizable);
-
-                if (strLocalizable != null && String.Compare(strLocalizable, "false", StringComparison.OrdinalIgnoreCase) == 0)
+                if (!string.Equals(strLocalizable, "false", StringComparison.OrdinalIgnoreCase))
                 {
-                    bIsLocalizable = false;
+                    bIsLocalizable = true;
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/FontCache/FontCacheUtil.cs
@@ -972,7 +972,7 @@ namespace MS.Internal.FontCache
 
             int IComparer<LocalizedName>.Compare(LocalizedName x, LocalizedName y)
             {
-                return String.Compare(x._language.IetfLanguageTag, y._language.IetfLanguageTag, StringComparison.OrdinalIgnoreCase);
+                return string.Compare(x._language.IetfLanguageTag, y._language.IetfLanguageTag, StringComparison.OrdinalIgnoreCase);
             }
 
             #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/AppSecurityManager.cs
@@ -88,7 +88,7 @@ namespace MS.Internal.AppModel
                                    (Object.ReferenceEquals(destinationUri.Scheme, Uri.UriSchemeHttps)) ||
                                    destinationUri.IsFile;
 
-            bool fIsMailTo = String.Compare(destinationUri.Scheme, Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase) == 0;
+            bool fIsMailTo = string.Equals(destinationUri.Scheme, Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase);
 
             // We elevate to navigate the browser iff: 
             //  We are user initiated AND

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourcePart.cs
@@ -132,12 +132,12 @@ namespace MS.Internal.AppModel
                 {
                     // We do not allow the use of .baml in any Avalon public APIs. This is the code pass needed to go through for loading baml file.
                     // Throw here we will catch all those cases.
-                    if (String.Compare(Path.GetExtension(_name), ResourceContainer.BamlExt, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(Path.GetExtension(_name), ResourceContainer.BamlExt, StringComparison.OrdinalIgnoreCase))
                     {
                         throw new IOException(SR.Format(SR.UnableToLocateResource, _name));
                     }
 
-                    if (String.Compare(Path.GetExtension(_name), ResourceContainer.XamlExt, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(Path.GetExtension(_name), ResourceContainer.XamlExt, StringComparison.OrdinalIgnoreCase))
                     {
                         // try baml extension first since it's our most common senario.
                         string newName = Path.ChangeExtension(_name, ResourceContainer.BamlExt);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ReturnEventSaver.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ReturnEventSaver.cs
@@ -119,7 +119,7 @@ namespace MS.Internal.AppModel
                     // E.g. - if we had a listener to OnFinish from a Button on the calling page.  
                     //  "Return event never fired from PageFunction hosted in its own window"
                     // 
-                    if (string.Compare(_returnList[i]._targetTypeName, caller.GetType().AssemblyQualifiedName, StringComparison.Ordinal) != 0)
+                    if (!string.Equals(_returnList[i]._targetTypeName, caller.GetType().AssemblyQualifiedName, StringComparison.Ordinal))
                     {
                         throw new NotSupportedException(SR.ReturnEventHandlerMustBeOnParentPage);
                     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/CustomCategoryAttribute.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/CustomCategoryAttribute.cs
@@ -28,11 +28,11 @@ namespace System.Windows
         protected override string GetLocalizedString(string value)
         {
             // Return a localized version of the custom category
-            if (String.Compare(value, "Content", StringComparison.Ordinal) == 0)
+            if (string.Equals(value, "Content", StringComparison.Ordinal))
                 return SR.DesignerMetadata_CustomCategory_Content;
-            else if(String.Compare(value, "Accessibility", StringComparison.Ordinal) == 0)
+            else if (string.Equals(value, "Accessibility", StringComparison.Ordinal))
                 return SR.DesignerMetadata_CustomCategory_Accessibility;
-            else /*if(String.Compare(value, "Navigation", StringComparison.Ordinal) == 0)*/
+            else // if (string.Equals(value, "Navigation", StringComparison.Ordinal))
                 return SR.DesignerMetadata_CustomCategory_Navigation;
         }
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/WebBrowserEvent.cs
@@ -85,8 +85,7 @@ namespace MS.Internal.Controls
                     // on a hyperlink, Goback/Forward), or programmatically call GoBack and Forward,
                     // When we get the navigating event, NavigatingToAboutBlank is true, but the source is not "about:blank".
                     // Clear the NavigatingToAboutBlank bit in that case.
-                    if ((_parent.NavigatingToAboutBlank) &&
-                         String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) != 0)
+                    if ((_parent.NavigatingToAboutBlank) && !string.Equals(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase))
                     {
                         _parent.NavigatingToAboutBlank = false;
                     }
@@ -181,8 +180,7 @@ namespace MS.Internal.Controls
                 // If we are loading from stream.
                 if (_parent.DocumentStream != null)
                 {
-                    Invariant.Assert(_parent.NavigatingToAboutBlank &&
-                        (String.Compare((string)url, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) == 0));
+                    Invariant.Assert(_parent.NavigatingToAboutBlank && string.Equals((string)url, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase));
 
                     try
                     {
@@ -210,10 +208,10 @@ namespace MS.Internal.Controls
                     // internally. Make sure we pass null in the event args.
                     if (_parent.NavigatingToAboutBlank)
                     {
-                        Invariant.Assert(String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) == 0);
+                        Invariant.Assert(string.Equals(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase));
                         urlString = null;
                     }
-                    Uri source = (String.IsNullOrEmpty(urlString) ? null : new Uri(urlString));
+                    Uri source = string.IsNullOrEmpty(urlString) ? null : new Uri(urlString);
                     NavigationEventArgs e = new NavigationEventArgs(source, null, null, null, null, true);
 
                     _parent.OnNavigated(e);
@@ -238,10 +236,10 @@ namespace MS.Internal.Controls
                 // internally. Make sure we pass null in the event args.
                 if (_parent.NavigatingToAboutBlank)
                 {
-                    Invariant.Assert(String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) == 0);
+                    Invariant.Assert(string.Equals(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase));
                     urlString = null;
                 }
-                Uri source = (String.IsNullOrEmpty(urlString) ? null : new Uri(urlString));
+                Uri source = string.IsNullOrEmpty(urlString) ? null : new Uri(urlString);
                 NavigationEventArgs e = new NavigationEventArgs(source, null, null, null, null, true);
 
                 _parent.OnLoadCompleted(e);
@@ -255,8 +253,7 @@ namespace MS.Internal.Controls
         private bool ShouldIgnoreCompletionEvent(ref object url)
         {
             string urlString = url as string;
-            return (_parent.NavigatingToAboutBlank &&
-                    String.Compare(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase) != 0);
+            return _parent.NavigatingToAboutBlank && !string.Equals(urlString, WebBrowser.AboutBlankUriString, StringComparison.OrdinalIgnoreCase);
         }
 
         public void CommandStateChange(long command, bool enable)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Globalization/LocalizationComments.cs
@@ -368,7 +368,7 @@ namespace MS.Internal.Globalization
 
                 for (int i = 0; i < _enumNames.Length; i++)
                 {
-                    if (string.Compare(enumName, _enumNames[i], StringComparison.Ordinal) == 0)
+                    if (string.Equals(enumName, _enumNames[i], StringComparison.Ordinal))
                     {
                         enumIndex = i;
                         return true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Win32/UxThemeWrapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Win32/UxThemeWrapper.cs
@@ -270,7 +270,7 @@ namespace MS.Win32
                 themeName = themeNameSB.ToString();
                 themeName = Path.GetFileNameWithoutExtension(themeName);
 
-                if(String.Compare(themeName, "aero", StringComparison.OrdinalIgnoreCase) == 0 && Utilities.IsOSWindows8OrNewer)
+                if(string.Equals(themeName, "aero", StringComparison.OrdinalIgnoreCase) && Utilities.IsOSWindows8OrNewer)
                 {
                     themeName = "Aero2";
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Application.cs
@@ -2412,7 +2412,7 @@ namespace System.Windows
                     Invariant.Assert(fileInBamlConvert != null, "fileInBamlConvert should not be null");
                     Invariant.Assert(fileCurrent != null, "fileCurrent should not be null");
 
-                    if (String.Compare(fileInBamlConvert, fileCurrent, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(fileInBamlConvert, fileCurrent, StringComparison.OrdinalIgnoreCase))
                     {
                         //
                         // This is the root element of the xaml page which is being loaded to creat a tree
@@ -2439,7 +2439,7 @@ namespace System.Windows
                         if (Math.Abs(diff) == 1)
                         {
                             // Check whether the file name is the same.
-                            if (String.Compare(bamlConvertUriSegments[l - 1], curUriSegments[m - 1], StringComparison.OrdinalIgnoreCase) == 0)
+                            if (string.Equals(bamlConvertUriSegments[l - 1], curUriSegments[m - 1], StringComparison.OrdinalIgnoreCase))
                             {
                                 string component = (diff == 1) ? bamlConvertUriSegments[1] : curUriSegments[1];
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -7220,7 +7220,7 @@ namespace System.Windows.Controls
                             // get the index of existing descriptor to replace it
                             for (int i = 0; i < Items.SortDescriptions.Count; i++)
                             {
-                                if (string.Compare(Items.SortDescriptions[i].PropertyName, sortPropertyName, StringComparison.Ordinal) == 0 &&
+                                if (string.Equals(Items.SortDescriptions[i].PropertyName, sortPropertyName, StringComparison.Ordinal) &&
                                     (GroupingSortDescriptionIndices == null ||
                                     !GroupingSortDescriptionIndices.Contains(i)))
                                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridBoundColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridBoundColumn.cs
@@ -211,13 +211,12 @@ namespace System.Windows.Controls
         /// <param name="propertyName"></param>
         protected internal override void RefreshCellContent(FrameworkElement element, string propertyName)
         {
-            DataGridCell cell = element as DataGridCell;
-            if (cell != null)
+            if (element is DataGridCell cell)
             {
                 bool isCellEditing = cell.IsEditing;
-                if ((string.Compare(propertyName, "Binding", StringComparison.Ordinal) == 0) ||
-                    (string.Compare(propertyName, "ElementStyle", StringComparison.Ordinal) == 0 && !isCellEditing) ||
-                    (string.Compare(propertyName, "EditingElementStyle", StringComparison.Ordinal) == 0 && isCellEditing))
+                if ((string.Equals(propertyName, "Binding", StringComparison.Ordinal)) ||
+                    (string.Equals(propertyName, "ElementStyle", StringComparison.Ordinal) && !isCellEditing) ||
+                    (string.Equals(propertyName, "EditingElementStyle", StringComparison.Ordinal) && isCellEditing))
                 {
                     cell.BuildVisualTree();
                     return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCheckBoxColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCheckBoxColumn.cs
@@ -123,12 +123,9 @@ namespace System.Windows.Controls
 
         protected internal override void RefreshCellContent(FrameworkElement element, string propertyName)
         {
-            DataGridCell cell = element as DataGridCell;
-            if (cell != null &&
-                string.Compare(propertyName, "IsThreeState", StringComparison.Ordinal) == 0)
+            if (element is DataGridCell cell && string.Equals(propertyName, "IsThreeState", StringComparison.Ordinal))
             {
-                var checkBox = cell.Content as CheckBox;
-                if (checkBox != null)
+                if (cell.Content is CheckBox checkBox)
                 {
                     checkBox.IsThreeState = IsThreeState;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
@@ -201,8 +201,7 @@ namespace System.Windows.Controls
                 {
                     OnCellsPanelHorizontalOffsetChanged(e);
                 }
-                else if (e.Property == DataGrid.HorizontalScrollOffsetProperty ||
-                         string.Compare(propertyName, "ViewportWidth", StringComparison.Ordinal) == 0)
+                else if (e.Property == DataGrid.HorizontalScrollOffsetProperty || string.Equals(propertyName, "ViewportWidth", StringComparison.Ordinal))
                 {
                     InvalidateColumnRealization(false);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridComboBoxColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridComboBoxColumn.cs
@@ -410,12 +410,11 @@ namespace System.Windows.Controls
 
         protected internal override void RefreshCellContent(FrameworkElement element, string propertyName)
         {
-            DataGridCell cell = element as DataGridCell;
-            if (cell != null)
+            if (element is DataGridCell cell)
             {
                 bool isCellEditing = cell.IsEditing;
-                if ((string.Compare(propertyName, "ElementStyle", StringComparison.Ordinal) == 0 && !isCellEditing) ||
-                    (string.Compare(propertyName, "EditingElementStyle", StringComparison.Ordinal) == 0 && isCellEditing))
+                if ((string.Equals(propertyName, "ElementStyle", StringComparison.Ordinal) && !isCellEditing) ||
+                    (string.Equals(propertyName, "EditingElementStyle", StringComparison.Ordinal) && isCellEditing))
                 {
                     cell.BuildVisualTree();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridHyperlinkColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridHyperlinkColumn.cs
@@ -112,14 +112,13 @@ namespace System.Windows.Controls
         /// <param name="propertyName"></param>
         protected internal override void RefreshCellContent(FrameworkElement element, string propertyName)
         {
-            DataGridCell cell = element as DataGridCell;
-            if (cell != null && !cell.IsEditing)
+            if (element is DataGridCell cell && !cell.IsEditing)
             {
-                if (string.Compare(propertyName, "ContentBinding", StringComparison.Ordinal) == 0)
+                if (string.Equals(propertyName, "ContentBinding", StringComparison.Ordinal))
                 {
                     cell.BuildVisualTree();
                 }
-                else if (string.Compare(propertyName, "TargetName", StringComparison.Ordinal) == 0)
+                else if (string.Equals(propertyName, "TargetName", StringComparison.Ordinal))
                 {
                     TextBlock outerBlock = cell.Content as TextBlock;
                     if (outerBlock != null && outerBlock.Inlines.Count > 0)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTemplateColumn.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridTemplateColumn.cs
@@ -206,17 +206,16 @@ namespace System.Windows.Controls
         /// <param name="propertyName"></param>
         protected internal override void RefreshCellContent(FrameworkElement element, string propertyName)
         {
-            DataGridCell cell = element as DataGridCell;
-            if (cell != null)
+            if (element is DataGridCell cell)
             {
                 bool isCellEditing = cell.IsEditing;
 
                 if ((!isCellEditing &&
-                        ((string.Compare(propertyName, "CellTemplate", StringComparison.Ordinal) == 0) ||
-                        (string.Compare(propertyName, "CellTemplateSelector", StringComparison.Ordinal) == 0))) ||
+                        (string.Equals(propertyName, "CellTemplate", StringComparison.Ordinal) ||
+                        string.Equals(propertyName, "CellTemplateSelector", StringComparison.Ordinal))) ||
                     (isCellEditing &&
-                        ((string.Compare(propertyName, "CellEditingTemplate", StringComparison.Ordinal) == 0) ||
-                        (string.Compare(propertyName, "CellEditingTemplateSelector", StringComparison.Ordinal) == 0))))
+                        (string.Equals(propertyName, "CellEditingTemplate", StringComparison.Ordinal) ||
+                        string.Equals(propertyName, "CellEditingTemplateSelector", StringComparison.Ordinal))))
                 {
                     cell.BuildVisualTree();
                     return;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DatePicker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DatePicker.cs
@@ -1201,7 +1201,7 @@ namespace System.Windows.Controls
                         // ex: SelectedDate = DateTime(1008,12,19) but when "12/19/08" is parsed it is interpreted as DateTime(2008,12,19)
                         string selectedDate = DateTimeToString(this.SelectedDate.Value);
 
-                        if (string.Compare(selectedDate, s, StringComparison.Ordinal) == 0)
+                        if (string.Equals(selectedDate, s, StringComparison.Ordinal))
                         {
                             return;
                         }
@@ -1237,7 +1237,7 @@ namespace System.Windows.Controls
         /// </summary>
         private void SafeSetText(string s)
         {
-            if (string.Compare(Text, s, StringComparison.Ordinal) != 0)
+            if (!string.Equals(Text, s, StringComparison.Ordinal))
             {
                 SetCurrentValueInternal(TextProperty, s);
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridCellsPresenter.cs
@@ -395,16 +395,16 @@ namespace System.Windows.Controls.Primitives
                     e.Property == DataGridColumn.VisibilityProperty ||
                     e.Property == DataGrid.CellsPanelHorizontalOffsetProperty ||
                     e.Property == DataGrid.HorizontalScrollOffsetProperty ||
-                    string.Compare(propertyName, "ViewportWidth", StringComparison.Ordinal) == 0 ||
-                    string.Compare(propertyName, "DelayedColumnWidthComputation", StringComparison.Ordinal) == 0)
+                    string.Equals(propertyName, "ViewportWidth", StringComparison.Ordinal) ||
+                    string.Equals(propertyName, "DelayedColumnWidthComputation", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange();
                 }
-                else if (string.Compare(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal) == 0)
+                else if (string.Equals(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ false);
                 }
-                else if (string.Compare(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal) == 0)
+                else if (string.Equals(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ true);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/DataGridColumnHeadersPresenter.cs
@@ -302,8 +302,8 @@ namespace System.Windows.Controls.Primitives
                 else if (e.Property == DataGrid.FrozenColumnCountProperty ||
                     e.Property == DataGridColumn.VisibilityProperty ||
                     e.Property == DataGrid.CellsPanelHorizontalOffsetProperty ||
-                    string.Compare(propertyName, "ViewportWidth", StringComparison.Ordinal) == 0 ||
-                    string.Compare(propertyName, "DelayedColumnWidthComputation", StringComparison.Ordinal) == 0)
+                    string.Equals(propertyName, "ViewportWidth", StringComparison.Ordinal) ||
+                    string.Equals(propertyName, "DelayedColumnWidthComputation", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange();
                 }
@@ -312,11 +312,11 @@ namespace System.Windows.Controls.Primitives
                     InvalidateArrange();
                     InvalidateDataGridCellsPanelMeasureAndArrange();
                 }
-                else if (string.Compare(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal) == 0)
+                else if (string.Equals(propertyName, "RealizedColumnsBlockListForNonVirtualizedRows", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ false);
                 }
-                else if (string.Compare(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal) == 0)
+                else if (string.Equals(propertyName, "RealizedColumnsBlockListForVirtualizedRows", StringComparison.Ordinal))
                 {
                     InvalidateDataGridCellsPanelMeasureAndArrange(/* withColumnVirtualization */ true);
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -3220,7 +3220,7 @@ namespace System.Windows.Controls.Primitives
                 {
                     if (UnsafeNativeMethods.GetClassName(new HandleRef(null, lastHwnd), sb, NativeMethods.MAX_PATH) != 0)
                     {
-                        if (String.Compare(sb.ToString(), WebOCWindowClassName, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals(sb.ToString(), WebOCWindowClassName, StringComparison.OrdinalIgnoreCase))
                         {
                             break;
                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/TextSearch.cs
@@ -211,8 +211,7 @@ namespace System.Windows.Controls
             //     Fallback search is if they type "bob" and then press "b"
             //     we'll look for "bobb" and when we don't find it we should
             //     find the next item starting with "bob".
-            if (_charsEntered.Count > 0
-                && (String.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo))==0))
+            if (_charsEntered.Count > 0 && string.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo)) == 0)
             {
                 repeatedChar = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
@@ -382,7 +382,6 @@ namespace System.Windows.Documents
             xmlReader.MoveToContent();
 
             StringBuilder pageString = new StringBuilder();
-            bool isSideways = false;
             string unicodeStr = null;
             
             while (xmlReader.Read())
@@ -398,11 +397,7 @@ namespace System.Windows.Documents
                             if (!string.IsNullOrEmpty(unicodeStr))
                             {
                                 string sidewaysString = xmlReader.GetAttribute("IsSideways");
-                                isSideways = false;
-                                if (sidewaysString != null && string.Equals(sidewaysString, bool.TrueString, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    isSideways = true;
-                                }
+                                bool isSideways = string.Equals(sidewaysString, "True", StringComparison.OrdinalIgnoreCase);
                                 
                                 if (reverseRTL)
                                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/FixedFindEngine.cs
@@ -395,12 +395,11 @@ namespace System.Windows.Documents
                         {
                             unicodeStr = xmlReader.GetAttribute("UnicodeString");
 
-                            if (!String.IsNullOrEmpty(unicodeStr))
+                            if (!string.IsNullOrEmpty(unicodeStr))
                             {
                                 string sidewaysString = xmlReader.GetAttribute("IsSideways");
                                 isSideways = false;
-                                if (sidewaysString != null &&
-                                    String.Compare(sidewaysString, Boolean.TrueString, StringComparison.OrdinalIgnoreCase) == 0)
+                                if (sidewaysString != null && string.Equals(sidewaysString, bool.TrueString, StringComparison.OrdinalIgnoreCase))
                                 {
                                     isSideways = true;
                                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/RtfToXamlReader.cs
@@ -3735,7 +3735,7 @@ namespace System.Windows.Documents
                                     // If both entries specify charset, they must match.
                                     if (lhs_tag.Length > 0 && rhs_tag.Length > 0)
                                     {
-                                        if (string.Compare(lhs_tag, rhs_tag, StringComparison.OrdinalIgnoreCase) == 0)
+                                        if (string.Equals(lhs_tag, rhs_tag, StringComparison.OrdinalIgnoreCase))
                                         {
                                             bAdd = true;
                                         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/Speller.cs
@@ -253,7 +253,7 @@ namespace System.Windows.Documents
                         {
                             string error = TextRangeBase.GetTextInternal(errorStart, errorEnd, ref charArray);
 
-                            if (String.Compare(word, error, true /* ignoreCase */, _defaultCulture) == 0)
+                            if (string.Compare(word, error, ignoreCase: true, _defaultCulture) == 0)
                             {
                                 _statusTable.MarkCleanRange(errorStart, errorEnd);
                             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/TextRangeSerialization.cs
@@ -1940,8 +1940,7 @@ namespace System.Windows.Documents
 
         private static string FilterNaNStringValueForDoublePropertyType(string stringValue, Type propertyType)
         {
-            if (propertyType == typeof(double) &&
-                String.Compare(stringValue, "NaN", StringComparison.OrdinalIgnoreCase) == 0)
+            if (propertyType == typeof(double) && string.Equals(stringValue, "NaN", StringComparison.OrdinalIgnoreCase))
             {
                 return "Auto"; // convert NaN to Auto, to keep parser happy
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Documents/XamlToRtfWriter.cs
@@ -2237,29 +2237,29 @@ namespace System.Windows.Documents
             {
                 string imageFormatName = imageName.Substring(extensionIndex);
 
-                if (string.Compare(".png", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".png", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Png;
                 }
-                if (string.Compare(".jpeg", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(".jpg", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".jpeg", imageFormatName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(".jpg", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Jpeg;
                 }
-                if (string.Compare(".gif", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".gif", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Gif;
                 }
-                if (string.Compare(".tif", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(".tiff", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".tif", imageFormatName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(".tiff", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Tif;
                 }
-                if (string.Compare(".bmp", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".bmp", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Bmp;
                 }
-                if (string.Compare(".dib", imageFormatName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(".dib", imageFormatName, StringComparison.OrdinalIgnoreCase))
                 {
                     imageFormat = RtfImageFormat.Dib;
                 }
@@ -2271,11 +2271,11 @@ namespace System.Windows.Documents
         // Get the image stretch type
         private System.Windows.Media.Stretch GetImageStretch(string imageStretch)
         {
-            if (string.Compare("Fill", imageStretch, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals("Fill", imageStretch, StringComparison.OrdinalIgnoreCase))
             {
                 return System.Windows.Media.Stretch.Fill;
             }
-            else if (string.Compare("UniformToFill", imageStretch, StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals("UniformToFill", imageStretch, StringComparison.OrdinalIgnoreCase))
             {
                 return System.Windows.Media.Stretch.UniformToFill;
             }
@@ -2288,11 +2288,11 @@ namespace System.Windows.Documents
         // Get the image stretch direction type
         private System.Windows.Controls.StretchDirection GetImageStretchDirection(string imageStretchDirection)
         {
-            if (string.Compare("UpOnly", imageStretchDirection, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals("UpOnly", imageStretchDirection, StringComparison.OrdinalIgnoreCase))
             {
                 return System.Windows.Controls.StretchDirection.UpOnly;
             }
-            else if (string.Compare("DownOnly", imageStretchDirection, StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals("DownOnly", imageStretchDirection, StringComparison.OrdinalIgnoreCase))
             {
                 return System.Windows.Controls.StretchDirection.DownOnly;
             }
@@ -2720,19 +2720,19 @@ namespace System.Windows.Documents
             {
                 XamlToRtfError xamlToRtfError = XamlToRtfError.None;
 
-                if (string.Compare(name, "&gt;", StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(name, "&gt;", StringComparison.OrdinalIgnoreCase))
                 {
                     return ((IXamlContentHandler)this).Characters(">");
                 }
-                else if (string.Compare(name, "&lt;", StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Equals(name, "&lt;", StringComparison.OrdinalIgnoreCase))
                 {
                     return ((IXamlContentHandler)this).Characters("<");
                 }
-                else if (string.Compare(name, "&amp;", StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Equals(name, "&amp;", StringComparison.OrdinalIgnoreCase))
                 {
                     return ((IXamlContentHandler)this).Characters("&");
                 }
-                else if (name.IndexOf("&#x", StringComparison.OrdinalIgnoreCase) == 0)
+                else if (name.StartsWith("&#x", StringComparison.OrdinalIgnoreCase))
                 {
                     xamlToRtfError = XamlToRtfError.InvalidFormat;
                     if (name.Length >= 5)
@@ -2746,7 +2746,7 @@ namespace System.Windows.Documents
                         }
                     }
                 }
-                else if (name.IndexOf("&#", StringComparison.OrdinalIgnoreCase) == 0)
+                else if (name.StartsWith("&#", StringComparison.OrdinalIgnoreCase))
                 {
                     if (name.Length >= 4)
                     {
@@ -2875,11 +2875,11 @@ namespace System.Windows.Documents
                                         break;
 
                                     case XamlAttribute.XAFontWeight:
-                                        if (string.Compare(valueString, "Normal", StringComparison.OrdinalIgnoreCase) == 0)
+                                        if (string.Equals(valueString, "Normal", StringComparison.OrdinalIgnoreCase))
                                         {
                                             formatState.Bold = false;
                                         }
-                                        else if (string.Compare(valueString, "Bold", StringComparison.OrdinalIgnoreCase) == 0)
+                                        else if (string.Equals(valueString, "Bold", StringComparison.OrdinalIgnoreCase))
                                         {
                                             formatState.Bold = true;
                                         }
@@ -2895,7 +2895,7 @@ namespace System.Windows.Documents
                                         break;
 
                                     case XamlAttribute.XAFontStyle:
-                                        if (string.Compare(valueString, "Italic", StringComparison.OrdinalIgnoreCase) == 0)
+                                        if (string.Equals(valueString, "Italic", StringComparison.OrdinalIgnoreCase))
                                         {
                                             formatState.Italic = true;
                                         }
@@ -3466,7 +3466,7 @@ namespace System.Windows.Documents
             {
                 for (int i = 0; i < entries.Length; i++)
                 {
-                    if (string.Compare(entries[i].Name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(entries[i].Name, name, StringComparison.OrdinalIgnoreCase))
                     {
                         return entries[i].Value;
                     }
@@ -3689,12 +3689,12 @@ namespace System.Windows.Documents
                 if (dirName.Length == 0)
                     return false;
 
-                if (string.Compare("RightToLeft", dirName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals("RightToLeft", dirName, StringComparison.OrdinalIgnoreCase))
                 {
                     dirState = DirState.DirRTL;
                     return true;
                 }
-                else if (string.Compare("LeftToRight", dirName, StringComparison.OrdinalIgnoreCase) == 0)
+                else if (string.Equals("LeftToRight", dirName, StringComparison.OrdinalIgnoreCase))
                 {
                     dirState = DirState.DirLTR;
                     return true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/BamlMapTable.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Markup
             {
                 int probe = (high + low) / 2;
                 Type probeType = KnownTypes.Types[probe];
-                int cmp = String.CompareOrdinal(typeShortName, probeType.Name);
+                int cmp = string.CompareOrdinal(typeShortName, probeType.Name);
                 if (cmp == 0)
                 {
                     // Found a potential match.  Now compare the namespaces & assembly to be sure

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlReaderHelper.cs
@@ -2507,7 +2507,7 @@ namespace System.Windows.Markup
             public bool TokenEquals(string value)
             {
                 int len = _current - _start;
-                return len == value.Length && String.CompareOrdinal(value, 0, _text, _start, len) == 0;
+                return len == value.Length && string.CompareOrdinal(value, 0, _text, _start, len) == 0;
             }
 
             public int Start { get { return _start; } }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlTypeMapper.cs
@@ -406,24 +406,24 @@ namespace System.Windows.Markup
 
         private void PreLoadDefaultAssemblies(string asmName, string asmPath)
         {
-            if (AssemblyWB == null && string.Compare(asmName, _assemblyNames[0], StringComparison.OrdinalIgnoreCase) == 0)
+            if (AssemblyWB == null && string.Equals(asmName, _assemblyNames[0], StringComparison.OrdinalIgnoreCase))
             {
                 AssemblyWB = ReflectionHelper.LoadAssembly(asmName, asmPath);
             }
-            else if (AssemblyPC == null && string.Compare(asmName, _assemblyNames[1], StringComparison.OrdinalIgnoreCase) == 0)
+            else if (AssemblyPC == null && string.Equals(asmName, _assemblyNames[1], StringComparison.OrdinalIgnoreCase))
             {
                 AssemblyPC = ReflectionHelper.LoadAssembly(asmName, asmPath);
             }
-            else if (AssemblyPF == null && string.Compare(asmName, _assemblyNames[2], StringComparison.OrdinalIgnoreCase) == 0)
+            else if (AssemblyPF == null && string.Equals(asmName, _assemblyNames[2], StringComparison.OrdinalIgnoreCase))
             {
                 AssemblyPF = ReflectionHelper.LoadAssembly(asmName, asmPath);
             }
-            else if (string.Compare(asmName, "SYSTEM.XML", StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals(asmName, "SYSTEM.XML", StringComparison.OrdinalIgnoreCase))
             {
                 // make sure System.Xml is at least loaded as ReflectionOnly
                 ReflectionHelper.LoadAssembly(asmName, asmPath);
             }
-            else if (string.Compare(asmName, "SYSTEM", StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals(asmName, "SYSTEM", StringComparison.OrdinalIgnoreCase))
             {
                 // make sure System is at least loaded as ReflectionOnly
                 ReflectionHelper.LoadAssembly(asmName, asmPath);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/JournalEntry.cs
@@ -340,13 +340,11 @@ namespace System.Windows.Navigation
                 return uri.ToString();
             }
 
-            bool isPack = String.Compare(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase) == 0;
             string displayName;
-
-            if (isPack)
+            if (string.Equals(uri.Scheme, PackUriHelper.UriSchemePack, StringComparison.OrdinalIgnoreCase))
             {
                 Uri relative = BaseUriHelper.MakeRelativeToSiteOfOriginIfPossible(uri);
-                if (! relative.IsAbsoluteUri)
+                if (!relative.IsAbsoluteUri)
                 {
                     displayName = (new Uri(siteOfOrigin, relative)).ToString();
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Navigation/NavigationService.cs
@@ -227,9 +227,7 @@ namespace System.Windows.Navigation
 
             if (isSame && withFragment)
             {
-                isSame = isSame &&
-                         (string.Compare(aResolved.Fragment, bResolved.Fragment,
-                                        StringComparison.OrdinalIgnoreCase) == 0);
+                isSame = isSame && string.Equals(aResolved.Fragment, bResolved.Fragment, StringComparison.OrdinalIgnoreCase);
             }
 
             return isSame;
@@ -701,7 +699,7 @@ namespace System.Windows.Navigation
             FrameworkElement fe = INavigatorHost as FrameworkElement;
 
             Debug.Assert(fe != null, "INavigatorHost needs to be FrameworkElement");
-            if (String.Compare(name, fe.Name, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(name, fe.Name, StringComparison.OrdinalIgnoreCase))
             {
                 return INavigatorHost;
             }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/IO/Packaging/PackagingUtilities.cs
@@ -417,8 +417,7 @@ namespace MS.Internal.IO.Packaging
             //MoveToNextAttribute is the same as MoveToFirstAttribute.
             while (reader.MoveToNextAttribute())
             {
-                if (String.CompareOrdinal(reader.Name, XmlNamespace) != 0 &&
-                    String.CompareOrdinal(reader.Prefix, XmlNamespace) != 0)
+                if (!string.Equals(reader.Name, XmlNamespace, StringComparison.Ordinal) && !string.Equals(reader.Prefix, XmlNamespace, StringComparison.Ordinal))
                     readerCount++;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -147,10 +147,10 @@ namespace System.Xaml
                 CultureInfo curCulture = curAsmName.CultureInfo;
                 byte[] curKeyToken = curAsmName.GetPublicKeyToken();
 
-                if ( (String.Compare(curAsmName.Name, assemblyName.Name, true, TypeConverterHelper.InvariantEnglishUS) == 0) &&
+                if (string.Equals(curAsmName.Name, assemblyName.Name, StringComparison.InvariantCultureIgnoreCase) &&
                      (reqVersion == null || reqVersion.Equals(curVersion)) &&
                      (reqCulture == null || reqCulture.Equals(curCulture)) &&
-                     (reqKeyToken == null || IsSameKeyToken(reqKeyToken, curKeyToken) ) )
+                     (reqKeyToken == null || IsSameKeyToken(reqKeyToken, curKeyToken)))
                 {
                     return assemblies[i];
                 }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/TextSearchInternal.cs
@@ -119,8 +119,7 @@ namespace Microsoft.Windows.Controls
             //     Fallback search is if they type "bob" and then press "b"
             //     we'll look for "bobb" and when we don't find it we should
             //     find the next item starting with "bob".
-            if (_charsEntered.Count > 0
-                && (String.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo)) == 0))
+            if (_charsEntered.Count > 0 && string.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo)) == 0)
             {
                 repeatedChar = true;
             }
@@ -261,8 +260,7 @@ namespace Microsoft.Windows.Controls
             //     Fallback search is if they type "bob" and then press "b"
             //     we'll look for "bobb" and when we don't find it we should
             //     find the next item starting with "bob".
-            if (_charsEntered.Count > 0
-                && (String.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo))==0))
+            if (_charsEntered.Count > 0 && string.Compare(_charsEntered[_charsEntered.Count - 1], nextChar, true, GetCulture(_attachedTo)) == 0)
             {
                 repeatedChar = true;
             }

--- a/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Xaml/System/Xaml/XamlObjectReader.cs
@@ -2246,7 +2246,7 @@ namespace System.Xaml
                     if (xIsDirective && !yIsDirective) { return XFirst; }
                     if (yIsDirective && !xIsDirective) { return YFirst; }
 
-                    return String.CompareOrdinal(xProperty.Name, yProperty.Name);
+                    return string.CompareOrdinal(xProperty.Name, yProperty.Name);
                 }
             }
 
@@ -2306,7 +2306,7 @@ namespace System.Xaml
                     if (xIsDirective && !yIsDirective) { return XFirst; }
                     if (yIsDirective && !yIsDirective) { return YFirst; }
 
-                    return String.CompareOrdinal(xProperty.Name, yProperty.Name);
+                    return string.CompareOrdinal(xProperty.Name, yProperty.Name);
                 }
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/ProxyManager.cs
@@ -270,7 +270,7 @@ namespace MS.Internal.Automation
 
             foreach (string str in BadImplClassnames)
             {
-                if (String.Compare(className, str, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(className, str, StringComparison.OrdinalIgnoreCase))
                     return true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WindowShowOrOpenTracker.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClient/MS/Internal/Automation/WindowShowOrOpenTracker.cs
@@ -74,7 +74,7 @@ namespace MS.Internal.Automation
                 // Ignore WCP hwnd creates; we get eventId EventObjectUIFragmentCreate for those
                 // Are these all the WCP classnames?  Is there a better way to ignore WCP windows?
                 string str = ProxyManager.GetClassName(nativeHwnd);
-                if (String.Compare(str, 0, _wcpClassName, 0, _wcpClassName.Length, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Compare(str, 0, _wcpClassName, 0, _wcpClassName.Length, StringComparison.OrdinalIgnoreCase) == 0)
                     return;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
@@ -367,7 +367,7 @@ namespace MS.Internal.AutomationProxies
                 // two different AutomationElements representing the same underlying
                 // UI in MCE may incorrectly compare as FALSE.
                 string className = Misc.GetClassName(_hwnd);
-                if(string.Equals(className, "eHome Render Window", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(className, "eHome Render Window", StringComparison.OrdinalIgnoreCase))
                     _isMCE = TristateBool.TestedTrue;
                 else
                     _isMCE = TristateBool.TestedFalse;

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/MSAANativeProvider.cs
@@ -130,11 +130,11 @@ namespace MS.Internal.AutomationProxies
         // needed based on a window handle, object and child ids.
         // It returns an IRawElementProviderSimple implementation for a native IAccessible object
         // or null if the hwnd doesn't natively implement IAccessible.
-        internal static IRawElementProviderSimple Create (IntPtr hwnd, int idChild, int idObject)
+        internal static IRawElementProviderSimple Create(IntPtr hwnd, int idChild, int idObject)
         {
 #if DEBUG
 //            // uncomment this if you want to prevent unwanted interactions with the debugger in Whidbey.
-//            if (string.Compare(hwnd.ProcessName, "devenv.exe", StringComparison.OrdinalIgnoreCase) == 0)
+//            if (string.Equals(hwnd.ProcessName, "devenv.exe", StringComparison.OrdinalIgnoreCase))
 //            {
 //                return null;
 //            }
@@ -367,7 +367,7 @@ namespace MS.Internal.AutomationProxies
                 // two different AutomationElements representing the same underlying
                 // UI in MCE may incorrectly compare as FALSE.
                 string className = Misc.GetClassName(_hwnd);
-                if(String.Compare(className, "eHome Render Window", StringComparison.OrdinalIgnoreCase) == 0)
+                if(string.Equals(className, "eHome Render Window", StringComparison.OrdinalIgnoreCase))
                     _isMCE = TristateBool.TestedTrue;
                 else
                     _isMCE = TristateBool.TestedFalse;
@@ -1066,7 +1066,7 @@ namespace MS.Internal.AutomationProxies
 
             foreach (string str in BadImplClassnames)
             {
-                if (String.Compare(className, str, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(className, str, StringComparison.OrdinalIgnoreCase))
                     return true;
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsComboBox.cs
@@ -678,7 +678,7 @@ namespace MS.Internal.AutomationProxies
                 return false;
             }
 
-            return (0 == String.Compare(Misc.GetClassName(hwndEx), ComboboxEx32, StringComparison.OrdinalIgnoreCase));
+            return string.Equals(Misc.GetClassName(hwndEx), ComboboxEx32, StringComparison.OrdinalIgnoreCase);
         }
 
         private bool IsEditableCombo()

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsListView.cs
@@ -1645,7 +1645,7 @@ namespace MS.Internal.AutomationProxies
         private bool InStartMenu()
         {
             string className = Misc.GetClassName(Misc.GetParent(_hwnd));
-            return string.Compare(className, "DesktopSFTBarHost", StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Equals(className, "DesktopSFTBarHost", StringComparison.OrdinalIgnoreCase);
         }
 
         private bool SetScrollPercent(double fScrollPos, int sbFlag, int cPelsAll, out int delta)

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsMenu.cs
@@ -912,11 +912,10 @@ namespace MS.Internal.AutomationProxies
         }
 
         // detect if hwnd corresponds to the submenu
-        private static bool IsWindowSubMenu (IntPtr hwnd)
+        private static bool IsWindowSubMenu(IntPtr hwnd)
         {
-            return (String.Compare(Misc.ProxyGetClassName(hwnd), WindowsMenu.MenuClassName, StringComparison.OrdinalIgnoreCase) == 0);
+            return string.Equals(Misc.ProxyGetClassName(hwnd), WindowsMenu.MenuClassName, StringComparison.OrdinalIgnoreCase);
         }
-
 
         private static int GetHighlightedMenuItem(IntPtr hmenu)
         {

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsRichEditRange.cs
@@ -729,7 +729,7 @@ namespace MS.Internal.AutomationProxies
                     else
                     {
                         // on subsequent iterations compare if the font name is the same.
-                        if (string.Compare(name, unitRange.Font.Name, StringComparison.Ordinal) != 0)
+                        if (!string.Equals(name, unitRange.Font.Name, StringComparison.Ordinal))
                         {
                             return TextPattern.MixedAttributeValue;
                         }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsScroll.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsScroll.cs
@@ -165,7 +165,7 @@ namespace MS.Internal.AutomationProxies
             string className = Misc.ProxyGetClassName(hwnd);
             if (className.StartsWith("RichEdit", StringComparison.OrdinalIgnoreCase) ||
                 className.StartsWith("WindowForms10.RichEdit", StringComparison.OrdinalIgnoreCase) ||
-                string.Compare(className, "Edit", StringComparison.OrdinalIgnoreCase) == 0)
+                string.Equals(className, "Edit", StringComparison.OrdinalIgnoreCase))
             {
                 hasScrollableStyle = Misc.IsBitSet(style, NativeMethods.ES_MULTILINE);
             }

--- a/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
+++ b/src/Microsoft.DotNet.Wpf/src/UIAutomation/UIAutomationClientSideProviders/MS/Internal/AutomationProxies/WindowsTooltip.cs
@@ -180,20 +180,20 @@ namespace MS.Internal.AutomationProxies
 
             string className = Misc.ProxyGetClassName(hwnd);
 
-            return String.Compare(className, "tooltips_class32", StringComparison.OrdinalIgnoreCase) == 0 ||
-                String.Compare(className, CLASS_TITLEBAR_TOOLTIP, StringComparison.OrdinalIgnoreCase) == 0 ||
-                String.Compare(className, "VBBubble", StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Equals(className, "tooltips_class32", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(className, CLASS_TITLEBAR_TOOLTIP, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(className, "VBBubble", StringComparison.OrdinalIgnoreCase);
         }
 
         private string GetText()
         {
             string className = Misc.ProxyGetClassName(_hwnd);
 
-            if (String.Compare(className, CLASS_TITLEBAR_TOOLTIP, StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(className, CLASS_TITLEBAR_TOOLTIP, StringComparison.OrdinalIgnoreCase))
             {
                 return GetTitleBarToolTipText();
             }
-            else if (String.Compare(className, "VBBubble", StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals(className, "VBBubble", StringComparison.OrdinalIgnoreCase))
             {
                 // The WM_GETTEXT should work for VBBubble.  It seems that the string being returned is having
                 // a problem with Unicode covertion and therefore trunk'ing the string after the first character.


### PR DESCRIPTION
## Description

Finishes up all the easily replaceable `string.Compare` method uses that are used strictly for equality. The only leftovers shall be now covered in my other PRs where I don't wanna create conflicts for each one of them.

### Difference in the last character

| Method  | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original | 36.525 ns |  0.7577 ns |   0.7781 ns |         446 B |             - |
| PR_EDIT  |  4.873 ns |  0.0175 ns |   0.0155 ns |         467 B |             - |

### Difference in 5th character

| Method   |  Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|--------------:|--------------:|
| Original |   4.627 ns |  0.0493 ns |   0.0437 ns |         446 B |             - |
| PR_EDIT  |  2.668 ns |  0.0138 ns |   0.0129 ns |         467 B |             - |

### Benchmark source strings
```csharp
//First invocation (last char is different)
return string.Compare("someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase) == 0;
return string.Equals("someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"someveryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase);

//Second invocation (5th char is different)
return string.Compare("some0veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"some1veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase) == 0;
return string.Equals("some0veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit0",
"some1veryrandomstringthatwillonlydifferintheveryendwewillmakesureofit1", 
StringComparison.OrdinalIgnoreCase);
```

## Customer Impact

Improved performance.

## Regression

No.

## Testing

Local build.

## Risk

Very low, those are IDE swaps besides three manual edits.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9740)