### PR TITLE
Optimize parsing and conversion in DurationConverter, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
@@ -483,7 +483,7 @@ namespace System.Windows
         {
             if (HasTimeSpan)
             {
-                return TypeDescriptor.GetConverter(_timeSpan).ConvertToString(_timeSpan);
+                return _timeSpan.ToString();
             }
             else if (_durationType == DurationType.Forever)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Duration.cs
@@ -481,18 +481,22 @@ namespace System.Windows
         /// <returns>A string representation of this Duration.</returns>
         public override string ToString()
         {
-            if (HasTimeSpan)
-            {
-                return _timeSpan.ToString();
-            }
-            else if (_durationType == DurationType.Forever)
-            {
+            return HasTimeSpan ? TypeDescriptor.GetConverter(_timeSpan).ConvertToString(_timeSpan) : ToStringInvariant();
+        }
+
+        /// <summary>
+        /// This method does not use the current <see cref="System.TimeSpan"/>'s <see cref="TypeDescriptor"/> for retrieving the
+        /// current converter, but rather uses the standard <see cref="TimeSpan.ToString()"/> override for <see cref="DurationConverter"/> needs.
+        /// </summary>
+        /// <returns>A culture-invariant representation of the <see cref="Duration"/> instance.</returns>
+        internal string ToStringInvariant()
+        {
+            if (_durationType == DurationType.Forever)
                 return "Forever";
-            }
-            else // IsAutomatic
-            {
+            else if (_durationType == DurationType.Automatic)
                 return "Automatic";
-            }
+
+            return _timeSpan.ToString();
         }
 
         #endregion

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
@@ -101,9 +101,10 @@ namespace System.Windows
             if (value is not Duration duration || (destinationType != typeof(InstanceDescriptor) && destinationType != typeof(string)))
                 return base.ConvertTo(context, cultureInfo, value, destinationType);
 
-            // For string we may currently use the type override
+            // The current behaviour produces culture-invariant result in case of a Duration with HasTimeSpan,
+            // whereas ConvertFrom accepts localized input, provided the correct cultureInfo was supplied.
             if (destinationType == typeof(string))
-                return duration.ToString();
+                return duration.ToStringInvariant();
 
             // InstanceDescriptor reflection magic
             if (duration.HasTimeSpan)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
@@ -34,15 +34,7 @@ namespace System.Windows
         /// <ExternalAPI/>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (   destinationType == typeof(InstanceDescriptor)
-                || destinationType == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return destinationType == typeof(InstanceDescriptor) || destinationType == typeof(string);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
@@ -22,14 +22,7 @@ namespace System.Windows
         /// <ExternalAPI/>
         public override bool CanConvertFrom(ITypeDescriptorContext td, Type t)
         {
-            if (t == typeof(string))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return t == typeof(string);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
@@ -97,13 +97,9 @@ namespace System.Windows
         {
             ArgumentNullException.ThrowIfNull(destinationType);
 
-            // Base calls do return string.Empty if value is null instead of throwing
-            if (value is null)
-                return string.Empty;
-
-            // Check that we actually support the conversion
+            // Check that we actually support the conversion, NULL value results in string.Empty, others throw
             if (value is not Duration duration || (destinationType != typeof(InstanceDescriptor) && destinationType != typeof(string)))
-                throw GetConvertToException(value, destinationType);
+                return base.ConvertTo(context, cultureInfo, value, destinationType);
 
             // For string we may currently use the type override
             if (destinationType == typeof(string))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DurationConverter.cs
@@ -1,19 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-//
 
 using System.ComponentModel.Design.Serialization;
 using System.ComponentModel;
 using System.Globalization;
-using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Windows
 {
     /// <summary>
-    /// Provides a type converter to convert from <see cref="Duration"/> to <see langword="string"/> and vice versa.
+    /// Provides a type converter to convert from <see cref="Duration"/> to <see cref="string"/> and vice versa.
     /// </summary>
     public class DurationConverter : TypeConverter
     {
@@ -22,30 +18,30 @@ namespace System.Windows
         /// </summary>
         /// <param name="td">Context information used for conversion.</param>
         /// <param name="t">Type being evaluated for conversion.</param>
-        /// <returns><see langword="true"/> if the given <paramref name="sourceType"/> can be converted from, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if the given <paramref name="t"/> can be converted from, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertFrom(ITypeDescriptorContext td, Type t)
         {
             return t == typeof(string);
         }
 
         /// <summary>
-        /// Returns whether this class can convert specified value to <see langword="string"/>.
+        /// Returns whether this class can convert specified value to <see cref="string"/>.
         /// </summary>
         /// <param name="context">Context information used for conversion.</param>
         /// <param name="destinationType">Type being evaluated for conversion.</param>
-        /// <returns><see langword="true"/> if conversion to <see langword="string"/> is possible, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if conversion to <see cref="string"/> is possible, <see langword="false"/> otherwise.</returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             return destinationType == typeof(InstanceDescriptor) || destinationType == typeof(string);
         }
 
         /// <summary>
-        /// Converts <paramref name="value"/> of <see langword="string"/> type to its <see cref="Duration"/> represensation.
+        /// Converts <paramref name="value"/> of <see cref="string"/> type to its <see cref="Duration"/> representation.
         /// </summary>
         /// <param name="td">Context information used for conversion.</param>
         /// <param name="cultureInfo">The culture specifier to use.</param>
         /// <param name="value">The string to convert from.</param>
-        /// <returns>A <see cref="Duration"/> representing the <see langword="string"/> specified by <paramref name="value"/>.</returns>
+        /// <returns>A <see cref="Duration"/> representing the <see cref="string"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext td, CultureInfo cultureInfo, object value)
         {
             // In case value is not a string, we can try to check InstanceDescriptor or we just throw NotSupportedException
@@ -66,7 +62,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Faciliaties parsing from <paramref name="valueSpan"/> to <see cref="TimeSpan"/> and initializes new <see cref="Duration"/> instance.
+        /// Facilities parsing from <paramref name="valueSpan"/> to <see cref="TimeSpan"/> and initializes new <see cref="Duration"/> instance.
         /// </summary>
         /// <param name="valueSpan">The string to convert from.</param>
         /// <param name="cultureInfo">The culture specifier to use.</param>
@@ -86,13 +82,13 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Converts a <paramref name="value"/> of <see cref="Duration"/> to its <see langword="string"/> represensation.
+        /// Converts a <paramref name="value"/> of <see cref="Duration"/> to its <see cref="string"/> representation.
         /// </summary>
         /// <param name="context">Context information used for conversion.</param>
         /// <param name="cultureInfo">The culture specifier to use, currently ignored during conversion.</param>
         /// <param name="value">Duration value to convert from.</param>
         /// <param name="destinationType">Type being evaluated for conversion.</param>
-        /// <returns>A <see langword="string"/> representing the <see cref="Duration"/> specified by <paramref name="value"/>.</returns>
+        /// <returns>A <see cref="string"/> representing the <see cref="Duration"/> specified by <paramref name="value"/>.</returns>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo cultureInfo, object value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);


### PR DESCRIPTION
## Description

Parsing optimization for `Duration` and its conversion from/to `string`. Conversion from is now alloc-free (besides the non-removable ones), conversion to is massively sped up by modification of `ToString` in `Duration`.
- Besides the obvious improvements, adds/completes code documentation for the whole class.
- The `TimeSpanConverter` from `ComponentModel` does nothing useful but `Parse`/`ToString` on `TimeSpan`/`string` instance; the exceptions are not localized. Using it means we have to use the string instance as ref structs cannot be boxed (`ReadOnlySpan<T>`), and that would result in additional trim for example.

### ConvertTo benchmarks
| Method   | source              | Mean [ns]  | Error [ns] | StdDev [ns] | Code Size | Gen0   | Allocated |
|--------- |-------------------- |-----------:|-----------:|------------:|----------:|-------:|----------:|
| Original | 17.22:10:15.4571230 | 449.078 ns |  1.3738 ns |   1.2178 ns |         107 B | 0.0134 |         224 B |
| PR__EDIT | 17.22:10:15.4571230 |  22.712 ns |  0.3210 ns |   0.3003 ns |         107 B | 0.0038 |          64 B |
| Original | Automatic           |   2.436 ns |  0.0249 ns |   0.0221 ns |         107 B |      - |             - |
| PR__EDIT | Automatic           |   2.183 ns |  0.0136 ns |   0.0114 ns |         107 B |      - |             - |

### ConvertFrom benchmarks
| Method   | source            | Mean [ns]  | Error [ns] | StdDev [ns] | Code Size | Gen0   | Allocated |
|--------- |------------------ |-----------:|-----------:|------------:|----------:|-------:|----------:|
| Original | \x207:12:14:45.3448  | 216.157 ns |  1.1200 ns |   0.9929 ns |       1,018 B | 0.0219 |         368 B |
| PR__EDIT | \x207:12:14:45.3448  | 207.656 ns |  0.8965 ns |   0.8386 ns |         570 B | 0.0138 |         232 B |
| Original | \x20Forever          |  10.444 ns |  0.2368 ns |   0.2326 ns |       1,289 B | 0.0043 |          72 B |
| PR__EDIT | \x20Forever          |   7.213 ns |  0.1097 ns |   0.1026 ns |         722 B | 0.0019 |          32 B |
| Original | Automatic\x20         |  19.617 ns |  0.1948 ns |   0.1822 ns |       1,920 B | 0.0043 |          72 B |
| PR__EDIT | Automatic\x20         |   7.794 ns |  0.1190 ns |   0.1055 ns |       1,132 B | 0.0019 |          32 B |
| Original | 6:12:14:45.3448   | 199.160 ns |  0.8665 ns |   0.7236 ns |         696 B | 0.0153 |         256 B |
| PR__EDIT | 6:12:14:45.3448   | 188.803 ns |  0.7456 ns |   0.6974 ns |         606 B | 0.0138 |         232 B |
| Original | Automatic         |   7.548 ns |  0.6944 ns |   2.0475 ns |         776 B | 0.0019 |          32 B |
| PR__EDIT | Automatic         |   5.561 ns |  0.1681 ns |   0.4955 ns |         900 B | 0.0019 |          32 B |
| Original | Forever           |   7.773 ns |  0.5075 ns |   1.4964 ns |         611 B | 0.0019 |          32 B |
| PR__EDIT | Forever           |   7.246 ns |  0.4819 ns |   1.4208 ns |         520 B | 0.0019 |          32 B |

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, CI, extensive assert testing:
```csharp
 CultureInfo russianCulture = new CultureInfo("ru-RU");
 //ConvertFrom Tests
 Duration x1 = (Duration)oldDurationConverter.ConvertFrom(null, null, "Automatic");
 Duration x2 = (Duration)newDurationConverter.ConvertFrom(null, null, "Automatic");
 
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, null, " Forever");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, null, " Forever");
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, null, "Automatic ");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, null, "Automatic ");
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, "07:12:14:45.3448 ");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, "07:12:14:45.3448 ");
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, russianCulture, " 6:12:14:45,3448 ");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, russianCulture, " 6:12:14:45,3448 ");
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6 ");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6 ");
 Assert.AreEqual(x1, x2);
 x1 = (Duration)oldDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6:12 ");
 x2 = (Duration)newDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6:12 ");
 Assert.AreEqual(x1, x2);
 // Invalid TimeSpan string specified
 Assert.ThrowsException<FormatException>(() => oldDurationConverter.ConvertFrom(null, null, " á "));
 Assert.ThrowsException<FormatException>(() => newDurationConverter.ConvertFrom(null, null, " á "));
 // Valid TimeSpan but wrong culture
 Assert.ThrowsException<FormatException>(() => oldDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6:12:14:45,3448 "));
 Assert.ThrowsException<FormatException>(() => newDurationConverter.ConvertFrom(null, CultureInfo.InvariantCulture, " 6:12:14:45,3448 "));
 // Wrong input type
 Assert.ThrowsException<NotSupportedException>(() => oldDurationConverter.ConvertFrom(null, null, 12345));
 Assert.ThrowsException<NotSupportedException>(() => newDurationConverter.ConvertFrom(null, null, 12345));
 // Input was null
 Assert.ThrowsException<NotSupportedException>(() => oldDurationConverter.ConvertFrom(null, null, null));
 Assert.ThrowsException<NotSupportedException>(() => newDurationConverter.ConvertFrom(null, null, null));

 // CanConvertTo Tests
 // True cases
 bool x6 = oldDurationConverter.CanConvertTo(null, typeof(InstanceDescriptor));
 bool x7 = newDurationConverter.CanConvertTo(null, typeof(InstanceDescriptor));
 Assert.AreEqual(x6, x7);
 x6 = oldDurationConverter.CanConvertTo(null, typeof(string));
 x7 = newDurationConverter.CanConvertTo(null, typeof(string));
 Assert.AreEqual(x6, x7);
 // False case
 x6 = oldDurationConverter.CanConvertTo(null, typeof(Int32));
 x7 = newDurationConverter.CanConvertTo(null, typeof(Int32));
 Assert.AreEqual(x6, x7);

 // ConvertTo Tests
 string x3 = (string)oldDurationConverter.ConvertTo(null, null, Duration.Automatic, typeof(string));
 string x4 = (string)newDurationConverter.ConvertTo(null, null, Duration.Automatic, typeof(string));
 Assert.AreEqual(x3, x4);

 x3 = (string)oldDurationConverter.ConvertTo(null, null, Duration.Forever, typeof(string));
 x4 = (string)newDurationConverter.ConvertTo(null, null, Duration.Forever, typeof(string));
 Assert.AreEqual(x3, x4);

 //It converts according to InvariantCulture everytime
 x3 = (string)oldDurationConverter.ConvertTo(null, CultureInfo.InvariantCulture, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(string));
 x4 = (string)newDurationConverter.ConvertTo(null, CultureInfo.InvariantCulture, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(string));
 string x5 = (string)oldDurationConverter.ConvertTo(null, russianCulture, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(string));
 string x9 = (string)newDurationConverter.ConvertTo(null, russianCulture, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(string));
 //Sanity test
 Assert.AreEqual(x3, x4);
 Assert.AreEqual(x5, x9);
 //Cross test
 Assert.AreEqual(x3, x9);
 Assert.AreEqual(x4, x5);

 //This is a special case, because original call was a base call, it does not throw for NULL but returns string.Empty
 x3 = (string)oldDurationConverter.ConvertTo(null, null, null, typeof(string));
 x4 = (string)newDurationConverter.ConvertTo(null, null, null, typeof(string));
 Assert.AreEqual(x3, x4);

 //Null destinationType
 Assert.ThrowsException<ArgumentNullException>(() => (string)oldDurationConverter.ConvertTo(null, null, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), null));
 Assert.ThrowsException<ArgumentNullException>(() => (string)newDurationConverter.ConvertTo(null, null, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), null));
 //Invalid destinationType
 Assert.ThrowsException<NotSupportedException>(() => (string)oldDurationConverter.ConvertTo(null, null, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(Int32)));
 Assert.ThrowsException<NotSupportedException>(() => (string)newDurationConverter.ConvertTo(null, null, new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(Int32)));
```

## Risk

Low, the behaviour has been matched as verified by the tests.

**There is a slight behavioral change in `ConvertTo` as in my opinion that is a bug**, since the original function delegates this to `Duration.ToString` override, which obtains a `TypeDescriptor` for `TimeSpan`, that in normal scenario is `TimeSpanConverter` but it is possible to change it and therefore change the output of the `DurationConverter` for `TimeSpan` values.
This doesn't apply onto `ConvertFrom` as a raw instance of `TimeSpanConverter` was used instead, originally.

The new behavior is to always use `TimeSpan.ToString` override, so the `ConvertTo`/`ConvertFrom` have consistent behavior. This is also consistent with other related `Timeline` types - e.g. `RepeatBehavior`, that just uses `TimeSpan.ToString` override. If anything, one shall directly change the `TypeDescriptor` for `Duration` to change the whole conversion logic.

Sample code would influence the output is `ConvertTo` (only, `ConvertFrom` would stay intact) [courtesy of @miloush]:

```csharp
AttributeCollection xx = TypeDescriptor.GetAttributes(typeof(TimeSpan));
TypeDescriptor.AddAttributes(typeof(TimeSpan), new TypeConverterAttribute(typeof(HahaConverter)));
string s = (string)oldDurationConverter.ConvertTo(null, null, 
                  new Duration(new TimeSpan(17, 22, 10, 15, 457, 123)), typeof(string));

class HahaConverter : TypeConverter
{
    public override object ConvertTo(ITypeDescriptorContext context,
    CultureInfo culture, object value, Type destinationType) => "haha";
 }
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9768)