### PR TITLE
Optimize parsing/conversion of TextDecorations from string, reduce allocations

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -152,15 +152,13 @@ namespace System.Windows
         {
             if (destinationType == typeof(InstanceDescriptor) && value is IEnumerable<TextDecoration>)
             {
-                ConstructorInfo ci = typeof(TextDecorationCollection).GetConstructor(
-                    new Type[]{typeof(IEnumerable<TextDecoration>)}
-                    );
-                    
-                return new InstanceDescriptor(ci, new object[]{value});                
+                ConstructorInfo ci = typeof(TextDecorationCollection).GetConstructor(new Type[] { typeof(IEnumerable<TextDecoration>) });
+
+                return new InstanceDescriptor(ci, new object[] { value });
             }
 
             // Pass unhandled cases to base class (which will throw exceptions for null value or destinationType.)
-            return base.ConvertTo(context, culture, value, destinationType);              
+            return base.ConvertTo(context, culture, value, destinationType);
         }
 
         //---------------------------------

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -36,12 +36,7 @@ namespace System.Windows
         /// <returns> true if it can convert from sourceType to TextDecorations, false otherwise </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-
-            return false;
+            return sourceType == typeof(string);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -145,34 +145,6 @@ namespace System.Windows
 
             // Pass unhandled cases to base class (which will throw exceptions for null value or destinationType.)
             return base.ConvertTo(context, culture, value, destinationType);
-        }
-
-        //---------------------------------
-        // Private members
-        //---------------------------------
-
-        //
-        // Predefined valid names for TextDecorations
-        // Names should be normalized to be upper case
-        //
-        private const string None    = "NONE";
-        private const char Separator = ',';        
-        
-        private static readonly string[] TextDecorationNames = new string[] {            
-            "OVERLINE",  
-            "BASELINE",
-            "UNDERLINE",
-            "STRIKETHROUGH"
-            };
-
-        // Predefined TextDecorationCollection values. It should match 
-        // the TextDecorationNames array
-        private static readonly TextDecorationCollection[] PredefinedTextDecorations = 
-            new TextDecorationCollection[] {
-                TextDecorations.OverLine,
-                TextDecorations.Baseline,
-                TextDecorations.Underline,
-                TextDecorations.Strikethrough           
-                };       
-}             
+        }     
+    }             
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -148,69 +148,6 @@ namespace System.Windows
         }
 
         //---------------------------------
-        // Private methods
-        //---------------------------------
-        /// <summary>
-        /// Match the input against a predefined pattern from certain index onwards
-        /// </summary>
-        private static bool Match(string pattern, string input, int index)
-        {
-            int i = 0;
-            for (;
-                    i < pattern.Length
-                 && index + i < input.Length
-                 && pattern[i] == Char.ToUpperInvariant(input[index + i]);
-                 i++) ;
-
-            return (i == pattern.Length);
-        }
-
-        /// <summary>
-        /// Advance to the start of next name
-        /// </summary>
-        private static int AdvanceToNextNameStart(string input, int index)
-        {
-            // Two names must be seperated by a comma and optionally spaces
-            int separator = AdvanceToNextNonWhiteSpace(input, index);
-
-            int nextNameStart;
-            if (separator >= input.Length)
-            {
-                // reach the end
-                nextNameStart = input.Length;
-            }
-            else
-            {
-                if (input[separator] == Separator)
-                {                    
-                    nextNameStart = AdvanceToNextNonWhiteSpace(input, separator + 1);
-                    if (nextNameStart >= input.Length)
-                    {
-                        // Error: Separator is at the end of the input
-                        nextNameStart = -1;
-                    }
-                }
-                else
-                {
-                    // Error: There is a non-whitespace, non-separator character following
-                    // the matched value
-                    nextNameStart = -1;
-                }
-            }
-
-            return nextNameStart;
-        }
-
-        /// <summary>
-        /// Advance to the next non-whitespace character
-        /// </summary>
-        private static int AdvanceToNextNonWhiteSpace(string input, int index)
-        {
-            for (; index < input.Length && Char.IsWhiteSpace(input[index]); index++) ;
-            return (index > input.Length) ? input.Length : index;
-        }
-
-        //---------------------------------
         // Private members
         //---------------------------------
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -9,16 +9,19 @@ using System.Reflection;
 namespace System.Windows
 {
     /// <summary>
-    /// TypeConverter for TextDecorationCollection 
-    /// </summary>
+    /// Provides a type converter to convert from <see langword="string"/> to <see cref="TextDecorationCollection"/> only.
+    /// </summary>     
     public sealed class TextDecorationCollectionConverter : TypeConverter
     {
         /// <summary>
-        /// CanConvertTo method
+        /// Returns whether this converter can convert the object to the specified
+        /// <paramref name="destinationType"/>, using the specified <paramref name="context"/>.
         /// </summary>
-        /// <param name="context"> ITypeDescriptorContext </param>
-        /// <param name="destinationType"> Type to convert to </param>
-        /// <returns> false will always be returned because TextDecorations cannot be converted to any other type. </returns>
+        /// <param name="context">Context information used for conversion.</param>
+        /// <param name="destinationType">Type being evaluated for conversion.</param>
+        /// <returns>
+        /// <see langword="false"/> will always be returned because <see cref="TextDecorations"/> cannot be converted to any other type.
+        /// </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // Return false for any other target type. Don't call base.CanConvertTo() because it would be confusing 
@@ -28,44 +31,46 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// CanConvertFrom
+        /// Returns whether this class can convert specific <see cref="Type"/> into <see cref="TextDecorationCollection"/>.
         /// </summary>
         /// <param name="context"> ITypeDescriptorContext </param>
-        /// <param name="sourceType">Type to convert to </param>
-        /// <returns> true if it can convert from sourceType to TextDecorations, false otherwise </returns>
+        /// <param name="sourceType">Type being evaluated for conversion.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="sourceType"/> is <see langword="string"/>, otherwise <see langword="false"/>.
+        /// </returns>
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             return sourceType == typeof(string);
         }
 
         /// <summary>
-        /// ConvertFrom
+        /// Converts <paramref name="input"/> of <see langword="string"/> type to its <see cref="TextDecorationCollection"/> represensation.
         /// </summary>
-        /// <param name="context"> ITypeDescriptorContext </param>
-        /// <param name="culture"> CultureInfo </param>        
-        /// <param name="input"> The input object to be converted to TextDecorations </param>
-        /// <returns> the converted value of the input object </returns>
+        /// <param name="context">Context information used for conversion, ignored currently.</param>
+        /// <param name="culture">The culture specifier to use, ignored currently.</param>        
+        /// <param name="input">The string to convert from.</param>
+        /// <returns>A <see cref="TextDecorationCollection"/> representing the <see langword="string"/> specified by <paramref name="input"/>.</returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object input)
         {
             if (input is null)
                 throw GetConvertFromException(input);
 
             if (input is not string value)
-                throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), nameof(input));                     
-                        
-            return ConvertFromString(value);            
+                throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), nameof(input));
+
+            return ConvertFromString(value);
         }
 
         /// <summary>
-        /// ConvertFromString
+        /// Converts <paramref name="text"/> to its <see cref="TextDecorationCollection"/> represensation.
         /// </summary>
-        /// <param name="text"> The string to be converted into TextDecorationCollection object </param>
-        /// <returns> the converted value of the string flag </returns>
+        /// <param name="text">The string to be converted into TextDecorationCollection object.</param>
+        /// <returns>A <see cref="TextDecorationCollection"/> representing the <see langword="string"/> specified by <paramref name="text"/>.</returns>
         /// <remarks>
-        /// The text parameter can be either string "None" or a combination of the predefined 
-        /// TextDecoration names delimited by commas (,). One or more blanks spaces can precede 
-        /// or follow each text decoration name or comma. There can't be duplicate TextDecoration names in the 
-        /// string. The operation is case-insensitive. 
+        /// The text parameter can be either be <see langword="null"/>; <see cref="string.Empty"/>; the string "None"
+        /// or a combination of the predefined <see cref="TextDecorations"/> names delimited by commas (,).
+        /// One or more blanks spaces can precede  or follow each text decoration name or comma.
+        /// There can't be duplicate TextDecoration names in the string. The operation is case-insensitive. 
         /// </remarks>
         public static new TextDecorationCollection ConvertFromString(string text)
         {
@@ -88,7 +93,7 @@ namespace System.Windows
             if (decorationsSpan.IsEmpty || decorationsSpan.Equals("None", StringComparison.OrdinalIgnoreCase))
                 return new TextDecorationCollection();
 
-            // Create new collection, save allocations
+            // Create new collection, save re-allocations
             TextDecorationCollection textDecorations = new(1 + decorationsSpan.Count(','));
 
             // Go through each item in the input and match accordingly
@@ -123,16 +128,16 @@ namespace System.Windows
             }
 
             return textDecorations;
-        }        
+        }
 
         /// <summary>
-        /// ConvertTo
+        /// Converts a <paramref name="value"/> of <see cref="TextDecorationCollection"/> to the specified <paramref name="destinationType"/>.
         /// </summary>
-        /// <param name="context"> ITypeDescriptorContext </param>
-        /// <param name="culture"> CultureInfo </param>        
-        /// <param name="value"> the object to be converted to another type </param>
-        /// <param name="destinationType"> The destination type of the conversion </param>
-        /// <returns> null will always be returned because TextDecorations cannot be converted to any other type. </returns>        
+        /// <param name="context">Context information used for conversion.</param>
+        /// <param name="culture">The culture specifier to use.</param>
+        /// <param name="value">Duration value to convert from.</param>
+        /// <param name="destinationType">Type being evaluated for conversion.</param>
+        /// <returns><see langword="null"/> will always be returned because <see cref="TextDecorations"/> cannot be converted to any other type.</returns>        
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
             if (destinationType == typeof(InstanceDescriptor) && value is IEnumerable<TextDecoration>)
@@ -144,6 +149,6 @@ namespace System.Windows
 
             // Pass unhandled cases to base class (which will throw exceptions for null value or destinationType.)
             return base.ConvertTo(context, culture, value, destinationType);
-        }     
-    }             
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -25,7 +25,7 @@ namespace System.Windows
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
             // Return false for any other target type. Don't call base.CanConvertTo() because it would be confusing 
-            // in some cases. For example, for destination typeof(string), base TypeConveter just converts the
+            // in some cases. For example, for destination typeof(string), base TypeConverter just converts the
             // ITypeDescriptorContext to the full name string of the given type.
             return destinationType == typeof(InstanceDescriptor);
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -48,17 +48,11 @@ namespace System.Windows
         /// <returns> the converted value of the input object </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object input)
         {
-            if (input == null)
-            {
+            if (input is null)
                 throw GetConvertFromException(input);
-            }
 
-            string value = input as string; 
-            
-            if (null == value)
-            {
-                throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), nameof(input));
-            }                       
+            if (input is not string value)
+                throw new ArgumentException(SR.Format(SR.General_BadType, "ConvertFrom"), nameof(input));                     
                         
             return ConvertFromString(value);            
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -22,15 +22,10 @@ namespace System.Windows
         /// <returns> false will always be returned because TextDecorations cannot be converted to any other type. </returns>
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (destinationType == typeof(InstanceDescriptor))
-            {
-                return true;
-            }
-
-            // return false for any other target type. Don't call base.CanConvertTo() because it would be confusing 
-            // in some cases. For example, for destination typeof(String), base convertor just converts the TDC to the 
-            // string full name of the type. 
-            return false; 
+            // Return false for any other target type. Don't call base.CanConvertTo() because it would be confusing 
+            // in some cases. For example, for destination typeof(string), base TypeConveter just converts the
+            // ITypeDescriptorContext to the full name string of the given type.
+            return destinationType == typeof(InstanceDescriptor);
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using System.ComponentModel.Design.Serialization;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
@@ -9,7 +9,7 @@ using System.Reflection;
 namespace System.Windows
 {
     /// <summary>
-    /// Provides a type converter to convert from <see langword="string"/> to <see cref="TextDecorationCollection"/> only.
+    /// Provides a type converter to convert from <see cref="string"/> to <see cref="TextDecorationCollection"/> only.
     /// </summary>     
     public sealed class TextDecorationCollectionConverter : TypeConverter
     {
@@ -44,7 +44,7 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Converts <paramref name="input"/> of <see langword="string"/> type to its <see cref="TextDecorationCollection"/> represensation.
+        /// Converts <paramref name="input"/> of <see langword="string"/> type to its <see cref="TextDecorationCollection"/> representation.
         /// </summary>
         /// <param name="context">Context information used for conversion, ignored currently.</param>
         /// <param name="culture">The culture specifier to use, ignored currently.</param>        
@@ -62,10 +62,10 @@ namespace System.Windows
         }
 
         /// <summary>
-        /// Converts <paramref name="text"/> to its <see cref="TextDecorationCollection"/> represensation.
+        /// Converts <paramref name="text"/> to its <see cref="TextDecorationCollection"/> representation.
         /// </summary>
         /// <param name="text">The string to be converted into TextDecorationCollection object.</param>
-        /// <returns>A <see cref="TextDecorationCollection"/> representing the <see langword="string"/> specified by <paramref name="text"/>.</returns>
+        /// <returns>A <see cref="TextDecorationCollection"/> representing the <see cref="string"/> specified by <paramref name="text"/>.</returns>
         /// <remarks>
         /// The text parameter can be either be <see langword="null"/>; <see cref="string.Empty"/>; the string "None"
         /// or a combination of the predefined <see cref="TextDecorations"/> names delimited by commas (,).

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -77,14 +77,8 @@ namespace System.Windows
             if (text is null)
                 return null;
 
-            // Define constants that will make sure the match has been unique
-            const byte OverlineMatch = 1 << 0;
-            const byte BaselineMatch = 1 << 1;
-            const byte UnderlineMatch = 1 << 2;
-            const byte StrikethroughMatch = 1 << 3;
-
             // Flags indicating which pre-defined TextDecoration have been matched
-            byte matchedDecorations = 0;
+            Decorations matchedDecorations = Decorations.None;
 
             // Sanitize the input
             ReadOnlySpan<char> decorationsSpan = text.AsSpan().Trim();
@@ -95,31 +89,29 @@ namespace System.Windows
 
             // Create new collection, save re-allocations
             TextDecorationCollection textDecorations = new(1 + decorationsSpan.Count(','));
-
-            // Go through each item in the input and match accordingly
             foreach (Range segment in decorationsSpan.Split(','))
             {
                 ReadOnlySpan<char> decoration = decorationsSpan[segment].Trim();
 
-                if (decoration.Equals("Overline", StringComparison.OrdinalIgnoreCase) && (matchedDecorations & OverlineMatch) == 0)
+                if (decoration.Equals("Overline", StringComparison.OrdinalIgnoreCase) && !matchedDecorations.HasFlag(Decorations.OverlineMatch))
                 {
                     textDecorations.Add(TextDecorations.OverLine[0]);
-                    matchedDecorations |= OverlineMatch;
+                    matchedDecorations |= Decorations.OverlineMatch;
                 }
-                else if (decoration.Equals("Baseline", StringComparison.OrdinalIgnoreCase) && (matchedDecorations & BaselineMatch) == 0)
+                else if (decoration.Equals("Baseline", StringComparison.OrdinalIgnoreCase) && !matchedDecorations.HasFlag(Decorations.BaselineMatch))
                 {
                     textDecorations.Add(TextDecorations.Baseline[0]);
-                    matchedDecorations |= BaselineMatch;
+                    matchedDecorations |= Decorations.BaselineMatch;
                 }
-                else if (decoration.Equals("Underline", StringComparison.OrdinalIgnoreCase) && (matchedDecorations & UnderlineMatch) == 0)
+                else if (decoration.Equals("Underline", StringComparison.OrdinalIgnoreCase) && !matchedDecorations.HasFlag(Decorations.UnderlineMatch))
                 {
                     textDecorations.Add(TextDecorations.Underline[0]);
-                    matchedDecorations |= UnderlineMatch;
+                    matchedDecorations |= Decorations.UnderlineMatch;
                 }
-                else if (decoration.Equals("Strikethrough", StringComparison.OrdinalIgnoreCase) && (matchedDecorations & StrikethroughMatch) == 0)
+                else if (decoration.Equals("Strikethrough", StringComparison.OrdinalIgnoreCase) && !matchedDecorations.HasFlag(Decorations.StrikethroughMatch))
                 {
                     textDecorations.Add(TextDecorations.Strikethrough[0]);
-                    matchedDecorations |= StrikethroughMatch;
+                    matchedDecorations |= Decorations.StrikethroughMatch;
                 }
                 else
                 {
@@ -149,6 +141,19 @@ namespace System.Windows
 
             // Pass unhandled cases to base class (which will throw exceptions for null value or destinationType.)
             return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        /// <summary>
+        /// Abstraction helper of matched decorations during conversion.
+        /// </summary>
+        [Flags]
+        private enum Decorations : byte
+        {
+            None = 0,
+            OverlineMatch = 1 << 0,
+            BaselineMatch = 1 << 1,
+            UnderlineMatch = 1 << 2,
+            StrikethroughMatch = 1 << 3,
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/TextDecorationCollectionConverter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using System.Reflection;
 


### PR DESCRIPTION
## Description

Optimize parsing of `TextDecorations` from string into `TextDecorationCollection`, reduces allocations in all steps and improves performance, also reduces the memory footprint + readibility of the entire class by a large amount.

- Removes static array `TextDecorationNames`, that also removes the strings allocations on its own (not used anywhere else).
- Removes static array `PredefinedTextDecorations`, which was redundant from the start.
- And removes another 120 lines trying to avoid allocations in NetFX by using few newer BCL features.
- The static collections are frozen after creation, so are its items, so we can just grab it via indexer.

### ConvertFromString benchmarks

| Method   | Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |  252.0 ns |    1.16 ns |     1.08 ns | 0.0234 |       1,243 B |         392 B |
| PR__EDIT |  119.0 ns |    0.41 ns |     0.38 ns | 0.0091 |       3,335 B |         152 B |

```csharp
ConvertFromString("  Strikethrough   ,Underline, Baseline        , Overline             ");
```

| Method   |  Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |   56.77 ns |   0.544 ns |    0.509 ns | 0.0091 |       1,141 B |         152 B |
| PR__EDIT |   36.73 ns |   0.414 ns |    0.388 ns | 0.0067 |       2,659 B |         112 B |

```csharp
ConvertFromString("Strikethrough");
```

| Method   |  Mean [ns] | Error [ns] | StdDev [ns] | Gen0   | Code Size [B] | Allocated [B] |
|--------- |-----------:|-----------:|------------:|-------:|--------------:|--------------:|
| Original |   20.19 ns |   0.318 ns |    0.298 ns | 0.0048 |       1,119 B |          80 B |
| PR__EDIT |   15.81 ns |   0.265 ns |    0.247 ns | 0.0048 |       1,730 B |          80 B |

```csharp
ConvertFromString("None");
```

## Customer Impact

Improved performance, decreased allocations.

## Regression

No.

## Testing

Local build, CI, extensive assert testing:

```csharp
private static void CheckEqual(TextDecorationCollection collection1, TextDecorationCollection collection2, int expectedCount)
{
    //Check count
    Assert.AreEqual(expectedCount, collection1.Count);
    Assert.AreEqual(collection1.Count, collection2.Count);

    for (int i = 0; i < collection1.Count; i++)
    {
        Assert.AreEqual(collection1[i], collection2[i]);
    }
}

// Valid cases
// "None" returns no items
CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString(string.Empty),
              TextDecorationCollectionConverter.ConvertFromString(string.Empty), 0);
CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("          "),
              TextDecorationCollectionConverter.ConvertFromString("          "), 0);
CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("None"),
              TextDecorationCollectionConverter.ConvertFromString("None"), 0);
CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("    None    "),
              TextDecorationCollectionConverter.ConvertFromString("    None    "), 0);

CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("Strikethrough"),
              TextDecorationCollectionConverter.ConvertFromString("Strikethrough"), 1);

CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("Strikethrough       "),
              TextDecorationCollectionConverter.ConvertFromString("Strikethrough       "), 1);

CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("Underline, Baseline "),
              TextDecorationCollectionConverter.ConvertFromString("Underline, Baseline "), 2);

CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("  Strikethrough   ,Underline, Baseline "),
              TextDecorationCollectionConverter.ConvertFromString("  Strikethrough   ,Underline, Baseline "), 3);

CheckEqual(TextDecorationCollectionConverterNEW.ConvertFromString("  Strikethrough   ,Underline, Baseline        , Overline             "),
              TextDecorationCollectionConverter.ConvertFromString("  Strikethrough   ,Underline, Baseline        , Overline             "), 4);

// Special case

Assert.AreEqual(TextDecorationCollectionConverterNEW.ConvertFromString(null), TextDecorationCollectionConverter.ConvertFromString(null));

// Exception cases
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString(",  Strikethrough   ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString("  Strikethrough  , Strikethrough, ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString("None,  Strikethrough   ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString("None,  Strikethrough   ,Underline, Baseline, Overline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString(" Strikethrough   ,Underline, Baseline, Overline, x "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString(" Strikethrough   ,Underline, Baseline, Overline, "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString(" Underline, Underline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverterNEW.ConvertFromString(" Noneee "));

Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(",  Strikethrough   ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString("  Strikethrough  , Strikethrough, ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString("None,  Strikethrough   ,Underline, Baseline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString("None,  Strikethrough   ,Underline, Baseline, Overline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(" Strikethrough   ,Underline, Baseline, Overline, x "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(" Strikethrough   ,Underline, Baseline, Overline, "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(" Underline, Underline "));
Assert.ThrowsException<ArgumentException>(() => TextDecorationCollectionConverter.ConvertFromString(" Noneee "));
```

## Risk

Should be safe, I believe I've tested thoroughly all cases and we shall have no surprises.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9778)