### PR TITLE
Use optimized DoubleUtil methods

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MetricEntry.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/InkSerializedFormat/MetricEntry.cs
@@ -324,7 +324,7 @@ namespace MS.Internal.Ink.InkSerializedFormat
                 if( Int32.MinValue == propertyInfo.Minimum &&
                     Int32.MaxValue == propertyInfo.Maximum &&
                     StylusPointPropertyUnit.None == propertyInfo.Unit &&
-                    DoubleUtil.AreClose(1.0, propertyInfo.Resolution) )
+                    DoubleUtil.IsOne(propertyInfo.Resolution) )
                     return false;
                 else
                     return true;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeData.cs
@@ -58,7 +58,7 @@ namespace MS.Internal.Ink
         { 
             get 
             {
-                Debug.Assert(DoubleUtil.AreClose(0, s_empty._pressure));
+                Debug.Assert(DoubleUtil.IsZero(s_empty._pressure));
                 return DoubleUtil.AreClose(_pressure, s_empty._pressure); 
             } 
         }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Ink/StrokeNodeOperations.cs
@@ -80,7 +80,7 @@ namespace MS.Internal.Ink
             System.Diagnostics.Debug.Assert((boundingBox.X <= 0) && (boundingBox.Y <= 0));
 
             double pressureFactor = node.PressureFactor;
-            if (!DoubleUtil.AreClose(pressureFactor,1d))
+            if (!DoubleUtil.IsOne(pressureFactor))
             {
                 boundingBox = new Rect(
                     _shapeBounds.X * pressureFactor,
@@ -97,7 +97,7 @@ namespace MS.Internal.Ink
         internal void GetNodeContourPoints(in StrokeNodeData node, List<Point> pointBuffer)
         {
             double pressureFactor = node.PressureFactor;
-            if (DoubleUtil.AreClose(pressureFactor, 1d))
+            if (DoubleUtil.IsOne(pressureFactor))
             {
                 for (int i = 0; i < _vertices.Length; i++)
                 {
@@ -959,7 +959,7 @@ namespace MS.Internal.Ink
                     // Adjust the arc for the node' pressure factor.
                     Vector hitCenter = hitSegment.Begin + hitSegment.Radius - position;
                     Vector hitRadius = hitSegment.Radius;
-                    if (!DoubleUtil.AreClose(pressureFactor, 1d))
+                    if (!DoubleUtil.IsOne(pressureFactor))
                     {
                         System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
                         hitCenter /= pressureFactor;
@@ -984,7 +984,7 @@ namespace MS.Internal.Ink
                     // Adjust the segment for the node's pressure factor
                     Vector hitBegin = hitSegment.Begin - position;
                     Vector hitEnd = hitBegin + hitSegment.Vector;
-                    if (!DoubleUtil.AreClose(pressureFactor, 1d))
+                    if (!DoubleUtil.IsOne(pressureFactor))
                     {
                         System.Diagnostics.Debug.Assert(DoubleUtil.IsZero(pressureFactor) == false);
                         hitBegin /= pressureFactor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/UIElement3DAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/UIElement3DAutomationPeer.cs
@@ -227,8 +227,8 @@ namespace System.Windows.Automation.Peers
                                 Rect boundingRect = UIElementAutomationPeer.CalculateVisibleBoundingRect(containingUIElement);
                                 
                                 isOffscreen = (DoubleUtil.AreClose(boundingRect, Rect.Empty) || 
-                                               DoubleUtil.AreClose(boundingRect.Height, 0) || 
-                                               DoubleUtil.AreClose(boundingRect.Width, 0));
+                                               DoubleUtil.IsZero(boundingRect.Height) || 
+                                               DoubleUtil.IsZero(boundingRect.Width));
                             }
                         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/UIElementAutomationPeer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Automation/Peers/UIElementAutomationPeer.cs
@@ -249,8 +249,8 @@ namespace System.Windows.Automation.Peers
                             Rect boundingRect = CalculateVisibleBoundingRect(_owner);
                             
                             isOffscreen = (DoubleUtil.AreClose(boundingRect, Rect.Empty) || 
-                                           DoubleUtil.AreClose(boundingRect.Height, 0) || 
-                                           DoubleUtil.AreClose(boundingRect.Width, 0));
+                                           DoubleUtil.IsZero(boundingRect.Height) || 
+                                           DoubleUtil.IsZero(boundingRect.Width));
                         }
 
                         return isOffscreen;
@@ -275,8 +275,8 @@ namespace System.Windows.Automation.Peers
             
             while (parent != null && 
                    !DoubleUtil.AreClose(boundingRect, Rect.Empty) && 
-                   !DoubleUtil.AreClose(boundingRect.Height, 0) && 
-                   !DoubleUtil.AreClose(boundingRect.Width, 0))
+                   !DoubleUtil.IsZero(boundingRect.Height) && 
+                   !DoubleUtil.IsZero(boundingRect.Width))
             {
                 Visual visualParent = parent as Visual;
                 if (visualParent != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerTouchDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Pointer/PointerTouchDevice.cs
@@ -95,7 +95,7 @@ namespace System.Windows.Input.StylusPointer
 
                 StylusPointPropertyInfo propertyInfo = stylusPoint.Description.GetPropertyInfo(property);
 
-                if (!DoubleUtil.AreClose(propertyInfo.Resolution, 0d))
+                if (!DoubleUtil.IsZero(propertyInfo.Resolution))
                 {
                     value /= propertyInfo.Resolution;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusTouchDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispStylusTouchDevice.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Input.StylusWisp
 
                 StylusPointPropertyInfo propertyInfo = stylusPoint.Description.GetPropertyInfo(property);
 
-                if (!DoubleUtil.AreClose(propertyInfo.Resolution, 0d))
+                if (!DoubleUtil.IsZero(propertyInfo.Resolution))
                 {
                     value /= propertyInfo.Resolution;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -2180,7 +2180,7 @@ namespace System.Windows.Interop
             int height = _hwndClientRectInScreenCoords.bottom - _hwndClientRectInScreenCoords.top;
 
             MILTransparencyFlags flags = MILTransparencyFlags.Opaque;
-            // if (!DoubleUtil.AreClose(_opacity, 1.0))
+            // if (!DoubleUtil.IsOne(_opacity))
             // {
             //     flags |= MILTransparencyFlags.ConstantAlpha;
             // }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/UIElement.cs
@@ -1091,7 +1091,7 @@ namespace System.Windows
             double newValue;
 
             // If DPI == 1, don't use DPI-aware rounding.
-            if (!DoubleUtil.AreClose(dpiScale, 1.0))
+            if (!DoubleUtil.IsOne(dpiScale))
             {
                 newValue = Math.Round(value * dpiScale) / dpiScale;
                 // If rounding produces a value unacceptable to layout (NaN, Infinity or MaxValue), use the original value.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/InkCanvasFeedbackAdorner.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Controls/InkCanvasFeedbackAdorner.cs
@@ -57,7 +57,7 @@ namespace MS.Internal.Controls
             desiredTransform.Children.Add(transform);
 
             // Check if we need translate the adorner.
-            if (!DoubleUtil.AreClose(_offsetX, 0) || !DoubleUtil.AreClose(_offsetY, 0))
+            if (!DoubleUtil.IsZero(_offsetX) || !DoubleUtil.IsZero(_offsetY))
             {
                 desiredTransform.Children.Add(new TranslateTransform(_offsetX, _offsetY));
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Helper.cs
@@ -1117,8 +1117,8 @@ namespace MS.Internal
                 }
                 itemPixelSize.Width = Math.Max(desiredSize.Width, itemPixelSize.Width);
 
-                if (DoubleUtil.AreClose(itemDesiredSizes.PixelSizeAfterViewport.Height, 0) &&
-                    DoubleUtil.AreClose(itemDesiredSizes.PixelSizeInViewport.Height, 0) &&
+                if (DoubleUtil.IsZero(itemDesiredSizes.PixelSizeAfterViewport.Height) &&
+                    DoubleUtil.IsZero(itemDesiredSizes.PixelSizeInViewport.Height) &&
                     DoubleUtil.GreaterThanZero(itemDesiredSizes.PixelSizeBeforeViewport.Height))
                 {
                     if (!correctionComputed)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/PtsHost/Line.cs
@@ -514,7 +514,7 @@ namespace MS.Internal.PtsHost
             {
                 // Verify that offset shift is 0 for this case. We should never shift offsets when ellipses are
                 // rendered.
-                Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                Invariant.Assert(DoubleUtil.IsZero(delta));
                 System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, TextParagraph.Properties));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 textBounds = line.GetTextBounds(cp, cch);
@@ -1008,7 +1008,7 @@ namespace MS.Internal.PtsHost
             if (_line.HasOverflowed && TextParagraph.Properties.TextTrimming != TextTrimming.None)
             {
                 // We should not shift offset in this case
-                Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                Invariant.Assert(DoubleUtil.IsZero(delta));
                 System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, TextParagraph.Properties));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 textBounds = line.GetTextBounds(cp, cch);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/ComplexLine.cs
@@ -273,7 +273,7 @@ namespace MS.Internal.Text
                 if (_line.HasOverflowed && _owner.ParagraphProperties.TextTrimming != TextTrimming.None)
                 {
                     // We should not shift offset in this case
-                    Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                    Invariant.Assert(DoubleUtil.IsZero(delta));
                     System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
                     Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/Text/Line.cs
@@ -172,7 +172,7 @@ namespace MS.Internal.Text
             if (_line.HasOverflowed && _owner.ParagraphProperties.TextTrimming != TextTrimming.None)
             {
                 // We should not shift offset in this case
-                Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                Invariant.Assert(DoubleUtil.IsZero(delta));
                 System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 textBounds = line.GetTextBounds(cp, cch);
@@ -208,7 +208,7 @@ namespace MS.Internal.Text
             if (_line.HasOverflowed && _owner.ParagraphProperties.TextTrimming != TextTrimming.None)
             {
                 System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
-                Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                Invariant.Assert(DoubleUtil.IsZero(delta));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 return line.GetCharacterHitFromDistance(distance);
             }
@@ -466,7 +466,7 @@ namespace MS.Internal.Text
             if (_line.HasOverflowed && _owner.ParagraphProperties.TextTrimming != TextTrimming.None)
             {
                 // We should not shift offset in this case
-                Invariant.Assert(DoubleUtil.AreClose(delta, 0));
+                Invariant.Assert(DoubleUtil.IsZero(delta));
                 System.Windows.Media.TextFormatting.TextLine line = _line.Collapse(GetCollapsingProps(_wrappingWidth, _owner.ParagraphProperties));
                 Invariant.Assert(line.HasCollapsed, "Line has not been collapsed");
                 textBounds = line.GetTextBounds(cp, cch);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/DocumentGrid.cs
@@ -2333,7 +2333,7 @@ namespace MS.Internal.Documents
                 return;
             }
 
-            if (!DoubleUtil.AreClose(1.0, neededScaleFactor))
+            if (!DoubleUtil.IsOne(neededScaleFactor))
             {
                 //Rescale the row.
                 ApplyViewParameters(pivotRow);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGrid.cs
@@ -1976,7 +1976,7 @@ namespace System.Windows.Controls
             if (!InternalColumns.ColumnWidthsComputationPending)
             {
                 double widthChange = newSize.Width - oldSize.Width;
-                if (!DoubleUtil.AreClose(widthChange, 0.0))
+                if (!DoubleUtil.IsZero(widthChange))
                 {
                     _finalViewportWidth = newSize.Width;
                     if (!_viewportWidthChangeNotificationPending)
@@ -2001,7 +2001,7 @@ namespace System.Windows.Controls
             }
 
             double widthChange = _finalViewportWidth - _originalViewportWidth;
-            if (!DoubleUtil.AreClose(widthChange, 0.0))
+            if (!DoubleUtil.IsZero(widthChange))
             {
                 NotifyPropertyChanged(this,
                     "ViewportWidth",

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridCellsPanel.cs
@@ -126,7 +126,7 @@ namespace System.Windows.Controls
                 childMeasureConstraint.Width = column.GetConstraintWidth(isColumnHeader);
             }
 
-            if (DoubleUtil.AreClose(desiredWidth, 0.0))
+            if (DoubleUtil.IsZero(desiredWidth))
             {
                 child.Measure(childMeasureConstraint);
             }
@@ -140,7 +140,7 @@ namespace System.Windows.Controls
                 // Allow the column to process the desired size
                 column.UpdateDesiredWidthForAutoColumn(
                     isColumnHeader,
-                    DoubleUtil.AreClose(desiredWidth, 0.0) ? childDesiredSize.Width : desiredWidth);
+                    DoubleUtil.IsZero(desiredWidth) ? childDesiredSize.Width : desiredWidth);
 
                 // For auto kind columns measure again with display value if
                 // the desired width is greater than display value.
@@ -250,7 +250,7 @@ namespace System.Windows.Controls
 
             bool hasStarColumns = parentDataGrid.InternalColumns.HasVisibleStarColumns;
             double averageColumnWidth = parentDataGrid.InternalColumns.AverageColumnWidth;
-            bool invalidAverage = DoubleUtil.AreClose(averageColumnWidth, 0.0);
+            bool invalidAverage = DoubleUtil.IsZero(averageColumnWidth);
             bool notVirtualizing = !IsVirtualizing;
             bool generateAll = invalidAverage || hasStarColumns || notVirtualizing;
             int frozenColumnCount = parentDataGrid.FrozenColumnCount;
@@ -357,7 +357,7 @@ namespace System.Windows.Controls
                                     }
 
                                     double cellChoppedWidth = viewportStartX - nextNonFrozenCellStart;
-                                    if (DoubleUtil.AreClose(cellChoppedWidth, 0.0))
+                                    if (DoubleUtil.IsZero(cellChoppedWidth))
                                     {
                                         nextNonFrozenCellStart = nextFrozenCellStart + childSize.Width;
                                         allocatedSpace += childSize.Width;
@@ -1517,7 +1517,7 @@ namespace System.Windows.Controls
                     else
                     {
                         double cellChoppedWidth = arrangeState.ViewportStartX - arrangeState.NextNonFrozenCellStart;
-                        if (DoubleUtil.AreClose(cellChoppedWidth, 0.0))
+                        if (DoubleUtil.IsZero(cellChoppedWidth))
                         {
                             rcChild.X = arrangeState.NextFrozenCellStart;
                             arrangeState.NextNonFrozenCellStart = arrangeState.NextFrozenCellStart + childWidth;
@@ -2021,7 +2021,7 @@ namespace System.Windows.Controls
 
             DataGridRowsPresenter parentRowsPresenter = ParentRowsPresenter;
 
-            if (DoubleUtil.AreClose(availableViewportWidth, 0.0) && parentRowsPresenter != null)
+            if (DoubleUtil.IsZero(availableViewportWidth) && parentRowsPresenter != null)
             {
                 Size rowPresenterAvailableSize = parentRowsPresenter.AvailableSize;
                 if (!double.IsNaN(rowPresenterAvailableSize.Width) && !Double.IsInfinity(rowPresenterAvailableSize.Width))
@@ -2294,7 +2294,7 @@ namespace System.Windows.Controls
                         {
                             columnStart = nextFrozenCellStart;
                             double cellChoppedWidth = viewportStartX - nextNonFrozenCellStart;
-                            if (DoubleUtil.AreClose(cellChoppedWidth, 0.0))
+                            if (DoubleUtil.IsZero(cellChoppedWidth))
                             {
                                 columnEnd = columnStart + columnWidth;
                                 nextNonFrozenCellStart = nextFrozenCellStart + columnWidth;
@@ -2342,7 +2342,7 @@ namespace System.Windows.Controls
                     offsetChange = columnStart - nextFrozenCellStart;
                 }
 
-                if (DoubleUtil.AreClose(offsetChange, 0.0))
+                if (DoubleUtil.IsZero(offsetChange))
                 {
                     return true;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridColumnCollection.cs
@@ -811,8 +811,8 @@ namespace System.Windows.Controls
                 if (width.IsStar)
                 {
                     hasStarColumns = true;
-                    if (!DoubleUtil.AreClose(width.Value, 0.0) &&
-                        !DoubleUtil.AreClose(width.DesiredValue, 0.0))
+                    if (!DoubleUtil.IsZero(width.Value) &&
+                        !DoubleUtil.IsZero(width.DesiredValue))
                     {
                         perStarWidth = width.DesiredValue / width.Value;
                         break;
@@ -1615,7 +1615,7 @@ namespace System.Windows.Controls
                 }
 
                 DataGridLength width = column.Width;
-                if (width.IsStar && !DoubleUtil.AreClose(width.Value, 0.0))
+                if (width.IsStar && !DoubleUtil.IsZero(width.Value))
                 {
                     if (DoubleUtil.GreaterThan(width.DisplayValue, column.MinWidth))
                     {
@@ -1835,7 +1835,7 @@ namespace System.Windows.Controls
                         perStarWidth,
                         retainAuto);
 
-                    if (DoubleUtil.AreClose(horizontalChange, 0.0))
+                    if (DoubleUtil.IsZero(horizontalChange))
                     {
                         break;
                     }
@@ -1865,7 +1865,7 @@ namespace System.Windows.Controls
                 }
 
                 DataGridLength width = column.Width;
-                if (width.IsStar && !DoubleUtil.AreClose(width.Value, 0.0))
+                if (width.IsStar && !DoubleUtil.IsZero(width.Value))
                 {
                     if (DoubleUtil.LessThan(width.DisplayValue, column.MaxWidth))
                     {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DataGridLengthConverter.cs
@@ -257,7 +257,7 @@ namespace System.Windows.Controls
             {
                 // Parse a numerical value
                 Debug.Assert(
-                    (unit == DataGridLengthUnitType.Pixel) || DoubleUtil.AreClose(unitFactor, 1.0),
+                    (unit == DataGridLengthUnitType.Pixel) || DoubleUtil.IsOne(unitFactor),
                     "unitFactor should not be other than 1.0 unless the unit type is Pixel.");
 
                 ReadOnlySpan<char> valueString = valueSpan.Slice(0, valueSpan.Length - strLenUnit);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ScrollViewer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/ScrollViewer.cs
@@ -1624,13 +1624,13 @@ namespace System.Windows.Controls
                     double viewportHeight = ViewportHeight + 1d; // Using +1 to account for last partially visible item in viewport
                     if (viewport != null)
                     {
-                        _panningInfo.DeltaPerHorizontalOffet = (DoubleUtil.AreClose(viewportWidth, 0) ? 0 : viewport.ActualWidth / viewportWidth);
-                        _panningInfo.DeltaPerVerticalOffset = (DoubleUtil.AreClose(viewportHeight, 0) ? 0 : viewport.ActualHeight / viewportHeight);
+                        _panningInfo.DeltaPerHorizontalOffet = (DoubleUtil.IsZero(viewportWidth) ? 0 : viewport.ActualWidth / viewportWidth);
+                        _panningInfo.DeltaPerVerticalOffset = (DoubleUtil.IsZero(viewportHeight) ? 0 : viewport.ActualHeight / viewportHeight);
                     }
                     else
                     {
-                        _panningInfo.DeltaPerHorizontalOffet = (DoubleUtil.AreClose(viewportWidth, 0) ? 0 : ActualWidth / viewportWidth);
-                        _panningInfo.DeltaPerVerticalOffset = (DoubleUtil.AreClose(viewportHeight, 0) ? 0 : ActualHeight / viewportHeight);
+                        _panningInfo.DeltaPerHorizontalOffet = (DoubleUtil.IsZero(viewportWidth) ? 0 : ActualWidth / viewportWidth);
+                        _panningInfo.DeltaPerVerticalOffset = (DoubleUtil.IsZero(viewportHeight) ? 0 : ActualHeight / viewportHeight);
                     }
 
                     // Template bind other Scroll Manipulation properties if needed.
@@ -1758,7 +1758,7 @@ namespace System.Windows.Controls
                 {
                     unusedX = 0;
                 }
-                _panningInfo.InHorizontalFeedback = (!DoubleUtil.AreClose(unusedX, 0));
+                _panningInfo.InHorizontalFeedback = (!DoubleUtil.IsZero(unusedX));
 
                 double unusedY = _panningInfo.UnusedTranslation.Y;
                 if (!_panningInfo.InVerticalFeedback &&
@@ -1766,7 +1766,7 @@ namespace System.Windows.Controls
                 {
                     unusedY = 0;
                 }
-                _panningInfo.InVerticalFeedback = (!DoubleUtil.AreClose(unusedY, 0));
+                _panningInfo.InVerticalFeedback = (!DoubleUtil.IsZero(unusedY));
 
                 if (_panningInfo.InHorizontalFeedback || _panningInfo.InVerticalFeedback)
                 {
@@ -1787,7 +1787,7 @@ namespace System.Windows.Controls
             double offset = (isHorizontal ? HorizontalOffset : VerticalOffset);
             double scrollableLength = (isHorizontal ? ScrollableWidth : ScrollableHeight);
 
-            if (DoubleUtil.AreClose(scrollableLength, 0))
+            if (DoubleUtil.IsZero(scrollableLength))
             {
                 // If the Scrollable length in this direction is 0,
                 // then we should neither scroll nor report the boundary feedback
@@ -1823,7 +1823,7 @@ namespace System.Windows.Controls
 
             if (isHorizontal)
             {
-                if (!DoubleUtil.AreClose(delta, 0))
+                if (!DoubleUtil.IsZero(delta))
                 {
                     // if there is any delta left, then re-evalute the horizontal offset
                     ScrollToHorizontalOffset(_panningInfo.OriginalHorizontalOffset -
@@ -1833,7 +1833,7 @@ namespace System.Windows.Controls
             }
             else
             {
-                if (!DoubleUtil.AreClose(delta, 0))
+                if (!DoubleUtil.IsZero(delta))
                 {
                     // if there is any delta left, then re-evalute the vertical offset
                     ScrollToVerticalOffset(_panningInfo.OriginalVerticalOffset -

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Slider.cs
@@ -1009,7 +1009,7 @@ namespace System.Windows.Controls
             if (Orientation == Orientation.Horizontal)
             {
                 // Calculate part size for HorizontalSlider
-                if (DoubleUtil.AreClose(range, 0d) || (DoubleUtil.AreClose(trackSize.Width, thumbSize.Width)))
+                if (DoubleUtil.IsZero(range) || (DoubleUtil.AreClose(trackSize.Width, thumbSize.Width)))
                 {
                     valueToSize = 0d;
                 }
@@ -1031,7 +1031,7 @@ namespace System.Windows.Controls
             else
             {
                 // Calculate part size for VerticalSlider
-                if (DoubleUtil.AreClose(range, 0d) || (DoubleUtil.AreClose(trackSize.Height, thumbSize.Height)))
+                if (DoubleUtil.IsZero(range) || (DoubleUtil.AreClose(trackSize.Height, thumbSize.Height)))
                 {
                     valueToSize = 0d;
                 }
@@ -1074,7 +1074,7 @@ namespace System.Windows.Controls
             if (Orientation == Orientation.Horizontal)
             {
                 // Calculate part size for HorizontalSlider
-                if (DoubleUtil.AreClose(range, 0d) || (DoubleUtil.AreClose(trackSize.Width, thumbSize.Width)))
+                if (DoubleUtil.IsZero(range) || (DoubleUtil.AreClose(trackSize.Width, thumbSize.Width)))
                 {
                     valueToSize = 0d;
                 }
@@ -1098,7 +1098,7 @@ namespace System.Windows.Controls
             else
             {
                 // Calculate part size for VerticalSlider
-                if (DoubleUtil.AreClose(range, 0d) || (DoubleUtil.AreClose(trackSize.Height, thumbSize.Height)))
+                if (DoubleUtil.IsZero(range) || (DoubleUtil.AreClose(trackSize.Height, thumbSize.Height)))
                 {
                     valueToSize = 0d;
                 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/VirtualizingStackPanel.cs
@@ -2631,7 +2631,7 @@ namespace System.Windows.Controls
 
                                                         double spanBeforeViewport = Math.Max(isHorizontal ? viewport.X : viewport.Y, 0.0);
                                                         double newContainerSpan = isHorizontal ? newContainerSize.Width : newContainerSize.Height;
-                                                        bool endsAfterViewport = DoubleUtil.AreClose(spanBeforeViewport, 0) ||
+                                                        bool endsAfterViewport = DoubleUtil.IsZero(spanBeforeViewport) ||
                                                             LayoutDoubleUtil.LessThan(spanBeforeViewport, firstItemInViewportOffset + newContainerSpan);
 
                                                         if (!endsAfterViewport)
@@ -2811,7 +2811,7 @@ namespace System.Windows.Controls
                     if (IsVirtualizing &&
                         !IsPixelBased &&
                         (hasVirtualizingChildren || virtualizationInfoProvider != null) &&
-                        (MeasureCaches || (DoubleUtil.AreClose(cacheSize.CacheBeforeViewport, 0) && DoubleUtil.AreClose(cacheSize.CacheAfterViewport, 0))))
+                        (MeasureCaches || (DoubleUtil.IsZero(cacheSize.CacheBeforeViewport) && DoubleUtil.IsZero(cacheSize.CacheAfterViewport))))
                     {
                         //
                         // All of the descendent panels in hierarchical item scrolling scenarios that are after the extended
@@ -5587,7 +5587,7 @@ namespace System.Windows.Controls
                 }
                 else
                 {
-                    if (DoubleUtil.AreClose(spanBeforeViewport, 0))
+                    if (DoubleUtil.IsZero(spanBeforeViewport))
                     {
                         foundFirstItemInViewport = true;
                         firstItemInViewportOffset = 0.0;
@@ -6475,8 +6475,8 @@ namespace System.Windows.Controls
 
             // compute the desired inset, avoiding catastrophic cancellation errors
             Size itemsSize = itemsHost.DesiredSize;
-            double left = DoubleUtil.AreClose(0, itemsRect.Left) ? 0 : -itemsRect.Left;
-            double top = DoubleUtil.AreClose(0, itemsRect.Top) ? 0 : -itemsRect.Top;
+            double left = DoubleUtil.IsZero(itemsRect.Left) ? 0 : -itemsRect.Left;
+            double top = DoubleUtil.IsZero(itemsRect.Top) ? 0 : -itemsRect.Top;
             double right = DoubleUtil.AreClose(itemsSize.Width, itemsRect.Right) ? 0 : itemsRect.Right-itemsSize.Width;
             double bottom = DoubleUtil.AreClose(itemsSize.Height, itemsRect.Bottom) ? 0 : itemsRect.Bottom-itemsSize.Height;
             Thickness inset = new Thickness(left, top, right, bottom);
@@ -6674,11 +6674,11 @@ namespace System.Windows.Controls
         {
             if (isHorizontal)
             {
-                return DoubleUtil.AreClose(viewport.Width, 0.0);
+                return DoubleUtil.IsZero(viewport.Width);
             }
             else
             {
-                return DoubleUtil.AreClose(viewport.Height, 0.0);
+                return DoubleUtil.IsZero(viewport.Height);
             }
         }
 
@@ -7228,7 +7228,7 @@ namespace System.Windows.Controls
                         // If the child is beyond the viewport in the opposite orientation to this panel then we musn't count that child in.
                         //
                         if (DoubleUtil.GreaterThanOrClose(childViewport.Y, childPixelSize.Height) ||
-                            DoubleUtil.AreClose(childViewport.Height, 0.0))
+                            DoubleUtil.IsZero(childViewport.Height))
                         {
                             return;
                         }
@@ -7246,7 +7246,7 @@ namespace System.Windows.Controls
                         // If the child is beyond the viewport in the opposite orientation to this panel then we musn't count that child in.
                         //
                         if (DoubleUtil.GreaterThanOrClose(childViewport.Y, childLogicalSize.Height) ||
-                            DoubleUtil.AreClose(childViewport.Height, 0.0))
+                            DoubleUtil.IsZero(childViewport.Height))
                         {
                             return;
                         }
@@ -7320,7 +7320,7 @@ namespace System.Windows.Controls
                         // If the child is beyond the viewport in the opposite orientation to this panel then we musn't count that child in.
                         //
                         if (DoubleUtil.GreaterThanOrClose(childViewport.X, childPixelSize.Width) ||
-                            DoubleUtil.AreClose(childViewport.Width, 0.0))
+                            DoubleUtil.IsZero(childViewport.Width))
                         {
                             return;
                         }
@@ -7338,7 +7338,7 @@ namespace System.Windows.Controls
                         // If the child is beyond the viewport in the opposite orientation to this panel then we musn't count that child in.
                         //
                         if (DoubleUtil.GreaterThanOrClose(childViewport.X, childLogicalSize.Width) ||
-                            DoubleUtil.AreClose(childViewport.Width, 0.0))
+                            DoubleUtil.IsZero(childViewport.Width))
                         {
                             return;
                         }
@@ -9719,12 +9719,12 @@ namespace System.Windows.Controls
             // returning an infinite desired size, which is forbidden.
             if (!Double.IsPositiveInfinity(constraint.Width))
             {
-                stackPixelSize.Width = IsPixelBased || DoubleUtil.AreClose(computedViewportOffset.X, 0) ?
+                stackPixelSize.Width = IsPixelBased || DoubleUtil.IsZero(computedViewportOffset.X) ?
                     Math.Min(stackPixelSize.Width, constraint.Width) : constraint.Width;
             }
             if (!Double.IsPositiveInfinity(constraint.Height))
             {
-                stackPixelSize.Height = IsPixelBased || DoubleUtil.AreClose(computedViewportOffset.Y, 0) ?
+                stackPixelSize.Height = IsPixelBased || DoubleUtil.IsZero(computedViewportOffset.Y) ?
                     Math.Min(stackPixelSize.Height, constraint.Height) : constraint.Height;
             }
 
@@ -9735,13 +9735,13 @@ namespace System.Windows.Controls
                 // to accumulate the fractional changes, but only the whole value is used for further computations.
                 if (isHorizontal)
                 {
-                    Debug.Assert(DoubleUtil.AreClose(viewportSize.Width - Math.Floor(viewportSize.Width), 0.0), "The viewport size must not contain fractional values when in item scrolling mode.");
-                    Debug.Assert(DoubleUtil.AreClose(extentSize.Width - Math.Floor(extentSize.Width), 0.0), "The extent size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(viewportSize.Width - Math.Floor(viewportSize.Width)), "The viewport size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(extentSize.Width - Math.Floor(extentSize.Width)), "The extent size must not contain fractional values when in item scrolling mode.");
                 }
                 else
                 {
-                    Debug.Assert(DoubleUtil.AreClose(viewportSize.Height - Math.Floor(viewportSize.Height), 0.0), "The viewport size must not contain fractional values when in item scrolling mode.");
-                    Debug.Assert(DoubleUtil.AreClose(extentSize.Height - Math.Floor(extentSize.Height), 0.0), "The extent size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(viewportSize.Height - Math.Floor(viewportSize.Height)), "The viewport size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(extentSize.Height - Math.Floor(extentSize.Height)), "The extent size must not contain fractional values when in item scrolling mode.");
                 }
             }
 #endif
@@ -10032,7 +10032,7 @@ namespace System.Windows.Controls
                             viewportOffset.X = Double.PositiveInfinity;
                             StorePreviouslyMeasuredOffset(ref previouslyMeasuredOffsets, computedViewportOffset.X);
 
-                            if (DoubleUtil.AreClose(viewportSize.Width, 0))
+                            if (DoubleUtil.IsZero(viewportSize.Width))
                             {
                                 viewportSize.Width = _scrollData._viewport.Width;
                             }
@@ -10073,8 +10073,8 @@ namespace System.Windows.Controls
                         // was initially intended.
                         else if (_scrollData.HorizontalScrollType == ScrollType.Absolute)
                         {
-                            if (!DoubleUtil.AreClose(_scrollData._extent.Width, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Width, 0))
+                            if (!DoubleUtil.IsZero(_scrollData._extent.Width) &&
+                                !DoubleUtil.IsZero(extentSize.Width))
                             {
                                 if (IsPixelBased)
                                 {
@@ -10140,8 +10140,8 @@ namespace System.Windows.Controls
                         // was initially intended.
                         else if (_scrollData.VerticalScrollType == ScrollType.Absolute)
                         {
-                            if (!DoubleUtil.AreClose(_scrollData._extent.Height, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Height, 0))
+                            if (!DoubleUtil.IsZero(_scrollData._extent.Height) &&
+                                !DoubleUtil.IsZero(extentSize.Height))
                             {
                                 if (!LayoutDoubleUtil.AreClose(computedViewportOffset.Y/extentSize.Height, _scrollData._offset.Y/_scrollData._extent.Height))
                                 {
@@ -10249,7 +10249,7 @@ namespace System.Windows.Controls
                             viewportOffset.Y = Double.PositiveInfinity;
                             StorePreviouslyMeasuredOffset(ref previouslyMeasuredOffsets, computedViewportOffset.Y);
 
-                            if (DoubleUtil.AreClose(viewportSize.Height, 0))
+                            if (DoubleUtil.IsZero(viewportSize.Height))
                             {
                                 viewportSize.Height = _scrollData._viewport.Height;
                             }
@@ -10290,8 +10290,8 @@ namespace System.Windows.Controls
                         // was initially intended.
                         else if (_scrollData.VerticalScrollType == ScrollType.Absolute)
                         {
-                            if (!DoubleUtil.AreClose(_scrollData._extent.Height, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Height, 0))
+                            if (!DoubleUtil.IsZero(_scrollData._extent.Height) &&
+                                !DoubleUtil.IsZero(extentSize.Height))
                             {
                                 if (IsPixelBased)
                                 {
@@ -10356,8 +10356,8 @@ namespace System.Windows.Controls
                         // was initially intended.
                         else if (_scrollData.HorizontalScrollType == ScrollType.Absolute)
                         {
-                            if (!DoubleUtil.AreClose(_scrollData._extent.Width, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Width, 0))
+                            if (!DoubleUtil.IsZero(_scrollData._extent.Width) &&
+                                !DoubleUtil.IsZero(extentSize.Width))
                             {
                                 if (!LayoutDoubleUtil.AreClose(computedViewportOffset.X/extentSize.Width, _scrollData._offset.X/_scrollData._extent.Width))
                                 {
@@ -10571,12 +10571,12 @@ namespace System.Windows.Controls
             // returning an infinite desired size, which is forbidden.
             if (!Double.IsPositiveInfinity(constraint.Width))
             {
-                stackPixelSize.Width = IsPixelBased || DoubleUtil.AreClose(computedViewportOffset.X, 0) ?
+                stackPixelSize.Width = IsPixelBased || DoubleUtil.IsZero(computedViewportOffset.X) ?
                     Math.Min(stackPixelSize.Width, constraint.Width) : constraint.Width;
             }
             if (!Double.IsPositiveInfinity(constraint.Height))
             {
-                stackPixelSize.Height = IsPixelBased || DoubleUtil.AreClose(computedViewportOffset.Y, 0) ?
+                stackPixelSize.Height = IsPixelBased || DoubleUtil.IsZero(computedViewportOffset.Y) ?
                     Math.Min(stackPixelSize.Height, constraint.Height) : constraint.Height;
             }
 
@@ -10587,13 +10587,13 @@ namespace System.Windows.Controls
                 // to accumulate the fractional changes, but only the whole value is used for further computations.
                 if (isHorizontal)
                 {
-                    Debug.Assert(DoubleUtil.AreClose(viewportSize.Width - Math.Floor(viewportSize.Width), 0.0), "The viewport size must not contain fractional values when in item scrolling mode.");
-                    Debug.Assert(DoubleUtil.AreClose(extentSize.Width - Math.Floor(extentSize.Width), 0.0), "The extent size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(viewportSize.Width - Math.Floor(viewportSize.Width)), "The viewport size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(extentSize.Width - Math.Floor(extentSize.Width)), "The extent size must not contain fractional values when in item scrolling mode.");
                 }
                 else
                 {
-                    Debug.Assert(DoubleUtil.AreClose(viewportSize.Height - Math.Floor(viewportSize.Height), 0.0), "The viewport size must not contain fractional values when in item scrolling mode.");
-                    Debug.Assert(DoubleUtil.AreClose(extentSize.Height - Math.Floor(extentSize.Height), 0.0), "The extent size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(viewportSize.Height - Math.Floor(viewportSize.Height)), "The viewport size must not contain fractional values when in item scrolling mode.");
+                    Debug.Assert(DoubleUtil.IsZero(extentSize.Height - Math.Floor(extentSize.Height)), "The extent size must not contain fractional values when in item scrolling mode.");
                 }
             }
 #endif
@@ -10697,7 +10697,7 @@ namespace System.Windows.Controls
                             viewportOffset.X = _scrollData._offset.X;
                             StorePreviouslyMeasuredOffset(ref previouslyMeasuredOffsets, computedViewportOffset.X);
 
-                            if (DoubleUtil.AreClose(viewportSize.Width, 0))
+                            if (DoubleUtil.IsZero(viewportSize.Width))
                             {
                                 viewportSize.Width = _scrollData._viewport.Width;
                             }
@@ -10744,8 +10744,8 @@ namespace System.Windows.Controls
                                 (_scrollData._firstContainerInViewport == null && computedViewportOffsetChanged && !LayoutDoubleUtil.AreClose(computedViewportOffset.X, _scrollData._computedOffset.X));
 
                             if (isAbsoluteMove &&
-                                !DoubleUtil.AreClose(_scrollData._extent.Width, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Width, 0))
+                                !DoubleUtil.IsZero(_scrollData._extent.Width) &&
+                                !DoubleUtil.IsZero(extentSize.Width))
                             {
                                 if (IsPixelBased)
                                 {
@@ -10828,7 +10828,7 @@ namespace System.Windows.Controls
                             viewportOffset.Y = _scrollData._offset.Y;
                             StorePreviouslyMeasuredOffset(ref previouslyMeasuredOffsets, computedViewportOffset.Y);
 
-                            if (DoubleUtil.AreClose(viewportSize.Height, 0))
+                            if (DoubleUtil.IsZero(viewportSize.Height))
                             {
                                 viewportSize.Height = _scrollData._viewport.Height;
                             }
@@ -10875,8 +10875,8 @@ namespace System.Windows.Controls
                                 (_scrollData._firstContainerInViewport == null && computedViewportOffsetChanged && !LayoutDoubleUtil.AreClose(computedViewportOffset.Y, _scrollData._computedOffset.Y));
 
                             if (isAbsoluteMove &&
-                                !DoubleUtil.AreClose(_scrollData._extent.Height, 0) &&
-                                !DoubleUtil.AreClose(extentSize.Height, 0))
+                                !DoubleUtil.IsZero(_scrollData._extent.Height) &&
+                                !DoubleUtil.IsZero(extentSize.Height))
                             {
                                 if (IsPixelBased)
                                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlFigureLengthSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlFigureLengthSerializer.cs
@@ -245,7 +245,7 @@ namespace System.Windows.Markup
             else
             {
                 Debug.Assert(   unit == FigureUnitType.Pixel 
-                            ||  DoubleUtil.AreClose(unitFactor, 1.0)    );
+                            ||  DoubleUtil.IsOne(unitFactor)    );
 
                 ReadOnlySpan<char> valueString = valueSpan.Slice(0, valueSpan.Length - strLenUnit);
                 value = double.Parse(valueString, provider: cultureInfo) * unitFactor;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlGridLengthSerializer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/XamlGridLengthSerializer.cs
@@ -246,7 +246,7 @@ namespace System.Windows.Markup
             else
             {
                 Debug.Assert(   unit == GridUnitType.Pixel 
-                            ||  DoubleUtil.AreClose(unitFactor, 1.0)    );
+                            ||  DoubleUtil.IsOne(unitFactor)    );
 
                 ReadOnlySpan<char> valueString = valueSpan.Slice(0, valueSpan.Length - strLenUnit);
                 value = double.Parse(valueString, provider: cultureInfo) * unitFactor;

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/InRibbonGallery.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/InRibbonGallery.cs
@@ -159,8 +159,8 @@ namespace Microsoft.Windows.Controls.Ribbon
             {
                 _cachedDesiredSize = desiredSize;
 
-                if (DoubleUtil.AreClose(_scrollButtonsBorderFactor, 0) || 
-                    (_contentPresenter != null && DoubleUtil.AreClose(_contentPresenter.MaxWidth, 0)))
+                if (DoubleUtil.IsZero(_scrollButtonsBorderFactor) || 
+                    (_contentPresenter != null && DoubleUtil.IsZero(_contentPresenter.MaxWidth)))
                 {
                     UpdateInRibbonGalleryModeProperties();
                 }
@@ -381,7 +381,7 @@ namespace Microsoft.Windows.Controls.Ribbon
                 _scrollButtonsBorderFactor = 0;
                 if (_scrollButtonsBorder != null)
                 {
-                    if (DoubleUtil.AreClose(_scrollButtonsBorder.ActualWidth, 0))
+                    if (DoubleUtil.IsZero(_scrollButtonsBorder.ActualWidth))
                     {
                         _scrollButtonsBorderFactor = 0;
                     }

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonContextualTabGroupsPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonContextualTabGroupsPanel.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
                         if (tabGroupHeader.Visibility == Visibility.Visible && tabGroupHeader.ArrangeWidth > 0)
                         {
                             double startX = tabGroupHeader.ArrangeX;
-                            if (DoubleUtil.AreClose(startX, 0.0))
+                            if (DoubleUtil.IsZero(startX))
                             {
                                 // For the first group, draw to the left as well
                                 drawingContext.DrawLine(separatorPen, new Point(startX, ActualHeight), new Point(startX, this.ActualHeight + separatorHeight));

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGalleryCategoriesPanel.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/Primitives/RibbonGalleryCategoriesPanel.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Windows.Controls.Ribbon.Primitives
 
         internal bool InRibbonModeCanLineUp()
         {
-            return !DoubleUtil.AreClose(VerticalOffset, 0.0);
+            return !DoubleUtil.IsZero(VerticalOffset);
         }
 
         internal bool InRibbonModeCanLineDown()

--- a/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLengthConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/System.Windows.Controls.Ribbon/Microsoft/Windows/Controls/Ribbon/RibbonControlLengthConverter.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Windows.Controls.Ribbon
             else
             {
                 Debug.Assert(unit == RibbonControlLengthUnitType.Pixel || unit == RibbonControlLengthUnitType.Item ||
-                    DoubleUtil.AreClose(unitFactor, 1.0));
+                    DoubleUtil.IsOne(unitFactor));
 
                 ReadOnlySpan<char> valueString = goodString.AsSpan(0, strLen - strLenUnit);
                 value = double.Parse(valueString, provider: cultureInfo) * unitFactor;


### PR DESCRIPTION
## Description
Uses existing optimized DoubleUtil methods instead of DoubleUtil.AreClose. It's a bit cleaner and provides tiny improvements in speed, IL size and JIT code size. The improvements are negligible but it's overall better so I believe the changes are worth it.

<details>
  <summary>Benchmark results for DoubleUtil.AreClose vs DoubleUtil.IsZero</summary>
  
| Method   | value                | Mean      | Error     | StdDev    | Ratio | RatioSD | Code Size |
|--------- |--------------------- |----------:|----------:|----------:|------:|--------:|----------:|
| AreClose | 1.110(...)5E-16 [22] | 0.2316 ns | 0.0034 ns | 0.0026 ns |  1.00 |    0.02 |      80 B |
| IsZero   | 1.110(...)5E-16 [22] | 0.0235 ns | 0.0099 ns | 0.0093 ns |  0.10 |    0.04 |      27 B |
|          |                      |           |           |           |       |         |           |
| AreClose | 1                    | 0.2294 ns | 0.0065 ns | 0.0061 ns |  1.00 |    0.04 |      80 B |
| IsZero   | 1                    | 0.0133 ns | 0.0044 ns | 0.0037 ns |  0.06 |    0.02 |      27 B |
  
</details>

<details>
  <summary>Benchmark results for DoubleUtil.AreClose vs DoubleUtil.IsOne</summary>
  
| Method   | value | Mean      | Error     | StdDev    | Ratio | RatioSD | Code Size |
|--------- |------ |----------:|----------:|----------:|------:|--------:|----------:|
| AreClose | 1     | 0.2084 ns | 0.0116 ns | 0.0103 ns |  1.00 |    0.07 |      88 B |
| IsOne    | 1     | 0.0142 ns | 0.0071 ns | 0.0059 ns |  0.07 |    0.03 |      35 B |
|          |       |           |           |           |       |         |           |
| AreClose | 2     | 0.2385 ns | 0.0058 ns | 0.0049 ns |  1.00 |    0.03 |      88 B |
| IsOne    | 2     | 0.0217 ns | 0.0069 ns | 0.0064 ns |  0.09 |    0.03 |      35 B |
  
</details>

## Customer Impact
Tiny improvements in speed, IL size and JIT code size.

## Regression
No.

## Testing
Local testing.

## Risk
Low.