### PR TITLE
Optimize ResourceContainer/AssemblyLoadEventHandler methods, remove allocs

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -294,13 +294,13 @@ namespace MS.Internal.AppModel
 
         private void UpdateCachedRMW(string key, Assembly assembly)
         {
-            if (s_registeredResourceManagers.ContainsKey(key))
+            if (s_registeredResourceManagers.TryGetValue(key, out ResourceManagerWrapper value))
             {
                 // Update the ResourceManagerWrapper with the new assembly. 
                 // Note Package caches Part and Part holds on to ResourceManagerWrapper. Package does not provide a way for 
                 // us to update their cache, so we update the assembly that the ResourceManagerWrapper holds on to. This way the 
                 // Part cached in the Package class can reference the new dll too. 
-                s_registeredResourceManagers[key].Assembly = assembly;
+                value.Assembly = assembly;
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -250,7 +250,6 @@ namespace MS.Internal.AppModel
                 AssemblyName assemblyInfo = new AssemblyName(assembly.FullName);
 
                 string assemblyName = assemblyInfo.Name;
-                string assemblyKey = string.Empty;
                 string key = assemblyName;
 
                 // Check if this newly loaded assembly is in the cache. If so, update the cache.
@@ -271,20 +270,16 @@ namespace MS.Internal.AppModel
                     UpdateCachedRMW(key, args.LoadedAssembly);
                 }
 
-                byte[] reqKeyToken = assemblyInfo.GetPublicKeyToken();
-                for (int i = 0; i < reqKeyToken.Length; i++)
+                byte[] publicKeyToken = assemblyInfo.GetPublicKeyToken();
+                Span<char> assemblyKey = stackalloc char[16];
+                if (Convert.TryToHexStringLower(publicKeyToken, assemblyKey, out int charsWritten) && charsWritten == 16)
                 {
-                    assemblyKey += reqKeyToken[i].ToString("x", NumberFormatInfo.InvariantInfo);
-                }
-
-                if (!String.IsNullOrEmpty(assemblyKey))
-                {
-                    key = key + assemblyKey;
+                    key = $"{key}{assemblyKey}";
 
                     // Check Name + Version + KeyToken
                     UpdateCachedRMW(key, args.LoadedAssembly);
 
-                    key = assemblyName + assemblyKey;
+                    key = $"{assemblyName}{assemblyKey}";
 
                     // Check Name + KeyToken
                     UpdateCachedRMW(key, args.LoadedAssembly);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -294,13 +294,13 @@ namespace MS.Internal.AppModel
 
         private void UpdateCachedRMW(string key, Assembly assembly)
         {
-            if (_registeredResourceManagers.ContainsKey(key))
+            if (s_registeredResourceManagers.ContainsKey(key))
             {
                 // Update the ResourceManagerWrapper with the new assembly. 
                 // Note Package caches Part and Part holds on to ResourceManagerWrapper. Package does not provide a way for 
                 // us to update their cache, so we update the assembly that the ResourceManagerWrapper holds on to. This way the 
                 // Part cached in the Package class can reference the new dll too. 
-                _registeredResourceManagers[key].Assembly = assembly;
+                s_registeredResourceManagers[key].Assembly = assembly;
             }
         }
 
@@ -328,7 +328,7 @@ namespace MS.Internal.AppModel
             {
                 string key = assemblyName + assemblyVersion + assemblyKey;
 
-                _registeredResourceManagers.TryGetValue(key.ToLowerInvariant(), out rmwResult);
+                s_registeredResourceManagers.TryGetValue(key.ToLowerInvariant(), out rmwResult);
 
                 // first time. Add this to the hash table
                 if (rmwResult == null)
@@ -348,7 +348,7 @@ namespace MS.Internal.AppModel
                         rmwResult = new ResourceManagerWrapper(assembly);
                     }
 
-                    _registeredResourceManagers[key.ToLowerInvariant()] = rmwResult;
+                    s_registeredResourceManagers[key.ToLowerInvariant()] = rmwResult;
                 }
             }
 
@@ -384,7 +384,7 @@ namespace MS.Internal.AppModel
 
         #region Private Members
 
-        private static Dictionary<string, ResourceManagerWrapper> _registeredResourceManagers = new Dictionary<string, ResourceManagerWrapper>();
+        private static Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new();
         private static ResourceManagerWrapper _applicationResourceManagerWrapper = null;
         private static FileShare _fileShare = FileShare.Read;
         private static bool assemblyLoadhandlerAttached = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -245,7 +245,7 @@ namespace MS.Internal.AppModel
             // We do not care about assemblies loaded into the reflection-only context or the Gaced assemblies.
             // For example, in Sparkle whenever a project is built all dependent assemblies will be loaded reflection only.
             // We do no care about those. Only when a assembly is loaded into the execution context, we will need to update the cache. 
-            if ((!assembly.ReflectionOnly))
+            if (!assembly.ReflectionOnly)
             {
                 AssemblyName assemblyInfo = new(assembly.FullName);
 
@@ -307,14 +307,10 @@ namespace MS.Internal.AppModel
         // <returns></returns>
         private static ResourceManagerWrapper GetResourceManagerWrapper(Uri uri, out string partName, out bool isContentFile)
         {
-            string assemblyName;
-            string assemblyVersion;
-            string assemblyKey;
             ResourceManagerWrapper rmwResult = ApplicationResourceManagerWrapper;
-
             isContentFile = false;
 
-            BaseUriHelper.GetAssemblyNameAndPart(uri, out partName, out assemblyName, out assemblyVersion, out assemblyKey);
+            BaseUriHelper.GetAssemblyNameAndPart(uri, out partName, out string assemblyName, out string assemblyVersion, out string assemblyKey);
 
             if (!String.IsNullOrEmpty(assemblyName))
             {
@@ -328,7 +324,6 @@ namespace MS.Internal.AppModel
                     if (assembly.Equals(Application.ResourceAssembly))
                     {
                         // This Uri maps to Application Entry assembly even though it has ";component".
-
                         rmwResult = ApplicationResourceManagerWrapper;
                     }
                     else
@@ -340,7 +335,7 @@ namespace MS.Internal.AppModel
                 }
             }
 
-            if ((rmwResult == ApplicationResourceManagerWrapper))
+            if (rmwResult == ApplicationResourceManagerWrapper)
             {
                 if (rmwResult != null)
                 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -49,7 +49,7 @@ namespace MS.Internal.AppModel
             {
                 if (s_applicationResourceManagerWrapper == null)
                 {
-                    // load main excutable assembly
+                    // load main executable assembly
                     Assembly asmApplication = Application.ResourceAssembly;
 
                     if (asmApplication != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -249,7 +249,7 @@ namespace MS.Internal.AppModel
             {
                 AssemblyName assemblyInfo = new AssemblyName(assembly.FullName);
 
-                string assemblyName = assemblyInfo.Name.ToLowerInvariant();
+                string assemblyName = assemblyInfo.Name;
                 string assemblyKey = string.Empty;
                 string key = assemblyName;
 
@@ -328,7 +328,7 @@ namespace MS.Internal.AppModel
             {
                 string key = assemblyName + assemblyVersion + assemblyKey;
 
-                s_registeredResourceManagers.TryGetValue(key.ToLowerInvariant(), out rmwResult);
+                s_registeredResourceManagers.TryGetValue(key, out rmwResult);
 
                 // first time. Add this to the hash table
                 if (rmwResult == null)
@@ -348,7 +348,7 @@ namespace MS.Internal.AppModel
                         rmwResult = new ResourceManagerWrapper(assembly);
                     }
 
-                    s_registeredResourceManagers[key.ToLowerInvariant()] = rmwResult;
+                    s_registeredResourceManagers[key] = rmwResult;
                 }
             }
 
@@ -384,7 +384,7 @@ namespace MS.Internal.AppModel
 
         #region Private Members
 
-        private static Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new();
+        private static Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.OrdinalIgnoreCase);
         private static ResourceManagerWrapper _applicationResourceManagerWrapper = null;
         private static FileShare _fileShare = FileShare.Read;
         private static bool assemblyLoadhandlerAttached = false;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -326,7 +326,8 @@ namespace MS.Internal.AppModel
 
             if (!String.IsNullOrEmpty(assemblyName))
             {
-                string key = assemblyName + assemblyVersion + assemblyKey;
+                // Create the key, this will rarely get over 128 chars in my experience
+                string key = string.Create(null, stackalloc char [128], $"{assemblyName}{assemblyVersion}{assemblyKey}");
 
                 // first time. Add this to the hash table
                 if (!s_registeredResourceManagers.TryGetValue(key, out rmwResult))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -1,6 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 //
 //
@@ -12,17 +11,12 @@
 // the NotSupportedException.
 // 
 
-using System.IO.Packaging;
-using System.IO;
-using System.Reflection;
-using System.Globalization;
-using System.Windows;
-using System.Reflection;
-using System.IO.Packaging;
 using System.Windows.Navigation;
-using System.Collections.Generic;
-
 using MS.Internal.Resources;
+using System.IO.Packaging;
+using System.Reflection;
+using System.Windows;
+using System.IO;
 
 namespace MS.Internal.AppModel
 {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -95,7 +95,8 @@ namespace MS.Internal.AppModel
         //
         //  Public Methods
         //
-        //------------------------------------------------------        
+        //------------------------------------------------------
+
         #region Public Methods
 
         /// <summary>
@@ -118,10 +119,11 @@ namespace MS.Internal.AppModel
 
         //------------------------------------------------------
         //
-        //  Internal Properties
+        //  Internal Constants
         //
         //------------------------------------------------------
-        #region Internal Members
+
+        #region Internal Constants
 
         internal const string XamlExt = ".xaml";
         internal const string BamlExt = ".baml";
@@ -133,6 +135,7 @@ namespace MS.Internal.AppModel
         //  Protected Methods
         //
         //------------------------------------------------------
+
         #region Protected Methods
 
         /// <summary>
@@ -206,7 +209,7 @@ namespace MS.Internal.AppModel
 
                 // Check if this newly loaded assembly is in the cache. If so, update the cache.
                 // If it is not in cache, do not do anything. It will be added on demand.
-                // The key could be Name; Name + Version; Name + PublicKeyToken; or Name + Version + PublicKeyToken.  
+                // The key could be Name, Name + Version, Name + PublicKeyToken, or Name + Version + PublicKeyToken.  
                 // Otherwise, update the cache with the newly loaded dll.
 
                 // Firstly, check the Name

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -292,7 +292,7 @@ namespace MS.Internal.AppModel
             }
         }
 
-        private void UpdateCachedRMW(string key, Assembly assembly)
+        private static void UpdateCachedRMW(string key, Assembly assembly)
         {
             if (s_registeredResourceManagers.TryGetValue(key, out ResourceManagerWrapper value))
             {
@@ -313,7 +313,7 @@ namespace MS.Internal.AppModel
         // <param name="partName">The name of the file in the resource manager</param>
         // <param name="isContentFile">A flag to indicate that this path is a known loose file at compile time</param>
         // <returns></returns>
-        private ResourceManagerWrapper GetResourceManagerWrapper(Uri uri, out string partName, out bool isContentFile)
+        private static ResourceManagerWrapper GetResourceManagerWrapper(Uri uri, out string partName, out bool isContentFile)
         {
             string assemblyName;
             string assemblyVersion;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -44,18 +44,18 @@ namespace MS.Internal.AppModel
         {
             get
             {
-                if (_applicationResourceManagerWrapper == null)
+                if (s_applicationResourceManagerWrapper == null)
                 {
                     // load main excutable assembly
                     Assembly asmApplication = Application.ResourceAssembly;
 
                     if (asmApplication != null)
                     {
-                        _applicationResourceManagerWrapper = new ResourceManagerWrapper(asmApplication);
+                        s_applicationResourceManagerWrapper = new ResourceManagerWrapper(asmApplication);
                     }
                 }
 
-                return _applicationResourceManagerWrapper;
+                return s_applicationResourceManagerWrapper;
             }
         }
 
@@ -68,7 +68,7 @@ namespace MS.Internal.AppModel
         {
             get
             {
-                return _fileShare;
+                return s_fileShare;
             }
         }
 
@@ -200,10 +200,10 @@ namespace MS.Internal.AppModel
             // old version dll when a newer one is loaded. So whenever the AssemblyLoad event is fired, we will need to update the cache 
             // with the newly loaded assembly. This is currently only for designer so not needed for browser hosted apps. 
             // Attach the event handler before the first time we get the ResourceManagerWrapper.
-            if (!assemblyLoadhandlerAttached)
+            if (!s_assemblyLoadhandlerAttached)
             {
                 AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(OnAssemblyLoadEventHandler);
-                assemblyLoadhandlerAttached = true;
+                s_assemblyLoadhandlerAttached = true;
             }
 
             ResourceManagerWrapper rmWrapper = GetResourceManagerWrapper(uri, out partName, out isContentFile);
@@ -379,10 +379,11 @@ namespace MS.Internal.AppModel
 
         #region Private Members
 
-        private static Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.OrdinalIgnoreCase);
-        private static ResourceManagerWrapper _applicationResourceManagerWrapper = null;
-        private static FileShare _fileShare = FileShare.Read;
-        private static bool assemblyLoadhandlerAttached = false;
+        private static readonly Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly FileShare s_fileShare = FileShare.Read;
+
+        private static ResourceManagerWrapper s_applicationResourceManagerWrapper = null;
+        private static bool s_assemblyLoadhandlerAttached = false;
 
         #endregion Private Members
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -202,7 +202,7 @@ namespace MS.Internal.AppModel
                 int totalLength = assemblyName.Length + assemblyVersion.Length + assemblyToken.Length;
 
                 Span<char> key = totalLength <= 256 ? stackalloc char[totalLength] : new char[totalLength];
-                assemblyName.CopyTo(key);
+                assemblyName.ToLowerInvariant(key);
 
                 // Check if this newly loaded assembly is in the cache. If so, update the cache.
                 // If it is not in cache, do not do anything. It will be added on demand.
@@ -210,7 +210,7 @@ namespace MS.Internal.AppModel
                 // Otherwise, update the cache with the newly loaded dll.
 
                 // Firstly, check the Name
-                UpdateCachedRMW(assemblyName, assembly);
+                UpdateCachedRMW(key.Slice(0, assemblyName.Length), assembly);
 
                 // Check Name + Version
                 if (!assemblyVersion.IsEmpty)
@@ -268,7 +268,7 @@ namespace MS.Internal.AppModel
                 // Create the key, in format of $"{assemblyName}{assemblyVersion}{assemblyToken}"
                 int totalLength = assemblyName.Length + assemblyVersion.Length + assemblyToken.Length;
                 Span<char> key = totalLength <= 256 ? stackalloc char[totalLength] : new char[totalLength];
-                assemblyName.CopyTo(key);
+                assemblyName.AsSpan().ToLowerInvariant(key);
                 assemblyVersion.CopyTo(key.Slice(assemblyName.Length));
                 assemblyToken.CopyTo(key.Slice(assemblyName.Length + assemblyVersion.Length));
 
@@ -322,7 +322,7 @@ namespace MS.Internal.AppModel
 
         #region Private Members
 
-        private static readonly Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, ResourceManagerWrapper> s_registeredResourceManagers = new(StringComparer.Ordinal);
         private static readonly Dictionary<string, ResourceManagerWrapper>.AlternateLookup<ReadOnlySpan<char>> s_registeredResourceManagersLookup = s_registeredResourceManagers.GetAlternateLookup<ReadOnlySpan<char>>();
         private static readonly FileShare s_fileShare = FileShare.Read;
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/AppModel/ResourceContainer.cs
@@ -328,15 +328,10 @@ namespace MS.Internal.AppModel
             {
                 string key = assemblyName + assemblyVersion + assemblyKey;
 
-                s_registeredResourceManagers.TryGetValue(key, out rmwResult);
-
                 // first time. Add this to the hash table
-                if (rmwResult == null)
+                if (!s_registeredResourceManagers.TryGetValue(key, out rmwResult))
                 {
-                    Assembly assembly;
-
-                    assembly = BaseUriHelper.GetLoadedAssembly(assemblyName, assemblyVersion, assemblyKey);
-
+                    Assembly assembly = BaseUriHelper.GetLoadedAssembly(assemblyName, assemblyVersion, assemblyKey);
                     if (assembly.Equals(Application.ResourceAssembly))
                     {
                         // This Uri maps to Application Entry assembly even though it has ";component".

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -7,6 +7,7 @@
 using System.Runtime.CompilerServices;
 using System.Reflection.Metadata;
 using System.Reflection;
+using System.Text;
 using System;
 
 namespace MS.Internal
@@ -17,9 +18,12 @@ namespace MS.Internal
     internal static class ReflectionUtils
     {
 #if !NETFX
+        private const string Version = ", Version=";
+        private const string PublicKeyToken = ", PublicKeyToken=";
+
         /// <summary>
-        ///  Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
-        ///  with everything else from <paramref name="assembly"/>.
+        /// Retrieves the full assembly name by combining the <paramref name="partialName"/> passed in
+        /// with everything else from <paramref name="assembly"/>.
         /// </summary>
         internal static string GetFullAssemblyNameFromPartialName(Assembly assembly, string partialName)
         {
@@ -33,7 +37,7 @@ namespace MS.Internal
 #endif
 
         /// <summary>
-        ///  Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
+        /// Given an <paramref name="assembly"/>, returns the partial/simple name of the assembly.
         /// </summary>
 #if !NETFX
         internal static ReadOnlySpan<char> GetAssemblyPartialName(Assembly assembly)
@@ -80,5 +84,47 @@ namespace MS.Internal
             return name.Name ?? string.Empty;
 #endif
         }
+
+#if !NETFX
+        /// <summary>
+        /// Parses <see cref="Assembly.FullName"/> and retrieves "Version" and "PublicKeyToken" values from the original string.
+        /// This should only be passed a RuntimeAssembly to ensure proper functionality.
+        /// </summary>
+        /// <param name="assembly">The RuntimeAssembly which will provide properly formatted full name.</param>
+        /// <param name="version">If present, returns the value of Version portion, otherwise Empty result.</param>
+        /// <param name="token">If present, returns the value of PublicKeyToken portion. Empty result is returned when the value is "null" or not present.</param>
+        internal static void GetAssemblyVersionPlusToken(Assembly assembly, out ReadOnlySpan<char> assemblyVersion, out ReadOnlySpan<char> assemblyToken)
+        {
+            ArgumentNullException.ThrowIfNull(assembly, nameof(assembly));
+            ReadOnlySpan<char> assemblyName = assembly.FullName;
+
+            assemblyVersion = ReadOnlySpan<char>.Empty;
+            assemblyToken = ReadOnlySpan<char>.Empty;
+
+            // Parse Version section
+            int versionIndex = assemblyName.IndexOf(Version);
+            if (versionIndex != -1)
+            {
+                int tokenEnding = assemblyName.Slice(versionIndex + 1).IndexOf(',') + 1;
+                int tokenLength = tokenEnding == 0 ? assemblyName.Slice(versionIndex).Length : tokenEnding;
+
+                assemblyVersion = assemblyName.Slice(versionIndex + Version.Length, tokenLength - Version.Length);
+            }
+
+            // Parse PublicKeyToken section
+            int tokenIndex = assemblyName.IndexOf(PublicKeyToken);
+            if (tokenIndex != -1)
+            {
+                int tokenEnding = assemblyName.Slice(tokenIndex + 1).IndexOf(',') + 1;
+                int tokenLength = tokenEnding == 0 ? assemblyName.Slice(tokenIndex).Length : tokenEnding;
+
+                // PublicKeyToken is always 8 bytes (16 chars in HEX), in other cases it is gonna be "null",
+                // however it is simply faster to match it via Length as original parser does it than anything else
+                assemblyToken = assemblyName.Slice(tokenIndex + PublicKeyToken.Length, tokenLength - PublicKeyToken.Length);
+                if (assemblyToken.Length != 16)
+                    assemblyToken = ReadOnlySpan<char>.Empty;
+            }
+        }
+#endif
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/ReflectionUtils.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 #nullable enable
 


### PR DESCRIPTION
## Description

Optimizes two rather important startup methods in `ResourceContainer` class, the handler for runtime assembly load events - `OnAssemblyLoadEventHandler` and `GetResourceManagerWrapper`. This saves several milliseconds upon startup.

- I retracted from using `StringComparer.OrdinalIgnoreCase` as it would be slower by ~60ns in the final solution.
- For parsing the assembly name from safe input (`RuntimeAssembly`), I've re-used the #9739 and added a new method for `Version`/`PublicKeyToken`
- I've originally used `ArrayPool<char>` for the unlikely event of needing an array (256+ chars) but seems redundant to initialize it this early, and we shall not really need to allocate an array anyways in 99% cases.
- Using `AlternativeLookup`, this now becomes fully allocation-free given that usually only 1 entry is in the dictionary.
- It is safe to assume that `ToLowerInvariant` produces same-length output, the own function's sanity check and several other dotnet runtime libraries (plus tons of user code) depend on this behavior of per-character folding.
- Some of the comments (e.g. about GACed assemblies) could have been removed, but I've kept them in.
- We seal the class for additional perf benefit as it is derived.

Do note that these benchmarks measure throughput and allocations (accurate), the savings are in milliseconds this early.
Allocations are dependent on presence of public key / assembly name length, this just illustrates general scenario.

### Single throughput of AssemblyLoadHandler

| Method    | assembly             | Mean [ns] | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|---------- |--------------------- |----------:|-----------:|------------:|--------------:|-------:|--------------:|
| Original  | Syste(...)7798e [89] |  636.3 ns |    6.57 ns |     6.14 ns |       5,880 B | 0.0896 |        1504 B |
| PR__EDIT | Syste(...)7798e [89] |  121.6 ns |    0.44 ns |     0.39 ns |       5,052 B |      - |             - |

### Standard app startup (28 libraries loaded)

| Method    | assembly             | Mean [ns]   | Error [ns] | StdDev [ns] | Code Size [B] | Gen0   | Allocated [B] |
|---------- |--------------------- |------------:|-----------:|------------:|--------------:|-------:|--------------:|
| Original  | Syste(...)7798e [89] | 17,579.6 ns |  151.20 ns |   141.43 ns |       8,030 B | 2.6245 |       44352 B |
| PR__EDIT | Syste(...)7798e [89] | 3,395.5 ns |    5.43 ns |     4.81 ns |       3,166 B |      - |             - |

## Customer Impact

Improved startup performance, decreased startup allocations.

## Regression

No.

## Testing

Local build, running few sample apps using resources and verifying functionality.

## Risk

Low, I believe I didn't achieve any change of the behavior, even unintentionally.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/wpf/pull/9822)