### PR TITLE
Simplify GlobalEventManager indexing, remove dead code and unnecessarry array

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventPrivateKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventPrivateKey.cs
@@ -17,20 +17,15 @@ namespace System.Windows
     /// </remarks>
     public class EventPrivateKey
     {
+        internal int GlobalIndex { get; }
+
         /// <summary>
         ///     Constructor for EventPrivateKey
         /// </summary>
         public EventPrivateKey()
         {
-            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
+            GlobalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
         }
-
-        internal int GlobalIndex
-        {
-            get { return _globalIndex; }
-        }
-        
-        private int _globalIndex;
     }
 }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventPrivateKey.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/EventPrivateKey.cs
@@ -22,7 +22,7 @@ namespace System.Windows
         /// </summary>
         public EventPrivateKey()
         {
-            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex(this);
+            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
         }
 
         internal int GlobalIndex

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
@@ -424,6 +424,11 @@ namespace System.Windows
 
         #region Global Index for RoutedEvent and EventPrivateKey
 
+        /// <summary>
+        /// Increments the global counter for <see cref="RoutedEvent"/> and <see cref="EventPrivateKey"/> storage.
+        /// </summary>
+        /// <returns>Globally unique index for the event within the application.</returns>
+        /// <exception cref="InvalidOperationException">Thrown in case the index is bigger than <see cref="int.MaxValue"/>.</exception>
         internal static int GetNextAvailableGlobalIndex()
         {
             // Prevent GlobalIndex from overflow. RoutedEvents are meant to be static members and are to be registered 
@@ -437,7 +442,9 @@ namespace System.Windows
             return (int)newIndex;
         }
 
-        // Access must be synchronized
+        /// <summary>
+        /// Access must be done atomically, currently only accessed via <see cref="GetNextAvailableGlobalIndex"/> method.
+        /// </summary>
         private static uint s_globalEventIndex = uint.MinValue;
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
@@ -441,12 +441,6 @@ namespace System.Windows
             return index;
         }
 
-        // Must be called from within a lock of GlobalEventManager.Synchronized
-        internal static object EventFromGlobalIndex(int globalIndex)
-        {
-            return _globalIndexToEventMap[globalIndex];
-        }
-
         // must be used within a lock of GlobalEventManager.Synchronized
         private static ArrayList _globalIndexToEventMap = new ArrayList(100); // figure out what this number is in a typical scenario
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
@@ -424,7 +424,7 @@ namespace System.Windows
 
         #region Global Index for RoutedEvent and EventPrivateKey
 
-        internal static int GetNextAvailableGlobalIndex(object value)
+        internal static int GetNextAvailableGlobalIndex()
         {
             // Prevent GlobalIndex from overflow. RoutedEvents are meant to be static members and are to be registered 
             // only via static constructors. However there is no cheap way of ensuring this, without having to do a stack walk. Hence 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/GlobalEventManager.cs
@@ -471,7 +471,7 @@ namespace System.Windows
         // This is the cached value for the DType of DependencyObject
         private static DependencyObjectType _dependencyObjectType = DependencyObjectType.FromSystemTypeInternal(typeof(DependencyObject));
 
-        internal static object Synchronized = new object();
+        internal static readonly Lock Synchronized = new();
 
         #endregion Data
     }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEvent.cs
@@ -129,7 +129,7 @@ namespace System.Windows
             _handlerType = handlerType;
             _ownerType = ownerType;
 
-            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex(this);
+            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEvent.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/RoutedEvent.cs
@@ -115,6 +115,12 @@ namespace System.Windows
 
         #region Construction
 
+
+        /// <summary>
+        /// Globally unique index in <see cref="GlobalEventManager"/>.
+        /// </summary>
+        internal int GlobalIndex { get; }
+
         // Constructor for a RoutedEvent (is internal 
         // to the EventManager and is onvoked when a new
         // RoutedEvent is registered)
@@ -129,16 +135,9 @@ namespace System.Windows
             _handlerType = handlerType;
             _ownerType = ownerType;
 
-            _globalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
+            GlobalIndex = GlobalEventManager.GetNextAvailableGlobalIndex();
         }
 
-        /// <summary>
-        ///    Index in GlobalEventManager 
-        /// </summary>
-        internal int GlobalIndex
-        {
-            get { return _globalIndex; }
-        }
         #endregion Construction
 
         #region Data
@@ -147,8 +146,6 @@ namespace System.Windows
         private RoutingStrategy _routingStrategy;
         private Type _handlerType;
         private Type _ownerType;
-
-        private int _globalIndex;
 
         #endregion Data
     }


### PR DESCRIPTION
## Description

Simplifies the global index generation for each routed event and the key, instead of using an `ArrayList` and the unused `_globalIndexToEventMap` covered in a lock, we shall be sufficient with memory barrier and a global index counter.

Removes `EventFromGlobalIndex` method that is a dead code since the dead calling method was removed in #4636 by @lindexi but I guess he forgot to remove this one as well.

## Customer Impact

Improved start-up performance/event registration, decreased memory usage without this static list.

## Regression

No.

## Testing

Local build, sample app run, event registration.

## Risk

Low, removes unused code and improves the mechanism.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9741)