### PR TITLE
Work around d3d redist incompat.

### DIFF
--- a/global.json
+++ b/global.json
@@ -20,6 +20,7 @@
   },
   "native-tools": {
     "strawberry-perl": "5.28.1.1-1",
-    "net-framework-48-ref-assemblies": "0.0.0.1"
+    "net-framework-48-ref-assemblies": "0.0.0.1",
+    "windows-sdk-d3d-redist": "1.0.0"
   }
 }

--- a/src/Microsoft.DotNet.Wpf/redist/D3DCompiler/D3DCompiler.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/redist/D3DCompiler/D3DCompiler.vcxproj
@@ -33,8 +33,10 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <!-- ARM64 will use the windows\system32 version --> 
-    <RedistSourcePath>$(Windows10SdkPath)Redist\D3D\$(Architecture)\$(D3DCompilerDllBaseName)$(D3DCompilerVersion).dll</RedistSourcePath>
+    <!-- ARM64 will use the windows\system32 version -->
+    <!-- ISSUE!! https://github.com/dotnet/wpf/issues/9670: An updated D3D Redist is incompatible with Win10, at least when built with the 19041 Windows SDK. This is
+         a temporary workaround for this issue. We pull from netcore native assets instead. -->
+    <RedistSourcePath>$(RepositoryToolsDir)native\bin\windows-sdk-d3d-redist\1.0.0\D3D\$(Architecture)\$(D3DCompilerDllBaseName)$(D3DCompilerVersion).dll</RedistSourcePath>
   </PropertyGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>


### PR DESCRIPTION
Porting workaround for D3DCompiler redist incompat from release/9.0-rc1 to release/8.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9765)