### PR TITLE
Add missing Bindings in Fluent ControlTemplates

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -480,7 +480,7 @@
     <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemAccentColor}" />
 
     <!--  Label  -->
-    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorPrimary}" />
 
     <!--  ListBox  -->
     <SolidColorBrush x:Key="ListBoxBackground" Color="{StaticResource CardBackgroundFillColorDefault}" />
@@ -492,6 +492,8 @@
     <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
 
     <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="ListViewBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -532,6 +534,10 @@
     <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
 
+    <!-- Page -->
+    <SolidColorBrush x:Key="PageForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="PageBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+
     <!--  ProgressBar  -->
     <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource ControlStrongStrokeColorDefault}" />
@@ -546,7 +552,13 @@
     <!--  RadioButton  -->
     <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTransparent}"/>
     <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="{StaticResource SubtleFillColorTransparent}"/>
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemAccentColorLight2}" Opacity="0.9" />
     <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource TextOnAccentFillColorPrimary}" />
@@ -558,8 +570,10 @@
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource ControlStrongStrokeColorDefault}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemAccentColorLight2}"/>
 
     <!--  RatingControl  -->
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemAccentColorLight2}" />
@@ -574,6 +588,11 @@
     <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+
+    <!-- ScrollBar -->
+    <SolidColorBrush x:Key="ScrollBarTrackFill" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />     
 
     <!--  Separator  -->
     <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Dark.xaml
@@ -429,6 +429,7 @@
     <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorLight2}" />
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}"/>
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -298,6 +298,7 @@
     <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource SystemColorWindowColor}"/>
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/HC.xaml
@@ -360,6 +360,8 @@
     <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource SystemColorHighlightTextColor}" />
 
     <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewBackground" Color="Transparent" />
+    <SolidColorBrush x:Key="ListViewBorderBrush" Color="Transparent" />
     <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
     <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
@@ -400,6 +402,10 @@
     <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
 
+    <!-- Page -->
+    <SolidColorBrush x:Key="PageForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="PageBackground" Color="Transparent" />
+
     <!--  ProgressBar  -->
     <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource SystemColorWindowColor}" />
@@ -415,7 +421,13 @@
     <!--  RadioButton  -->
     <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonBackground" Color="Transparent"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="Transparent"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="Transparent"/>
     <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="Transparent"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="Transparent"/>
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
     <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource SystemColorHighlightColor}" />
@@ -427,8 +439,10 @@
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource SystemColorWindowColor}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource SystemColorButtonTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource SystemColorHighlightTextColor}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemColorHighlightColor}"/>
 
     <!--  RatingControl  -->
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
@@ -443,6 +457,11 @@
     <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+
+    <!-- ScrollBar -->
+    <SolidColorBrush x:Key="ScrollBarTrackFill" Color="Transparent" />
+    <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SystemColorWindowTextColor}" />
+    <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SystemColorWindowColor}" />   
 
     <!--  Separator  -->
     <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -474,7 +474,7 @@
     <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemAccentColor}" />
 
     <!--  Label  -->
-    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorPrimary}" />
 
     <!--  ListBox  -->
     <Color x:Key="SystemChromeMediumLowColor">#FFF2F2F2</Color>
@@ -487,6 +487,8 @@
     <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
 
     <!--  ListView  -->
+    <SolidColorBrush x:Key="ListViewBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="ListViewBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
     <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -527,6 +529,10 @@
     <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
 
+    <!-- Page -->
+    <SolidColorBrush x:Key="PageForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="PageBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+
     <!--  ProgressBar  -->
     <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource ControlStrongStrokeColorDefault}" />
@@ -541,7 +547,13 @@
     <!--  RadioButton  -->
     <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTransparent}"/>
     <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="{StaticResource SubtleFillColorTransparent}"/>
+    <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="{StaticResource SubtleFillColorTransparent}"/>
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemAccentColorDark1}" Opacity="0.9" />
     <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource TextOnAccentFillColorPrimary}" />
@@ -553,8 +565,10 @@
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource ControlStrongStrokeColorDefault}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
     <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemAccentColorDark1}"/>
 
     <!--  RatingControl  -->
     <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemAccentColorDark1}" />
@@ -569,6 +583,11 @@
     <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+
+    <!-- ScrollBar -->
+     <SolidColorBrush x:Key="ScrollBarTrackFill" Color="{StaticResource SubtleFillColorTransparent}" />
+     <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SubtleFillColorTransparent}" />
+     <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />     
 
     <!--  Separator  -->
     <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Resources/Theme/Light.xaml
@@ -423,6 +423,7 @@
     <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorDark1}" />
     <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
     <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}"/>
 
     <!--  DynamicScrollBar  -->
     <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Button.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Button.xaml
@@ -33,7 +33,7 @@
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
+                <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Border x:Name="ContentBorder" 
                             Width="{TemplateBinding Width}" 
                             Height="{TemplateBinding Height}" 

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Calendar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Calendar.xaml
@@ -486,11 +486,11 @@
         <Setter Property="CalendarDayButtonStyle" Value="{StaticResource DefaultCalendarDayButtonStyle}" />
         <Setter Property="CalendarItemStyle" Value="{StaticResource DefaultCalendarItemStyle}" />
         <Setter Property="Foreground" Value="{DynamicResource CalendarViewForeground}" />
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Background" Value="{DynamicResource CalendarViewBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewBorderBrush}" />
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Calendar}">
@@ -498,9 +498,9 @@
                         x:Name="PART_Root"
                         Margin="0"
                         Padding="0"
-                        Background="{DynamicResource CalendarViewBackground}"
-                        BorderBrush="{DynamicResource CalendarViewBorderBrush}"
-                        BorderThickness="1"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         HorizontalAlignment="{TemplateBinding HorizontalAlignment}" 
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
                         CornerRadius="4">
@@ -510,9 +510,9 @@
                             Padding="0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
                             Style="{TemplateBinding CalendarItemStyle}" />
                     </Border>
                 </ControlTemplate>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -205,6 +205,8 @@
                                             Content="{TemplateBinding SelectionBoxItem}"
                                             ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                             ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                            ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                             IsHitTestVisible="False"
                                             TextElement.Foreground="{TemplateBinding Foreground}" />
                                     </Grid>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ComboBox.xaml
@@ -263,7 +263,6 @@
                                     VerticalOffset="1">
                                     <Border
                                         x:Name="DropDownBorder"
-                                        Margin="12,0,12,18"
                                         Padding="0,4,0,6"
                                         Background="{DynamicResource ComboBoxDropDownBackground}"
                                         BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ContextMenu.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ContextMenu.xaml
@@ -9,11 +9,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <Thickness x:Key="ContextMenuBorderThickness">1</Thickness>
+
     <Style x:Key="DefaultContextMenuStyle" TargetType="{x:Type ContextMenu}">
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
         <Setter Property="Foreground" Value="{DynamicResource ContextMenuForeground}" />
         <Setter Property="Background" Value="{DynamicResource ContextMenuBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ContextMenuBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{StaticResource ContextMenuBorderThickness}" />
         <Setter Property="MinWidth" Value="140" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Margin" Value="0" />
@@ -30,7 +33,7 @@
                         Padding="0,3,0,3"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="1"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="8">
                         <Border.RenderTransform>
                             <TranslateTransform />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/DatePicker.xaml
@@ -71,10 +71,14 @@
         </Setter>
     </Style>
 
+    <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
+        <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+    </Style>
+
     <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-        <Setter Property="CalendarStyle" Value="{DynamicResource DefaultCalendarStyle}" />
+        <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
         <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
         <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Expander.xaml
@@ -289,7 +289,7 @@
                                 DockPanel.Dock="Top"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="1"
+                                BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Border.CornerRadius}">
                             <ToggleButton
                                         x:Name="HeaderSite"
@@ -301,7 +301,13 @@
                                         HorizontalContentAlignment="Stretch"
                                         VerticalContentAlignment="Center"
                                         Content="{TemplateBinding Header}"
+                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                        FontFamily="{TemplateBinding FontFamily}"
                                         FontSize="{TemplateBinding FontSize}"
+                                        FontStyle="{TemplateBinding FontStyle}"
+                                        FontStretch="{TemplateBinding FontStretch}"
+                                        FontWeight="{TemplateBinding FontWeight}"
                                         Foreground="{TemplateBinding Foreground}"
                                         IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}"
                                         IsEnabled="{TemplateBinding IsEnabled}"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBox.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBox.xaml
@@ -34,15 +34,19 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBox}">
-                    <Grid Background="{TemplateBinding Background }">
+                    <Border Name="Bd"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <ScrollViewer
                             x:Name="PART_ContentHost"
+                            Padding="{TemplateBinding Padding}"
                             CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                             HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter />
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </ScrollViewer>
-                    </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsGrouping" Value="True">
                             <Setter Property="ScrollViewer.CanContentScroll" Value="False" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBoxItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListBoxItem.xaml
@@ -11,10 +11,13 @@
 
     <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
         <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
-        <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
         <Setter Property="Margin" Value="0" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="12" />
         <Setter Property="Border.CornerRadius" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -26,10 +29,14 @@
                         x:Name="Border"
                         Margin="0"
                         Padding="{TemplateBinding Padding}"
-                        Background="Transparent"
-                        BorderThickness="1"
+                        Background="{TemplateBinding Background}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
                         CornerRadius="{TemplateBinding Border.CornerRadius}">
-                        <ContentPresenter />
+                        <ContentPresenter 
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListView.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListView.xaml
@@ -12,7 +12,9 @@
     <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="0" />
-        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Background" Value="{DynamicResource ListViewBackground}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ListViewBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
@@ -31,28 +33,34 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListView}">
-                    <Grid>
-                        <ScrollViewer
-                            x:Name="PART_ContentHost"
-                            CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter />
-                        </ScrollViewer>
-                        <Rectangle
-                            x:Name="PART_DisabledVisual"
-                            Opacity="0"
-                            RadiusX="2"
-                            RadiusY="2"
-                            Stretch="Fill"
-                            Stroke="Transparent"
-                            StrokeThickness="0"
-                            Visibility="Collapsed">
-                            <Rectangle.Fill>
-                                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-                            </Rectangle.Fill>
-                        </Rectangle>
-                    </Grid>
+                    <Border
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        Background="{TemplateBinding Background}">
+                        <Grid>
+                            <ScrollViewer
+                                x:Name="PART_ContentHost"
+                                Padding="{TemplateBinding Padding}"
+                                CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                            </ScrollViewer>
+                            <Rectangle
+                                x:Name="PART_DisabledVisual"
+                                Opacity="0"
+                                RadiusX="2"
+                                RadiusY="2"
+                                Stretch="Fill"
+                                Stroke="Transparent"
+                                StrokeThickness="0"
+                                Visibility="Collapsed">
+                                <Rectangle.Fill>
+                                    <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                                </Rectangle.Fill>
+                            </Rectangle>
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsGrouping" Value="True">
                             <Setter Property="ScrollViewer.CanContentScroll" Value="False" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListViewItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ListViewItem.xaml
@@ -4,14 +4,25 @@
     Copyright (C) Leszek Pomianowski and WPF UI Contributors.
     All Rights Reserved.
 -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
+    <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
+
 
     <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
         <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
+        <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Margin" Value="0,0,0,2" />
-        <Setter Property="Padding" Value="4" />
+        <Setter Property="Padding" Value="16,0,12,0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
         <Setter Property="Template">
@@ -21,11 +32,15 @@
                         x:Name="Border"
                         Margin="0"
                         Padding="0"
-                        Background="Transparent"
-                        BorderThickness="1"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         CornerRadius="{TemplateBinding Border.CornerRadius}">
                         <Grid>
-                            <ContentPresenter Margin="{TemplateBinding Padding}" />
+                            <ContentPresenter 
+                                Margin="{TemplateBinding Padding}" 
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             <Rectangle
                                 x:Name="ActiveRectangle"
                                 Width="3"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Menu.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Menu.xaml
@@ -21,7 +21,8 @@
                     <Border
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}">
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Padding="{TemplateBinding Padding}">
                         <StackPanel
                             ClipToBounds="True"
                             IsItemsHost="True"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/MenuItem.xaml
@@ -46,7 +46,9 @@
         <Border
             x:Name="Border"
             Margin="4"
-            Background="Transparent"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
             CornerRadius="6">
             <Grid>
                 <Grid.RowDefinitions>
@@ -64,6 +66,7 @@
                         Grid.Column="0"
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                         Content="{TemplateBinding Icon}" />
                     <ContentPresenter
                         x:Name="HeaderPresenter"
@@ -71,6 +74,8 @@
                         VerticalAlignment="Center"
                         ContentSource="Header"
                         RecognizesAccessKey="True"
+                        Margin="{TemplateBinding Padding}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                         TextElement.Foreground="{TemplateBinding Foreground}" />
                 </Grid>
 
@@ -158,7 +163,9 @@
         <Border
             x:Name="Border"
             Margin="4"
-            Background="Transparent"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
             CornerRadius="6">
             <Grid Margin="10">
                 <Grid.ColumnDefinitions>
@@ -169,6 +176,7 @@
                     x:Name="Icon"
                     Grid.Column="0"
                     Margin="0,0,6,0"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     VerticalAlignment="Center"
                     Content="{TemplateBinding Icon}" />
                 <ContentPresenter
@@ -176,6 +184,8 @@
                     Grid.Column="1"
                     VerticalAlignment="Center"
                     ContentSource="Header"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     RecognizesAccessKey="True"
                     TextElement.Foreground="{TemplateBinding Foreground}" />
             </Grid>
@@ -206,7 +216,9 @@
         <Border
             x:Name="Border"
             Margin="4,1,4,1"
-            Background="Transparent"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
             CornerRadius="4">
             <Grid Margin="8,6,8,6">
                 <Grid.ColumnDefinitions>
@@ -243,12 +255,15 @@
                     Grid.Column="1"
                     Margin="0,0,6,0"
                     VerticalAlignment="Center"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     Content="{TemplateBinding Icon}" />
 
                 <ContentPresenter
                     Grid.Column="2"
                     ContentSource="Header"
                     RecognizesAccessKey="True"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     TextElement.Foreground="{TemplateBinding Foreground}" />
 
                 <TextBlock
@@ -300,7 +315,9 @@
                 x:Name="Border"
                 Grid.Row="1"
                 Margin="4,1,4,1"
-                BorderThickness="1"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
                 CornerRadius="4">
                 <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
                     <Grid.ColumnDefinitions>
@@ -313,11 +330,14 @@
                         Grid.Column="0"
                         Margin="0,0,6,0"
                         VerticalAlignment="Center"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                         Content="{TemplateBinding Icon}" />
 
                     <ContentPresenter
                         x:Name="HeaderHost"
                         Grid.Column="1"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                        Margin="{TemplateBinding Padding}"
                         ContentSource="Header"
                         RecognizesAccessKey="True" />
 
@@ -416,8 +436,13 @@
     </ControlTemplate>
 
     <Style x:Key="DefaultMenuItemStyle" TargetType="{x:Type MenuItem}">
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
         <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Focusable" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Style.Triggers>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Page.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/Page.xaml
@@ -8,12 +8,8 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Style x:Key="DefaultPageStyle" TargetType="{x:Type Page}">
-        <Setter Property="Control.Foreground">
-            <Setter.Value>
-                <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource PageForeground}" />
+        <Setter Property="Background" Value="{DynamicResource PageBackground}" />
         <!--  The Display option casues a large aliasing effect  -->
         <!-- <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" /> -->
         <Setter Property="Focusable" Value="False" />
@@ -22,13 +18,13 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Page}">
-                    <Grid>
+                    <Border 
+                        Background="{TemplateBinding Background}" 
+                        CornerRadius="8">
                         <ContentPresenter
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Stretch"
                             Content="{TemplateBinding ContentControl.Content}"
-                            TextElement.Foreground="{TemplateBinding Control.Foreground}" />
-                    </Grid>
+                            TextElement.Foreground="{TemplateBinding Foreground}" />
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/RadioButton.xaml
@@ -25,9 +25,10 @@
         <!--  Universal WPF UI focus  -->
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <!--  Universal WPF UI focus  -->
-        <Setter Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+        <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
-        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+        <Setter Property="Border.CornerRadius" Value="4" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
@@ -44,25 +45,26 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
-                    <Grid
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        Background="Transparent">
-
+                    <Border x:Name="RootBorder"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="{TemplateBinding Border.CornerRadius}">
+                        
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal">
                                     <Storyboard>
                                         <DoubleAnimation
-                                            Storyboard.TargetName="CheckGlyph"
-                                            Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)"
-                                            To="1"
-                                            Duration="0:0:0.25" />
+                                        Storyboard.TargetName="CheckGlyph"
+                                        Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleX)"
+                                        To="1"
+                                        Duration="0:0:0.25" />
                                         <DoubleAnimation
-                                            Storyboard.TargetName="CheckGlyph"
-                                            Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)"
-                                            To="1"
-                                            Duration="0:0:0.25" />
+                                        Storyboard.TargetName="CheckGlyph"
+                                        Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)"
+                                        To="1"
+                                        Duration="0:0:0.25" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="MouseOver">
@@ -77,9 +79,9 @@
                                             Storyboard.TargetProperty="(Ellipse.RenderTransform).(ScaleTransform.ScaleY)"
                                             To="1.167"
                                             Duration="0:0:0.25" />
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Pressed">
                                     <Storyboard>
                                         <DoubleAnimation
                                             Storyboard.TargetName="CheckGlyph"
@@ -95,65 +97,67 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Grid Height="32" VerticalAlignment="Top">
-                            <Ellipse
-                                x:Name="OuterEllipse"
-                                Width="{StaticResource RadioButtonOuterEllipseSize}"
-                                Height="{StaticResource RadioButtonOuterEllipseSize}"
-                                Fill="{DynamicResource RadioButtonOuterEllipseFill}"
-                                Stroke="{DynamicResource RadioButtonOuterEllipseStroke}"
-                                StrokeThickness="{StaticResource RadioButtonStrokeThickness}"
-                                UseLayoutRounding="False" />
-                            <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-                            <Ellipse
-                                x:Name="CheckOuterEllipse"
-                                Width="{StaticResource RadioButtonOuterEllipseSize}"
-                                Height="{StaticResource RadioButtonOuterEllipseSize}"
-                                Fill="{TemplateBinding Background}"
-                                Opacity="0"
-                                Stroke="{TemplateBinding Background}"
-                                StrokeThickness="{StaticResource RadioButtonStrokeThickness}"
-                                UseLayoutRounding="False" />
-                            <Ellipse
-                                x:Name="CheckGlyph"
-                                Width="{StaticResource RadioButtonCheckGlyphSize}"
-                                Height="{StaticResource RadioButtonCheckGlyphSize}"
-                                Fill="{DynamicResource RadioButtonCheckGlyphFill}"
-                                RenderTransformOrigin="0.5, 0.5"
-                                Opacity="0"
-                                Stroke="{DynamicResource CircleElevationBorderBrush}"
-                                UseLayoutRounding="False">
-                                <Ellipse.RenderTransform>
-                                    <ScaleTransform />
-                                </Ellipse.RenderTransform>
-                            </Ellipse>
-                            <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-                            <Border
-                                x:Name="PressedCheckGlyph"
-                                Width="4"
-                                Height="4"
-                                Background="{DynamicResource RadioButtonCheckGlyphFill}"
-                                BorderBrush="{DynamicResource CircleElevationBorderBrush}"
-                                CornerRadius="6"
-                                Opacity="0"
-                                UseLayoutRounding="False" />
-
+                            
+                        <Grid x:Name="RootGrid">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="20" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid Height="32" VerticalAlignment="Top">
+                                <Ellipse
+                                    x:Name="OuterEllipse"
+                                    Width="20"
+                                    Height="20"
+                                    Fill="{DynamicResource RadioButtonOuterEllipseFill}"
+                                    Stroke="{DynamicResource RadioButtonOuterEllipseStroke}"
+                                    StrokeThickness="{StaticResource RadioButtonStrokeThickness}"
+                                    UseLayoutRounding="False" />
+                                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                                <Ellipse
+                                    x:Name="CheckOuterEllipse"
+                                    Width="20"
+                                    Height="20"
+                                    Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}"
+                                    Opacity="0"
+                                    Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}"
+                                    StrokeThickness="{StaticResource RadioButtonStrokeThickness}"
+                                    UseLayoutRounding="False" />
+                                <Ellipse
+                                    x:Name="CheckGlyph"
+                                    Width="{StaticResource RadioButtonCheckGlyphSize}"
+                                    Height="{StaticResource RadioButtonCheckGlyphSize}"
+                                    Fill="{DynamicResource RadioButtonCheckGlyphFill}"
+                                    RenderTransformOrigin="0.5, 0.5"
+                                    Opacity="0"
+                                    Stroke="{DynamicResource CircleElevationBorderBrush}"
+                                    UseLayoutRounding="False">
+                                    <Ellipse.RenderTransform>
+                                        <ScaleTransform />
+                                    </Ellipse.RenderTransform>
+                                </Ellipse>
+                                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                                <Border
+                                    x:Name="PressedCheckGlyph"
+                                    Width="4"
+                                    Height="4"
+                                    Background="{DynamicResource RadioButtonCheckGlyphFill}"
+                                    BorderBrush="{DynamicResource CircleElevationBorderBrush}"
+                                    CornerRadius="6"
+                                    Opacity="0"
+                                    UseLayoutRounding="False" />
+    
+                            </Grid>
+                            <ContentPresenter
+                                x:Name="ContentPresenter"
+                                Grid.Column="1"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                TextElement.Foreground="{TemplateBinding Foreground}" />
                         </Grid>
-                        <ContentPresenter
-                            x:Name="ContentPresenter"
-                            Grid.Column="1"
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding Content}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            TextElement.Foreground="{TemplateBinding Foreground}" />
-                    </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -164,6 +168,8 @@
                             <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
                             <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPressed}" />
                             <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePressed}" />
+                            <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+                            <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
                         </MultiTrigger>
 
                         <Trigger Property="IsChecked" Value="True">
@@ -181,6 +187,9 @@
                                 <Condition Property="IsEnabled" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+                            <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+                            <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+                            <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -189,9 +198,12 @@
                                 <Condition Property="IsEnabled" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+                            <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
                             <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPointerOver}" />
                             <!--<Setter TargetName="CheckGlyph" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />-->
                             <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+                            <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+                            <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -201,6 +213,8 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
                             <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+                            <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+                            <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
                             <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedStrokePressed}" />
                         </MultiTrigger>
                         <MultiTrigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
@@ -176,6 +176,7 @@
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
                 <Trigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ScrollBar.xaml
@@ -16,6 +16,7 @@
 
     <sys:Double x:Key="LineButtonHeight">12</sys:Double>
     <sys:Double x:Key="LineButtonWidth">12</sys:Double>
+    <sys:Double x:Key="ScrollBarButtonArrowIconFontSize">8</sys:Double>
 
     <system:String x:Key="ScrollBarCaretUpGlyph">&#xEDDB;</system:String>
     <system:String x:Key="ScrollBarCaretDownGlyph">&#xEDDC;</system:String>    
@@ -26,7 +27,7 @@
         <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
         <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
         <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
-        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontSize" Value="{StaticResource ScrollBarButtonArrowIconFontSize}" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -129,7 +130,8 @@
                 Grid.RowSpan="3"
                 Width="12"
                 HorizontalAlignment="Center"
-                Background="{DynamicResource ScrollBarTrackFillPointerOver}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
                 CornerRadius="6"
                 Opacity="0" />
             <RepeatButton
@@ -144,7 +146,7 @@
             <Track
                 x:Name="PART_Track"
                 Grid.Row="1"
-                Width="6"
+                Width="4"
                 IsDirectionReversed="True">
                 <Track.DecreaseRepeatButton>
                     <RepeatButton Command="ScrollBar.PageUpCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
@@ -180,7 +182,7 @@
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
-                                From="6"
+                                From="4"
                                 To="8"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
@@ -211,7 +213,7 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Width"
                                 From="8"
-                                To="6"
+                                To="4"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
@@ -250,7 +252,8 @@
                 Grid.ColumnSpan="3"
                 Height="12"
                 VerticalAlignment="Center"
-                Background="{DynamicResource ScrollBarButtonBackground}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
                 CornerRadius="6"
                 Opacity="0" />
 
@@ -266,7 +269,7 @@
             <Track
                 x:Name="PART_Track"
                 Grid.Column="1"
-                Height="6"
+                Height="4"
                 VerticalAlignment="Center"
                 IsDirectionReversed="False">
                 <Track.DecreaseRepeatButton>
@@ -294,13 +297,14 @@
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
                 <Trigger.EnterActions>
                     <BeginStoryboard>
                         <Storyboard>
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
-                                From="6"
+                                From="4"
                                 To="8"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
@@ -331,7 +335,7 @@
                                 Storyboard.TargetName="PART_Track"
                                 Storyboard.TargetProperty="Height"
                                 From="8"
-                                To="6"
+                                To="4"
                                 Duration="{StaticResource ScrollAnimationDuration}" />
                             <DoubleAnimation
                                 Storyboard.TargetName="PART_Border"
@@ -359,7 +363,8 @@
     </ControlTemplate>
 
     <Style x:Key="DefaultScrollBarStyle" TargetType="{x:Type ScrollBar}">
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFill}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackStroke}" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -367,11 +372,11 @@
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Horizontal">
                 <Setter Property="Width" Value="Auto" />
-                <Setter Property="Height" Value="14" />
+                <Setter Property="Height" Value="12" />
                 <Setter Property="Template" Value="{StaticResource HorizontalScrollBarTemplate}" />
             </Trigger>
             <Trigger Property="Orientation" Value="Vertical">
-                <Setter Property="Width" Value="14" />
+                <Setter Property="Width" Value="12" />
                 <Setter Property="Height" Value="Auto" />
                 <Setter Property="Template" Value="{StaticResource VerticalScrollBarTemplate}" />
             </Trigger>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
@@ -183,6 +183,7 @@
         <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="0,1,0,0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -211,8 +212,8 @@
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
         <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
         <Setter Property="Focusable" Value="True" />
@@ -234,8 +235,8 @@
                             CornerRadius="8,8,0,0">
                             <ContentPresenter
                                 x:Name="ContentSite"
-                                HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
-                                VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
                                 ContentSource="Header"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
                                 Margin="{TemplateBinding Padding}"

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/TabControl.xaml
@@ -28,14 +28,15 @@
                 Grid.Row="1"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="0,1,0,0"
+                BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="0,4,4,4"
                 KeyboardNavigation.DirectionalNavigation="Contained"
                 KeyboardNavigation.TabIndex="2"
                 KeyboardNavigation.TabNavigation="Local">
                 <ContentPresenter
                     x:Name="PART_SelectedContentHost"
-                    Margin="0"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     ContentSource="SelectedContent"
@@ -70,14 +71,15 @@
                 Grid.Row="0"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="0,0,0,1"
+                BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="0,4,4,4"
                 KeyboardNavigation.DirectionalNavigation="Contained"
                 KeyboardNavigation.TabIndex="2"
                 KeyboardNavigation.TabNavigation="Local">
                 <ContentPresenter
                     x:Name="PART_SelectedContentHost"
-                    Margin="0"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     ContentSource="SelectedContent"
@@ -112,14 +114,15 @@
                 Grid.Column="1"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="1,0,0,0"
+                BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="0,4,4,4"
                 KeyboardNavigation.DirectionalNavigation="Contained"
                 KeyboardNavigation.TabIndex="2"
                 KeyboardNavigation.TabNavigation="Local">
                 <ContentPresenter
                     x:Name="PART_SelectedContentHost"
-                    Margin="0"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     ContentSource="SelectedContent"
@@ -154,14 +157,15 @@
                 Grid.Column="0"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="0,0,1,0"
+                BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="0,4,4,4"
                 KeyboardNavigation.DirectionalNavigation="Contained"
                 KeyboardNavigation.TabIndex="2"
                 KeyboardNavigation.TabNavigation="Local">
                 <ContentPresenter
                     x:Name="PART_SelectedContentHost"
-                    Margin="0"
+                    Margin="{TemplateBinding Padding}"
+                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     ContentSource="SelectedContent"
@@ -179,20 +183,25 @@
         <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
         <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+        <Setter Property="BorderThickness" Value="0,1,0,0" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
             <Style.Triggers>
                 <Trigger Property="TabStripPlacement" Value="Bottom">
                     <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+                    <Setter Property="BorderThickness" Value="0,0,0,1" />
                 </Trigger>
 
                 <Trigger Property="TabStripPlacement" Value="Left">
                     <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+                    <Setter Property="BorderThickness" Value="1,0,0,0" />
                 </Trigger>
 
                 <Trigger Property="TabStripPlacement" Value="Right">
                     <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+                    <Setter Property="BorderThickness" Value="0,0,1,0" />
                 </Trigger>
             </Style.Triggers>
     </Style>
@@ -225,10 +234,11 @@
                             CornerRadius="8,8,0,0">
                             <ContentPresenter
                                 x:Name="ContentSite"
-                                Margin="0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
+                                HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
+                                VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" 
                                 ContentSource="Header"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
+                                Margin="{TemplateBinding Padding}"
                                 RecognizesAccessKey="True" />
                         </Border>
                         <VisualStateManager.VisualStateGroups>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
@@ -5,10 +5,16 @@
     All Rights Reserved.
 -->
 
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
+    <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
+    <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
 
     <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
-        <Setter Property="MaxWidth" Value="260" />
+        <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
         <Setter Property="Height" Value="Auto" />
         <Setter Property="Width" Value="Auto" />
         <Setter Property="TextElement.FontSize" Value="12" />
@@ -17,6 +23,10 @@
         <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
         <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}"/>
+        <Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Top"/>
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Template">
@@ -27,10 +37,9 @@
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}"
                         MaxWidth="{TemplateBinding MaxWidth}"
-                        Padding="8"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="1"
+                        BorderThickness="{TemplateBinding BorderThickness}" 
                         CornerRadius="4"
                         SnapsToDevicePixels="True">
                         <Border.Effect>
@@ -42,9 +51,10 @@
                                 Color="#202020" />
                         </Border.Effect>
                         <ContentPresenter
-                            Margin="4"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top">
+                            Margin="{TemplateBinding Padding}"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <ContentPresenter.Resources>
                                 <Style TargetType="{x:Type TextBlock}">
                                     <Setter Property="TextWrapping" Value="WrapWithOverflow" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Styles/ToolTip.xaml
@@ -11,7 +11,7 @@
 
     <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
     <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
-    <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
+    <Thickness x:Key="ToolTipBorderThemeThickness">1</Thickness>
 
     <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
         <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -430,6 +430,7 @@
   <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
   <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+  <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <!--  DynamicScrollBar  -->
   <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
@@ -2119,10 +2120,13 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
+    <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+  </Style>
   <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <Setter Property="CalendarStyle" Value="{DynamicResource DefaultCalendarStyle}" />
+    <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -3562,6 +3566,7 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -1369,7 +1369,7 @@
                   </Grid>
                 </Grid>
                 <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Margin="12,0,12,18" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
                     <!--Will revist this code while doing performance evaluation for dynamic resources.-->
                     <Border.RenderTransform>
                       <TranslateTransform />
@@ -3978,6 +3978,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="BorderThickness" Value="0,1,0,0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -4003,8 +4004,8 @@
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Stretch" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
     <Setter Property="Focusable" Value="True" />
@@ -4015,7 +4016,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4535,7 +4536,7 @@
   </Style>
   <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
   <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
-  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
+  <Thickness x:Key="ToolTipBorderThemeThickness">1</Thickness>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
     <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Dark.xaml
@@ -471,7 +471,7 @@
   <SolidColorBrush x:Key="InfoBarSuccessSeverityIconBackground" Color="{StaticResource SystemFillColorSuccess}" />
   <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemAccentColor}" />
   <!--  Label  -->
-  <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorPrimary}" />
   <!--  ListBox  -->
   <SolidColorBrush x:Key="ListBoxBackground" Color="{StaticResource CardBackgroundFillColorDefault}" />
   <SolidColorBrush x:Key="ListBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
@@ -481,6 +481,8 @@
   <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
   <!--  ListView  -->
+  <SolidColorBrush x:Key="ListViewBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ListViewBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -514,6 +516,9 @@
   <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+  <!-- Page -->
+  <SolidColorBrush x:Key="PageForeground" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="PageBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <!--  ProgressBar  -->
   <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource ControlStrongStrokeColorDefault}" />
@@ -526,7 +531,13 @@
   <!--  RadioButton  -->
   <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemAccentColorLight2}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemAccentColorLight2}" Opacity="0.9" />
   <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource TextOnAccentFillColorPrimary}" />
@@ -538,8 +549,10 @@
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource ControlStrongStrokeColorDefault}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemAccentColorLight2}" />
   <!--  RatingControl  -->
   <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemAccentColorLight2}" />
   <!-- RepeatButton -->
@@ -552,6 +565,10 @@
   <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <!-- ScrollBar -->
+  <SolidColorBrush x:Key="ScrollBarTrackFill" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <!--  Separator  -->
   <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />
   <!--  Slider  -->
@@ -679,7 +696,7 @@
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type Button}">
+        <ControlTemplate TargetType="{x:Type ButtonBase}">
           <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
           </Border>
@@ -1048,16 +1065,16 @@
     <Setter Property="CalendarDayButtonStyle" Value="{StaticResource DefaultCalendarDayButtonStyle}" />
     <Setter Property="CalendarItemStyle" Value="{StaticResource DefaultCalendarItemStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource CalendarViewForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource CalendarViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewBorderBrush}" />
     <Setter Property="HorizontalAlignment" Value="Center" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Calendar}">
-          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{DynamicResource CalendarViewBackground}" BorderBrush="{DynamicResource CalendarViewBorderBrush}" BorderThickness="1" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
-            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Style="{TemplateBinding CalendarItemStyle}" />
+          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
+            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Style="{TemplateBinding CalendarItemStyle}" />
           </Border>
         </ControlTemplate>
       </Setter.Value>
@@ -1335,7 +1352,7 @@
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
+                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
                     <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
@@ -1436,11 +1453,13 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />
+  <Thickness x:Key="ContextMenuBorderThickness">1</Thickness>
   <Style x:Key="DefaultContextMenuStyle" TargetType="{x:Type ContextMenu}">
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Background" Value="{DynamicResource ContextMenuBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ContextMenuBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ContextMenuBorderThickness}" />
     <Setter Property="MinWidth" Value="140" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="Margin" Value="0" />
@@ -1452,7 +1471,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ContextMenu}">
-          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="8">
+          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="8">
             <Border.RenderTransform>
               <TranslateTransform />
             </Border.RenderTransform>
@@ -2341,8 +2360,8 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Expander}">
           <DockPanel>
-            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
+            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
@@ -2594,11 +2613,11 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBox}">
-          <Grid Background="{TemplateBinding Background }">
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
+          <Border Name="Bd" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+              <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2611,10 +2630,13 @@
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
-    <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Margin" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Padding" Value="12" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -2622,8 +2644,8 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-            <ContentPresenter />
+          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsSelected" Value="True">
@@ -2653,7 +2675,9 @@
   <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Background" Value="{DynamicResource ListViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ListViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
@@ -2672,16 +2696,18 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListView}">
-          <Grid>
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
-            </ScrollViewer>
-            <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
-              <Rectangle.Fill>
-                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-              </Rectangle.Fill>
-            </Rectangle>
-          </Grid>
+          <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+            <Grid>
+              <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              </ScrollViewer>
+              <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
+                <Rectangle.Fill>
+                  <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+              </Rectangle>
+            </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2695,20 +2721,27 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
+  <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
+  <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
+    <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="4" />
+    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="0" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
+          <Border x:Name="Border" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <Grid>
-              <ContentPresenter Margin="{TemplateBinding Padding}" />
+              <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
               <Rectangle x:Name="ActiveRectangle" Width="3" Height="18" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource ListViewItemPillFillBrush}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
             </Grid>
           </Border>
@@ -2739,7 +2772,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Menu}">
-          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
             <StackPanel ClipToBounds="True" IsItemsHost="True" Orientation="Horizontal" />
           </Border>
         </ControlTemplate>
@@ -2770,7 +2803,7 @@
   </Style>
   <!--  TopLevelHeader  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid>
         <Grid.RowDefinitions>
           <RowDefinition Height="*" />
@@ -2781,8 +2814,8 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
           <Grid>
@@ -2836,14 +2869,14 @@
   </ControlTemplate>
   <!--  TopLevelItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
     <ControlTemplate.Triggers>
@@ -2868,7 +2901,7 @@
   </ControlTemplate>
   <!--  SubmenuItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4,1,4,1" Background="Transparent" CornerRadius="4">
+    <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
@@ -2879,8 +2912,8 @@
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
     </Border>
@@ -2916,15 +2949,15 @@
         <RowDefinition Height="*" />
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
-      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="1" CornerRadius="4">
+      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
@@ -2986,8 +3019,13 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultMenuItemStyle" TargetType="{x:Type MenuItem}">
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Focusable" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Style.Triggers>
@@ -3008,12 +3046,8 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultMenuItemStyle}" TargetType="{x:Type MenuItem}" />
   <Style x:Key="DefaultPageStyle" TargetType="{x:Type Page}">
-    <Setter Property="Control.Foreground">
-      <Setter.Value>
-        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-      </Setter.Value>
-    </Setter>
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource PageForeground}" />
+    <Setter Property="Background" Value="{DynamicResource PageBackground}" />
     <!--  The Display option casues a large aliasing effect  -->
     <!-- <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" /> -->
     <Setter Property="Focusable" Value="False" />
@@ -3022,9 +3056,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Page}">
-          <Grid>
-            <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Control.Foreground}" />
-          </Grid>
+          <Border Background="{TemplateBinding Background}" CornerRadius="8">
+            <ContentPresenter Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -3185,9 +3219,10 @@
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <!--  Universal WPF UI focus  -->
-    <Setter Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+    <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+    <Setter Property="Border.CornerRadius" Value="4" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
@@ -3204,7 +3239,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RadioButton}">
-          <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="Transparent">
+          <Border x:Name="RootBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal">
@@ -3227,24 +3262,26 @@
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="20" />
-              <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Height="32" VerticalAlignment="Top">
-              <Ellipse x:Name="OuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Ellipse x:Name="CheckOuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{TemplateBinding Background}" Opacity="0" Stroke="{TemplateBinding Background}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
-                <Ellipse.RenderTransform>
-                  <ScaleTransform />
-                </Ellipse.RenderTransform>
-              </Ellipse>
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+            <Grid x:Name="RootGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Grid Height="32" VerticalAlignment="Top">
+                <Ellipse x:Name="OuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Ellipse x:Name="CheckOuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}" Opacity="0" Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
+                  <Ellipse.RenderTransform>
+                    <ScaleTransform />
+                  </Ellipse.RenderTransform>
+                </Ellipse>
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+              </Grid>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
             </Grid>
-            <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3255,6 +3292,8 @@
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPressed}" />
               <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
             </MultiTrigger>
             <Trigger Property="IsChecked" Value="True">
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
@@ -3271,6 +3310,9 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3279,9 +3321,12 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPointerOver}" />
               <!--<Setter TargetName="CheckGlyph" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />-->
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3291,6 +3336,8 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedStrokePressed}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -3418,6 +3465,7 @@
   <Duration x:Key="ButtonHoverAnimationDuration">0:0:0.16</Duration>
   <sys:Double x:Key="LineButtonHeight">12</sys:Double>
   <sys:Double x:Key="LineButtonWidth">12</sys:Double>
+  <sys:Double x:Key="ScrollBarButtonArrowIconFontSize">8</sys:Double>
   <system:String x:Key="ScrollBarCaretUpGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretDownGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretLeftGlyph"></system:String>
@@ -3426,7 +3474,7 @@
     <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
     <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
     <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="{StaticResource ScrollBarButtonArrowIconFontSize}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -3494,9 +3542,9 @@
         <RowDefinition Height="0.00001*" />
         <RowDefinition MaxHeight="14" />
       </Grid.RowDefinitions>
-      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{DynamicResource ScrollBarTrackFillPointerOver}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollUp" Grid.Row="0" HorizontalContentAlignment="Left" Command="ScrollBar.LineUpCommand" Content="{StaticResource ScrollBarCaretUpGlyph}" Opacity="0" AutomationProperties.Name="Scroll Up" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Row="1" Width="6" IsDirectionReversed="True">
+      <Track x:Name="PART_Track" Grid.Row="1" Width="4" IsDirectionReversed="True">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageUpCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3517,7 +3565,7 @@
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3527,7 +3575,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3544,9 +3592,9 @@
         <ColumnDefinition Width="0.00001*" />
         <ColumnDefinition MaxWidth="18" />
       </Grid.ColumnDefinitions>
-      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollLeft" Grid.Column="0" VerticalAlignment="Center" Command="ScrollBar.LineLeftCommand" Content="{StaticResource ScrollBarCaretLeftGlyph}" Opacity="0" AutomationProperties.Name="Scroll Left" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Column="1" Height="6" VerticalAlignment="Center" IsDirectionReversed="False">
+      <Track x:Name="PART_Track" Grid.Column="1" Height="4" VerticalAlignment="Center" IsDirectionReversed="False">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageLeftCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3561,10 +3609,11 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3574,7 +3623,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3585,7 +3634,8 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultScrollBarStyle" TargetType="{x:Type ScrollBar}">
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFill}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackStroke}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -3593,11 +3643,11 @@
     <Style.Triggers>
       <Trigger Property="Orientation" Value="Horizontal">
         <Setter Property="Width" Value="Auto" />
-        <Setter Property="Height" Value="14" />
+        <Setter Property="Height" Value="12" />
         <Setter Property="Template" Value="{StaticResource HorizontalScrollBarTemplate}" />
       </Trigger>
       <Trigger Property="Orientation" Value="Vertical">
-        <Setter Property="Width" Value="14" />
+        <Setter Property="Width" Value="12" />
         <Setter Property="Height" Value="Auto" />
         <Setter Property="Template" Value="{StaticResource VerticalScrollBarTemplate}" />
       </Trigger>
@@ -3860,8 +3910,8 @@
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3878,8 +3928,8 @@
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,0,1" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3896,8 +3946,8 @@
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3914,8 +3964,8 @@
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3928,18 +3978,23 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="0,1,0,0" />
+    <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
     <Style.Triggers>
       <Trigger Property="TabStripPlacement" Value="Bottom">
         <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Left">
         <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Right">
         <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
       </Trigger>
     </Style.Triggers>
   </Style>
@@ -3960,7 +4015,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4478,8 +4533,11 @@
     </Setter>
     <Setter Property="Margin" Value="0" />
   </Style>
+  <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
+  <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
+  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
-    <Setter Property="MaxWidth" Value="260" />
+    <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />
     <Setter Property="Width" Value="Auto" />
     <Setter Property="TextElement.FontSize" Value="12" />
@@ -4488,16 +4546,20 @@
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="ToolTip">
-          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Padding="8" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="4" SnapsToDevicePixels="True">
+          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4" SnapsToDevicePixels="True">
             <Border.Effect>
               <DropShadowEffect BlurRadius="30" Direction="0" Opacity="0.4" ShadowDepth="0" Color="#202020" />
             </Border.Effect>
-            <ContentPresenter Margin="4" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <ContentPresenter.Resources>
                 <Style TargetType="{x:Type TextBlock}">
                   <Setter Property="TextWrapping" Value="WrapWithOverflow" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -372,6 +372,8 @@
   <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource SystemColorButtonFaceColor}" />
   <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource SystemColorHighlightTextColor}" />
   <!--  ListView  -->
+  <SolidColorBrush x:Key="ListViewBackground" Color="Transparent" />
+  <SolidColorBrush x:Key="ListViewBorderBrush" Color="Transparent" />
   <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource SystemColorWindowTextColor}" />
   <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SystemColorWindowColor}" />
@@ -405,6 +407,9 @@
   <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource SystemColorWindowColor}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource SystemColorWindowTextColor}" />
+  <!-- Page -->
+  <SolidColorBrush x:Key="PageForeground" Color="{StaticResource SystemColorWindowTextColor}" />
+  <SolidColorBrush x:Key="PageBackground" Color="Transparent" />
   <!--  ProgressBar  -->
   <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource SystemColorWindowColor}" />
@@ -417,7 +422,13 @@
   <!--  RadioButton  -->
   <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource SystemColorButtonTextColor}" />
   <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <SolidColorBrush x:Key="RadioButtonBackground" Color="Transparent" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="Transparent" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="Transparent" />
   <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="Transparent" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="Transparent" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="Transparent" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemColorButtonTextColor}" />
   <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource SystemColorHighlightColor}" />
@@ -429,8 +440,10 @@
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource SystemColorHighlightTextColor}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource SystemColorWindowColor}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource SystemColorButtonTextColor}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource SystemColorHighlightTextColor}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemColorHighlightColor}" />
   <!--  RatingControl  -->
   <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemColorHighlightColor}" />
   <!-- RepeatButton -->
@@ -443,6 +456,10 @@
   <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource SystemColorWindowTextColor}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource SystemColorGrayTextColor}" />
+  <!-- ScrollBar -->
+  <SolidColorBrush x:Key="ScrollBarTrackFill" Color="Transparent" />
+  <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SystemColorWindowTextColor}" />
+  <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource SystemColorWindowColor}" />
   <!--  Separator  -->
   <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource SystemColorWindowTextColor}" />
   <!--  Slider  -->
@@ -651,7 +668,7 @@
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type Button}">
+        <ControlTemplate TargetType="{x:Type ButtonBase}">
           <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
           </Border>
@@ -1020,16 +1037,16 @@
     <Setter Property="CalendarDayButtonStyle" Value="{StaticResource DefaultCalendarDayButtonStyle}" />
     <Setter Property="CalendarItemStyle" Value="{StaticResource DefaultCalendarItemStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource CalendarViewForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource CalendarViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewBorderBrush}" />
     <Setter Property="HorizontalAlignment" Value="Center" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Calendar}">
-          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{DynamicResource CalendarViewBackground}" BorderBrush="{DynamicResource CalendarViewBorderBrush}" BorderThickness="1" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
-            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Style="{TemplateBinding CalendarItemStyle}" />
+          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
+            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Style="{TemplateBinding CalendarItemStyle}" />
           </Border>
         </ControlTemplate>
       </Setter.Value>
@@ -1307,7 +1324,7 @@
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
+                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
                     <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
@@ -1408,11 +1425,13 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />
+  <Thickness x:Key="ContextMenuBorderThickness">1</Thickness>
   <Style x:Key="DefaultContextMenuStyle" TargetType="{x:Type ContextMenu}">
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Background" Value="{DynamicResource ContextMenuBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ContextMenuBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ContextMenuBorderThickness}" />
     <Setter Property="MinWidth" Value="140" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="Margin" Value="0" />
@@ -1424,7 +1443,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ContextMenu}">
-          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="8">
+          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="8">
             <Border.RenderTransform>
               <TranslateTransform />
             </Border.RenderTransform>
@@ -2313,8 +2332,8 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Expander}">
           <DockPanel>
-            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
+            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
@@ -2566,11 +2585,11 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBox}">
-          <Grid Background="{TemplateBinding Background }">
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
+          <Border Name="Bd" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+              <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2583,10 +2602,13 @@
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
-    <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Margin" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Padding" Value="12" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -2594,8 +2616,8 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-            <ContentPresenter />
+          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsSelected" Value="True">
@@ -2625,7 +2647,9 @@
   <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Background" Value="{DynamicResource ListViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ListViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
@@ -2644,16 +2668,18 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListView}">
-          <Grid>
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
-            </ScrollViewer>
-            <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
-              <Rectangle.Fill>
-                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-              </Rectangle.Fill>
-            </Rectangle>
-          </Grid>
+          <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+            <Grid>
+              <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              </ScrollViewer>
+              <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
+                <Rectangle.Fill>
+                  <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+              </Rectangle>
+            </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2667,20 +2693,27 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
+  <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
+  <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
+    <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="4" />
+    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="0" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
+          <Border x:Name="Border" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <Grid>
-              <ContentPresenter Margin="{TemplateBinding Padding}" />
+              <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
               <Rectangle x:Name="ActiveRectangle" Width="3" Height="18" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource ListViewItemPillFillBrush}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
             </Grid>
           </Border>
@@ -2711,7 +2744,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Menu}">
-          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
             <StackPanel ClipToBounds="True" IsItemsHost="True" Orientation="Horizontal" />
           </Border>
         </ControlTemplate>
@@ -2742,7 +2775,7 @@
   </Style>
   <!--  TopLevelHeader  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid>
         <Grid.RowDefinitions>
           <RowDefinition Height="*" />
@@ -2753,8 +2786,8 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
           <Grid>
@@ -2808,14 +2841,14 @@
   </ControlTemplate>
   <!--  TopLevelItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
     <ControlTemplate.Triggers>
@@ -2840,7 +2873,7 @@
   </ControlTemplate>
   <!--  SubmenuItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4,1,4,1" Background="Transparent" CornerRadius="4">
+    <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
@@ -2851,8 +2884,8 @@
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
     </Border>
@@ -2888,15 +2921,15 @@
         <RowDefinition Height="*" />
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
-      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="1" CornerRadius="4">
+      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
@@ -2958,8 +2991,13 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultMenuItemStyle" TargetType="{x:Type MenuItem}">
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Focusable" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Style.Triggers>
@@ -2980,12 +3018,8 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultMenuItemStyle}" TargetType="{x:Type MenuItem}" />
   <Style x:Key="DefaultPageStyle" TargetType="{x:Type Page}">
-    <Setter Property="Control.Foreground">
-      <Setter.Value>
-        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-      </Setter.Value>
-    </Setter>
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource PageForeground}" />
+    <Setter Property="Background" Value="{DynamicResource PageBackground}" />
     <!--  The Display option casues a large aliasing effect  -->
     <!-- <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" /> -->
     <Setter Property="Focusable" Value="False" />
@@ -2994,9 +3028,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Page}">
-          <Grid>
-            <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Control.Foreground}" />
-          </Grid>
+          <Border Background="{TemplateBinding Background}" CornerRadius="8">
+            <ContentPresenter Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -3157,9 +3191,10 @@
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <!--  Universal WPF UI focus  -->
-    <Setter Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+    <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+    <Setter Property="Border.CornerRadius" Value="4" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
@@ -3176,7 +3211,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RadioButton}">
-          <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="Transparent">
+          <Border x:Name="RootBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal">
@@ -3199,24 +3234,26 @@
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="20" />
-              <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Height="32" VerticalAlignment="Top">
-              <Ellipse x:Name="OuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Ellipse x:Name="CheckOuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{TemplateBinding Background}" Opacity="0" Stroke="{TemplateBinding Background}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
-                <Ellipse.RenderTransform>
-                  <ScaleTransform />
-                </Ellipse.RenderTransform>
-              </Ellipse>
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+            <Grid x:Name="RootGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Grid Height="32" VerticalAlignment="Top">
+                <Ellipse x:Name="OuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Ellipse x:Name="CheckOuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}" Opacity="0" Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
+                  <Ellipse.RenderTransform>
+                    <ScaleTransform />
+                  </Ellipse.RenderTransform>
+                </Ellipse>
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+              </Grid>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
             </Grid>
-            <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3227,6 +3264,8 @@
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPressed}" />
               <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
             </MultiTrigger>
             <Trigger Property="IsChecked" Value="True">
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
@@ -3243,6 +3282,9 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3251,9 +3293,12 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPointerOver}" />
               <!--<Setter TargetName="CheckGlyph" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />-->
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3263,6 +3308,8 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedStrokePressed}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -3390,6 +3437,7 @@
   <Duration x:Key="ButtonHoverAnimationDuration">0:0:0.16</Duration>
   <sys:Double x:Key="LineButtonHeight">12</sys:Double>
   <sys:Double x:Key="LineButtonWidth">12</sys:Double>
+  <sys:Double x:Key="ScrollBarButtonArrowIconFontSize">8</sys:Double>
   <system:String x:Key="ScrollBarCaretUpGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretDownGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretLeftGlyph"></system:String>
@@ -3398,7 +3446,7 @@
     <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
     <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
     <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="{StaticResource ScrollBarButtonArrowIconFontSize}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -3466,9 +3514,9 @@
         <RowDefinition Height="0.00001*" />
         <RowDefinition MaxHeight="14" />
       </Grid.RowDefinitions>
-      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{DynamicResource ScrollBarTrackFillPointerOver}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollUp" Grid.Row="0" HorizontalContentAlignment="Left" Command="ScrollBar.LineUpCommand" Content="{StaticResource ScrollBarCaretUpGlyph}" Opacity="0" AutomationProperties.Name="Scroll Up" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Row="1" Width="6" IsDirectionReversed="True">
+      <Track x:Name="PART_Track" Grid.Row="1" Width="4" IsDirectionReversed="True">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageUpCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3489,7 +3537,7 @@
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3499,7 +3547,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3516,9 +3564,9 @@
         <ColumnDefinition Width="0.00001*" />
         <ColumnDefinition MaxWidth="18" />
       </Grid.ColumnDefinitions>
-      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollLeft" Grid.Column="0" VerticalAlignment="Center" Command="ScrollBar.LineLeftCommand" Content="{StaticResource ScrollBarCaretLeftGlyph}" Opacity="0" AutomationProperties.Name="Scroll Left" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Column="1" Height="6" VerticalAlignment="Center" IsDirectionReversed="False">
+      <Track x:Name="PART_Track" Grid.Column="1" Height="4" VerticalAlignment="Center" IsDirectionReversed="False">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageLeftCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3533,10 +3581,11 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3546,7 +3595,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3557,7 +3606,8 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultScrollBarStyle" TargetType="{x:Type ScrollBar}">
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFill}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackStroke}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -3565,11 +3615,11 @@
     <Style.Triggers>
       <Trigger Property="Orientation" Value="Horizontal">
         <Setter Property="Width" Value="Auto" />
-        <Setter Property="Height" Value="14" />
+        <Setter Property="Height" Value="12" />
         <Setter Property="Template" Value="{StaticResource HorizontalScrollBarTemplate}" />
       </Trigger>
       <Trigger Property="Orientation" Value="Vertical">
-        <Setter Property="Width" Value="14" />
+        <Setter Property="Width" Value="12" />
         <Setter Property="Height" Value="Auto" />
         <Setter Property="Template" Value="{StaticResource VerticalScrollBarTemplate}" />
       </Trigger>
@@ -3832,8 +3882,8 @@
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3850,8 +3900,8 @@
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,0,1" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3868,8 +3918,8 @@
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3886,8 +3936,8 @@
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3900,18 +3950,23 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="0,1,0,0" />
+    <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
     <Style.Triggers>
       <Trigger Property="TabStripPlacement" Value="Bottom">
         <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Left">
         <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Right">
         <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
       </Trigger>
     </Style.Triggers>
   </Style>
@@ -3932,7 +3987,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4450,8 +4505,11 @@
     </Setter>
     <Setter Property="Margin" Value="0" />
   </Style>
+  <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
+  <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
+  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
-    <Setter Property="MaxWidth" Value="260" />
+    <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />
     <Setter Property="Width" Value="Auto" />
     <Setter Property="TextElement.FontSize" Value="12" />
@@ -4460,16 +4518,20 @@
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="ToolTip">
-          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Padding="8" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="4" SnapsToDevicePixels="True">
+          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4" SnapsToDevicePixels="True">
             <Border.Effect>
               <DropShadowEffect BlurRadius="30" Direction="0" Opacity="0.4" ShadowDepth="0" Color="#202020" />
             </Border.Effect>
-            <ContentPresenter Margin="4" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <ContentPresenter.Resources>
                 <Style TargetType="{x:Type TextBlock}">
                   <Setter Property="TextWrapping" Value="WrapWithOverflow" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -1341,7 +1341,7 @@
                   </Grid>
                 </Grid>
                 <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Margin="12,0,12,18" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
                     <!--Will revist this code while doing performance evaluation for dynamic resources.-->
                     <Border.RenderTransform>
                       <TranslateTransform />
@@ -3950,6 +3950,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="BorderThickness" Value="0,1,0,0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -3975,8 +3976,8 @@
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Stretch" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
     <Setter Property="Focusable" Value="True" />
@@ -3987,7 +3988,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4507,7 +4508,7 @@
   </Style>
   <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
   <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
-  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
+  <Thickness x:Key="ToolTipBorderThemeThickness">1</Thickness>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
     <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.HC.xaml
@@ -322,6 +322,7 @@
   <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemColorHighlightColor}" />
   <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource SystemColorHighlightTextColor}" />
   <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource SystemColorHighlightTextColor}" />
+  <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource SystemColorWindowColor}" />
   <!--  DynamicScrollBar  -->
   <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="Transparent" />
   <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource SystemColorButtonTextColor}" />
@@ -2091,10 +2092,13 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
+    <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+  </Style>
   <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <Setter Property="CalendarStyle" Value="{DynamicResource DefaultCalendarStyle}" />
+    <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -3534,6 +3538,7 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -424,6 +424,7 @@
   <SolidColorBrush x:Key="DatePickerFocusedBorderBrush" Color="{StaticResource SystemAccentColorDark1}" />
   <SolidColorBrush x:Key="DatePickerBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
   <SolidColorBrush x:Key="DatePickerBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+  <SolidColorBrush x:Key="DatePickerPopupBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <!--  DynamicScrollBar  -->
   <SolidColorBrush x:Key="ScrollBarButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="{StaticResource ControlStrongFillColorDefault}" />
@@ -2114,10 +2115,13 @@
       </Setter.Value>
     </Setter>
   </Style>
+  <Style x:Key="DatePickerCalendarStyle" BasedOn="{StaticResource DefaultCalendarStyle}" TargetType="{x:Type Calendar}">
+    <Setter Property="Background" Value="{DynamicResource DatePickerPopupBackground}" />
+  </Style>
   <Style x:Key="DefaultDatePickerStyle" TargetType="{x:Type DatePicker}">
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="ContextMenu" Value="{DynamicResource DefaultControlContextMenu}" />
-    <Setter Property="CalendarStyle" Value="{DynamicResource DefaultCalendarStyle}" />
+    <Setter Property="CalendarStyle" Value="{DynamicResource DatePickerCalendarStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource DatePickerForeground}" />
     <Setter Property="Background" Value="{DynamicResource DatePickerBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
@@ -3557,6 +3561,7 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -465,7 +465,7 @@
   <SolidColorBrush x:Key="InfoBarSuccessSeverityIconBackground" Color="{StaticResource SystemFillColorSuccess}" />
   <SolidColorBrush x:Key="InfoBarInformationalSeverityIconBackground" Color="{StaticResource SystemAccentColor}" />
   <!--  Label  -->
-  <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorSecondary}" />
+  <SolidColorBrush x:Key="LabelForeground" Color="{StaticResource TextFillColorPrimary}" />
   <!--  ListBox  -->
   <Color x:Key="SystemChromeMediumLowColor">#FFF2F2F2</Color>
   <SolidColorBrush x:Key="ListBoxBackground" Color="{StaticResource SystemChromeMediumLowColor}" />
@@ -476,6 +476,8 @@
   <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ListBoxItemUnselectedBackgroundPointerOverThemeBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
   <!--  ListView  -->
+  <SolidColorBrush x:Key="ListViewBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ListViewBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="ListViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="ListViewItemPillFillBrush" Color="{StaticResource SystemAccentColorDark1}" />
   <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
@@ -509,6 +511,9 @@
   <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+  <!-- Page -->
+  <SolidColorBrush x:Key="PageForeground" Color="{StaticResource TextFillColorPrimary}" />
+  <SolidColorBrush x:Key="PageBackground" Color="{StaticResource SubtleFillColorTransparent}" />
   <!--  ProgressBar  -->
   <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemAccentColorDark1}" />
   <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource ControlStrongStrokeColorDefault}" />
@@ -521,7 +526,13 @@
   <!--  RadioButton  -->
   <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPointerOver" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBackgroundPressed" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="RadioButtonBackgroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPointerOver" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="RadioButtonBorderBrushPressed" Color="{StaticResource SubtleFillColorTransparent}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemAccentColorDark1}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStrokePointerOver" Color="{StaticResource SystemAccentColorDark1}" Opacity="0.9" />
   <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource TextOnAccentFillColorPrimary}" />
@@ -533,8 +544,10 @@
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillPressed" Color="{StaticResource ControlAltFillColorQuarternary}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseFillDisabled" Color="{StaticResource ControlAltFillColorDisabled}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePointerOver" Color="{StaticResource ControlStrongStrokeColorDefault}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokePressed" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
   <SolidColorBrush x:Key="RadioButtonOuterEllipseStrokeDisabled" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
+  <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedFill" Color="{StaticResource SystemAccentColorDark1}" />
   <!--  RatingControl  -->
   <SolidColorBrush x:Key="RatingControlSelectedForeground" Color="{StaticResource SystemAccentColorDark1}" />
   <!-- RepeatButton -->
@@ -547,6 +560,10 @@
   <SolidColorBrush x:Key="RepeatButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
   <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+  <!-- ScrollBar -->
+  <SolidColorBrush x:Key="ScrollBarTrackFill" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ScrollBarTrackStroke" Color="{StaticResource SubtleFillColorTransparent}" />
+  <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
   <!--  Separator  -->
   <SolidColorBrush x:Key="SeparatorBorderBrush" Color="{StaticResource DividerStrokeColorDefault}" />
   <!--  Slider  -->
@@ -674,7 +691,7 @@
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="{x:Type Button}">
+        <ControlTemplate TargetType="{x:Type ButtonBase}">
           <Border x:Name="ContentBorder" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MinWidth="{TemplateBinding MinWidth}" MinHeight="{TemplateBinding MinHeight}" Padding="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <ContentPresenter x:Name="ContentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
           </Border>
@@ -1043,16 +1060,16 @@
     <Setter Property="CalendarDayButtonStyle" Value="{StaticResource DefaultCalendarDayButtonStyle}" />
     <Setter Property="CalendarItemStyle" Value="{StaticResource DefaultCalendarItemStyle}" />
     <Setter Property="Foreground" Value="{DynamicResource CalendarViewForeground}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource CalendarViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource CalendarViewBorderBrush}" />
     <Setter Property="HorizontalAlignment" Value="Center" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Calendar}">
-          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{DynamicResource CalendarViewBackground}" BorderBrush="{DynamicResource CalendarViewBorderBrush}" BorderThickness="1" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
-            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Style="{TemplateBinding CalendarItemStyle}" />
+          <Border x:Name="PART_Root" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" CornerRadius="4">
+            <CalendarItem x:Name="PART_CalendarItem" Margin="0" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="Transparent" BorderBrush="Transparent" BorderThickness="0" Style="{TemplateBinding CalendarItemStyle}" />
           </Border>
         </ControlTemplate>
       </Setter.Value>
@@ -1330,7 +1347,7 @@
                     <ColumnDefinition Width="Auto" />
                   </Grid.ColumnDefinitions>
                   <Grid Grid.Column="0" Margin="{TemplateBinding Padding}">
-                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
+                    <ContentPresenter Name="PART_ContentPresenter" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" IsHitTestVisible="False" TextElement.Foreground="{TemplateBinding Foreground}" />
                   </Grid>
                   <Grid Grid.Column="1" Margin="{StaticResource ComboBoxChevronMargin}">
                     <TextBlock x:Name="ChevronIcon" Margin="0" VerticalAlignment="Center" FontSize="{StaticResource ComboBoxChevronSize}" Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}" RenderTransformOrigin="0.5, 0.5" FontFamily="{DynamicResource SymbolThemeFontFamily}" Text="{StaticResource ComboBoxChevronDownGlyph}">
@@ -1431,11 +1448,13 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultComboBoxItemStyle}" TargetType="{x:Type ComboBoxItem}" />
   <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="{x:Type ComboBox}" />
+  <Thickness x:Key="ContextMenuBorderThickness">1</Thickness>
   <Style x:Key="DefaultContextMenuStyle" TargetType="{x:Type ContextMenu}">
     <Setter Property="TextElement.Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Foreground" Value="{DynamicResource ContextMenuForeground}" />
     <Setter Property="Background" Value="{DynamicResource ContextMenuBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ContextMenuBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{StaticResource ContextMenuBorderThickness}" />
     <Setter Property="MinWidth" Value="140" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="Margin" Value="0" />
@@ -1447,7 +1466,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ContextMenu}">
-          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="8">
+          <Border x:Name="Border" Padding="0,3,0,3" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="8">
             <Border.RenderTransform>
               <TranslateTransform />
             </Border.RenderTransform>
@@ -2336,8 +2355,8 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Expander}">
           <DockPanel>
-            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" FontSize="{TemplateBinding FontSize}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
+            <Border x:Name="ToggleButtonBorder" DockPanel.Dock="Top" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+              <ToggleButton x:Name="HeaderSite" AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}" Margin="0" Padding="{TemplateBinding Padding}" HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontWeight="{TemplateBinding FontWeight}" Foreground="{TemplateBinding Foreground}" IsChecked="{Binding Path=IsExpanded,Mode=TwoWay,RelativeSource={RelativeSource TemplatedParent}}" IsEnabled="{TemplateBinding IsEnabled}" OverridesDefaultStyle="True" Template="{StaticResource DefaultExpanderToggleButtonDownStyle}" FocusVisualStyle="{DynamicResource DefaultControlFocusVisualStyle}" />
             </Border>
             <Grid x:Name="ContentPresenterGrid" DockPanel.Dock="Bottom" ClipToBounds="True">
               <Border x:Name="ContentPresenterBorder" Background="{DynamicResource ExpanderContentBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,4,4" Visibility="Collapsed">
@@ -2589,11 +2608,11 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBox}">
-          <Grid Background="{TemplateBinding Background }">
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
+          <Border Name="Bd" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+              <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             </ScrollViewer>
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2606,10 +2625,13 @@
   <Style BasedOn="{StaticResource DefaultListBoxStyle}" TargetType="{x:Type ListBox}" />
   <Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListBoxItemForeground}" />
-    <Setter Property="Background" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ListBoxItemSelectedBackgroundThemeBrush}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Margin" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Padding" Value="12" />
     <Setter Property="Border.CornerRadius" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -2617,8 +2639,8 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
-            <ContentPresenter />
+          <Border x:Name="Border" Margin="0" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="{TemplateBinding Border.CornerRadius}">
+            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
           </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsSelected" Value="True">
@@ -2648,7 +2670,9 @@
   <Style x:Key="DefaultListViewStyle" TargetType="{x:Type ListView}">
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
-    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Background" Value="{DynamicResource ListViewBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ListViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
@@ -2667,16 +2691,18 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListView}">
-          <Grid>
-            <ScrollViewer x:Name="PART_ContentHost" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-              <ItemsPresenter />
-            </ScrollViewer>
-            <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
-              <Rectangle.Fill>
-                <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
-              </Rectangle.Fill>
-            </Rectangle>
-          </Grid>
+          <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+            <Grid>
+              <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+              </ScrollViewer>
+              <Rectangle x:Name="PART_DisabledVisual" Opacity="0" RadiusX="2" RadiusY="2" Stretch="Fill" Stroke="Transparent" StrokeThickness="0" Visibility="Collapsed">
+                <Rectangle.Fill>
+                  <SolidColorBrush Color="{DynamicResource ControlFillColorDefault}" />
+                </Rectangle.Fill>
+              </Rectangle>
+            </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <Trigger Property="IsGrouping" Value="True">
               <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
@@ -2690,20 +2716,27 @@
     </Setter>
   </Style>
   <Style BasedOn="{StaticResource DefaultListViewStyle}" TargetType="{x:Type ListView}" />
+  <system:Double x:Key="ListViewItemMinHeight">40</system:Double>
+  <system:Double x:Key="ListViewItemMinWidth">88</system:Double>
   <Style x:Key="DefaultListViewItemStyle" TargetType="{x:Type ListViewItem}">
     <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="MinHeight" Value="{StaticResource ListViewItemMinHeight}" />
+    <Setter Property="MinWidth" Value="{StaticResource ListViewItemMinWidth}" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Margin" Value="0,0,0,2" />
-    <Setter Property="Padding" Value="4" />
+    <Setter Property="Padding" Value="16,0,12,0" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ListBoxItem}">
-          <Border x:Name="Border" Margin="0" Padding="0" Background="Transparent" BorderThickness="1" CornerRadius="{TemplateBinding Border.CornerRadius}">
+          <Border x:Name="Border" Margin="0" Padding="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <Grid>
-              <ContentPresenter Margin="{TemplateBinding Padding}" />
+              <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
               <Rectangle x:Name="ActiveRectangle" Width="3" Height="18" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" Fill="{DynamicResource ListViewItemPillFillBrush}" RadiusX="2" RadiusY="2" Visibility="Collapsed" />
             </Grid>
           </Border>
@@ -2734,7 +2767,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Menu}">
-          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}">
             <StackPanel ClipToBounds="True" IsItemsHost="True" Orientation="Horizontal" />
           </Border>
         </ControlTemplate>
@@ -2765,7 +2798,7 @@
   </Style>
   <!--  TopLevelHeader  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelHeaderTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid>
         <Grid.RowDefinitions>
           <RowDefinition Height="*" />
@@ -2776,8 +2809,8 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         </Grid>
         <Popup x:Name="PART_Popup" Grid.Row="1" Grid.Column="0" AllowsTransparency="True" Focusable="False" HorizontalOffset="-12" IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Bottom" PlacementTarget="{Binding ElementName=Border}" PopupAnimation="None" VerticalOffset="1">
           <Grid>
@@ -2831,14 +2864,14 @@
   </ControlTemplate>
   <!--  TopLevelItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.TopLevelItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4" Background="Transparent" CornerRadius="6">
+    <Border x:Name="Border" Margin="4" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6">
       <Grid Margin="10">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
+        <ContentPresenter x:Name="HeaderPresenter" Grid.Column="1" VerticalAlignment="Center" ContentSource="Header" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Grid>
     </Border>
     <ControlTemplate.Triggers>
@@ -2863,7 +2896,7 @@
   </ControlTemplate>
   <!--  SubmenuItem  -->
   <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">
-    <Border x:Name="Border" Margin="4,1,4,1" Background="Transparent" CornerRadius="4">
+    <Border x:Name="Border" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
       <Grid Margin="8,6,8,6">
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
@@ -2874,8 +2907,8 @@
         <Border x:Name="CheckBoxIconBorder" Grid.Column="0" Width="20" Height="20" Margin="0,0,6,0" VerticalAlignment="Center" Background="{DynamicResource CheckBoxBackground}" BorderBrush="{DynamicResource CheckBoxBorderBrush}" BorderThickness="1" CornerRadius="4" Visibility="Collapsed">
           <TextBlock x:Name="CheckBoxIcon" HorizontalAlignment="Center" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="16" Text="" TextAlignment="Center" />
         </Border>
-        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" TextElement.Foreground="{TemplateBinding Foreground}" />
+        <ContentPresenter x:Name="Icon" Grid.Column="1" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+        <ContentPresenter Grid.Column="2" ContentSource="Header" RecognizesAccessKey="True" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" TextElement.Foreground="{TemplateBinding Foreground}" />
         <TextBlock x:Name="InputGestureText" Grid.Column="3" Margin="25,0,0,0" VerticalAlignment="Bottom" DockPanel.Dock="Right" FontSize="11" Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="{TemplateBinding InputGestureText}" />
       </Grid>
     </Border>
@@ -2911,15 +2944,15 @@
         <RowDefinition Height="*" />
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
-      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="1" CornerRadius="4">
+      <Border x:Name="Border" Grid.Row="1" Margin="4,1,4,1" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="4">
         <Grid x:Name="MenuItemContent" Margin="8,6,8,6">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
           </Grid.ColumnDefinitions>
-          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" Content="{TemplateBinding Icon}" />
-          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" ContentSource="Header" RecognizesAccessKey="True" />
+          <ContentPresenter x:Name="Icon" Grid.Column="0" Margin="0,0,6,0" VerticalAlignment="Center" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Content="{TemplateBinding Icon}" />
+          <ContentPresenter x:Name="HeaderHost" Grid.Column="1" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" ContentSource="Header" RecognizesAccessKey="True" />
           <Grid Grid.Column="2">
             <TextBlock x:Name="Chevron" Margin="0,3,0,0" VerticalAlignment="Center" FontFamily="{DynamicResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Text="{StaticResource MenuItemChevronRightGlyph}" />
           </Grid>
@@ -2981,8 +3014,13 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultMenuItemStyle" TargetType="{x:Type MenuItem}">
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultCollectionFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Focusable" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Style.Triggers>
@@ -3003,12 +3041,8 @@
   </Style>
   <Style BasedOn="{StaticResource DefaultMenuItemStyle}" TargetType="{x:Type MenuItem}" />
   <Style x:Key="DefaultPageStyle" TargetType="{x:Type Page}">
-    <Setter Property="Control.Foreground">
-      <Setter.Value>
-        <SolidColorBrush Color="{DynamicResource TextFillColorPrimary}" />
-      </Setter.Value>
-    </Setter>
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource PageForeground}" />
+    <Setter Property="Background" Value="{DynamicResource PageBackground}" />
     <!--  The Display option casues a large aliasing effect  -->
     <!-- <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" /> -->
     <Setter Property="Focusable" Value="False" />
@@ -3017,9 +3051,9 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type Page}">
-          <Grid>
-            <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Control.Foreground}" />
-          </Grid>
+          <Border Background="{TemplateBinding Background}" CornerRadius="8">
+            <ContentPresenter Content="{TemplateBinding ContentControl.Content}" TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Border>
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -3180,9 +3214,10 @@
     <!--  Universal WPF UI focus  -->
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <!--  Universal WPF UI focus  -->
-    <Setter Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+    <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
-    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+    <Setter Property="Border.CornerRadius" Value="4" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="{StaticResource RadioButtonPadding}" />
     <Setter Property="HorizontalAlignment" Value="Left" />
@@ -3199,7 +3234,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type RadioButton}">
-          <Grid HorizontalAlignment="Stretch" VerticalAlignment="{TemplateBinding VerticalAlignment}" Background="Transparent">
+          <Border x:Name="RootBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding Border.CornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal">
@@ -3222,24 +3257,26 @@
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="20" />
-              <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid Height="32" VerticalAlignment="Top">
-              <Ellipse x:Name="OuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Ellipse x:Name="CheckOuterEllipse" Width="{StaticResource RadioButtonOuterEllipseSize}" Height="{StaticResource RadioButtonOuterEllipseSize}" Fill="{TemplateBinding Background}" Opacity="0" Stroke="{TemplateBinding Background}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
-              <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
-                <Ellipse.RenderTransform>
-                  <ScaleTransform />
-                </Ellipse.RenderTransform>
-              </Ellipse>
-              <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
-              <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+            <Grid x:Name="RootGrid">
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+              </Grid.ColumnDefinitions>
+              <Grid Height="32" VerticalAlignment="Top">
+                <Ellipse x:Name="OuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseFill}" Stroke="{DynamicResource RadioButtonOuterEllipseStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Ellipse x:Name="CheckOuterEllipse" Width="20" Height="20" Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}" Opacity="0" Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" StrokeThickness="{StaticResource RadioButtonStrokeThickness}" UseLayoutRounding="False" />
+                <Ellipse x:Name="CheckGlyph" Width="{StaticResource RadioButtonCheckGlyphSize}" Height="{StaticResource RadioButtonCheckGlyphSize}" Fill="{DynamicResource RadioButtonCheckGlyphFill}" RenderTransformOrigin="0.5, 0.5" Opacity="0" Stroke="{DynamicResource CircleElevationBorderBrush}" UseLayoutRounding="False">
+                  <Ellipse.RenderTransform>
+                    <ScaleTransform />
+                  </Ellipse.RenderTransform>
+                </Ellipse>
+                <!--  A seperate element is added since the two orthogonal state groups that cannot touch the same property  -->
+                <Border x:Name="PressedCheckGlyph" Width="4" Height="4" Background="{DynamicResource RadioButtonCheckGlyphFill}" BorderBrush="{DynamicResource CircleElevationBorderBrush}" CornerRadius="6" Opacity="0" UseLayoutRounding="False" />
+              </Grid>
+              <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
             </Grid>
-            <ContentPresenter x:Name="ContentPresenter" Grid.Column="1" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" TextElement.Foreground="{TemplateBinding Foreground}" />
-          </Grid>
+          </Border>
           <ControlTemplate.Triggers>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3250,6 +3287,8 @@
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPressed}" />
               <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
             </MultiTrigger>
             <Trigger Property="IsChecked" Value="True">
               <Setter TargetName="CheckGlyph" Property="Opacity" Value="1.0" />
@@ -3266,6 +3305,9 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3274,9 +3316,12 @@
                 <Condition Property="IsEnabled" Value="True" />
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillPointerOver}" />
+              <Setter TargetName="OuterEllipse" Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPointerOver}" />
               <!--<Setter TargetName="CheckGlyph" Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />-->
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePointerOver}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPointerOver}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPointerOver}" />
             </MultiTrigger>
             <MultiTrigger>
               <MultiTrigger.Conditions>
@@ -3286,6 +3331,8 @@
               </MultiTrigger.Conditions>
               <Setter TargetName="OuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
               <Setter TargetName="CheckOuterEllipse" Property="Fill" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedFillPressed}" />
+              <Setter TargetName="RootBorder" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+              <Setter TargetName="RootBorder" Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
               <Setter TargetName="PressedCheckGlyph" Property="Background" Value="{DynamicResource RadioButtonCheckOuterEllipseCheckedStrokePressed}" />
             </MultiTrigger>
             <MultiTrigger>
@@ -3413,6 +3460,7 @@
   <Duration x:Key="ButtonHoverAnimationDuration">0:0:0.16</Duration>
   <sys:Double x:Key="LineButtonHeight">12</sys:Double>
   <sys:Double x:Key="LineButtonWidth">12</sys:Double>
+  <sys:Double x:Key="ScrollBarButtonArrowIconFontSize">8</sys:Double>
   <system:String x:Key="ScrollBarCaretUpGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretDownGlyph"></system:String>
   <system:String x:Key="ScrollBarCaretLeftGlyph"></system:String>
@@ -3421,7 +3469,7 @@
     <Setter Property="Foreground" Value="{DynamicResource ScrollBarButtonArrowForeground}" />
     <Setter Property="Width" Value="{StaticResource LineButtonWidth}" />
     <Setter Property="Height" Value="{StaticResource LineButtonHeight}" />
-    <Setter Property="FontSize" Value="11" />
+    <Setter Property="FontSize" Value="{StaticResource ScrollBarButtonArrowIconFontSize}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -3489,9 +3537,9 @@
         <RowDefinition Height="0.00001*" />
         <RowDefinition MaxHeight="14" />
       </Grid.RowDefinitions>
-      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{DynamicResource ScrollBarTrackFillPointerOver}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.RowSpan="3" Width="12" HorizontalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollUp" Grid.Row="0" HorizontalContentAlignment="Left" Command="ScrollBar.LineUpCommand" Content="{StaticResource ScrollBarCaretUpGlyph}" Opacity="0" AutomationProperties.Name="Scroll Up" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Row="1" Width="6" IsDirectionReversed="True">
+      <Track x:Name="PART_Track" Grid.Row="1" Width="4" IsDirectionReversed="True">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageUpCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3512,7 +3560,7 @@
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3522,7 +3570,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Width" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollUp" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollDown" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3539,9 +3587,9 @@
         <ColumnDefinition Width="0.00001*" />
         <ColumnDefinition MaxWidth="18" />
       </Grid.ColumnDefinitions>
-      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{DynamicResource ScrollBarButtonBackground}" CornerRadius="6" Opacity="0" />
+      <Border x:Name="PART_Border" Grid.ColumnSpan="3" Height="12" VerticalAlignment="Center" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" CornerRadius="6" Opacity="0" />
       <RepeatButton x:Name="PART_ButtonScrollLeft" Grid.Column="0" VerticalAlignment="Center" Command="ScrollBar.LineLeftCommand" Content="{StaticResource ScrollBarCaretLeftGlyph}" Opacity="0" AutomationProperties.Name="Scroll Left" Style="{StaticResource ScrollBarLineButtonStyle}" />
-      <Track x:Name="PART_Track" Grid.Column="1" Height="6" VerticalAlignment="Center" IsDirectionReversed="False">
+      <Track x:Name="PART_Track" Grid.Column="1" Height="4" VerticalAlignment="Center" IsDirectionReversed="False">
         <Track.DecreaseRepeatButton>
           <RepeatButton Command="ScrollBar.PageLeftCommand" Style="{StaticResource ScrollBarPageButtonStyle}" />
         </Track.DecreaseRepeatButton>
@@ -3556,10 +3604,11 @@
     </Grid>
     <ControlTemplate.Triggers>
       <Trigger Property="IsMouseOver" Value="True">
+        <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFillPointerOver}" />
         <Trigger.EnterActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="6" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="4" To="8" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="0.0" To="1.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3569,7 +3618,7 @@
         <Trigger.ExitActions>
           <BeginStoryboard>
             <Storyboard>
-              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="6" Duration="{StaticResource ScrollAnimationDuration}" />
+              <DoubleAnimation Storyboard.TargetName="PART_Track" Storyboard.TargetProperty="Height" From="8" To="4" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_Border" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollLeft" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
               <DoubleAnimation Storyboard.TargetName="PART_ButtonScrollRight" Storyboard.TargetProperty="Opacity" From="1.0" To="0.0" Duration="{StaticResource ScrollAnimationDuration}" />
@@ -3580,7 +3629,8 @@
     </ControlTemplate.Triggers>
   </ControlTemplate>
   <Style x:Key="DefaultScrollBarStyle" TargetType="{x:Type ScrollBar}">
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource ScrollBarTrackFill}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarTrackStroke}" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -3588,11 +3638,11 @@
     <Style.Triggers>
       <Trigger Property="Orientation" Value="Horizontal">
         <Setter Property="Width" Value="Auto" />
-        <Setter Property="Height" Value="14" />
+        <Setter Property="Height" Value="12" />
         <Setter Property="Template" Value="{StaticResource HorizontalScrollBarTemplate}" />
       </Trigger>
       <Trigger Property="Orientation" Value="Vertical">
-        <Setter Property="Width" Value="14" />
+        <Setter Property="Width" Value="12" />
         <Setter Property="Height" Value="Auto" />
         <Setter Property="Template" Value="{StaticResource VerticalScrollBarTemplate}" />
       </Trigger>
@@ -3855,8 +3905,8 @@
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3873,8 +3923,8 @@
         <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Row="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,0,1" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Row="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3891,8 +3941,8 @@
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="0" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0,0,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="1" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3909,8 +3959,8 @@
         <ColumnDefinition Width="Auto" />
       </Grid.ColumnDefinitions>
       <TabPanel x:Name="HeaderPanel" Grid.Column="1" Margin="0" Panel.ZIndex="1" Background="Transparent" IsItemsHost="True" KeyboardNavigation.TabIndex="1" />
-      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0,0,1,0" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
-        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
+      <Border x:Name="Border" Grid.Column="0" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0,4,4,4" KeyboardNavigation.DirectionalNavigation="Contained" KeyboardNavigation.TabIndex="2" KeyboardNavigation.TabNavigation="Local">
+        <ContentPresenter x:Name="PART_SelectedContentHost" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ContentSource="SelectedContent" TextElement.Foreground="{TemplateBinding Foreground}" />
       </Border>
       <VisualStateManager.VisualStateGroups>
         <VisualStateGroup x:Name="CommonStates">
@@ -3923,18 +3973,23 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="BorderThickness" Value="0,1,0,0" />
+    <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="Template" Value="{StaticResource DefaultTopTabControlStyle}" />
     <Style.Triggers>
       <Trigger Property="TabStripPlacement" Value="Bottom">
         <Setter Property="Template" Value="{StaticResource DefaultBottomTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Left">
         <Setter Property="Template" Value="{StaticResource DefaultLeftTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="1,0,0,0" />
       </Trigger>
       <Trigger Property="TabStripPlacement" Value="Right">
         <Setter Property="Template" Value="{StaticResource DefaultRightTabControlStyle}" />
+        <Setter Property="BorderThickness" Value="0,0,1,0" />
       </Trigger>
     </Style.Triggers>
   </Style>
@@ -3955,7 +4010,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" Margin="0" HorizontalAlignment="Left" VerticalAlignment="Center" ContentSource="Header" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4473,8 +4528,11 @@
     </Setter>
     <Setter Property="Margin" Value="0" />
   </Style>
+  <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
+  <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
+  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
-    <Setter Property="MaxWidth" Value="260" />
+    <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />
     <Setter Property="Width" Value="Auto" />
     <Setter Property="TextElement.FontSize" Value="12" />
@@ -4483,16 +4541,20 @@
     <Setter Property="Foreground" Value="{DynamicResource ToolTipForeground}" />
     <Setter Property="Background" Value="{DynamicResource ToolTipBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ToolTipBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ToolTipBorderThemeThickness}" />
+    <Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Top" />
     <Setter Property="SnapsToDevicePixels" Value="True" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="ToolTip">
-          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Padding="8" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="4" SnapsToDevicePixels="True">
+          <Border Name="Border" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" MaxWidth="{TemplateBinding MaxWidth}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4" SnapsToDevicePixels="True">
             <Border.Effect>
               <DropShadowEffect BlurRadius="30" Direction="0" Opacity="0.4" ShadowDepth="0" Color="#202020" />
             </Border.Effect>
-            <ContentPresenter Margin="4" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <ContentPresenter Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
               <ContentPresenter.Resources>
                 <Style TargetType="{x:Type TextBlock}">
                   <Setter Property="TextWrapping" Value="WrapWithOverflow" />

--- a/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
+++ b/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Fluent/Themes/Fluent.Light.xaml
@@ -1364,7 +1364,7 @@
                   </Grid>
                 </Grid>
                 <Popup x:Name="PART_Popup" MinWidth="{TemplateBinding ActualWidth}" VerticalAlignment="Center" AllowsTransparency="True" Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="{TemplateBinding Popup.Placement}" PopupAnimation="{TemplateBinding Popup.PopupAnimation}" VerticalOffset="1">
-                  <Border x:Name="DropDownBorder" Margin="12,0,12,18" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
+                  <Border x:Name="DropDownBorder" Padding="0,4,0,6" Background="{DynamicResource ComboBoxDropDownBackground}" BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}" BorderThickness="1.5" CornerRadius="{DynamicResource PopupCornerRadius}" SnapsToDevicePixels="True">
                     <!--Will revist this code while doing performance evaluation for dynamic resources.-->
                     <Border.RenderTransform>
                       <TranslateTransform />
@@ -3973,6 +3973,7 @@
     <Setter Property="Foreground" Value="{DynamicResource TabViewForeground}" />
     <Setter Property="Background" Value="{DynamicResource TabViewBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TabViewBorderBrush}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="BorderThickness" Value="0,1,0,0" />
     <Setter Property="Padding" Value="0" />
     <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -3998,8 +3999,8 @@
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="VerticalAlignment" Value="Stretch" />
-    <Setter Property="VerticalContentAlignment" Value="Stretch" />
-    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+    <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
     <Setter Property="FocusVisualStyle" Value="{DynamicResource DefaultControlFocusVisualStyle}" />
     <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
     <Setter Property="Focusable" Value="True" />
@@ -4010,7 +4011,7 @@
         <ControlTemplate TargetType="{x:Type TabItem}">
           <Grid x:Name="Root">
             <Border x:Name="Border" MinWidth="180" MinHeight="36" Margin="0" Padding="6" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,1,1,0" CornerRadius="8,8,0,0">
-              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
+              <ContentPresenter x:Name="ContentSite" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" ContentSource="Header" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" />
             </Border>
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="SelectionStates">
@@ -4530,7 +4531,7 @@
   </Style>
   <Thickness x:Key="ToolTipBorderPadding">9,6,9,8</Thickness>
   <sys:Double x:Key="ToolTipMaxWidth">320</sys:Double>
-  <sys:Double x:Key="ToolTipBorderThemeThickness">1</sys:Double>
+  <Thickness x:Key="ToolTipBorderThemeThickness">1</Thickness>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}">
     <Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
     <Setter Property="Height" Value="Auto" />


### PR DESCRIPTION
Fixes #9564 

## Description
In many of the Fluent styles template bindings are not set correctly. In this PR, I have tried to fix most of the template binding issues by comparing the styles to both Aero2 and WinUI styles.

## Customer Impact
Developers using the new Fluent styles won't have to create custom styles for setting properties like BorderBrush, Background, BorderThickness and alignment properties.

## Regression
Technically no, but any developer who will try to port their application to use the new styles will face this issue and the properties won't work for them.

## Testing
Local testing with sample apps and WPF Gallery application.

## Risk
Minimal. Apps are not using this feature ( except those who are working with .NET 9 preview releases )

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9786)