### PR TITLE
Remove invalid Fluent DataGridColumn styles

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/Generator/ThemeGenerator.Fluent.ps1
@@ -28,16 +28,16 @@ foreach($themeColor in $themeColors)
         if($file.BaseName -eq "Fluent") {
             continue
         }
-        [xml]$currentXaml = Get-Content $file.FullName
+        [xml]$currentXaml = Get-Content $file.FullName -Encoding UTF8
         
         $combinedXaml.ResourceDictionary.InnerXml += $currentXaml.ResourceDictionary.InnerXml
     }
     
-    [xml]$themeColorXaml = Get-Content $themeColorFilePath
+    [xml]$themeColorXaml = Get-Content $themeColorFilePath -Encoding UTF8
     $combinedXaml.ResourceDictionary.InnerXml += $themeColorXaml.ResourceDictionary.InnerXml
     
     foreach ($file in Get-ChildItem $styleFilesDir -Filter "*.xaml") {
-        [xml]$currentXaml = Get-Content $file.FullName
+        [xml]$currentXaml = Get-Content $file.FullName -Encoding UTF8
         $combinedXaml.ResourceDictionary.InnerXml += $currentXaml.ResourceDictionary.InnerXml
     }
 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -59,8 +59,6 @@
 
     <!--  END REMOVE COLORS  -->
 
-    <!--<Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />-->
-
     <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
@@ -502,9 +500,6 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <!--<Style TargetType="{x:Type DataGridTextColumn}">
-        <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-    </Style>-->
 
     <!--  Style and template for the DataGrid.  -->
     <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
@@ -788,11 +783,6 @@
         TargetType="{x:Type CheckBox}">
         <Setter Property="SnapsToDevicePixels" Value="True" />
     </Style>
-
-    <!--<Style TargetType="{x:Type DataGridCheckBoxColumn}">
-        <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-        <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
-    </Style>-->
 
     <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
     <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DataGrid.xaml
@@ -59,7 +59,7 @@
 
     <!--  END REMOVE COLORS  -->
 
-    <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
+    <!--<Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />-->
 
     <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -502,9 +502,9 @@
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style TargetType="{x:Type DataGridTextColumn}">
+    <!--<Style TargetType="{x:Type DataGridTextColumn}">
         <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-    </Style>
+    </Style>-->
 
     <!--  Style and template for the DataGrid.  -->
     <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
@@ -789,10 +789,10 @@
         <Setter Property="SnapsToDevicePixels" Value="True" />
     </Style>
 
-    <Style TargetType="{x:Type DataGridCheckBoxColumn}">
+    <!--<Style TargetType="{x:Type DataGridCheckBoxColumn}">
         <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
         <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
-    </Style>
+    </Style>-->
 
     <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
     <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1507,7 +1507,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1836,9 +1835,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2043,10 +2039,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />
@@ -3059,7 +3051,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="●" />
+    <Setter Property="PasswordChar" Value="â—" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -3051,7 +3051,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="â—" />
+    <Setter Property="PasswordChar" Value="●" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -3023,7 +3023,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="â—" />
+    <Setter Property="PasswordChar" Value="●" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1479,7 +1479,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1808,9 +1807,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2015,10 +2011,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />
@@ -3031,7 +3023,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="●" />
+    <Setter Property="PasswordChar" Value="â—" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -3046,7 +3046,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="â—" />
+    <Setter Property="PasswordChar" Value="●" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1502,7 +1502,6 @@
     </LinearGradientBrush.GradientStops>
   </LinearGradientBrush>
   <!--  END REMOVE COLORS  -->
-  <Style x:Key="DefaultDataGridCheckBoxColumnCellStyle" TargetType="{x:Type DataGridColumn}" />
   <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
@@ -1831,9 +1830,6 @@
       </Trigger>
     </Style.Triggers>
   </Style>
-  <Style TargetType="{x:Type DataGridTextColumn}">
-    <Setter Property="EditingElementStyle" Value="{StaticResource TextBoxStyle}" />
-  </Style>
   <!--  Style and template for the DataGrid.  -->
   <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}">
     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -2038,10 +2034,6 @@
   </Style>
   <Style x:Key="DataGridCheckBoxEditingElementDefaultStyle" BasedOn="{StaticResource DataGridCheckBoxElementDefaultStyle}" TargetType="{x:Type CheckBox}">
     <Setter Property="SnapsToDevicePixels" Value="True" />
-  </Style>
-  <Style TargetType="{x:Type DataGridCheckBoxColumn}">
-    <Setter Property="ElementStyle" Value="{StaticResource DataGridCheckBoxElementDefaultStyle}" />
-    <Setter Property="EditingElementStyle" Value="{StaticResource DataGridCheckBoxEditingElementDefaultStyle}" />
   </Style>
   <Style BasedOn="{StaticResource DefaultDataGridColumnHeadersPresenterStyle}" TargetType="{x:Type DataGridColumnHeadersPresenter}" />
   <Style BasedOn="{StaticResource DefaultDataGridStyle}" TargetType="{x:Type DataGrid}" />
@@ -3054,7 +3046,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinWidth}" />
     <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-    <Setter Property="PasswordChar" Value="●" />
+    <Setter Property="PasswordChar" Value="â—" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />


### PR DESCRIPTION
Fixes #9755

## Description

Removes invalid Fluent DataGridColumn styles

## Customer Impact

Would be good to fix this before .NET 9 releases so that existing codebases can have a smoother transition to new Windows 11 themes

## Regression

No

## Testing
- Used reproduction from #9755 to reference all resource dictionaries like in [Fluent.xaml](https://github.com/dotnet/wpf/blob/94751f56a45603960704642bdbc245a78e725644/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.xaml)
```xaml
	<Application.Resources>
		<ResourceDictionary>
			<ResourceDictionary.MergedDictionaries>
				...
				<ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ComboBox.xaml" />
				<ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/ContextMenu.xaml" />
				<ResourceDictionary Source="pack://application:,,,/TestResources;component/DataGrid.xaml" />
				<ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/DatePicker.xaml" />
				<ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Styles/Expander.xaml" />
				...
			</ResourceDictionary.MergedDictionaries>
		</ResourceDictionary>
	</Application.Resources>
```

- Created a local copy of DataGrid.xaml which I made the changes to
- Referenced the local DataGrid.xaml in MergedDictionaries instead of the one in PresentationFramework
- Ran the application a few times
Now able to iterate through theme resources without any exceptions

## Risk
Minimal

Does not look like these styles are referenced anywhere else.

Likely just something that was missed when the resource dictionaries were ported from [WPF UI. ](https://github.com/lepoco/wpfui)

Documentation confirms in multiple places that only FrameworkElement or derived types can have styles [for example](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/styles-templates-overview?view=netdesktop-8.0#styles)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9757)