### PR TITLE
Redefine RepeatBehavior as readonly struct to prevent defensive copies

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Media.Animation
             if (double.IsInfinity(count) || double.IsNaN(count) || count < 0.0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.Timing_RepeatBehaviorInvalidIterationCount, count));
 
-            _repeatDuration = new TimeSpan(0);
+            _repeatDuration = TimeSpan.Zero;
             _iterationCount = count;
             _type = RepeatBehaviorType.IterationCount;
         }
@@ -51,7 +51,7 @@ namespace System.Windows.Media.Animation
         /// <param name="duration">A TimeSpan representing the repeat duration specified by this RepeatBehavior.</param>
         public RepeatBehavior(TimeSpan duration)
         {
-            if (duration < new TimeSpan(0))
+            if (duration < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(duration), SR.Format(SR.Timing_RepeatBehaviorInvalidRepeatDuration, duration));
 
             _iterationCount = 0.0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -107,10 +107,8 @@ namespace System.Windows.Media.Animation
         {
             get
             {
-                if (_type != RepeatBehaviorType.IterationCount)
-                {
+                if (!HasCount)
                     throw new InvalidOperationException(SR.Format(SR.Timing_RepeatBehaviorNotIterationCount, this));
-                }
 
                 return _iterationCount;
             }
@@ -125,7 +123,7 @@ namespace System.Windows.Media.Animation
         {
             get
             {
-                if (_type != RepeatBehaviorType.RepeatDuration)
+                if (!HasDuration)
                     throw new InvalidOperationException(SR.Format(SR.Timing_RepeatBehaviorNotRepeatDuration, this));
 
                 return _repeatDuration;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -22,11 +22,11 @@ namespace System.Windows.Media.Animation
     /// <para>A Forever RepeatBehavior specifies that a Timeline will repeat forever.</para>
     /// </summary>
     [TypeConverter(typeof(RepeatBehaviorConverter))]
-    public struct RepeatBehavior : IFormattable
+    public readonly struct RepeatBehavior : IFormattable
     {
-        private double _iterationCount;
-        private TimeSpan _repeatDuration;
-        private RepeatBehaviorType _type;
+        private readonly double _iterationCount;
+        private readonly TimeSpan _repeatDuration;
+        private readonly RepeatBehaviorType _type;
 
         #region Constructors
 
@@ -66,22 +66,14 @@ namespace System.Windows.Media.Animation
         }
 
         /// <summary>
-        /// Creates and returns a RepeatBehavior that indicates that a Timeline should repeat its
-        /// simple duration forever.
+        /// Private constructor, serves for creation of <see cref="RepeatBehavior.Forever"/> only.
         /// </summary>
-        /// <value>A RepeatBehavior that indicates that a Timeline should repeat its simple duration
-        /// forever.</value>
-        public static RepeatBehavior Forever
+        /// <param name="behaviorType">Only <see cref="RepeatBehaviorType.Forever"/> value is permitted.</param>
+        private RepeatBehavior(RepeatBehaviorType behaviorType)
         {
-            get
-            {
-                RepeatBehavior forever = new RepeatBehavior
-                {
-                    _type = RepeatBehaviorType.Forever
-                };
+            Debug.Assert(behaviorType == RepeatBehaviorType.Forever);
 
-                return forever;
-            }
+            _type = behaviorType;
         }
 
         #endregion // Constructors
@@ -140,11 +132,23 @@ namespace System.Windows.Media.Animation
             get
             {
                 if (_type != RepeatBehaviorType.RepeatDuration)
-                {
                     throw new InvalidOperationException(SR.Format(SR.Timing_RepeatBehaviorNotRepeatDuration, this));
-                }
 
                 return _repeatDuration;
+            }
+        }
+
+        /// <summary>
+        /// Creates and returns a <see cref="RepeatBehavior"/> that indicates that a <see cref="Timeline"/>
+        /// should repeat its simple duration forever.
+        /// </summary>
+        /// <value>A <see cref="RepeatBehavior"/> that indicates that a <see cref="Timeline"/>
+        /// should repeat its simple duration forever.</value>
+        public static RepeatBehavior Forever
+        {
+            get
+            {
+                return new RepeatBehavior(RepeatBehaviorType.Forever);
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -102,7 +102,7 @@ namespace System.Windows.Media.Animation
         /// Returns the iteration count specified by this RepeatBehavior.
         /// </summary>
         /// <value>The iteration count specified by this RepeatBehavior.</value>
-        /// <exception cref="System.InvalidOperationException">Thrown if this RepeatBehavior does not represent an iteration count.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if this RepeatBehavior does not represent an iteration count.</exception>
         public double Count
         {
             get
@@ -118,7 +118,7 @@ namespace System.Windows.Media.Animation
         /// Returns the repeat duration specified by this RepeatBehavior.
         /// </summary>
         /// <value>A TimeSpan representing the repeat duration specified by this RepeatBehavior.</value>
-        /// <exception cref="System.InvalidOperationException">Thrown if this RepeatBehavior does not represent a repeat duration.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if this RepeatBehavior does not represent a repeat duration.</exception>
         public TimeSpan Duration
         {
             get
@@ -223,7 +223,7 @@ namespace System.Windows.Media.Animation
                 case RepeatBehaviorType.Forever:
 
                     // We try to choose an unlikely hash code value for Forever.
-                    // All Forevers need to return the same hash code value.
+                    // All Forever instances need to return the same hash code value.
                     return int.MaxValue - 42;
 
                 default:

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -161,16 +161,9 @@ namespace System.Windows.Media.Animation
         /// </summary>
         /// <param name="value"></param>
         /// <returns>true if value is a RepeatBehavior and is equal to this instance; otherwise false.</returns>
-        public override bool Equals(Object value)
+        public override bool Equals(object value)
         {
-            if (value is RepeatBehavior)
-            {
-                return this.Equals((RepeatBehavior)value);
-            }
-            else
-            {
-                return false;
-            }
+            return value is RepeatBehavior behavior && Equals(behavior);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Media/Animation/RepeatBehavior.cs
@@ -36,12 +36,8 @@ namespace System.Windows.Media.Animation
         /// <param name="count">The number of iterations specified by this RepeatBehavior.</param>
         public RepeatBehavior(double count)
         {
-            if (   Double.IsInfinity(count)
-                || double.IsNaN(count)
-                || count < 0.0)
-            {
-                throw new ArgumentOutOfRangeException("count", SR.Format(SR.Timing_RepeatBehaviorInvalidIterationCount, count));
-            }
+            if (double.IsInfinity(count) || double.IsNaN(count) || count < 0.0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.Format(SR.Timing_RepeatBehaviorInvalidIterationCount, count));
 
             _repeatDuration = new TimeSpan(0);
             _iterationCount = count;
@@ -56,9 +52,7 @@ namespace System.Windows.Media.Animation
         public RepeatBehavior(TimeSpan duration)
         {
             if (duration < new TimeSpan(0))
-            {
-                throw new ArgumentOutOfRangeException("duration", SR.Format(SR.Timing_RepeatBehaviorInvalidRepeatDuration, duration));
-            }
+                throw new ArgumentOutOfRangeException(nameof(duration), SR.Format(SR.Timing_RepeatBehaviorInvalidRepeatDuration, duration));
 
             _iterationCount = 0.0;
             _repeatDuration = duration;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/PresentationCore.cs
@@ -10119,7 +10119,7 @@ namespace System.Windows.Media.Animation
         void System.Collections.IList.Remove(object keyFrame) { }
     }
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Windows.Media.Animation.RepeatBehaviorConverter))]
-    public partial struct RepeatBehavior : System.IFormattable
+    public readonly partial struct RepeatBehavior : System.IFormattable
     {
         public RepeatBehavior(double count) { throw null; }
         public RepeatBehavior(System.TimeSpan duration) { throw null; }


### PR DESCRIPTION
## Description

Since `RepeatBehavior` is immutable by design, we should adjust it to `readonly struct`. This will also prevent defensive copies, even though the struct is small, it will already matter a bit here. It will also improve code quality. **This is not a breaking change**.

- A private constructor for the static `Forever` property creation will be added.
- `new TimeSpan(0)` is exactly what `TimeSpan.Zero` does but it is cleaner imho.
- Some code cleanup included.

## Customer Impact

Possibly a bit of perf and a clear directive that `RepeatBehavior` and all its methods are not adjusting the state of the `struct`.

## Regression

No.

## Testing

Local build, base testing, type creation, etc.

## Risk

I do not asses any, since the struct is immutable and this is not a breaking change. It is a change to a public type but such changes have been done previously in runtime, see for example [#97421](https://github.com/dotnet/runtime/pull/97421).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9776)