### PR TITLE
Convert static float variables in FloatUtil into compile-time constants

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FloatUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FloatUtil.cs
@@ -20,9 +20,9 @@ namespace MS.Internal
 {
     internal static class FloatUtil
     {
-        internal const float FLT_EPSILON = 1.192092896E-07f;
-        internal const float FLT_MAX_PRECISION = 0x00FFFFFF;
-        internal const float INVERSE_FLT_MAX_PRECISION = 1.0f / FLT_MAX_PRECISION;
+        private const float FLT_EPSILON = 1.192092896E-07f;
+        private const float FLT_MAX_PRECISION = 0x00FFFFFF;
+        private const float INVERSE_FLT_MAX_PRECISION = 1.0f / FLT_MAX_PRECISION;
 
         /// <summary>
         /// AreClose

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FloatUtil.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/FloatUtil.cs
@@ -12,10 +12,6 @@
 //              provides "fuzzy" comparison functionality for floats and
 //              float-based classes and structs in our code.
 //
-//
-//
-//
-//
 //---------------------------------------------------------------------------
 
 using System;
@@ -24,20 +20,23 @@ namespace MS.Internal
 {
     internal static class FloatUtil
     {
-        internal static float FLT_EPSILON  =   1.192092896e-07F;
-        internal static float FLT_MAX_PRECISION = 0xffffff;
-        internal static float INVERSE_FLT_MAX_PRECISION = 1.0F / FLT_MAX_PRECISION;
+        internal const float FLT_EPSILON = 1.192092896E-07f;
+        internal const float FLT_MAX_PRECISION = 0x00FFFFFF;
+        internal const float INVERSE_FLT_MAX_PRECISION = 1.0f / FLT_MAX_PRECISION;
 
         /// <summary>
         /// AreClose
         /// </summary>
         public static bool AreClose(float a, float b)
         {
-            if(a == b) return true;
+            if (a == b)
+                return true;
+
             // This computes (|a-b| / (|a| + |b| + 10.0f)) < FLT_EPSILON
             float eps = ((float)Math.Abs(a) + (float)Math.Abs(b) + 10.0f) * FLT_EPSILON;
             float delta = a - b;
-            return(-eps < delta) && (eps > delta);
+
+            return (-eps < delta) && (eps > delta);
         }
 
         /// <summary>
@@ -45,7 +44,7 @@ namespace MS.Internal
         /// </summary>
         public static bool IsOne(float a)
         {
-            return (float)Math.Abs(a-1.0f) < 10.0f * FLT_EPSILON;
+            return (float)Math.Abs(a - 1.0f) < 10.0f * FLT_EPSILON;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Converts three static variables into compile-time constants as there's no reason they shall be static variables in the first place. This will allow us to save a few precious bytes of memory. `IsOne`/`IsZero` are unused right now but I'll keep them in.

## Customer Impact

Decreased static allocations by a few bytes and tiny bit of perf!

## Regression

No.

## Testing

Local build.

## Risk

None.
_Besides if someone was using reflection to change them — miloush doesn't like when I say "None", haha._

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9817)